### PR TITLE
Make nicotine work with FreeBSD

### DIFF
--- a/nicotine
+++ b/nicotine
@@ -1,4 +1,4 @@
-#!/usr/bin/python2
+#!/usr/bin/env python2
 # -*- coding: utf-8 -*-
 #
 # COPYRIGHT (C) 2016-2017 Michael Labouebe <gfarmerfr@free.fr>


### PR DESCRIPTION
FreeBSD has python2 under /usr/local/bin, but using a /usr/bin/env sha-bang should fix this for all POSIX platforms.