### PR TITLE
Use bindip option for server socket

### DIFF
--- a/languages/fr/LC_MESSAGES/nicotine.po
+++ b/languages/fr/LC_MESSAGES/nicotine.po
@@ -124,6 +124,8 @@ msgstr ""
 "minimisé\n"
 "  -b ip,  --bindip=ip                            Attache Nicotine+ à l'IP "
 "spécifiée (utile pour les VPN)\n"
+"  -l port, --port=port        Écoutez le port donné. Annule la configuration "
+"de la portrange\n"
 "  -v, --version                                   Affiche la version et "
 "quitte"
 

--- a/languages/nicotine.pot
+++ b/languages/nicotine.pot
@@ -85,6 +85,8 @@ msgid ""
 "  -s,      --hidden           Start the program hidden so only the tray icon "
 "is shown\n"
 "  -b ip,   --bindip=ip        Bind sockets to the given IP (useful for VPN)\n"
+"  -l port, --port=port        Listen on the given port. Overrides the "
+"portrange configuration\n"
 "  -v,      --version          Display version and exit"
 msgstr ""
 

--- a/languages/pl/LC_MESSAGES/nicotine.po
+++ b/languages/pl/LC_MESSAGES/nicotine.po
@@ -121,6 +121,8 @@ msgstr ""
 "  -s,      --hidden       Uruchom program ukryty\n"
 "  -b ip,  --bindip=ip      Zbinduj sockety to podanego adresu IP (przydatne "
 "dla VPN-ów)\n"
+"  -l port, --port=port    Posłuchaj danego portu. Uporządkowanie konfiguracji "
+"portrange\n"
 "  -v,      --version       Pokaż wersję i wyjdź"
 
 msgid "Errors occured while trying to change process name:"

--- a/manpages/nicotine.1
+++ b/manpages/nicotine.1
@@ -29,6 +29,9 @@ Start the program hidden so only the tray icon is shown.
 .BI \-b " <ip>" "\fR,\fP \-\^\-bindip=" <ip>
 Bind sockets to the given <ip> (useful for VPN).
 .TP
+.BI \-l " <port>" "\fR,\fP \-\^\-port=" <port>
+Listen on the given port. Overrides the portrange configuration.
+.TP
 .B \-v, \-\^\-version
 Show version number and exit.
 .SH "EXIT STATUS"

--- a/nicotine
+++ b/nicotine
@@ -144,6 +144,7 @@ Usage: nicotine [OPTION]...
   -h,      --help             Show help and exit
   -s,      --hidden           Start the program hidden so only the tray icon is shown
   -b ip,   --bindip=ip        Bind sockets to the given IP (useful for VPN)
+  -l port, --port=port        Listen on the given port. Overrides the portrange configuration
   -v,      --version          Display version and exit""")
 
 
@@ -200,7 +201,8 @@ def run():
                                     "disable-trayicon",
                                     "version",
                                     "hidden",
-                                    "bindip="
+                                    "bindip=",
+                                    "port="
                                    ]
                                    )
     except getopt.GetoptError:
@@ -223,6 +225,7 @@ def run():
     trayicon = 1
     hidden = False
     bindip = None
+    port = None
 
     for o, a in opts:
         if o in ("-h", "--help"):
@@ -234,6 +237,8 @@ def run():
             plugins = a
         if o in ("-b", "--bindip"):
             bindip = a
+        if o in ("-l", "--port"):
+            port = a
         if o == "--profile":
             profile = 1
         if o in ("-t", "--enable-trayicon"):
@@ -251,7 +256,7 @@ def run():
     if result is None:
         from pynicotine.gtkgui import frame
 
-        app = frame.MainApp(config, plugins, trayicon, hidden, bindip)
+        app = frame.MainApp(config, plugins, trayicon, hidden, bindip, port)
 
         if profile:
 

--- a/pynicotine/gtkgui/frame.py
+++ b/pynicotine/gtkgui/frame.py
@@ -189,7 +189,7 @@ class BuddiesComboBox:
 
 class NicotineFrame:
 
-    def __init__(self, config, plugindir, use_trayicon, start_hidden=False, bindip=None):
+    def __init__(self, config, plugindir, use_trayicon, start_hidden=False, bindip=None, port=None):
 
         self.clip_data = ""
         self.configfile = config
@@ -208,6 +208,7 @@ class NicotineFrame:
         self.SEXY = SEXY
         self.chatrooms = None
         self.bindip = bindip
+        self.port = port
         self.got_focus = False
 
         try:
@@ -220,7 +221,7 @@ class NicotineFrame:
         except ImportError:
             self.pynotify = None
 
-        self.np = NetworkEventProcessor(self, self.callback, self.logMessage, self.SetStatusText, self.bindip, config)
+        self.np = NetworkEventProcessor(self, self.callback, self.logMessage, self.SetStatusText, self.bindip, self.port, config)
 
         config = self.np.config.sections
 
@@ -3728,8 +3729,8 @@ class gstreamer:
 
 class MainApp:
 
-    def __init__(self, config, plugindir, trayicon, start_hidden, bindip):
-        self.frame = NicotineFrame(config, plugindir, trayicon, start_hidden, bindip)
+    def __init__(self, config, plugindir, trayicon, start_hidden, bindip, port):
+        self.frame = NicotineFrame(config, plugindir, trayicon, start_hidden, bindip, port)
 
     def MainLoop(self):
         signal.signal(signal.SIGINT, signal.SIG_IGN)

--- a/pynicotine/pynicotine.py
+++ b/pynicotine/pynicotine.py
@@ -101,7 +101,7 @@ class NetworkEventProcessor:
     """ This class contains handlers for various messages from the networking
     thread"""
 
-    def __init__(self, frame, callback, writelog, setstatus, bindip, configfile):
+    def __init__(self, frame, callback, writelog, setstatus, bindip, port, configfile):
 
         self.frame = frame
         self.callback = callback
@@ -120,6 +120,7 @@ class NetworkEventProcessor:
             self.callback([PopupMessage(short, long)])
 
         self.bindip = bindip
+        self.port = port
         self.config.frame = frame
         self.config.readConfig()
         self.peerconns = []
@@ -142,7 +143,7 @@ class NetworkEventProcessor:
             except ImportError:
                 self.geoip = None
 
-        self.protothread = slskproto.SlskProtoThread(self.frame.networkcallback, self.queue, self.bindip, self.config, self)
+        self.protothread = slskproto.SlskProtoThread(self.frame.networkcallback, self.queue, self.bindip, self.port, self.config, self)
 
         uselimit = self.config.sections["transfers"]["uselimit"]
         uploadlimit = self.config.sections["transfers"]["uploadlimit"]

--- a/pynicotine/slskproto.py
+++ b/pynicotine/slskproto.py
@@ -259,8 +259,8 @@ class SlskProtoThread(threading.Thread):
 	# - With Windows, based on #473, it would seem these connections are never removed
 	CONNECTION_MAX_IDLE = 60
 
-	def __init__(self, ui_callback, queue, bindip, config, eventprocessor):
-		""" ui_callback is a UI callback function to be called with messages 
+	def __init__(self, ui_callback, queue, bindip, port, config, eventprocessor):
+		""" ui_callback is a UI callback function to be called with messages
 		list as a parameter. queue is Queue object that holds messages from UI
 		thread.
 		"""
@@ -272,7 +272,7 @@ class SlskProtoThread(threading.Thread):
 		self._bindip = bindip
 		self._config = config
 		self._eventprocessor = eventprocessor
-		portrange = config.sections["server"]["portrange"]
+		portrange = (port, port) if port else config.sections["server"]["portrange"]
 		self.serverclasses = {}
 		for i in self.servercodes.keys():
 			self.serverclasses[self.servercodes[i]] = i

--- a/pynicotine/slskproto.py
+++ b/pynicotine/slskproto.py
@@ -296,7 +296,7 @@ class SlskProtoThread(threading.Thread):
 
 		for listenport in range(int(portrange[0]), int(portrange[1])+1):
 			try:
-				self._p.bind(('', listenport))
+				self._p.bind((bindip or '', listenport))
 			except socket.error:
 				listenport = None
 			else:


### PR DESCRIPTION
Right now nicotine+ listens on all interfaces. This is not desirable for VPN usage because the Soulseek port will be exposed on non-VPN routes, or if the VPN disconnects.

You can verify the listening address with `lsof -i`.