### PR TITLE
Fixes loading of images from the launch directory (#113)

### DIFF
--- a/pynicotine/gtkgui/frame.py
+++ b/pynicotine/gtkgui/frame.py
@@ -794,7 +794,7 @@ class NicotineFrame:
             "plugin"
         ]
 
-        if "icontheme" in self.np.config.sections["ui"]:
+        if self.np.config.sections["ui"].get("icontheme"):
             extensions = ["jpg", "jpeg", "bmp", "png", "svg"]
             for name in names:
                 path = None


### PR DESCRIPTION
The ui/icontheme which defaults as the empty string, was being evaluated
as to whether it existed (as opposed to was non-empty). Thus the code
always ran, and the path for a theme was constructed using the default
empty string ("") + the image path for the icon.

This meant if there was path-local resolvable images of the same name
and no theme, they would get dropped into the interface as if it was
a theme.

The fix is to use `dict.__getitem__'s` shortform of `dict.get` which
evaluates the empty string as a bottom value, as intended.

This bug appears to have been introduced in 40a0d921 when the icontheme
was first implemented in 2006.