### PR TITLE
Stop log spamming

### DIFF
--- a/pynicotine/pynicotine.py
+++ b/pynicotine/pynicotine.py
@@ -684,7 +684,7 @@ class NetworkEventProcessor:
         else:
             for i in self.peerconns[:]:
                 if i.conn == conn:
-                    self.logMessage(_("Connection closed by peer: %s") % vars(i))
+                    self.logMessage(_("Connection closed by peer: %s") % vars(i), debugLevel=3)
 
                     if i.conntimer is not None:
                         i.conntimer.cancel()

--- a/pynicotine/shares.py
+++ b/pynicotine/shares.py
@@ -969,7 +969,7 @@ class Shares:
         stream = bytes([1]) + message.packObject(fileinfo[0]) + message.packObject(NetworkLongLongType(fileinfo[1]))
         if fileinfo[2] is not None:
             try:
-                msgbytes = ''
+                msgbytes = b''
                 msgbytes += message.packObject('mp3') + message.packObject(3)
                 msgbytes += (
                     message.packObject(0) +


### PR DESCRIPTION
* set messages about closed peer connection to the appropriate debug level
* fixed warning about possible corrupt files