### PR TITLE
Fixes to chats and log view

### DIFF
--- a/nicotine
+++ b/nicotine
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/python
 # COPYRIGHT (C) 2020 Lene Preuss <lene.preuss@gmail.com>
 # COPYRIGHT (C) 2016-2017 Michael Labouebe <gfarmerfr@free.fr>
 # COPYRIGHT (C) 2008-2011 Quinox <quinox@users.sf.net>
@@ -42,14 +42,14 @@ win32 = platform.system().startswith("Win")
 
 def checkenv():
 
-    # Require Python 3.6 or newer
+    # Require Python 3.5 or newer
     try:
-        assert sys.version_info[:2] >= (3, 6), '.'.join(
+        assert sys.version_info[:2] >= (3, 5), '.'.join(
             map(str, sys.version_info[:3])
         )
     except AssertionError as e:
         return _("""You're using an unsupported version of Python (%s).
-You should install Python 3.7 or newer.""") % (e)
+You should install Python 3.5 or newer.""") % (e)
 
     # Require GTK+ >= 3
     try:

--- a/nicotine
+++ b/nicotine
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 # COPYRIGHT (C) 2020 Lene Preuss <lene.preuss@gmail.com>
 # COPYRIGHT (C) 2016-2017 Michael Labouebe <gfarmerfr@free.fr>
 # COPYRIGHT (C) 2008-2011 Quinox <quinox@users.sf.net>
@@ -42,14 +42,14 @@ win32 = platform.system().startswith("Win")
 
 def checkenv():
 
-    # Require Python 3.5 or newer
+    # Require Python 3.6 or newer
     try:
-        assert sys.version_info[:2] >= (3, 5), '.'.join(
+        assert sys.version_info[:2] >= (3, 6), '.'.join(
             map(str, sys.version_info[:3])
         )
     except AssertionError as e:
         return _("""You're using an unsupported version of Python (%s).
-You should install Python 3.5 or newer.""") % (e)
+You should install Python 3.7 or newer.""") % (e)
 
     # Require GTK+ >= 3
     try:

--- a/pynicotine/gtkgui/chatrooms.py
+++ b/pynicotine/gtkgui/chatrooms.py
@@ -870,16 +870,16 @@ def TickDialog(parent, default=""):
     dlg.vbox.pack_start(entry, True, True, 0)
 
     v = gtk.VBox(False, False)
-    r1 = gtk.RadioButton()
+    r1 = gtk.RadioButton().new_from_widget(None)
     r1.set_label(_("Just this time"))
     r1.set_active(True)
     v.pack_start(r1, False, False, 0)
 
-    r2 = gtk.RadioButton(r1)
+    r2 = gtk.RadioButton().new_from_widget(r1)
     r2.set_label(_("Always for this channel"))
     v.pack_start(r2, False, False, 0)
 
-    r3 = gtk.RadioButton(r1)
+    r3 = gtk.RadioButton().new_from_widget(r1)
     r3.set_label(_("Default for all channels"))
     v.pack_start(r3, False, False, 0)
 
@@ -897,12 +897,7 @@ def TickDialog(parent, default=""):
         elif r3.get_active():
             t = 2
 
-        bytes = entry.get_text()
-        try:
-            result = str(bytes, "UTF-8")
-        except UnicodeDecodeError:
-            log.addwarning(_("We have a problem, PyGTK get_text does not seem to return UTF-8. Please file a bug report. Bytes: %s") % (repr(bytes)))
-            result = str(bytes, "UTF-8", "replace")
+        result = entry.get_text()
 
     dlg.destroy()
 
@@ -1934,9 +1929,9 @@ class ChatRoom:
 
         map = self.ChatScroll.get_style_context()
         try:
-            self.backupcolor = map.get_color(gtk.StateFlags.NORMAL)
+            self.backuprgba = map.get_color(gtk.StateFlags.NORMAL)
         except IndexError:
-            self.backupcolor = ''
+            self.backuprgba = ''
         buffer = self.ChatScroll.get_buffer()
 
         self.tag_remote = self.makecolour(buffer, "chatremote")
@@ -1984,7 +1979,7 @@ class ChatRoom:
         font = self.frame.np.config.sections["ui"]["chatfont"]
 
         if color == "":
-            color = self.backupcolor
+            color = self.backuprgba.to_color()
         else:
             color = Gdk.color_parse(color)
 
@@ -2014,7 +2009,7 @@ class ChatRoom:
     def ChangeColours(self):
 
         map = self.ChatScroll.get_style_context()
-        self.backupcolor = map.get_color(gtk.StateFlags.NORMAL)
+        self.backuprgba = map.get_color(gtk.StateFlags.NORMAL)
 
         self.changecolour(self.tag_remote, "chatremote")
         self.changecolour(self.tag_local, "chatlocal")

--- a/pynicotine/gtkgui/frame.py
+++ b/pynicotine/gtkgui/frame.py
@@ -451,7 +451,6 @@ class NicotineFrame:
         self.LogScrolledWindow = gtk.ScrolledWindow()
         self.LogScrolledWindow.set_shadow_type(gtk.ShadowType.IN)
         self.LogScrolledWindow.set_policy(gtk.PolicyType.AUTOMATIC, gtk.PolicyType.AUTOMATIC)
-        self.LogScrolledWindow.set_propagate_natural_height(True)
         self.LogScrolledWindow.show()
 
         self.LogWindow = gtk.TextView()
@@ -462,7 +461,7 @@ class NicotineFrame:
         self.LogScrolledWindow.add(self.LogWindow)
         self.LogWindow.connect("button-press-event", self.OnPopupLogMenu)
 
-        self.debugLogBox.pack_start(self.LogScrolledWindow, False, False, 0)
+        self.debugLogBox.pack_start(self.LogScrolledWindow, True, True, 0)
         self.debugWarnings.set_active((1 in config["logging"]["debugmodes"]))
         self.debugSearches.set_active((2 in config["logging"]["debugmodes"]))
         self.debugConnections.set_active((3 in config["logging"]["debugmodes"]))

--- a/pynicotine/gtkgui/frame.py
+++ b/pynicotine/gtkgui/frame.py
@@ -271,6 +271,8 @@ class NicotineFrame:
 
         pynicotine.utils.log = self.logMessage
 
+        log.addlistener(self.logCallback)
+
         self.LoadIcons()
 
         self.accel_group = gtk.AccelGroup()
@@ -657,11 +659,6 @@ class NicotineFrame:
         self.SetMainTabsVisibility()
 
         self.startup = False
-
-        for (timestamp, level, msg) in log.history:
-            self.updateLog(msg, level)
-
-        log.addlistener(self.logCallback)
 
     def AddDebugLevel(self, debugLevel):
         if debugLevel not in self.np.config.sections["logging"]["debugmodes"]:

--- a/pynicotine/gtkgui/privatechat.py
+++ b/pynicotine/gtkgui/privatechat.py
@@ -831,7 +831,7 @@ class PrivateChat:
 
         color = self.frame.np.config.sections["ui"][colour]
         if color == "":
-            color = Gdk.color_parse(self.backupcolor)
+            color = self.backuprgba.to_color()
         else:
             color = Gdk.color_parse(color)
 
@@ -847,9 +847,9 @@ class PrivateChat:
         map = self.frame.MainWindow.get_style_context()
 
         try:
-            self.backupcolor = map.get_color(gtk.StateFlags.NORMAL)
+            self.backuprgba = map.get_color(gtk.StateFlags.NORMAL)
         except IndexError:
-            self.backupcolor = ''
+            self.backuprgba = ''
 
         buffer = self.ChatScroll.get_buffer()
         self.tag_remote = self.makecolour(buffer, "chatremote")
@@ -912,7 +912,7 @@ class PrivateChat:
         font = self.frame.np.config.sections["ui"]["chatfont"]
 
         if color == "":
-            color = self.backupcolor
+            color = self.backuprgba.to_color()
         else:
             color = Gdk.color_parse(color)
 
@@ -941,7 +941,7 @@ class PrivateChat:
     def ChangeColours(self):
 
         map = self.ChatScroll.get_style_context()
-        self.backupcolor = map.get_color(gtk.StateFlags.NORMAL)
+        self.backuprgba = map.get_color(gtk.StateFlags.NORMAL)
 
         self.changecolour(self.tag_remote, "chatremote")
         self.changecolour(self.tag_local, "chatlocal")

--- a/pynicotine/gtkgui/ui/mainwindow.ui
+++ b/pynicotine/gtkgui/ui/mainwindow.ui
@@ -3113,13 +3113,11 @@
           <object class="GtkHBox" id="hbox10">
             <property name="visible">True</property>
             <property name="can_focus">False</property>
-            <property name="border_width">2</property>
             <child>
               <object class="GtkStatusbar" id="UpStatus">
                 <property name="width_request">200</property>
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
-                <property name="border_width">1</property>
                 <!--property name="has_resize_grip">False</property-->
               </object>
               <packing>
@@ -3134,7 +3132,6 @@
                 <property name="width_request">200</property>
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
-                <property name="border_width">1</property>
                 <!--property name="has_resize_grip">False</property-->
               </object>
               <packing>
@@ -3149,7 +3146,6 @@
                 <property name="width_request">150</property>
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
-                <property name="border_width">1</property>
                 <!--property name="has_resize_grip">False</property-->
               </object>
               <packing>
@@ -3164,7 +3160,6 @@
                 <property name="width_request">80</property>
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
-                <property name="border_width">1</property>
                 <!--property name="has_resize_grip">False</property-->
               </object>
               <packing>
@@ -3178,7 +3173,9 @@
               <object class="GtkProgressBar" id="BuddySharesProgress">
                 <property name="can_focus">False</property>
                 <property name="pulse_step">0.10000000149</property>
+                <property name="show_text">True</property>
                 <property name="text" translatable="yes">Scanning Buddy Shares</property>
+                <property name="valign">GTK_ALIGN_CENTER</property>
               </object>
               <packing>
                 <property name="expand">False</property>
@@ -3191,7 +3188,9 @@
               <object class="GtkProgressBar" id="SharesProgress">
                 <property name="can_focus">False</property>
                 <property name="pulse_step">0.10000000149</property>
+                <property name="show_text">True</property>
                 <property name="text" translatable="yes">Scanning Shares</property>
+                <property name="valign">GTK_ALIGN_CENTER</property>
               </object>
               <packing>
                 <property name="expand">False</property>
@@ -3204,7 +3203,6 @@
               <object class="GtkStatusbar" id="Statusbar">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
-                <property name="border_width">1</property>
                 <!--property name="has_resize_grip">False</property-->
               </object>
               <packing>

--- a/pynicotine/gtkgui/ui/mainwindow.ui
+++ b/pynicotine/gtkgui/ui/mainwindow.ui
@@ -3173,7 +3173,7 @@
               <object class="GtkProgressBar" id="BuddySharesProgress">
                 <property name="can_focus">False</property>
                 <property name="pulse_step">0.10000000149</property>
-                <property name="show_text">True</property>
+                <property name="show_text">False</property>
                 <property name="text" translatable="yes">Scanning Buddy Shares</property>
                 <property name="valign">GTK_ALIGN_CENTER</property>
               </object>
@@ -3188,7 +3188,7 @@
               <object class="GtkProgressBar" id="SharesProgress">
                 <property name="can_focus">False</property>
                 <property name="pulse_step">0.10000000149</property>
-                <property name="show_text">True</property>
+                <property name="show_text">False</property>
                 <property name="text" translatable="yes">Scanning Shares</property>
                 <property name="valign">GTK_ALIGN_CENTER</property>
               </object>


### PR DESCRIPTION
- Start logging earlier instead of fetching the log history after startup. Fixes a crash issue in some scenarios.
- Remove GTK 3.22 "set_propagate_natural_height" dependency, make the log view fill the height immediately instead. Fixes https://github.com/Nicotine-Plus/nicotine-plus/issues/140
- Fix Color/RGBA mismatches in chats
- Make tick dialog radio buttons functional again
- Reduce statusbar padding to default