### PR TITLE
Ship plugins system-wide

### DIFF
--- a/plugins/README
+++ b/plugins/README
@@ -1,20 +1,14 @@
 README Concerning plugins for N+
 
 
-FOR EVERYBODY
-
-The plugin system is in its infant stage, a lot of things aren't implemented yet
-and a few things might be buggy. The provided plugins should be regarded as
-documentation and shouldn't be loaded unless you're willing to break things.
-
-
 FOR END USERS
 
-In order to get the plugins working you need to copy them to
-~/.nicotine/plugins, creating this directory if it doesn't exist yet. Plugins
-will be loaded upon startup, and can be reloaded with /reload. This reload
-command does not always completely reload the plugins due to the way Python
-works, in some cases a restart of N+ is needed to get new versions working.
+In order to load your own plugins you need to copy them to
+~/.local/share/nicotine/plugins, creating this directory if it doesn't exist
+yet. Plugins will be loaded upon startup, and can be reloaded with /reload.
+This reload command does not always completely reload the plugins due to the
+way Python works, in some cases a restart of N+ is needed to get new versions
+working.
 
 
 FOR DEVELOPERS

--- a/plugins/README
+++ b/plugins/README
@@ -1,7 +1,7 @@
 README Concerning plugins for N+
 
 
-FOR END USERS
+FOR DEVELOPERS
 
 In order to load your own plugins you need to copy them to
 ~/.local/share/nicotine/plugins, creating this directory if it doesn't exist
@@ -9,9 +9,6 @@ yet. Plugins will be loaded upon startup, and can be reloaded with /reload.
 This reload command does not always completely reload the plugins due to the
 way Python works, in some cases a restart of N+ is needed to get new versions
 working.
-
-
-FOR DEVELOPERS
 
 There are two kinds of actions you can hook into:
 

--- a/pynicotine/pluginsystem.py
+++ b/pynicotine/pluginsystem.py
@@ -101,6 +101,10 @@ class PluginHandler(object):
         except Exception:
             pass
 
+        # Load system-wide plugins
+        self.plugindirs.append(os.path.join(sys.prefix, "share/nicotine/plugins"))
+
+        # Load home directory plugins
         self.plugindirs.append(plugindir)
 
         if os.path.isdir(plugindir):

--- a/setup.py
+++ b/setup.py
@@ -34,6 +34,7 @@ import glob
 
 from os.path import isdir
 from distutils.core import setup
+from distutils.dir_util import copy_tree
 
 # Compute data_files
 files = []
@@ -91,6 +92,9 @@ for mo in mo_dirs:
             [os.path.join(lc_messages_path, "nicotine.mo")]
         )
     )
+
+# Plugins
+copy_tree("plugins", os.path.join(sys.prefix, "share/nicotine/plugins"))
 
 # Sounds
 sound_dirs = glob.glob(os.path.join("sounds", "*"))


### PR DESCRIPTION
Would be nice to have the plugins included by default, and potentially detect issues in them.