### PR TITLE
Attach menus to a parent widget

### DIFF
--- a/pynicotine/gtkgui/chatrooms.py
+++ b/pynicotine/gtkgui/chatrooms.py
@@ -141,6 +141,8 @@ class RoomsControl:
             ("#" + _("Refresh"), self.OnPopupRefresh)
         )
 
+        self.popup_menu.attach_to_widget(self.frame.roomlist.RoomsList, None)
+
         items = self.popup_menu.get_children()
         self.Menu_Join, self.Menu_Leave, self.Menu_Empty1, self.Menu_PrivateRoom_Enable, self.Menu_PrivateRoom_Disable, self.Menu_Empty2, self.Menu_PrivateRoom_Create, self.Menu_PrivateRoom_Disown, self.Menu_PrivateRoom_Dismember, self.Menu_Empty3, self.Menu_JoinPublicRoom, self.Menu_Empty4, self.Menu_Refresh = items
 
@@ -1109,6 +1111,8 @@ class ChatRoom:
             (1, _("Private rooms"), self.popup_menu_privaterooms, self.OnPrivateRooms)
         )
 
+        popup.attach_to_widget(self.UserList, None)
+
         items = self.popup_menu.get_children()
 
         self.Menu_SendMessage = items[2]
@@ -1137,6 +1141,8 @@ class ChatRoom:
             ("", None),
             ("#" + _("Clear log"), self.OnClearRoomLog)
         )
+
+        self.logpopupmenu.attach_to_widget(self.RoomLog, None)
         self.RoomLog.connect("button-press-event", self.OnPopupRoomLogMenu)
 
         self.chatpopmenu = PopupMenu(self.frame).setup(
@@ -1147,6 +1153,8 @@ class ChatRoom:
             ("", None),
             ("#" + _("Clear log"), self.OnClearChatLog)
         )
+
+        self.chatpopmenu.attach_to_widget(self.ChatScroll, None)
         self.ChatScroll.connect("button-press-event", self.OnPopupChatRoomMenu)
 
         self.buildingcompletion = False
@@ -2449,6 +2457,7 @@ class ChatRooms(IconNotebook):
             ("#" + _("Detach this tab"), self.roomsctrl.joinedrooms[room].Detach),
             ("#" + _("Leave this room"), self.roomsctrl.joinedrooms[room].OnLeave)
         )
+        popup.attach_to_widget(self.roomsctrl.joinedrooms[room], None)
         popup.set_user(room)
 
         return popup

--- a/pynicotine/gtkgui/downloads.py
+++ b/pynicotine/gtkgui/downloads.py
@@ -85,6 +85,7 @@ class Downloads(TransferList):
             ("", None),
             (1, _("Clear Groups"), self.popup_menu2, None)
         )
+        self.popup_menu.attach_to_widget(frame.DownloadList, None)
 
         frame.DownloadList.connect("button_press_event", self.OnPopupMenu, "mouse")
         frame.DownloadList.connect("key-press-event", self.on_key_press_event)

--- a/pynicotine/gtkgui/frame.py
+++ b/pynicotine/gtkgui/frame.py
@@ -332,16 +332,6 @@ class NicotineFrame:
         display = Gdk.Display.get_default()  # noqa: F841
         self.clip = gtk.Clipboard.get(Gdk.SELECTION_CLIPBOARD)
 
-        # Popup menu on the log windows
-        self.logpopupmenu = PopupMenu(self).setup(
-            ("#" + _("Find"), self.OnFindLogWindow),
-            ("", None),
-            ("#" + _("Copy"), self.OnCopyLogWindow),
-            ("#" + _("Copy All"), self.OnCopyAllLogWindow),
-            ("", None),
-            ("#" + _("Clear log"), self.OnClearLogWindow)
-        )
-
         # for iterating buddy changes to the combos
         self.CreateRecommendationsWidgets()
 
@@ -448,6 +438,7 @@ class NicotineFrame:
                 )
             )
 
+            popup.attach_to_widget(self.MainNotebook, None)
             popup.set_user(map_tablabels_to_box[label_tab])
 
         self.LogScrolledWindow = gtk.ScrolledWindow()
@@ -461,6 +452,18 @@ class NicotineFrame:
 
         self.LogScrolledWindow.add(self.LogWindow)
         self.LogWindow.connect("button-press-event", self.OnPopupLogMenu)
+
+        # Popup menu on the log windows
+        self.logpopupmenu = PopupMenu(self).setup(
+            ("#" + _("Find"), self.OnFindLogWindow),
+            ("", None),
+            ("#" + _("Copy"), self.OnCopyLogWindow),
+            ("#" + _("Copy All"), self.OnCopyAllLogWindow),
+            ("", None),
+            ("#" + _("Clear log"), self.OnClearLogWindow)
+        )
+        
+        self.logpopupmenu.attach_to_widget(self.LogScrolledWindow, None)
 
         self.debugLogBox.pack_start(self.LogScrolledWindow, True, True, 0)
         self.debugWarnings.set_active((1 in config["logging"]["debugmodes"]))
@@ -901,6 +904,8 @@ class NicotineFrame:
             ("", None),
             ("#" + _("_Search for this item"), self.OnRecommendSearch)
         )
+        
+        popup.attach_to_widget(self.LikesList, None)
 
         self.LikesList.connect("button_press_event", self.OnPopupTILMenu)
 
@@ -923,6 +928,8 @@ class NicotineFrame:
             ("", None),
             ("#" + _("_Search for this item"), self.OnRecommendSearch)
         )
+
+        popup.attach_to_widget(self.DislikesList, None)
 
         self.DislikesList.connect("button_press_event", self.OnPopupTIDLMenu)
 
@@ -952,6 +959,8 @@ class NicotineFrame:
             ("#" + _("_Search for this item"), self.OnRecommendSearch)
         )
 
+        popup.attach_to_widget(self.RecommendationsList, None)
+
         self.RecommendationsList.connect("button_press_event", self.OnPopupRMenu)
 
         cols = utils.InitialiseColumns(
@@ -979,6 +988,8 @@ class NicotineFrame:
             ("", None),
             ("#" + _("_Search for this item"), self.OnRecommendSearch)
         )
+
+        popup.attach_to_widget(self.UnrecommendationsList, None)
 
         self.UnrecommendationsList.connect("button_press_event", self.OnPopupUnRecMenu)
         self.RecommendationsExpander.connect("activate", self.RecommendationsExpanderStatus)
@@ -1025,6 +1036,8 @@ class NicotineFrame:
             ("$" + _("_Ban this user"), popup.OnBanUser),
             ("$" + _("_Ignore this user"), popup.OnIgnoreUser)
         )
+
+        popup.attach_to_widget(self.RecommendationUsersList, None)
 
         self.RecommendationUsersList.connect("button_press_event", self.OnPopupRUMenu)
 

--- a/pynicotine/gtkgui/privatechat.py
+++ b/pynicotine/gtkgui/privatechat.py
@@ -178,6 +178,7 @@ class PrivateChats(IconNotebook):
             ("#" + _("Close this tab"), self.users[user].OnClose)
         )
 
+        popup.attach_to_widget(self.frame.PrivatechatNotebookRaw, None)
         popup.set_user(user)
 
         me = (popup.user is None or popup.user == self.frame.np.config.sections["server"]["login"])
@@ -422,6 +423,7 @@ class PrivateChat:
             ("$" + _("Ignore this user's IP Address"), popup.OnIgnoreIP)
         )
 
+        popup.attach_to_widget(self.ChatScroll, None)
         popup.set_user(user)
 
         self.popup_menu = popup = PopupMenu(self.frame)
@@ -438,6 +440,7 @@ class PrivateChat:
             ("#" + _("Close"), self.OnClose)
         )
 
+        popup.attach_to_widget(self.ChatScroll, None)
         popup.set_user(user)
 
         self.ChatScroll.connect("button_press_event", self.OnPopupMenu)

--- a/pynicotine/gtkgui/search.py
+++ b/pynicotine/gtkgui/search.py
@@ -545,6 +545,9 @@ class Searches(IconNotebook):
             ("#" + _("Detach this tab"), self.searches[id][2].Detach),
             ("#" + _("Close this tab"), self.searches[id][2].OnClose)
         )
+
+        popup.attach_to_widget(self.frame.SearchNotebookRaw, None)
+
         items = popup.get_children()  # noqa: F841
 
         return popup
@@ -757,6 +760,8 @@ class Search:
             ("", None),
             (1, _("User(s)"), self.popup_menu_users, self.OnPopupMenuUsers)
         )
+
+        popup.attach_to_widget(self.ResultsList, None)
 
         self.ResultsList.connect("button_press_event", self.OnListClicked)
 

--- a/pynicotine/gtkgui/uploads.py
+++ b/pynicotine/gtkgui/uploads.py
@@ -76,6 +76,7 @@ class Uploads(TransferList):
             ("", None),
             (1, _("Clear Groups"), self.popup_menu2, None)
         )
+        self.popup_menu.attach_to_widget(frame.UploadList, None)
 
         frame.UploadList.connect("button_press_event", self.OnPopupMenu, "mouse")
         frame.UploadList.connect("key-press-event", self.on_key_press_event)

--- a/pynicotine/gtkgui/userbrowse.py
+++ b/pynicotine/gtkgui/userbrowse.py
@@ -140,6 +140,8 @@ class UserBrowse:
                 ("$" + _("_Ignore this user"), menu.OnIgnoreUser)
             )
 
+        self.popup_menu_users2.attach_to_widget(self.FolderTreeView, None)
+
         self.popup_menu_downloads_folders = PopupMenu(self.frame)
         self.popup_menu_downloads_folders.setup(
             ("#" + _("_Download directory"), self.OnDownloadDirectory),
@@ -147,6 +149,8 @@ class UserBrowse:
             ("#" + _("Download _recursive"), self.OnDownloadDirectoryRecursive),
             ("#" + _("Download r_ecursive to..."), self.OnDownloadDirectoryRecursiveTo)
         )
+
+        self.popup_menu_downloads_folders.attach_to_widget(self.FolderTreeView, None)
 
         self.popup_menu_downloads_files = PopupMenu(self.frame)
         self.popup_menu_downloads_files.setup(
@@ -159,11 +163,15 @@ class UserBrowse:
             ("#" + _("Download r_ecursive to..."), self.OnDownloadDirectoryRecursiveTo)
         )
 
+        self.popup_menu_downloads_files.attach_to_widget(self.FolderTreeView, None)
+
         self.popup_menu_uploads_folders = PopupMenu(self.frame)
         self.popup_menu_uploads_folders.setup(
             ("#" + _("Upload Directory to..."), self.OnUploadDirectoryTo),
             ("#" + _("Upload Directory recursive to..."), self.OnUploadDirectoryRecursiveTo)
         )
+
+        self.popup_menu_uploads_folders.attach_to_widget(self.FolderTreeView, None)
 
         self.popup_menu_uploads_files = PopupMenu(self.frame)
         self.popup_menu_uploads_files.setup(
@@ -171,6 +179,8 @@ class UserBrowse:
             ("#" + _("Upload Directory recursive to..."), self.OnUploadDirectoryRecursiveTo),
             ("#" + _("Up_load file(s)"), self.OnUploadFiles)
         )
+
+        self.popup_menu_uploads_files.attach_to_widget(self.FolderTreeView, None)
 
         self.folder_popup_menu = PopupMenu(self.frame)
         self.folder_popup_menu.set_user(user)
@@ -193,6 +203,8 @@ class UserBrowse:
                 ("", None),
                 ("#" + _("Copy _URL"), self.OnCopyDirURL)
             )
+
+        self.folder_popup_menu.attach_to_widget(self.FolderTreeView, None)
 
         self.FolderTreeView.connect("button_press_event", self.OnFolderClicked)
         self.FolderTreeView.get_selection().connect("changed", self.OnSelectDir)
@@ -250,6 +262,8 @@ class UserBrowse:
                 ("", None),
                 ("#" + _("Copy _URL"), self.OnCopyURL)
             )
+
+        self.file_popup_menu.attach_to_widget(self.FolderTreeView, None)
 
         self.FileTreeView.connect("button_press_event", self.OnFileClicked)
 

--- a/pynicotine/gtkgui/userinfo.py
+++ b/pynicotine/gtkgui/userinfo.py
@@ -169,6 +169,8 @@ class UserTabs(IconNotebook):
             ("#" + _("Detach this tab"), self.users[user].Detach),
             ("#" + _("Close this tab"), self.users[user].OnClose)
         )
+
+        popup.attach_to_widget(self.frame.userinfovbox, None)
         popup.set_user(user)
 
         items = popup.get_children()
@@ -291,6 +293,8 @@ class UserInfo:
             ("", None),
             ("#" + _("_Search for this item"), self.frame.OnRecommendSearch)
         )
+
+        popup.attach_to_widget(self.Likes, None)
         self.Likes.connect("button_press_event", self.OnPopupLikesMenu)
 
         self.hates_popup_menu = popup = PopupMenu(self)
@@ -300,6 +304,8 @@ class UserInfo:
             ("", None),
             ("#" + _("_Search for this item"), self.frame.OnRecommendSearch)
         )
+
+        popup.attach_to_widget(self.Hates, None)
         self.Hates.connect("button_press_event", self.OnPopupHatesMenu)
 
         self.image_menu = popup = PopupMenu(self)
@@ -310,6 +316,8 @@ class UserInfo:
             ("", None),
             ("#" + _("Save Image"), self.OnSavePicture)
         )
+
+        popup.attach_to_widget(self.frame.userinfovbox, None)
 
     def OnPopupLikesMenu(self, widget, event):
 

--- a/pynicotine/gtkgui/userlist.py
+++ b/pynicotine/gtkgui/userlist.py
@@ -202,6 +202,8 @@ class UserList:
             (1, _("Private rooms"), self.Popup_Menu_PrivateRooms, popup.OnPrivateRooms)
         )
 
+        popup.attach_to_widget(self.UserList, None)
+
         items = self.popup_menu.get_children()
         self.Menu_SendMessage = items[0]
         self.Menu_ShowIPaddress = items[2]

--- a/pynicotine/gtkgui/utils.py
+++ b/pynicotine/gtkgui/utils.py
@@ -255,6 +255,7 @@ def PressHeader(widget, event):
         pos += 1
 
     menu.show_all()
+    menu.attach_to_widget(widget.get_parent(), None)
     menu.popup(None, None, None, None, event.button, event.time)
 
     return True

--- a/pynicotine/pynicotine.py
+++ b/pynicotine/pynicotine.py
@@ -1462,6 +1462,7 @@ class NetworkEventProcessor:
             if i.conn is msg.conn.conn and self.userinfo is not None:
                 # probably impossible to do this
                 if i.username != self.config.sections["server"]["login"]:
+                    msg.descr = msg.descr.encode("utf-8")
                     self.userinfo.ShowInfo(i.username, msg)
 
     def UserInfoRequest(self, msg):

--- a/pynicotine/pynicotine.py
+++ b/pynicotine/pynicotine.py
@@ -1462,7 +1462,6 @@ class NetworkEventProcessor:
             if i.conn is msg.conn.conn and self.userinfo is not None:
                 # probably impossible to do this
                 if i.username != self.config.sections["server"]["login"]:
-                    msg.descr = msg.descr.encode()
                     self.userinfo.ShowInfo(i.username, msg)
 
     def UserInfoRequest(self, msg):

--- a/pynicotine/pynicotine.py
+++ b/pynicotine/pynicotine.py
@@ -1462,7 +1462,7 @@ class NetworkEventProcessor:
             if i.conn is msg.conn.conn and self.userinfo is not None:
                 # probably impossible to do this
                 if i.username != self.config.sections["server"]["login"]:
-                    msg.descr = msg.descr.encode("utf-8")
+                    msg.descr = msg.descr.encode()
                     self.userinfo.ShowInfo(i.username, msg)
 
     def UserInfoRequest(self, msg):

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,6 @@ import glob
 
 from os.path import isdir
 from distutils.core import setup
-from distutils.dir_util import copy_tree
 
 # Compute data_files
 files = []
@@ -94,7 +93,17 @@ for mo in mo_dirs:
     )
 
 # Plugins
-copy_tree("plugins", os.path.join(sys.prefix, "share/nicotine/plugins"))
+for (path, dirs, pluginfiles) in os.walk("plugins"):
+
+    dst_path = os.sep.join(path.split("/")[1:])
+
+    for f in pluginfiles:
+        files.append(
+            (
+                os.path.join(sys.prefix, "share/nicotine/plugins", dst_path),
+                [os.path.join(path, f)]
+            )
+        )
 
 # Sounds
 sound_dirs = glob.glob(os.path.join("sounds", "*"))


### PR DESCRIPTION
Attach menus to a parent widget to prevent them from closing unintentionally.

Fixes https://github.com/Nicotine-Plus/nicotine-plus/issues/143
Fixes a few console warning messages when using Wayland.