### PR TITLE
Don't show empty MOTD

### DIFF
--- a/pynicotine/gtkgui/frame.py
+++ b/pynicotine/gtkgui/frame.py
@@ -1770,7 +1770,8 @@ class NicotineFrame:
         self.downloads.InitInterface(self.np.transfers.downloads)
         gobject.idle_add(self.FetchUserListStatus)
 
-        AppendLine(self.LogWindow, self.np.decode(msg.banner), self.tag_log)
+        if msg.banner != "":
+            AppendLine(self.LogWindow, msg.banner, self.tag_log)
 
         return self.privatechats, self.chatrooms, self.userinfo, self.userbrowse, self.Searches, self.downloads, self.uploads, self.userlist
 


### PR DESCRIPTION
The Soulseek protocol supports a MOTD feature, but I don't think the official server sends one. Don't show an empty line if the MOTD is empty. Also no point in decoding the message here, since it's already decoded.