### PR TITLE
Encoding/decoding cleanup

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -2,10 +2,6 @@
 
 ### Active
 
-Michael Labouebe (aka gfarmerfr)
-- Developer
-- [gfarmerfr(at)free(dot)fr]
-
 Mutnick
 - Created Nicotine+ GitHub Organization
 - Developer
@@ -19,6 +15,14 @@ eLvErDe
 Kip Warner
 - Debianization
 - [kip(at)thevertigo(dot)com]
+
+Lene Preuss
+- Python3 migration
+- [lene.preuss(at)here(dot)com]
+
+mathiascode
+- Developer
+- [mail(at)mathias(dot)is]
 
 ### Retired
 
@@ -57,6 +61,10 @@ osiris
 - handy-man, documentation, some GNU/Linux packaging, Nicotine+ on win32
 - Author of Nicotine+ Guide
 - [osiris.contact(at)gmail(dot)com]
+
+Michael Labouebe (aka gfarmerfr)
+- Developer
+- [gfarmerfr(at)free(dot)fr]
 
 ---
 

--- a/debian/copyright
+++ b/debian/copyright
@@ -4,7 +4,7 @@ Upstream-Contact: Kip Warner <kip@thevertigo.com>
 Source: https://github.com/Nicotine-Plus/nicotine-plus/
 
 Files: *
-Copyright: Copyright (C) 2020 Michael Labouebe
+Copyright: Copyright (C) 2020 Nicotine+ Contributors
 License: GPL-3+
  /usr/share/common-licenses/GPL-3
 

--- a/pynicotine/config.py
+++ b/pynicotine/config.py
@@ -1,4 +1,3 @@
-# COPYRIGHT (C) 2020 Mathias <mail@mathias.is>
 # COPYRIGHT (C) 2016-2017 Michael Labouebe <gfarmerfr@free.fr>
 # COPYRIGHT (C) 2016-2018 Mutnick <mutnick@techie.com>
 # COPYRIGHT (C) 2008-2011 Quinox <quinox@users.sf.net>

--- a/pynicotine/config.py
+++ b/pynicotine/config.py
@@ -1,3 +1,4 @@
+# COPYRIGHT (C) 2020 Mathias <mail@mathias.is>
 # COPYRIGHT (C) 2016-2017 Michael Labouebe <gfarmerfr@free.fr>
 # COPYRIGHT (C) 2016-2018 Mutnick <mutnick@techie.com>
 # COPYRIGHT (C) 2008-2011 Quinox <quinox@users.sf.net>

--- a/pynicotine/config.py
+++ b/pynicotine/config.py
@@ -78,12 +78,8 @@ class Config:
                 "ctcpmsgs": 0,
                 "autosearch": [],
                 "autoreply": "",
-                "roomencoding": {},
-                "fallbackencodings": ['utf-8', 'cp1252'],  # Put the multi-byte encodings up front - they are the most likely to err
-                "userencoding": {},
                 "portrange": (2234, 2239),
                 "upnp": False,
-                "enc": "utf-8",
                 "userlist": [],
                 "banlist": [],
                 "ignorelist": [],
@@ -530,6 +526,12 @@ class Config:
         # Transition from 1.4.1 -> 1.4.2
         self.removeOldOption("columns", "downloads")
         self.removeOldOption("columns", "uploads")
+
+        # Remove old encoding settings (1.4.3)
+        self.removeOldOption("server", "enc")
+        self.removeOldOption("server", "fallbackencodings")
+        self.removeOldOption("server", "roomencoding")
+        self.removeOldOption("server", "userencoding")
 
         # Checking for unknown section/options
         unknown1 = [

--- a/pynicotine/gtkgui/about.py
+++ b/pynicotine/gtkgui/about.py
@@ -228,10 +228,6 @@ class AboutCreditsDialog(GenericAboutDialog):
 
 ### Active
 
-Michael Labouebe (aka gfarmerfr)
-- Developer
-- [gfarmerfr(at)free(dot)fr]
-
 Mutnick
 - Created Nicotine+ GitHub Organization
 - Developer
@@ -249,6 +245,10 @@ Kip Warner
 Lene Preuss
 - Python3 migration
 - [lene.preuss(at)here(dot)com]
+
+mathiascode
+- Developer
+- [mail(at)mathias(dot)is]
 
 ### Retired
 
@@ -287,6 +287,10 @@ osiris
 - handy-man, documentation, some GNU/Linux packaging, Nicotine+ on win32
 - Author of Nicotine+ Guide
 - [osiris.contact(at)gmail(dot)com]
+
+Michael Labouebe (aka gfarmerfr)
+- Developer
+- [gfarmerfr(at)free(dot)fr]
 
 # Nicotine MAINTAINERS
 

--- a/pynicotine/gtkgui/chatrooms.py
+++ b/pynicotine/gtkgui/chatrooms.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 #
-# COPYRIGHT (C) 2020 Mathias <mail@mathias.is>
 # COPYRIGHT (C) 2016-2017 Michael Labouebe <gfarmerfr@free.fr>
 # COPYRIGHT (C) 2016 Mutnick <muhing@yahoo.com>
 # COPYRIGHT (C) 2008-2011 Quinox <quinox@users.sf.net>

--- a/pynicotine/gtkgui/chatrooms.py
+++ b/pynicotine/gtkgui/chatrooms.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 #
+# COPYRIGHT (C) 2020 Mathias <mail@mathias.is>
 # COPYRIGHT (C) 2016-2017 Michael Labouebe <gfarmerfr@free.fr>
 # COPYRIGHT (C) 2016 Mutnick <muhing@yahoo.com>
 # COPYRIGHT (C) 2008-2011 Quinox <quinox@users.sf.net>
@@ -2152,8 +2153,6 @@ class ChatRoom:
 
         # no duplicates
         def _combilower(x):
-            if not isinstance(x, str):
-                x = x.decode('utf-8')
             try:
                 return x.lower()
             except Exception:
@@ -2166,8 +2165,6 @@ class ChatRoom:
 
         if config["dropdown"]:
             for word in clist:
-                if not isinstance(word, str):
-                    word = word.decode('utf-8')
                 liststore.append([word])
 
             completion.set_popup_completion(True)

--- a/pynicotine/gtkgui/chatrooms.py
+++ b/pynicotine/gtkgui/chatrooms.py
@@ -51,7 +51,6 @@ from pynicotine.gtkgui.utils import showCountryTooltip
 from pynicotine.logfacility import log
 from pynicotine.utils import cmp
 from pynicotine.utils import debug
-from pynicotine.utils import findBestEncoding
 
 gi.require_version('Gtk', '3.0')
 gi.require_version('Gdk', '3.0')
@@ -1162,8 +1161,6 @@ class ChatRoom:
             roomlines = 15
 
         try:
-            encodings = ['UTF-8']  # New style logging, always in UTF-8
-
             f = open(log, "r")
             logfile = f.read()
             f.close()
@@ -1171,7 +1168,7 @@ class ChatRoom:
 
             for bytes in loglines[-roomlines:-1]:
 
-                l = findBestEncoding(bytes, encodings)  # noqa: E741
+                l = bytes
 
                 # Try to parse line for username
                 if len(l) > 20 and l[10].isspace() and l[11].isdigit() and l[20] in ("[", "*"):
@@ -1180,7 +1177,6 @@ class ChatRoom:
                     if l[20] == "[" and l[20:].find("] ") != -1:
                         namepos = l[20:].find("] ")
                         user = l[21:20 + namepos].strip()
-                        user = user.encode('UTF-8')  # this could go screwy! But there's no other way without logging raw bytes in the log file
                         self.getUserTag(user)
                         usertag = self.tag_users[user]
                     else:

--- a/pynicotine/gtkgui/frame.py
+++ b/pynicotine/gtkgui/frame.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 #
-# COPYRIGHT (C) 2020 Mathias <mail@mathias.is>
 # COPYRIGHT (C) 2016-2017 Michael Labouebe <gfarmerfr@free.fr>
 # COPYRIGHT (C) 2016-2018 Mutnick <mutnick@techie.com>
 # COPYRIGHT (C) 2008-2011 Quinox <quinox@users.sf.net>

--- a/pynicotine/gtkgui/frame.py
+++ b/pynicotine/gtkgui/frame.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 #
+# COPYRIGHT (C) 2020 Mathias <mail@mathias.is>
 # COPYRIGHT (C) 2016-2017 Michael Labouebe <gfarmerfr@free.fr>
 # COPYRIGHT (C) 2016-2018 Mutnick <mutnick@techie.com>
 # COPYRIGHT (C) 2008-2011 Quinox <quinox@users.sf.net>

--- a/pynicotine/gtkgui/frame.py
+++ b/pynicotine/gtkgui/frame.py
@@ -2784,7 +2784,7 @@ class NicotineFrame:
             except Exception:
                 pic = None
 
-            descr = self.np.encode(eval(self.np.config.sections["userinfo"]["descr"], {}))
+            descr = self.np.config.sections["userinfo"]["descr"]
 
             if self.np.transfers is not None:
 
@@ -3038,7 +3038,7 @@ class NicotineFrame:
             self.np.config.sections["interests"]["likes"].append(thing)
             self.likes[thing] = self.likeslist.append([thing])
             self.np.config.writeConfiguration()
-            self.np.queue.put(slskmessages.AddThingILike(self.np.encode(thing)))
+            self.np.queue.put(slskmessages.AddThingILike(thing))
 
     def OnAddThingIDislike(self, widget):
         thing = utils.InputDialog(self.MainWindow, _("Add thing I don't like"), _("I don't like") + ":")
@@ -3047,19 +3047,17 @@ class NicotineFrame:
             self.np.config.sections["interests"]["dislikes"].append(thing)
             self.dislikes[thing] = self.dislikeslist.append([thing])
             self.np.config.writeConfiguration()
-            self.np.queue.put(slskmessages.AddThingIHate(self.np.encode(thing)))
+            self.np.queue.put(slskmessages.AddThingIHate(thing))
 
     def SetRecommendations(self, title, recom):
         self.recommendationslist.clear()
         for (thing, rating) in recom.items():
-            thing = self.np.decode(thing)
             self.recommendationslist.append([thing, Humanize(rating), rating])
         self.recommendationslist.set_sort_column_id(2, gtk.SortType.DESCENDING)
 
     def SetUnrecommendations(self, title, recom):
         self.unrecommendationslist.clear()
         for (thing, rating) in recom.items():
-            thing = self.np.decode(thing)
             self.unrecommendationslist.append([thing, Humanize(rating), rating])
         self.unrecommendationslist.set_sort_column_id(2, gtk.SortType.ASCENDING)
 
@@ -3137,12 +3135,12 @@ class NicotineFrame:
         del self.likes[thing]
         self.np.config.sections["interests"]["likes"].remove(thing)
         self.np.config.writeConfiguration()
-        self.np.queue.put(slskmessages.RemoveThingILike(self.np.encode(thing)))
+        self.np.queue.put(slskmessages.RemoveThingILike(thing))
 
     def OnRecommendItem(self, widget):
         thing = self.til_popup_menu.get_user()
-        self.np.queue.put(slskmessages.ItemRecommendations(self.np.encode(thing)))
-        self.np.queue.put(slskmessages.ItemSimilarUsers(self.np.encode(thing)))
+        self.np.queue.put(slskmessages.ItemRecommendations(thing))
+        self.np.queue.put(slskmessages.ItemSimilarUsers(thing))
 
     def OnPopupTILMenu(self, widget, event):
         if event.button != 3:
@@ -3164,7 +3162,7 @@ class NicotineFrame:
         del self.dislikes[thing]
         self.np.config.sections["interests"]["dislikes"].remove(thing)
         self.np.config.writeConfiguration()
-        self.np.queue.put(slskmessages.RemoveThingIHate(self.np.encode(thing)))
+        self.np.queue.put(slskmessages.RemoveThingIHate(thing))
 
     def OnPopupTIDLMenu(self, widget, event):
         if event.button != 3:
@@ -3184,13 +3182,13 @@ class NicotineFrame:
             self.np.config.sections["interests"]["likes"].append(thing)
             self.likes[thing] = self.likeslist.append([thing])
             self.np.config.writeConfiguration()
-            self.np.queue.put(slskmessages.AddThingILike(self.np.encode(thing)))
+            self.np.queue.put(slskmessages.AddThingILike(thing))
         elif not widget.get_active() and thing in self.np.config.sections["interests"]["likes"]:
             self.likeslist.remove(self.likes[thing])
             del self.likes[thing]
             self.np.config.sections["interests"]["likes"].remove(thing)
             self.np.config.writeConfiguration()
-            self.np.queue.put(slskmessages.RemoveThingILike(self.np.encode(thing)))
+            self.np.queue.put(slskmessages.RemoveThingILike(thing))
 
     def OnDislikeRecommendation(self, widget):
         thing = widget.get_parent().get_user()
@@ -3198,18 +3196,18 @@ class NicotineFrame:
             self.np.config.sections["interests"]["dislikes"].append(thing)
             self.dislikes[thing] = self.dislikeslist.append([thing])
             self.np.config.writeConfiguration()
-            self.np.queue.put(slskmessages.AddThingIHate(self.np.encode(thing)))
+            self.np.queue.put(slskmessages.AddThingIHate(thing))
         elif not widget.get_active() and thing in self.np.config.sections["interests"]["dislikes"]:
             self.dislikeslist.remove(self.dislikes[thing])
             del self.dislikes[thing]
             self.np.config.sections["interests"]["dislikes"].remove(thing)
             self.np.config.writeConfiguration()
-            self.np.queue.put(slskmessages.RemoveThingIHate(self.np.encode(thing)))
+            self.np.queue.put(slskmessages.RemoveThingIHate(thing))
 
     def OnRecommendRecommendation(self, widget):
         thing = self.r_popup_menu.get_user()
-        self.np.queue.put(slskmessages.ItemRecommendations(self.np.encode(thing)))
-        self.np.queue.put(slskmessages.ItemSimilarUsers(self.np.encode(thing)))
+        self.np.queue.put(slskmessages.ItemRecommendations(thing))
+        self.np.queue.put(slskmessages.ItemSimilarUsers(thing))
 
     def OnRecommendSearch(self, widget):
         thing = widget.get_parent().get_user()

--- a/pynicotine/gtkgui/privatechat.py
+++ b/pynicotine/gtkgui/privatechat.py
@@ -40,7 +40,6 @@ from pynicotine.gtkgui.utils import expand_alias
 from pynicotine.gtkgui.utils import fixpath
 from pynicotine.gtkgui.utils import is_alias
 from pynicotine.logfacility import log
-from pynicotine.slskmessages import ToBeEncoded
 from pynicotine.utils import version
 
 gi.require_version('Gtk', '3.0')

--- a/pynicotine/gtkgui/privatechat.py
+++ b/pynicotine/gtkgui/privatechat.py
@@ -33,10 +33,8 @@ from gi.repository import Pango as pango
 from pynicotine import slskmessages
 from pynicotine.gtkgui.chatrooms import GetCompletion
 from pynicotine.gtkgui.utils import AppendLine
-from pynicotine.gtkgui.utils import EncodingsMenu
 from pynicotine.gtkgui.utils import IconNotebook
 from pynicotine.gtkgui.utils import PopupMenu
-from pynicotine.gtkgui.utils import SaveEncoding
 from pynicotine.gtkgui.utils import WriteLog
 from pynicotine.gtkgui.utils import expand_alias
 from pynicotine.gtkgui.utils import fixpath
@@ -367,25 +365,6 @@ class PrivateChat:
         self.status = -1
         self.clist = []
 
-        # Encoding Combobox
-        self.Elist = {}
-        self.encoding, m = EncodingsMenu(self.frame.np, "userencoding", user)
-        self.EncodingStore = gtk.ListStore(gobject.TYPE_STRING, gobject.TYPE_STRING)
-        self.Encoding.set_model(self.EncodingStore)
-
-        cell = gtk.CellRendererText()
-        self.Encoding.pack_start(cell, True)
-        self.Encoding.add_attribute(cell, 'text', 0)
-
-        cell2 = gtk.CellRendererText()
-        self.Encoding.pack_start(cell2, False)
-        self.Encoding.add_attribute(cell2, 'text', 1)
-
-        for item in m:
-            self.Elist[item[1]] = self.EncodingStore.append([item[1], item[0]])
-            if self.encoding == item[1]:
-                self.Encoding.set_active_iter(self.Elist[self.encoding])
-
         if self.frame.SEXY and self.frame.np.config.sections["ui"]["spellcheck"]:
             import sexy
             self.hbox5.remove(self.ChatLine)
@@ -625,13 +604,13 @@ class PrivateChat:
         if bytestring:
             payload = text
         else:
-            payload = ToBeEncoded(self.frame.AutoReplace(text), self.encoding)
+            payload = self.frame.AutoReplace(text)
 
         if self.PeerPrivateMessages.get_active():
             # not in the soulseek protocol
-            self.frame.np.ProcessRequestToPeer(self.user, slskmessages.PMessageUser(None, my_username, payload))
+            self.frame.np.ProcessRequestToPeer(self.user, slskmessages.PMessageUser(None, my_username, text))
         else:
-            self.frame.np.queue.put(slskmessages.MessageUser(self.user, payload))
+            self.frame.np.queue.put(slskmessages.MessageUser(self.user, text))
 
     def threadAlias(self, alias):
 
@@ -643,7 +622,7 @@ class PrivateChat:
         if text[:2] == "//":
             text = text[1:]
 
-        self.frame.np.queue.put(slskmessages.MessageUser(self.user, ToBeEncoded(self.frame.AutoReplace(text), self.encoding)))
+        self.frame.np.queue.put(slskmessages.MessageUser(self.user, self.frame.AutoReplace(text)))
 
     def OnEnter(self, widget):
 
@@ -1072,11 +1051,3 @@ class PrivateChat:
         widget.emit_stop_by_name("key_press_event")
 
         return True
-
-    def OnEncodingChanged(self, widget):
-
-        encoding = self.Encoding.get_model().get(self.Encoding.get_active_iter(), 0)[0]
-
-        if encoding != self.encoding:
-            self.encoding = encoding
-            SaveEncoding(self.frame.np, "userencoding", self.user, self.encoding)

--- a/pynicotine/gtkgui/search.py
+++ b/pynicotine/gtkgui/search.py
@@ -383,7 +383,6 @@ class Searches(IconNotebook):
         if search[2] is not None:
             self.set_current_page(self.page_num(search[2].Main))
 
-        # text = self.frame.np.encode(text)
         if mode == 0:
             self.DoGlobalSearch(self.searchid, text)
         elif mode == 1:
@@ -880,8 +879,6 @@ class Search:
         else:
             imdl = "N"
 
-        decode = self.frame.np.decode  # noqa: F841
-
         for result in msg.list:
 
             name = result[1].split('\\')[-1]
@@ -999,8 +996,6 @@ class Search:
 
         counter = len(self.all_data) + 1
 
-        encode = self.frame.np.encodeuser
-
         for r in results:
 
             user, filename, size, speed, queue, immediatedl, h_bitrate, length, directory, bitrate, fullpath, country, status = r
@@ -1035,8 +1030,8 @@ class Search:
             if (counter <= self.frame.np.config.sections['searches']["max_displayed_results"]) and (not self.filters or self.check_filter(row)):
 
                 encoded_row = [
-                    counter, user, encode(filename, user), h_size, h_speed, h_queue, immediatedl, h_bitrate, length,
-                    self.get_flag(user, country), encode(directory, user), bitrate, encode(fullpath, user), country, size, speed, queue, status
+                    counter, user, filename, h_size, h_speed, h_queue, immediatedl, h_bitrate, length,
+                    self.get_flag(user, country), directory, bitrate, fullpath, country, size, speed, queue, status
                 ]
 
                 gobject.idle_add(self._add_to_model, user, encoded_row)
@@ -1199,11 +1194,6 @@ class Search:
 
     def set_filters(self, enable, f_in, f_out, size, bitrate, freeslot, country):
 
-        if self.frame.np.transfers is None:
-            encode = self.frame.np.encode
-        else:
-            encode = self.frame.np.transfers.encode
-
         self.filters = [None, None, None, None, freeslot, None]
 
         if f_in:
@@ -1253,8 +1243,8 @@ class Search:
                     )
 
                 encoded_row = [
-                    ix, user, encode(filename, user), h_size, h_speed, h_queue, immediatedl, h_bitrate, length,
-                    self.get_flag(user, country), encode(directory, user), bitrate, encode(fullpath, user), country, size, speed, queue, status
+                    ix, user, filename, h_size, h_speed, h_queue, immediatedl, h_bitrate, length,
+                    self.get_flag(user, country), directory, bitrate, fullpath, country, size, speed, queue, status
                 ]
 
                 try:

--- a/pynicotine/gtkgui/settingswindow.py
+++ b/pynicotine/gtkgui/settingswindow.py
@@ -87,7 +87,7 @@ class buildFrame:
 
 class ServerFrame(buildFrame):
 
-    def __init__(self, parent):
+    def __init__(self, parents):
 
         self.p = parent
 

--- a/pynicotine/gtkgui/settingswindow.py
+++ b/pynicotine/gtkgui/settingswindow.py
@@ -87,32 +87,17 @@ class buildFrame:
 
 class ServerFrame(buildFrame):
 
-    def __init__(self, parent, encodings):
+    def __init__(self, parent):
 
         self.p = parent
 
         buildFrame.__init__(self, "ServerFrame")
-
-        self.EncodingStore = gtk.ListStore(gobject.TYPE_STRING, gobject.TYPE_STRING)
-        self.Encoding.set_model(self.EncodingStore)
-
-        cell = gtk.CellRendererText()
-        self.Encoding.pack_start(cell, True)
-        self.Encoding.add_attribute(cell, 'text', 0)
-
-        cell2 = gtk.CellRendererText()
-        self.Encoding.pack_start(cell2, False)
-        self.Encoding.add_attribute(cell2, 'text', 1)
-
-        for item in encodings:
-            self.EncodingStore.append([item[1], item[0]])
 
         self.options = {
             "server": {
                 "server": None,
                 "login": self.Login,
                 "passw": self.Password,
-                "enc": self.Encoding,
                 "portrange": None,
                 "firewalled": self.DirectConnection,
                 "upnp": self.UseUPnP,
@@ -228,7 +213,6 @@ class ServerFrame(buildFrame):
                 "server": server,
                 "login": self.Login.get_text(),
                 "passw": self.Password.get_text(),
-                "enc": self.Encoding.get_model().get(self.Encoding.get_active_iter(), 0)[0],
                 "portrange": portrange,
                 "firewalled": firewalled,
                 "upnp": self.UseUPnP.get_active(),
@@ -3427,7 +3411,7 @@ class SettingsWindow:
         self.tree["User info"] = model.append(row, [_("User info"), "User info"])
 
         # Build individual categories
-        p["Server"] = ServerFrame(self, frame.np.getencodings())
+        p["Server"] = ServerFrame(self)
         p["Shares"] = SharesFrame(self)
 
         p["Transfers"] = TransfersFrame(self)

--- a/pynicotine/gtkgui/settingswindow.py
+++ b/pynicotine/gtkgui/settingswindow.py
@@ -87,7 +87,7 @@ class buildFrame:
 
 class ServerFrame(buildFrame):
 
-    def __init__(self, parents):
+    def __init__(self, parent):
 
         self.p = parent
 

--- a/pynicotine/gtkgui/transferlist.py
+++ b/pynicotine/gtkgui/transferlist.py
@@ -539,7 +539,7 @@ class TransferList:
                 6, HumanSpeed(speed),
                 7, elap,
                 8, left,
-                9, self.frame.np.decode(transfer.path),
+                9, transfer.path,
                 11, istatus,
                 12, size,
                 13, currentbytes,
@@ -564,7 +564,7 @@ class TransferList:
                 parent = None
 
             # Add a new transfer
-            path = self.frame.np.decode(transfer.path)
+            path = transfer.path
 
             iter = self.transfersmodel.append(
                 parent,

--- a/pynicotine/gtkgui/transferlist.py
+++ b/pynicotine/gtkgui/transferlist.py
@@ -466,7 +466,7 @@ class TransferList:
 
         fn = transfer.filename
         user = transfer.user
-        shortfn = self.frame.np.transfers.encode(fn.split("\\")[-1], user)
+        shortfn = fn.split("\\")[-1]
         currentbytes = transfer.currentbytes
         place = transfer.place
 

--- a/pynicotine/gtkgui/ui/chatrooms.ui
+++ b/pynicotine/gtkgui/ui/chatrooms.ui
@@ -375,19 +375,6 @@
                         <property name="position">0</property>
                       </packing>
                     </child>
-                    <child>
-                      <object class="GtkComboBox" id="Encoding">
-                        <property name="visible">True</property>
-                        <property name="can_focus">True</property>
-                        <property name="tooltip_text" translatable="yes">Character encoding</property>
-                        <signal name="changed" handler="OnEncodingChanged" swapped="no"/>
-                      </object>
-                      <packing>
-                        <property name="expand">True</property>
-                        <property name="fill">True</property>
-                        <property name="position">1</property>
-                      </packing>
-                    </child>
                   </object>
                   <packing>
                     <property name="expand">False</property>

--- a/pynicotine/gtkgui/ui/privatechat.ui
+++ b/pynicotine/gtkgui/ui/privatechat.ui
@@ -55,19 +55,6 @@
               </packing>
             </child>
             <child>
-              <object class="GtkComboBox" id="Encoding">
-                <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <property name="tooltip_text" translatable="yes">Character encoding</property>
-                <signal name="changed" handler="OnEncodingChanged" swapped="no"/>
-              </object>
-              <packing>
-                <property name="expand">False</property>
-                <property name="fill">False</property>
-                <property name="position">1</property>
-              </packing>
-            </child>
-            <child>
               <object class="GtkCheckButton" id="PeerPrivateMessages">
                 <property name="label" translatable="yes">Direct</property>
                 <property name="visible">True</property>

--- a/pynicotine/gtkgui/ui/settingswindow_ServerFrame.ui
+++ b/pynicotine/gtkgui/ui/settingswindow_ServerFrame.ui
@@ -428,43 +428,6 @@
                 <property name="position">10</property>
               </packing>
             </child>
-            <child>
-              <object class="GtkHBox" id="hbox108">
-                <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="spacing">5</property>
-                <child>
-                  <object class="GtkLabel" id="label169">
-                    <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <property name="xalign">0</property>
-                    <property name="label" translatable="yes">Network Character Encoding (utf-8 is a good choice)</property>
-                  </object>
-                  <packing>
-                    <property name="expand">False</property>
-                    <property name="fill">False</property>
-                    <property name="position">0</property>
-                  </packing>
-                </child>
-                <child>
-                  <object class="GtkComboBox" id="Encoding">
-                    <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                  </object>
-                  <packing>
-                    <property name="expand">False</property>
-                    <property name="fill">True</property>
-                    <property name="position">1</property>
-                  </packing>
-                </child>
-              </object>
-              <packing>
-                <property name="expand">False</property>
-                <property name="fill">False</property>
-                <property name="padding">5</property>
-                <property name="position">11</property>
-              </packing>
-            </child>
           </object>
         </child>
         <child type="label">

--- a/pynicotine/gtkgui/ui/userbrowse.ui
+++ b/pynicotine/gtkgui/ui/userbrowse.ui
@@ -44,19 +44,6 @@
                 <property name="position">1</property>
               </packing>
             </child>
-            <child>
-              <object class="GtkComboBox" id="Encoding">
-                <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <property name="tooltip_text" translatable="yes">Character encoding</property>
-                <signal name="changed" handler="OnEncodingChanged" swapped="no"/>
-              </object>
-              <packing>
-                <property name="expand">False</property>
-                <property name="fill">False</property>
-                <property name="position">2</property>
-              </packing>
-            </child>
           </object>
           <packing>
             <property name="expand">False</property>

--- a/pynicotine/gtkgui/ui/userinfo.ui
+++ b/pynicotine/gtkgui/ui/userinfo.ui
@@ -61,19 +61,6 @@
                         <property name="position">1</property>
                       </packing>
                     </child>
-                    <child>
-                      <object class="GtkComboBox" id="Encoding">
-                        <property name="visible">True</property>
-                        <property name="can_focus">True</property>
-                        <property name="tooltip_text" translatable="yes">Character encoding</property>
-                        <signal name="changed" handler="OnEncodingChanged" swapped="no"/>
-                      </object>
-                      <packing>
-                        <property name="expand">False</property>
-                        <property name="fill">False</property>
-                        <property name="position">2</property>
-                      </packing>
-                    </child>
                   </object>
                   <packing>
                     <property name="expand">True</property>

--- a/pynicotine/gtkgui/userinfo.py
+++ b/pynicotine/gtkgui/userinfo.py
@@ -34,12 +34,10 @@ from gi.repository import Gtk as gtk
 
 from pynicotine import slskmessages
 from pynicotine.gtkgui.utils import AppendLine
-from pynicotine.gtkgui.utils import EncodingsMenu
 from pynicotine.gtkgui.utils import Humanize
 from pynicotine.gtkgui.utils import IconNotebook
 from pynicotine.gtkgui.utils import InitialiseColumns
 from pynicotine.gtkgui.utils import PopupMenu
-from pynicotine.gtkgui.utils import SaveEncoding
 from pynicotine.logfacility import log
 from pynicotine.utils import CleanFile
 
@@ -260,25 +258,6 @@ class UserInfo:
         cols[0].set_sort_column_id(0)
         self.likesStore.set_sort_column_id(0, gtk.SortType.ASCENDING)
 
-        # Encoding Combobox
-        self.Elist = {}
-        self.encoding, m = EncodingsMenu(self.frame.np, "userencoding", user)
-        self.EncodingStore = gtk.ListStore(gobject.TYPE_STRING, gobject.TYPE_STRING)
-        self.Encoding.set_model(self.EncodingStore)
-
-        cell = gtk.CellRendererText()
-        self.Encoding.pack_start(cell, True)
-        self.Encoding.add_attribute(cell, 'text', 0)
-
-        cell2 = gtk.CellRendererText()
-        self.Encoding.pack_start(cell2, False)
-        self.Encoding.add_attribute(cell2, 'text', 1)
-
-        for item in m:
-            self.Elist[item[1]] = self.EncodingStore.append([item[1], item[0]])
-            if self.encoding == item[1]:
-                self.Encoding.set_active_iter(self.Elist[self.encoding])
-
         self.tag_local = self.makecolour("chatremote")  # noqa: F821
         self.ChangeColours()
 
@@ -447,7 +426,7 @@ class UserInfo:
         self.image_pixbuf = None
         self.descr.get_buffer().set_text("")
 
-        AppendLine(self.descr, descr.decode(self.encoding), self.tag_local, showstamp=False, scroll=False)
+        AppendLine(self.descr, descr, self.tag_local, showstamp=False, scroll=False)
 
         self.uploads.set_text(_("Total uploads allowed: %i") % totalupl)
         self.queuesize.set_text(_("Queue size: %i") % queuesize)
@@ -561,16 +540,6 @@ class UserInfo:
             log.add(_("Picture saved to %s") % pathname)
         else:
             log.add(_("Picture not saved, %s already exists.") % pathname)
-
-    def OnEncodingChanged(self, widget):
-
-        encoding = self.Encoding.get_model().get(self.Encoding.get_active_iter(), 0)[0]
-
-        if encoding != self.encoding:
-            self.encoding = encoding
-            buffer = self.descr.get_buffer()
-            buffer.set_text(self._descr.decode(self.encoding))
-            SaveEncoding(self.frame.np, "userencoding", self.user, self.encoding)
 
     def OnImageClick(self, widget, event):
 

--- a/pynicotine/gtkgui/utils.py
+++ b/pynicotine/gtkgui/utils.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 #
-# COPYRIGHT (C) 2020 Mathias <mail@mathias.is>
 # COPYRIGHT (C) 2020 Lene Preuss <lene.preuss@gmail.com>
 # COPYRIGHT (C) 2016-2017 Michael Labouebe <gfarmerfr@free.fr>
 # COPYRIGHT (C) 2016 Mutnick <muhing@yahoo.com>

--- a/pynicotine/gtkgui/utils.py
+++ b/pynicotine/gtkgui/utils.py
@@ -1470,24 +1470,3 @@ def _expand_alias(aliases, cmd):
         print(error)
         pass
     return ""
-
-
-def EncodingsMenu(np, section=None, entry=None):
-    if section and entry and entry in np.config.sections["server"][section]:
-        encoding = np.config.sections["server"][section][entry]
-    else:
-        encoding = np.config.sections["server"]["enc"]
-
-    z = []
-    for enc in np.getencodings():
-        z.append(enc)
-
-    return encoding, z
-
-
-def SaveEncoding(np, section, entry, encoding):
-    if encoding != np.config.sections["server"]["enc"]:
-        np.config.sections["server"][section][entry] = encoding
-    elif entry in np.config.sections["server"][section]:
-        del np.config.sections["server"][section][entry]
-    np.config.writeConfiguration()

--- a/pynicotine/gtkgui/utils.py
+++ b/pynicotine/gtkgui/utils.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 #
+# COPYRIGHT (C) 2020 Mathias <mail@mathias.is>
 # COPYRIGHT (C) 2020 Lene Preuss <lene.preuss@gmail.com>
 # COPYRIGHT (C) 2016-2017 Michael Labouebe <gfarmerfr@free.fr>
 # COPYRIGHT (C) 2016 Mutnick <muhing@yahoo.com>

--- a/pynicotine/pluginsystem.py
+++ b/pynicotine/pluginsystem.py
@@ -39,7 +39,6 @@ from gi.repository import GObject as gobject
 from _thread import start_new_thread
 from pynicotine.logfacility import log
 from pynicotine.pynicotine import slskmessages
-from pynicotine.slskmessages import ToBeEncoded
 
 gi.require_version('Gtk', '3.0')
 
@@ -426,7 +425,7 @@ class PluginHandler(object):
 
     def saychatroom(self, room, text):
         text = cast_to_unicode_if_needed(text, log.addwarning)
-        self.frame.np.queue.put(slskmessages.SayChatroom(room, ToBeEncoded(text, 'UTF-8')))
+        self.frame.np.queue.put(slskmessages.SayChatroom(room, text))
 
     def sayprivate(self, user, text):
         '''Send user message in private (showing up in GUI)'''
@@ -576,7 +575,7 @@ class BasePlugin(object):
         except KeyError:
             return False
         text = cast_to_unicode_if_needed(text, self.log)
-        msg = slskmessages.SayChatroom(room, ToBeEncoded(text, 'UTF-8'))
+        msg = slskmessages.SayChatroom(room, text)
         msg.user = user
         room.SayChatRoom(msg, text)
         return True

--- a/pynicotine/pynicotine.py
+++ b/pynicotine/pynicotine.py
@@ -45,7 +45,6 @@ from pynicotine.config import Config
 from pynicotine.ConfigParser import Error as ConfigParserError
 from pynicotine.shares import Shares
 from pynicotine.slskmessages import PopupMessage
-from pynicotine.slskmessages import ToBeEncoded
 from pynicotine.slskmessages import newId
 from pynicotine.utils import CleanFile
 from pynicotine.utils import findBestEncoding
@@ -697,9 +696,6 @@ class NetworkEventProcessor:
 
     def MessageUser(self, msg):
 
-        encodings = [self.config.sections["server"]["enc"]] + self.config.sections["server"]["fallbackencodings"]
-
-        msg.msg = findBestEncoding(msg.msg, encodings)
         status = 0
         if self.logintime:
             if time.time() <= self.logintime + 2:
@@ -728,8 +724,6 @@ class NetworkEventProcessor:
 
     def PublicRoomMessage(self, msg):
 
-        msg.msg = findBestEncoding(msg.msg, [self.config.sections["server"]["enc"]] + self.config.sections["server"]["fallbackencodings"])
-
         if self.chatrooms is not None:
             self.chatrooms.roomsctrl.PublicRoomMessage(msg, msg.msg)
             self.frame.pluginhandler.PublicRoomMessageNotification(msg.room, msg.user, msg.msg)
@@ -749,8 +743,7 @@ class NetworkEventProcessor:
                 ticker = self.config.sections["ticker"]["default"]
 
             if ticker:
-                encoding = self.config.sections["server"]["enc"]
-                self.queue.put(slskmessages.RoomTickerSet(msg.room, ToBeEncoded(ticker, encoding)))
+                self.queue.put(slskmessages.RoomTickerSet(msg.room, ticker))
 
         self.logMessage("%s %s" % (msg.__class__, vars(msg)), 4)
 
@@ -876,9 +869,6 @@ class NetworkEventProcessor:
         return False
 
     def SayChatRoom(self, msg):
-        encodings = [self.config.sections["server"]["enc"]] + self.config.sections["server"]["fallbackencodings"]
-
-        msg.msg = findBestEncoding(msg.msg, encodings)
 
         if self.chatrooms is not None:
             event = self.frame.pluginhandler.IncomingPublicChatEvent(msg.room, msg.user, msg.msg)
@@ -1823,9 +1813,6 @@ class NetworkEventProcessor:
 
     def RoomTickerAdd(self, msg):
 
-        encodings = [self.config.sections["server"]["enc"]] + self.config.sections["server"]["fallbackencodings"]
-
-        msg.msg = findBestEncoding(msg.msg, encodings)
         if self.chatrooms is not None:
             self.chatrooms.roomsctrl.TickerAdd(msg)
 

--- a/pynicotine/pynicotine.py
+++ b/pynicotine/pynicotine.py
@@ -1,3 +1,4 @@
+# COPYRIGHT (C) 2020 Mathias <mail@mathias.is>
 # COPYRIGHT (C) 2016-2017 Michael Labouebe <gfarmerfr@free.fr>
 # COPYRIGHT (C) 2016 Mutnick <muhing@yahoo.com>
 # COPYRIGHT (C) 2013 eL_vErDe <gandalf@le-vert.net>

--- a/pynicotine/pynicotine.py
+++ b/pynicotine/pynicotine.py
@@ -1799,13 +1799,6 @@ class NetworkEventProcessor:
 
     def RoomTickerState(self, msg):
 
-        encodings = [self.config.sections["server"]["enc"]] + self.config.sections["server"]["fallbackencodings"]
-
-        unicodes = {}
-        for user, bytes in msg.msgs.items():
-            unicodes[user] = findBestEncoding(bytes, encodings)
-
-        msg.msgs = unicodes
         if self.chatrooms is not None:
             self.chatrooms.roomsctrl.TickerSet(msg)
 

--- a/pynicotine/shares.py
+++ b/pynicotine/shares.py
@@ -400,14 +400,14 @@ class Shares:
                     self.logMessage(
                         _("User %(user)s is directly searching for %(query)s, returning %(num)i results") % {
                             'user': user,
-                            'query': self.np.decode(searchterm),
+                            'query': searchterm,
                             'num': len(results)
                         }, 2)
                 else:
                     self.logMessage(
                         _("User %(user)s is searching for %(query)s, returning %(num)i results") % {
                             'user': user,
-                            'query': self.np.decode(searchterm),
+                            'query': searchterm,
                             'num': len(results)
                         }, 2)
 

--- a/pynicotine/slskmessages.py
+++ b/pynicotine/slskmessages.py
@@ -102,7 +102,7 @@ class ToBeEncoded:
         if self.cached:
             return self.cached
         self.cached = self.str.encode(self.encoding, "replace")
-        # print "The bytes of %s are %s" % (self.unicode, repr(self.cached))
+        # print("The bytes of %s are %s" % (self.unicode, repr(self.cached)))
         return self.cached
 
     def dont(self):
@@ -1692,7 +1692,7 @@ class UserInfoReply(PeerMessage):
         self.uploadallowed = uploadallowed
 
     def parseNetworkMessage(self, message):
-        pos, self.descr = self.getObject(message, bytes, 0, 0, 0, True, True)
+        pos, self.descr = self.getObject(message, bytes)
         pos, self.has_pic = pos + 1, message[pos]
         if self.has_pic:
             pos, self.pic = self.getObject(message, bytes, pos, 0, 0, True, True)

--- a/pynicotine/slskmessages.py
+++ b/pynicotine/slskmessages.py
@@ -56,9 +56,12 @@ def _str(arg: Union[bytes, str]) -> str:
     Until we figure out the best way to convert between protocol messages, which
     are in bytes, and strings, use this function explicitly
     """
+    print("hit")
     if isinstance(arg, bytes):
+        print("bytes")
         return arg.decode('utf-8')
     elif isinstance(arg, str):
+        print("str")
         return arg
     return arg
 
@@ -87,69 +90,6 @@ class NetworkSignedIntType(NetworkBaseType):
 class NetworkLongLongType(NetworkBaseType):
     """Cast to <Q, little-endian unsigned long long (8 bytes)"""
     pass
-
-
-class ToBeEncoded:
-    """Holds text and the desired eventual encoding"""
-    def __init__(self, uni, encoding):
-        if not isinstance(uni, str):
-            raise ValueError("ZOMG, you really don't know what you're doing! %s is NOT unicode, its a %s: %s" % (uni, type(uni), repr(uni)))
-        self.str = uni
-        self.encoding = encoding
-        self.cached = None
-
-    def getbytes(self):
-        if self.cached:
-            return self.cached
-        self.cached = self.str.encode(self.encoding, "replace")
-        # print("The bytes of %s are %s" % (self.unicode, repr(self.cached)))
-        return self.cached
-
-    def dont(self):
-        print("Dont do that")
-    bytes = property(getbytes, dont)
-
-    def __getitem__(self, key):
-        return self.str[key]
-
-    def __str__(self):
-        return "%s" % (self.getbytes(),)
-
-    def __repr__(self):
-        return "ToBeEncoded(%s, %s)" % (repr(self.getbytes()), self.encoding)
-
-
-class JustDecoded:
-    """Holds text, the original bytes and its supposed encoding"""
-    def __init__(self, bytes, encoding):
-        if not isinstance(bytes, str):
-            raise ValueError("ZOMG, you really don't know what you're doing! %s is NOT string, its a %s: %s" % (bytes, type(bytes), repr(bytes)))
-        self.bytes = bytes
-        self.encoding = encoding
-        self.cached = None
-        self.modified = False
-
-    def getunicode(self):
-        if self.cached:
-            return self.cached
-        self.cached = self.bytes.decode(self.encoding, "replace")
-        return self.cached
-
-    def setunicode(self, uni):
-        if not isinstance(uni, str):
-            print("ZOMG, you really don't know what you're doing! %s is NOT unicode, its a %s: %s" % (uni, type(uni), repr(bytes)))
-            raise Exception
-        self.cached = uni
-    str = property(getunicode, setunicode)
-
-    def __getitem__(self, key):
-        return self.str[key]
-
-    def __str__(self):
-        return "%s" % (self.getbytes(),)
-
-    def __repr__(self):
-        return "ToBeEncoded(%s, %s)" % (repr(self.getbytes()), self.encoding)
 
 
 class InternalMessage:
@@ -356,9 +296,6 @@ class SlskMessage:
                 return struct.pack("<Q", object)
         elif type(object) is bytes:
             return struct.pack("<i", len(object)) + object
-        elif type(object) is ToBeEncoded:
-            # The server seems to cut off strings at \x00 regardless of the length
-            return struct.pack("<i", len(object.bytes)) + object.bytes
         elif type(object) is str:
             encoded = object.encode("utf-8", 'replace')
             return struct.pack("<i", len(encoded)) + encoded

--- a/pynicotine/slskmessages.py
+++ b/pynicotine/slskmessages.py
@@ -56,12 +56,9 @@ def _str(arg: Union[bytes, str]) -> str:
     Until we figure out the best way to convert between protocol messages, which
     are in bytes, and strings, use this function explicitly
     """
-    print("hit")
     if isinstance(arg, bytes):
-        print("bytes")
         return arg.decode('utf-8')
     elif isinstance(arg, str):
-        print("str")
         return arg
     return arg
 

--- a/setup.py
+++ b/setup.py
@@ -141,8 +141,7 @@ if __name__ == '__main__':
         version=version,
         license="GPLv3",
         description="Nicotine+, a client for the SoulSeek filesharing network.",
-        author="Michael Labouebe",
-        author_email="gfarmerfr@free.fr",
+        author="Nicotine+ Contributors",
         url="https://www.nicotine-plus.org/",
         packages=[
             'pynicotine', 'pynicotine.gtkgui', 'pynicotine.gtkgui.ui',


### PR DESCRIPTION
An attempt at cleaning up the mess that is decoding/encoding of strings.
- Remove a lot of needless conversions back and forth
- Use utf-8 everywhere, remove encoding settings. I don't see a reason for including these settings anymore, and I'm not sure they even worked properly anymore.