### PR TITLE
Remove unnecessary log messages

### DIFF
--- a/pynicotine/config.py
+++ b/pynicotine/config.py
@@ -456,7 +456,6 @@ class Config:
                                 )
                                 errorlevel = 2
 
-                            self.frame.logMessage(_("Config option unset: Section: %(section)s, Option: %(option)s") % {'section': i, 'option': j})
                             self.frame.settingswindow.InvalidSettings(i, j)
 
         except Exception as error:

--- a/pynicotine/gtkgui/fastconfigure.py
+++ b/pynicotine/gtkgui/fastconfigure.py
@@ -246,6 +246,11 @@ class FastConfigureAssistant(object):
     def OnApply(self, widget):
         self.store()
         self.window.hide()
+
+        self.frame.logMessage(
+            _("Setup complete! Connecting...")
+        )
+
         if not self.frame.np.serverconn:
             self.frame.OnFirstConnect(-1)
 


### PR DESCRIPTION
Fixes https://github.com/Nicotine-Plus/nicotine-plus/issues/64

There is nothing wrong with username/password configuration, but the log messages caused confusion. Remove log messages about unset username/password, and add a log message when setup was successful.