### PR TITLE
Don't add Mutagen exceptions to log

### DIFF
--- a/pynicotine/metadata_mutagen.py
+++ b/pynicotine/metadata_mutagen.py
@@ -40,7 +40,7 @@ def detect(path):
     except IOError:
         return None
     except Exception as e:
-        log.addwarning("Mutagen crashed on '%s': %s" % (path, e))
+        print("Mutagen crashed on '%s': %s" % (path, e))
         return None
 
     try:


### PR DESCRIPTION
Closes https://github.com/Nicotine-Plus/nicotine-plus/issues/62

I was not able to reproduce the issue, I'd assume it's fixed in mutagen. If it still occurs, there isn't much we can do about it.

Mutagen exceptions can still show up in the console, but hide them from the log view.