### PR TITLE
Use GTK way of opening links by default

### DIFF
--- a/pynicotine/config.py
+++ b/pynicotine/config.py
@@ -345,7 +345,7 @@ class Config:
 
             "urls": {
                 "urlcatching": 1,
-                "protocols": {"http": "", "https": ""},
+                "protocols": {},
                 "humanizeurls": 1
             },
 
@@ -377,20 +377,6 @@ class Config:
                 "enabled": []
             }
         }
-
-        # URls handling for Windows
-        if sys.platform.startswith('win'):
-            self.sections["urls"]["protocols"] = {
-                "http": "python -m webbrowser -t $",
-                "https": "python -m webbrowser -t $"
-            }
-
-        # URls handling for Linux
-        if sys.platform.startswith('linux'):
-            self.sections["urls"]["protocols"] = {
-                "http": "xdg-open $",
-                "https": "xdg-open $"
-            }
 
         # Windows specific stuff
         if sys.platform.startswith('win'):

--- a/pynicotine/gtkgui/fastconfigure.py
+++ b/pynicotine/gtkgui/fastconfigure.py
@@ -460,7 +460,8 @@ class FastConfigureAssistant(object):
                 '='.join([
                     'http://tools.slsknet.org/porttest.php?port',
                     str(self.frame.np.waitport)
-                ])
+                ]),
+                self.window
             )
 
         if name == "addshare":

--- a/pynicotine/gtkgui/frame.py
+++ b/pynicotine/gtkgui/frame.py
@@ -2577,18 +2577,18 @@ class NicotineFrame:
 
     def OnProjectWebsite(self, widget):
         url = "https://github.com/Nicotine-Plus/nicotine-plus/"
-        OpenUri(url)
+        OpenUri(url, self.MainWindow)
 
     def onProjectGithubPage(self, widget):
         url = "https://github.com/Nicotine-Plus/nicotine-plus"
-        OpenUri(url)
+        OpenUri(url, self.MainWindow)
 
     def OnCheckLatest(self, widget):
         checklatest(self.MainWindow)
 
     def OnReportBug(self, widget):
         url = "https://github.com/Nicotine-Plus/nicotine-plus/issues"
-        OpenUri(url)
+        OpenUri(url, self.MainWindow)
 
     def OnAbout(self, widget):
         dlg = AboutDialog(self.MainWindow, self)

--- a/pynicotine/gtkgui/settingswindow.py
+++ b/pynicotine/gtkgui/settingswindow.py
@@ -225,7 +225,7 @@ class ServerFrame(buildFrame):
         self.frame.OnChangePassword(self.Password.get_text())
 
     def OnCheckPort(self, widget):
-        OpenUri('='.join(['http://tools.slsknet.org/porttest.php?port', str(self.frame.np.waitport)]))
+        OpenUri('='.join(['http://tools.slsknet.org/porttest.php?port', str(self.frame.np.waitport)]), self.p.SettingsWindow)
 
     def OnUPnPToggled(self, widget):
 

--- a/pynicotine/gtkgui/utils.py
+++ b/pynicotine/gtkgui/utils.py
@@ -279,11 +279,11 @@ def UrlEvent(tag, widget, event, iter, url):
     if tag.last_event_type == Gdk.EventType.BUTTON_PRESS and event.button.type == Gdk.EventType.BUTTON_RELEASE and event.button.button == 1:
         if url[:4] == "www.":
             url = "http://" + url
-        OpenUri(url)
+        OpenUri(url, widget.get_toplevel())
     tag.last_event_type = event.button.type
 
 
-def OpenUri(uri):
+def OpenUri(uri, window):
     """Open a URI in an external (web) browser. The given argument has
     to be a properly formed URI including the scheme (fe. HTTP).
 
@@ -299,18 +299,8 @@ def OpenUri(uri):
             executeCommand(PROTOCOL_HANDLERS[protocol], uri)
             return
 
-    # Situation 2, user did not define a way of handling the protocol, we'll leave it up to python
-    if webbrowser:
-        webbrowser.open(uri)
-        return
-
-    # Situation 3, we let Gnome VFS deal with it
-    try:
-        import gnomevfs
-        gnomevfs.url_show(uri)
-        return
-    except Exception as e:  # noqa: F841
-        pass
+    # Situation 2, user did not define a way of handling the protocol
+    gtk.show_uri_on_window(window, uri, Gdk.CURRENT_TIME)
 
 
 def AppendLine(textview, line, tag=None, timestamp=None, showstamp=True, timestamp_format="%H:%M:%S", username=None, usertag=None, scroll=True):


### PR DESCRIPTION
Don't rely on commands/handlers by default to open links, which seems to have failed on Windows. Fixes https://github.com/Nicotine-Plus/nicotine-plus/issues/65

GnomeVFS was deprecated in 2008.