### PR TITLE
Clean up color handling

### DIFF
--- a/pynicotine/gtkgui/chatrooms.py
+++ b/pynicotine/gtkgui/chatrooms.py
@@ -1848,11 +1848,11 @@ class ChatRoom:
 
         colour = self.frame.np.config.sections["ui"][colour]
         font = self.frame.np.config.sections["ui"]["chatfont"]
+        
+        tag = buffer.create_tag(font=font)
 
         if colour:
-            tag = buffer.create_tag(foreground=colour, font=font)
-        else:
-            tag = buffer.create_tag(font=font)
+            tag.set_property("foreground", colour)
 
         if username is not None:
 
@@ -1906,10 +1906,6 @@ class ChatRoom:
         self.frame.ChangeListFont(self.UserList, self.frame.np.config.sections["ui"]["listfont"])
 
         map = self.ChatScroll.get_style_context()
-        try:
-            self.backuprgba = map.get_color(gtk.StateFlags.NORMAL)
-        except IndexError:
-            self.backuprgba = ''
         buffer = self.ChatScroll.get_buffer()
 
         self.tag_remote = self.makecolour(buffer, "chatremote")
@@ -1949,19 +1945,14 @@ class ChatRoom:
 
     def changecolour(self, tag, colour):
 
-        if colour in self.frame.np.config.sections["ui"]:
-            color = self.frame.np.config.sections["ui"][colour]
-        else:
-            color = ""
-
-        font = self.frame.np.config.sections["ui"]["chatfont"]
+        color = self.frame.np.config.sections["ui"][colour]
 
         if color == "":
-            color = self.backuprgba.to_color()
-        else:
-            color = Gdk.color_parse(color)
+            color = None
 
-        tag.set_property("foreground-gdk", color)
+        tag.set_property("foreground", color)
+
+        font = self.frame.np.config.sections["ui"]["chatfont"]
         tag.set_property("font", font)
 
         # Hotspots
@@ -1987,7 +1978,6 @@ class ChatRoom:
     def ChangeColours(self):
 
         map = self.ChatScroll.get_style_context()
-        self.backuprgba = map.get_color(gtk.StateFlags.NORMAL)
 
         self.changecolour(self.tag_remote, "chatremote")
         self.changecolour(self.tag_local, "chatlocal")

--- a/pynicotine/gtkgui/frame.py
+++ b/pynicotine/gtkgui/frame.py
@@ -1417,21 +1417,6 @@ class NicotineFrame:
             colour = None
         cellrenderer.set_property("foreground", colour)
 
-    def changecolour(self, tag, colour):
-        if colour in self.frame.np.config.sections["ui"]:
-            color = self.frame.np.config.sections["ui"][colour]
-        else:
-            color = None
-        font = self.frame.np.config.sections["ui"]["chatfont"]
-
-        if color:
-            if color == "":
-                color = None
-            tag.set_property("foreground", color)
-            tag.set_property("font", font)
-        else:
-            tag.set_property("font", font)
-
     def ChangeListFont(self, listview, font):
         for c in listview.get_columns():
             for r in c.get_cells():
@@ -1439,19 +1424,18 @@ class NicotineFrame:
                     r.set_property("font", font)
 
     def UpdateColours(self, first=0):
-        color = self.np.config.sections["ui"]["chatremote"]
-        font = self.np.config.sections["ui"]["chatfont"]
-
-        if color == "":
-            map = self.LogWindow.get_style_context()
-            colour = map.get_color(gtk.StateFlags.NORMAL)
-        else:
-            colour = Gdk.RGBA()
-            colour.parse(color)
         if first:
             self.tag_log = self.LogWindow.get_buffer().create_tag()
+
+        color = self.np.config.sections["ui"]["chatremote"]
+
+        if color == "":
+            color = None
+
+        self.tag_log.set_property("foreground", color)
+
+        font = self.np.config.sections["ui"]["chatfont"]
         self.tag_log.set_property("font", font)
-        self.tag_log.set_property("foreground-rgba", colour)
 
         self.SetTextBG(self.LogWindow)
         self.SetTextBG(self.userlist.UserList)

--- a/pynicotine/gtkgui/privatechat.py
+++ b/pynicotine/gtkgui/privatechat.py
@@ -807,27 +807,19 @@ class PrivateChat:
 
     def makecolour(self, buffer, colour):
 
-        color = self.frame.np.config.sections["ui"][colour]
-        if color == "":
-            color = self.backuprgba.to_color()
-        else:
-            color = Gdk.color_parse(color)
-
+        colour = self.frame.np.config.sections["ui"][colour]
         font = self.frame.np.config.sections["ui"]["chatfont"]
-        tag = buffer.create_tag()
-        tag.set_property("foreground-gdk", color)
-        tag.set_property("font", font)
+        
+        tag = buffer.create_tag(font=font)
+
+        if colour:
+            tag.set_property("foreground", colour)
 
         return tag
 
     def UpdateColours(self):
 
         map = self.frame.MainWindow.get_style_context()
-
-        try:
-            self.backuprgba = map.get_color(gtk.StateFlags.NORMAL)
-        except IndexError:
-            self.backuprgba = ''
 
         buffer = self.ChatScroll.get_buffer()
         self.tag_remote = self.makecolour(buffer, "chatremote")
@@ -882,19 +874,14 @@ class PrivateChat:
 
     def changecolour(self, tag, colour):
 
-        if colour in self.frame.np.config.sections["ui"]:
-            color = self.frame.np.config.sections["ui"][colour]
-        else:
-            color = ""
-
-        font = self.frame.np.config.sections["ui"]["chatfont"]
+        color = self.frame.np.config.sections["ui"][colour]
 
         if color == "":
-            color = self.backuprgba.to_color()
-        else:
-            color = Gdk.color_parse(color)
+            color = None
 
-        tag.set_property("foreground-gdk", color)
+        self.tag_log.set_property("foreground", color)
+
+        font = self.frame.np.config.sections["ui"]["chatfont"]
         tag.set_property("font", font)
 
         if colour in ["useraway", "useronline", "useroffline"]:
@@ -919,7 +906,6 @@ class PrivateChat:
     def ChangeColours(self):
 
         map = self.ChatScroll.get_style_context()
-        self.backuprgba = map.get_color(gtk.StateFlags.NORMAL)
 
         self.changecolour(self.tag_remote, "chatremote")
         self.changecolour(self.tag_local, "chatlocal")

--- a/pynicotine/gtkgui/userinfo.py
+++ b/pynicotine/gtkgui/userinfo.py
@@ -369,29 +369,23 @@ class UserInfo:
         buffer = self.descr.get_buffer()
         colour = self.frame.np.config.sections["ui"][colour]
         font = self.frame.np.config.sections["ui"]["chatfont"]
+        
+        tag = buffer.create_tag(font=font)
 
         if colour:
-            return buffer.create_tag(foreground=colour, font=font)
-        else:
-            return buffer.create_tag(font=font)
+            tag.set_property("foreground", colour)
 
     def changecolour(self, tag, colour):
 
-        if colour in self.frame.np.config.sections["ui"]:
-            color = self.frame.np.config.sections["ui"][colour]
-        else:
+        color = self.frame.np.config.sections["ui"][colour]
+
+        if color == "":
             color = None
 
+        tag.set_property("foreground", color)
+        
         font = self.frame.np.config.sections["ui"]["chatfont"]
-
-        if color:
-            if color == "":
-                color = None
-
-            tag.set_property("foreground", color)
-            tag.set_property("font", font)
-        else:
-            tag.set_property("font", font)
+        tag.set_property("font", font)
 
     def ChangeColours(self):
 

--- a/pynicotine/gtkgui/utils.py
+++ b/pynicotine/gtkgui/utils.py
@@ -311,7 +311,11 @@ def AppendLine(textview, line, tag=None, timestamp=None, showstamp=True, timesta
     def _makeurltag(buffer, tag, url):
         props = {}
 
-        props["foreground"] = NICOTINE.np.config.sections["ui"]["urlcolor"]
+        color = NICOTINE.np.config.sections["ui"]["urlcolor"]
+
+        if color != "":
+            props["foreground"] = color
+
         props["underline"] = pango.Underline.SINGLE
         tag = buffer.create_tag(**props)
         tag.last_event_type = -1

--- a/pynicotine/gtkgui/utils.py
+++ b/pynicotine/gtkgui/utils.py
@@ -311,7 +311,7 @@ def AppendLine(textview, line, tag=None, timestamp=None, showstamp=True, timesta
     def _makeurltag(buffer, tag, url):
         props = {}
 
-        props["foreground_gdk"] = Gdk.color_parse(NICOTINE.np.config.sections["ui"]["urlcolor"])
+        props["foreground"] = NICOTINE.np.config.sections["ui"]["urlcolor"]
         props["underline"] = pango.Underline.SINGLE
         tag = buffer.create_tag(**props)
         tag.last_event_type = -1


### PR DESCRIPTION
If no custom color was specified, a default color for the currently applied theme was hardcoded. If the theme was changed, the color would therefore not update. Instead of doing this, we now set the color to None.

Fixes the color issue in https://github.com/Nicotine-Plus/nicotine-plus/issues/186

Also cleaned up needless complexity and some unused code.