### PR TITLE
gir1.2-notify-0.7 dependency

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -26,6 +26,7 @@ Depends:
     miniupnpc (>= 1.9),
     gobject-introspection,
     gir1.2-gtk-3.0,
+    gir1.2-notify-0.7,
     python3 (>= 3.5),
     python3-dbus,
     python3-geoip (>= 1.3.2),

--- a/test/integration/nicotine.robot
+++ b/test/integration/nicotine.robot
@@ -11,5 +11,5 @@ Library           nicotine_library.py
 
 Run nicotine as shell command
     Running nicotine starts a process    nicotine    3
-    Result should be    0
+    Result should be    ${True}
 


### PR DESCRIPTION
This dependency was introduced somewhere but not added to debian/control. Fixing this.