### PR TITLE
Initialize a few windows/dialogs later

### DIFF
--- a/pynicotine/config.py
+++ b/pynicotine/config.py
@@ -335,6 +335,7 @@ class Config:
                 "height": 600,
                 "xposition": -1,
                 "yposition": -1,
+                "maximized": True,
                 "urgencyhint": True
             },
 

--- a/pynicotine/pynicotine.py
+++ b/pynicotine/pynicotine.py
@@ -638,8 +638,10 @@ class NetworkEventProcessor:
             self.frame.manualdisconnect = 1
             self.setStatus(_("Can not log in, reason: %s") % (msg.reason))
             self.logMessage(_("Can not log in, reason: %s") % (msg.reason))
-            self.frame.settingswindow.SetSettings(self.config.sections)
-            self.frame.settingswindow.SwitchToPage("Server")
+
+            if self.frame.settingswindow is not None:
+                self.frame.settingswindow.SetSettings(self.config.sections)
+                self.frame.settingswindow.SwitchToPage("Server")
 
     def ChangePassword(self, msg):
         password = msg.password


### PR DESCRIPTION
Part of https://github.com/Nicotine-Plus/nicotine-plus/issues/215. Cuts loading time of the main window in half for me. Improvements can possibly be made in the settings dialog later.

Also remember if the main window is maximized or not.