### PR TITLE
Use Python selectors module instead of select()

### DIFF
--- a/pynicotine/gtkgui/downloads.py
+++ b/pynicotine/gtkgui/downloads.py
@@ -90,7 +90,6 @@ class Downloads(TransferList):
         cols = frame.DownloadList.get_columns()
 
         try:
-            print(len(cols))
             for i in range(len(cols)):
 
                 parent = cols[i].get_widget().get_ancestor(gtk.Button)

--- a/pynicotine/multiselect.py
+++ b/pynicotine/multiselect.py
@@ -109,29 +109,3 @@ def multiselect(r_fds, w_fds, x_fds, timeout=None, limit=MAX_SELECT_SOCKETS):
 
     # return our data
     return ret
-
-
-if __name__ == '__main__':
-    import socket
-    import random
-    fds = []
-    files = {}
-    for i in range(100):
-        s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-        s.connect(('www.nxs.nl', 80))
-        s.send('GET /files/100mb.bin\r\n')
-        fds.append(s)
-        files[s] = open("data/100mb.%03i" % i, 'wb')
-    while fds:
-        r, w, x = multiselect(fds, [], [], None, 25)
-        if r:
-            print('data on fds:', ', '.join([str(fd.fileno()) for fd in r]))
-            for s in r:
-                data = s.recv(int(random.random() * 4096) + 1)
-                if not data:
-                    files[s].close()
-                    del files[s]
-                    fds.remove(s)
-                else:
-                    files[s].write(data)
-    print('done')


### PR DESCRIPTION
This way we automatically use the best syscall for the platform (epoll, poll etc.), thus bypassing the file descriptor limit of select().

Fixes https://github.com/Nicotine-Plus/nicotine-plus/issues/77 (this happened when there were many search results, and thus too many connections)