### PR TITLE
Don't remove non-existent away timer

### DIFF
--- a/pynicotine/gtkgui/downloads.py
+++ b/pynicotine/gtkgui/downloads.py
@@ -90,7 +90,6 @@ class Downloads(TransferList):
         cols = frame.DownloadList.get_columns()
 
         try:
-            print(len(cols))
             for i in range(len(cols)):
 
                 parent = cols[i].get_widget().get_ancestor(gtk.Button)


### PR DESCRIPTION
If the away timer expires, we shouldn't attempt to remove it, since it's already destroyed.
Fixes https://github.com/Nicotine-Plus/nicotine-plus/issues/103