### PR TITLE
Small chat improvements

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -75,6 +75,7 @@ Bugs closed in GitHub
  * Speed up program startup times (#215)
  * custom tray icons not respected (#239)
  * Request: Modes Tab Placement? (#242)
+ * text in log aera in chat rooms lag to display from entry (#253)
 
 Version 1.4.3 (unstable)
 -----------------------------

--- a/pynicotine/gtkgui/chatrooms.py
+++ b/pynicotine/gtkgui/chatrooms.py
@@ -45,6 +45,7 @@ from pynicotine.gtkgui.utils import IconNotebook
 from pynicotine.gtkgui.utils import InitialiseColumns
 from pynicotine.gtkgui.utils import PopupMenu
 from pynicotine.gtkgui.utils import PressHeader
+from pynicotine.gtkgui.utils import ScrollBottom
 from pynicotine.gtkgui.utils import WriteLog
 from pynicotine.gtkgui.utils import expand_alias
 from pynicotine.gtkgui.utils import fixpath
@@ -1204,7 +1205,7 @@ class ChatRoom:
         except IOError as e:  # noqa: F841
             pass
 
-        GLib.idle_add(self.frame.ScrollBottom, self.ChatScroll.get_parent())
+        GLib.idle_add(ScrollBottom, self.ChatScroll.get_parent())
 
     def on_key_press_event(self, widget, event):
 
@@ -1639,7 +1640,7 @@ class ChatRoom:
 
         elif cmd == "/attach":
             self.roomsctrl.ChatNotebook.attach_tab(self.Main)
-            GLib.idle_add(self.frame.ScrollBottom, self.ChatScroll.get_parent())
+            GLib.idle_add(ScrollBottom, self.ChatScroll.get_parent())
 
         elif cmd == "/rescan":
 
@@ -1688,7 +1689,7 @@ class ChatRoom:
 
     def Detach(self, widget=None):
         self.roomsctrl.ChatNotebook.detach_tab(self.Main, _("Nicotine+ Chatroom: %s") % self.room)
-        GLib.idle_add(self.frame.ScrollBottom, self.ChatScroll.get_parent())
+        GLib.idle_add(ScrollBottom, self.ChatScroll.get_parent())
 
     def Say(self, text):
         text = re.sub("\\s\\s+", "  ", text)

--- a/pynicotine/gtkgui/chatrooms.py
+++ b/pynicotine/gtkgui/chatrooms.py
@@ -937,7 +937,6 @@ class ChatRoom:
         self.Ticker = Ticker(self.TickerEventBox)
 
         self.room = room
-        self.lines = []
         self.leaving = 0
         self.meta = meta  # not a real room if set to True
         config = self.frame.np.config.sections
@@ -1159,8 +1158,8 @@ class ChatRoom:
 
         try:
             with open(log, 'r') as lines:
-                # Only show as many log lines as specified in config (one line is empty)
-                lines = deque(lines, numlines + 1)
+                # Only show as many log lines as specified in config
+                lines = deque(lines, numlines)
 
                 for bytes in lines:
                     li = bytes
@@ -1195,12 +1194,12 @@ class ChatRoom:
                     line = re.sub(r"\\s\\s+", "  ", line)
 
                     if user != config["server"]["login"]:
-                        self.lines.append(AppendLine(self.ChatScroll, self.frame.CensorChat(line), tag, username=user, usertag=usertag, timestamp_format=""))
+                        AppendLine(self.ChatScroll, self.frame.CensorChat(line), tag, username=user, usertag=usertag, timestamp_format="")
                     else:
-                        self.lines.append(AppendLine(self.ChatScroll, line, tag, username=user, usertag=usertag, timestamp_format=""))
+                        AppendLine(self.ChatScroll, line, tag, username=user, usertag=usertag, timestamp_format="")
 
                 if len(lines) > 0:
-                    self.lines.append(AppendLine(self.ChatScroll, _("--- old messages above ---"), self.tag_hilite))
+                    AppendLine(self.ChatScroll, _("--- old messages above ---"), self.tag_hilite)
 
         except IOError as e:  # noqa: F841
             pass
@@ -1429,13 +1428,6 @@ class ChatRoom:
 
             speech = text
 
-        if len(self.lines) >= 400:
-            buffer = self.ChatScroll.get_buffer()
-            start = buffer.get_start_iter()
-            end = buffer.get_iter_at_line(1)
-            self.ChatScroll.get_buffer().delete(start, end)
-            del self.lines[0]
-
         line = "\n-- ".join(line.split("\n"))
         if self.Log.get_active():
             WriteLog(self.frame.np.config.sections["logging"]["roomlogsdir"], self.room, line)
@@ -1446,11 +1438,9 @@ class ChatRoom:
 
         if user != login:
 
-            self.lines.append(
-                AppendLine(
-                    self.ChatScroll, self.frame.CensorChat(line), tag,
-                    username=user, usertag=self.tag_users[user], timestamp_format=timestamp_format
-                )
+            AppendLine(
+                self.ChatScroll, self.frame.CensorChat(line), tag,
+                username=user, usertag=self.tag_users[user], timestamp_format=timestamp_format
             )
 
             if self.Speech.get_active():
@@ -1463,11 +1453,9 @@ class ChatRoom:
                     }
                 )
         else:
-            self.lines.append(
-                AppendLine(
-                    self.ChatScroll, line, tag,
-                    username=user, usertag=self.tag_users[user], timestamp_format=timestamp_format
-                )
+            AppendLine(
+                self.ChatScroll, line, tag,
+                username=user, usertag=self.tag_users[user], timestamp_format=timestamp_format
             )
 
     def getUserTag(self, user):
@@ -1623,7 +1611,6 @@ class ChatRoom:
 
         elif cmd in ["/clear", "/cl"]:
             self.ChatScroll.get_buffer().set_text("")
-            self.lines = []
 
         elif cmd in ["/a", "/away"]:
             self.frame.OnAway(None)
@@ -2292,7 +2279,6 @@ class ChatRoom:
 
     def OnClearChatLog(self, widget):
         self.ChatScroll.get_buffer().set_text("")
-        self.lines = []
 
     def OnClearRoomLog(self, widget):
         self.RoomLog.get_buffer().set_text("")

--- a/pynicotine/gtkgui/frame.py
+++ b/pynicotine/gtkgui/frame.py
@@ -1566,15 +1566,6 @@ class NicotineFrame:
                     print(e)
         return False
 
-    def ScrollBottom(self, widget):
-        va = widget.get_vadjustment()
-        try:
-            va.set_value(va.upper - va.page_size)
-        except AttributeError:
-            pass
-        widget.set_vadjustment(va)
-        return False
-
     def SetStatusText(self, msg):
         self.Statusbar.pop(self.status_context_id)
         self.Statusbar.push(self.status_context_id, msg)

--- a/pynicotine/gtkgui/privatechat.py
+++ b/pynicotine/gtkgui/privatechat.py
@@ -37,6 +37,7 @@ from pynicotine.gtkgui.chatrooms import GetCompletion
 from pynicotine.gtkgui.utils import AppendLine
 from pynicotine.gtkgui.utils import IconNotebook
 from pynicotine.gtkgui.utils import PopupMenu
+from pynicotine.gtkgui.utils import ScrollBottom
 from pynicotine.gtkgui.utils import WriteLog
 from pynicotine.gtkgui.utils import expand_alias
 from pynicotine.gtkgui.utils import fixpath
@@ -446,7 +447,7 @@ class PrivateChat:
         except IOError as e:  # noqa: F841
             pass
 
-        GLib.idle_add(self.frame.ScrollBottom, self.ChatScroll.get_parent())
+        GLib.idle_add(ScrollBottom, self.ChatScroll.get_parent())
 
     def Login(self):
         timestamp_format = self.frame.np.config.sections["logging"]["private_timestamp"]
@@ -788,7 +789,7 @@ class PrivateChat:
 
     def Attach(self, widget=None):
         self.chats.attach_tab(self.Main)
-        GLib.idle_add(self.frame.ScrollBottom, self.ChatScroll.get_parent())
+        GLib.idle_add(ScrollBottom, self.ChatScroll.get_parent())
 
     def Detach(self, widget=None):
         self.chats.detach_tab(
@@ -798,7 +799,7 @@ class PrivateChat:
                 'status': [_("Offline"), _("Away"), _("Online")][self.status]
             }
         )
-        GLib.idle_add(self.frame.ScrollBottom, self.ChatScroll.get_parent())
+        GLib.idle_add(ScrollBottom, self.ChatScroll.get_parent())
 
     def NowPlayingThread(self):
         np = self.frame.now.DisplayNowPlaying(None, 0, self.SendMessage)  # noqa: F841

--- a/pynicotine/gtkgui/privatechat.py
+++ b/pynicotine/gtkgui/privatechat.py
@@ -20,6 +20,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 import os
+from collections import deque
 from gettext import gettext as _
 from time import altzone
 from time import daylight
@@ -431,17 +432,17 @@ class PrivateChat:
         log = os.path.join(config["logging"]["privatelogsdir"], fixpath(self.user.replace(os.sep, "-")) + ".log")
 
         try:
-            lines = int(config["logging"]["readprivatelines"])
+            numlines = int(config["logging"]["readprivatelines"])
         except Exception:
-            lines = 15
+            numlines = 15
 
         try:
-            f = open(log, "r")
-            d = f.read()
-            f.close()
-            s = d.split("\n")
-            for line in s[- lines:-1]:
-                AppendLine(self.ChatScroll, line + "\n", self.tag_hilite, timestamp_format="", username=self.user, usertag=self.tag_hilite)
+            with open(log, 'r') as lines:
+                # Only show as many log lines as specified in config (one line is empty)
+                lines = deque(lines, numlines + 1)
+
+                for line in lines:
+                    AppendLine(self.ChatScroll, line, self.tag_hilite, timestamp_format="", username=self.user, usertag=self.tag_hilite)
         except IOError as e:  # noqa: F841
             pass
 

--- a/pynicotine/gtkgui/privatechat.py
+++ b/pynicotine/gtkgui/privatechat.py
@@ -439,8 +439,8 @@ class PrivateChat:
 
         try:
             with open(log, 'r') as lines:
-                # Only show as many log lines as specified in config (one line is empty)
-                lines = deque(lines, numlines + 1)
+                # Only show as many log lines as specified in config
+                lines = deque(lines, numlines)
 
                 for line in lines:
                     AppendLine(self.ChatScroll, line, self.tag_hilite, timestamp_format="", username=self.user, usertag=self.tag_hilite)

--- a/pynicotine/gtkgui/utils.py
+++ b/pynicotine/gtkgui/utils.py
@@ -272,6 +272,7 @@ def ScrollBottom(widget):
         va.set_value(va.get_upper() - va.get_page_size())
     except AttributeError:
         pass
+    widget.set_vadjustment(va)
     return False
 
 


### PR DESCRIPTION
- Read log files line by line instead of loading the whole file into memory
- Unify ScrollBottom functions into one
- Drop textbuffer history clearing code, since 1. it caused issues, and 2. there isn't really a point in limiting visible chat rows to 400. Fixes https://github.com/Nicotine-Plus/nicotine-plus/issues/253