### PR TITLE
Don't store Windows file downloads in hidden folder

### DIFF
--- a/pynicotine/config.py
+++ b/pynicotine/config.py
@@ -377,9 +377,6 @@ class Config:
         # Windows specific stuff
         if sys.platform.startswith('win'):
             self.sections['ui']['filemanager'] = 'explorer $'
-            self.sections['transfers']['incompletedir'] = os.path.join(os.environ['APPDATA'], 'nicotine', 'incompletefiles')
-            self.sections['transfers']['downloaddir'] = os.path.join(os.environ['APPDATA'], 'nicotine', 'uploads')
-            self.sections['transfers']['uploaddir'] = os.path.join(os.environ['APPDATA'], 'nicotine', 'uploads')
 
         self.defaults = {}
         for key, value in list(self.sections.items()):


### PR DESCRIPTION
I think one way https://github.com/Nicotine-Plus/nicotine-plus/issues/66 could be reproduced is when using the default download folder on Windows, which is stored in the hidden Nicotine appdata folder. Nicotine+ doesn't share hidden folders by design.

Just use the default location already used outside Windows, which is a "nicotine-downloads" folder in the home directory.

On Linux, this issue shouldn't be possible if you're using the defaults.

Closes https://github.com/Nicotine-Plus/nicotine-plus/issues/66