### PR TITLE
Fix setting process title without procname

### DIFF
--- a/nicotine
+++ b/nicotine
@@ -120,7 +120,7 @@ def renameprocess(newname, debug=False):
         import ctypes
         # GNU/Linux style
         libc = ctypes.CDLL('libc.so.6')
-        libc.prctl(15, newname, 0, 0, 0)
+        libc.prctl(15, ctypes.c_char_p(newname.encode('ascii')), 0, 0, 0)
     except Exception:
         errors.append("Failed GNU/Linux style")
 


### PR DESCRIPTION
I'm not sure how the c interface works but it was setting the process title to "n" for me. When passing it as a list of bytes like this it is correctly set to "nicotine".

Also not sure why I've ran into this on two machines (finally updated the one on my seedbox) and no-one else has reported it.

Locales shouldn't be an issue as it doesn't look like the string passed is being localized.