### PR TITLE
Show correct number of results with filters enabled

### DIFF
--- a/pynicotine/gtkgui/search.py
+++ b/pynicotine/gtkgui/search.py
@@ -885,7 +885,7 @@ class Search:
 
             self.all_data.append(row)
 
-            if (counter <= self.frame.np.config.sections['searches']["max_displayed_results"]) and (not self.filters or self.check_filter(row)):
+            if (len(self.resultsmodel) < self.frame.np.config.sections['searches']["max_displayed_results"]) and (not self.filters or self.check_filter(row)):
                 self._add_to_model(user, row)
 
     def _add_to_model(self, user, row):
@@ -918,7 +918,7 @@ class Search:
 
         for r in self.all_data:
             if user == r[1]:
-                self.all_data[pos][16] = status
+                self.all_data[pos][17] = status
             pos += 1
 
         iter = self.resultsmodel.get_iter_first()


### PR DESCRIPTION
If you had a preset filter, and searched for something, only results from the first 500 stored ones would show up. Thus, you ended up with significantly less results displayed than the 500 limit. Before adding results, we now check the length of the actual results model, instead of the result's count, allowing us to add data from the full 1500 stored results.

Also store the status at the correct index in the row.