### PR TITLE
Properly share downloaded files

### DIFF
--- a/pynicotine/gtkgui/frame.py
+++ b/pynicotine/gtkgui/frame.py
@@ -248,8 +248,6 @@ class NicotineFrame:
                 Notify.init("Nicotine+")
                 self.notify = Notify
                 self.notifyBox = None
-                from xml.dom.minidom import getDOMImplementation
-                self.xmldocument = getDOMImplementation().createDocument(None, None, None)
             except (ImportError, ValueError):
                 self.notify = None
 
@@ -794,12 +792,11 @@ class NicotineFrame:
         if self.notify is None:
             return
 
-        xmlmessage = self.xmldocument.createTextNode(message).toxml()
         if self.notifyBox is None:
-            self.notifyBox = self.notify.Notification.new(title, xmlmessage)
+            self.notifyBox = self.notify.Notification.new(title, message)
             self.notifyBox.set_image_from_pixbuf(self.images["notify"])
         else:
-            self.notifyBox.update(title, xmlmessage)
+            self.notifyBox.update(title, message)
 
         try:
             self.notifyBox.show()

--- a/pynicotine/shares.py
+++ b/pynicotine/shares.py
@@ -1057,21 +1057,25 @@ class Shares:
         sharedstreams = config["transfers"]["sharedfilesstreams"]
         wordindex = config["transfers"]["wordindex"]
         fileindex = config["transfers"]["fileindex"]
+
         shareddirs = [path for _name, path in config["transfers"]["shared"]]
         shareddirs.append(config["transfers"]["downloaddir"])
 
+        sharedmtimes = config["transfers"]["sharedmtimes"]
+
         dir = str(os.path.expanduser(os.path.dirname(name)))
+        vdir = self.real2virtual(dir)
         file = str(os.path.basename(name))
-        size = os.path.getsize(name)  # noqa: F841
 
-        shared[dir] = shared.get(dir, [])
+        shared[vdir] = shared.get(vdir, [])
 
-        if file not in [i[0] for i in shared[dir]]:
+        if file not in [i[0] for i in shared[vdir]]:
             fileinfo = self.getFileInfo(file, name)
-            shared[dir] = shared[dir] + [fileinfo]
-            sharedstreams[dir] = self.getDirStream(shared[dir])
-            words = self.getIndexWords(dir, file, shareddirs)
-            self.addToIndex(wordindex, fileindex, words, dir, fileinfo)
+            shared[vdir] = shared[vdir] + [fileinfo]
+            sharedstreams[vdir] = self.getDirStream(shared[vdir])
+            words = self.getIndexWords(vdir, file, shareddirs)
+            self.addToIndex(wordindex, fileindex, words, vdir, fileinfo)
+            sharedmtimes[vdir] = os.path.getmtime(dir)
             self.newnormalshares = True
 
         if config["transfers"]["enablebuddyshares"]:
@@ -1090,22 +1094,26 @@ class Shares:
         bsharedstreams = config["transfers"]["bsharedfilesstreams"]
         bwordindex = config["transfers"]["bwordindex"]
         bfileindex = config["transfers"]["bfileindex"]
-        bshareddirs = config["transfers"]["buddyshared"] + config["transfers"]["shared"] + [config["transfers"]["downloaddir"]]
+
+        bshareddirs = [path for _name, path in config["transfers"]["shared"]]
+        bshareddirs += [path for _name, path in config["transfers"]["buddyshared"]]
+        bshareddirs.append(config["transfers"]["downloaddir"])
+
         bsharedmtimes = config["transfers"]["bsharedmtimes"]
 
         dir = str(os.path.expanduser(os.path.dirname(name)))
+        vdir = self.real2virtual(dir)
         file = str(os.path.basename(name))
-        size = os.path.getsize(name)  # noqa: F841
 
-        bshared[dir] = bshared.get(dir, [])
+        bshared[vdir] = bshared.get(vdir, [])
 
-        if file not in [i[0] for i in bshared[dir]]:
+        if file not in [i[0] for i in bshared[vdir]]:
             fileinfo = self.getFileInfo(file, name)
-            bshared[dir] = bshared[dir] + [fileinfo]
-            bsharedstreams[dir] = self.getDirStream(bshared[dir])
-            words = self.getIndexWords(dir, file, bshareddirs)
-            self.addToIndex(bwordindex, bfileindex, words, dir, fileinfo)
-            bsharedmtimes[dir] = os.path.getmtime(dir)
+            bshared[vdir] = bshared[vdir] + [fileinfo]
+            bsharedstreams[vdir] = self.getDirStream(bshared[vdir])
+            words = self.getIndexWords(vdir, file, bshareddirs)
+            self.addToIndex(bwordindex, bfileindex, words, vdir, fileinfo)
+            bsharedmtimes[vdir] = os.path.getmtime(dir)
             self.newbuddyshares = True
 
     def addToIndex(self, wordindex, fileindex, words, dir, fileinfo):

--- a/pynicotine/transfers.py
+++ b/pynicotine/transfers.py
@@ -1253,17 +1253,17 @@ class Transfers:
                             self.addToShared(newname)
                         self.eventprocessor.shares.sendNumSharedFoldersFiles()
 
+                        if config["transfers"]["shownotification"]:
+                            self.eventprocessor.frame.NewNotification(
+                                _("%(file)s downloaded from %(user)s") % {
+                                    'user': i.user,
+                                    'file': newname.rsplit(os.sep, 1)[1]
+                                },
+                                title=_("Nicotine+ :: file downloaded")
+                            )
+
                     self.SaveDownloads()
                     self.downloadspanel.update(i)
-
-                    if config["transfers"]["shownotification"]:
-                        self.eventprocessor.frame.NewNotification(
-                            _("%(file)s downloaded from %(user)s") % {
-                                'user': i.user,
-                                'file': newname.rsplit(os.sep, 1)[1]
-                            },
-                            title=_("Nicotine+ :: file downloaded")
-                        )
 
                     if newname and config["transfers"]["afterfinish"]:
                         if not executeCommand(config["transfers"]["afterfinish"], newname):


### PR DESCRIPTION
- If we're sharing our downloads folder, make sure we use the virtual directory name instead of the real one when adding new files, otherwise people can't download our files.
- If buddy shares were enabled, the downloads share wouldn't update properly due to code errors.
- Don't attempt to show the notification if the file didn't download properly