### PR TITLE
Make recursive downloads functional in empty folders

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -84,6 +84,7 @@ Bugs closed in GitHub
  * unable to download to created folder (#301)
  * status never reach 100% becasue of filtered files (#302)
  * twice downloaded same folder, aborted duplicate files, remove aborted does not remove (#305)
+ * downloading folder from user browse doesn't work (#311)
 
 Version 1.4.3 (unstable)
 -----------------------------

--- a/pynicotine/gtkgui/userbrowse.py
+++ b/pynicotine/gtkgui/userbrowse.py
@@ -667,6 +667,7 @@ class UserBrowse:
             self.DownloadDirectory(self.selected_folder)
 
     def OnDownloadDirectoryRecursive(self, widget):
+
         self.DownloadDirectory(self.selected_folder, "", 1)
 
     def OnDownloadDirectoryTo(self, widget):
@@ -698,13 +699,13 @@ class UserBrowse:
         if dir is None:
             return
 
+        ldir = prefix + dir.split("\\")[-1]
+
         for d, f in self.shares:
 
             # Find the wanted directory
             if d != dir:
                 continue
-
-            ldir = prefix + dir.split("\\")[-1]
 
             priorityfiles = []
             normalfiles = []
@@ -749,12 +750,12 @@ class UserBrowse:
 
                 self.frame.np.transfers.getFile(self.user, path, ldir, size=size, bitrate=bitrate, length=length)
 
-            if not recurse:
-                break
+        if not recurse:
+            return
 
-            for subdir, subf in self.shares:
-                if dir in subdir and dir != subdir:
-                    self.DownloadDirectory(subdir, os.path.join(ldir, ""), recurse)
+        for subdir, subf in self.shares:
+            if dir in subdir and dir != subdir:
+                self.DownloadDirectory(subdir, os.path.join(ldir, ""), recurse)
 
     def OnDownloadFiles(self, widget, prefix=""):
 

--- a/pynicotine/gtkgui/userbrowse.py
+++ b/pynicotine/gtkgui/userbrowse.py
@@ -755,7 +755,7 @@ class UserBrowse:
 
         for subdir, subf in self.shares:
             if dir in subdir and dir != subdir:
-                self.DownloadDirectory(subdir, os.path.join(ldir, ""), recurse)
+                self.DownloadDirectory(subdir, os.path.join(ldir, ""))
 
     def OnDownloadFiles(self, widget, prefix=""):
 


### PR DESCRIPTION
An empty folder is not necessarily going to be listed in the shares list, which results in the recurse code never being reached due to the d != dir check. Move the code outside the main loop instead.

Fixes https://github.com/Nicotine-Plus/nicotine-plus/issues/311