### PR TITLE
Remove unnecessary loop when deleting downloads

### DIFF
--- a/pynicotine/gtkgui/transferlist.py
+++ b/pynicotine/gtkgui/transferlist.py
@@ -590,9 +590,7 @@ class TransferList:
             i.req = None
 
             if clear:
-                for t in self.list[:]:
-                    if i.user == t.user and i.filename == t.filename:
-                        self.list.remove(t)
+                self.list.remove(i)
 
         self.update()
 


### PR DESCRIPTION
A selected transfer shouldn't be absent from the transfer list.