### PR TITLE
Only check for duplicate downloads when appropriate

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -85,6 +85,7 @@ Bugs closed in GitHub
  * status never reach 100% becasue of filtered files (#302)
  * twice downloaded same folder, aborted duplicate files, remove aborted does not remove (#305)
  * downloading folder from user browse doesn't work (#311)
+ * cannot connect (#312)
 
 Version 1.4.3 (unstable)
 -----------------------------

--- a/pynicotine/gtkgui/entrydialog.py
+++ b/pynicotine/gtkgui/entrydialog.py
@@ -268,7 +268,7 @@ class MetaDialog(gtk.Dialog):
 
     def OnDownloadItem(self, widget):
         meta = self.data[self.current]
-        self.nicotine.np.transfers.getFile(meta["user"], meta["fn"], "")
+        self.nicotine.np.transfers.getFile(meta["user"], meta["fn"], "", checkduplicate=True)
 
     def OnBrowseUser(self, widget):
         meta = self.data[self.current]
@@ -276,7 +276,7 @@ class MetaDialog(gtk.Dialog):
 
     def OnDownloadAll(self, widget):
         for item, meta in list(self.data.items()):
-            self.nicotine.np.transfers.getFile(meta["user"], meta["fn"], "")
+            self.nicotine.np.transfers.getFile(meta["user"], meta["fn"], "", checkduplicate=True)
 
     def OnPrevious(self, widget):
 

--- a/pynicotine/gtkgui/search.py
+++ b/pynicotine/gtkgui/search.py
@@ -1414,7 +1414,7 @@ class Search:
             return
 
         for file in self.selected_results:
-            self.frame.np.transfers.getFile(file[0], file[1], prefix, size=file[2], bitrate=file[3], length=file[4])
+            self.frame.np.transfers.getFile(file[0], file[1], prefix, size=file[2], bitrate=file[3], length=file[4], checkduplicate=True)
 
     def OnDownloadFilesTo(self, widget):
 

--- a/pynicotine/gtkgui/userbrowse.py
+++ b/pynicotine/gtkgui/userbrowse.py
@@ -748,7 +748,7 @@ class UserBrowse:
 
                     length = "%i:%02i" % (int(rl // 60), rl % 60)
 
-                self.frame.np.transfers.getFile(self.user, path, ldir, size=size, bitrate=bitrate, length=length)
+                self.frame.np.transfers.getFile(self.user, path, ldir, size=size, bitrate=bitrate, length=length, checkduplicate=True)
 
         if not recurse:
             return
@@ -792,7 +792,7 @@ class UserBrowse:
                     length = "%i:%02i" % (int(rl // 60), rl % 60)
 
                 # Get the file
-                self.frame.np.transfers.getFile(self.user, path, prefix, size=size, bitrate=bitrate, length=length)
+                self.frame.np.transfers.getFile(self.user, path, prefix, size=size, bitrate=bitrate, length=length, checkduplicate=True)
 
             # We have found the wanted directory: we can break out of the loop
             break

--- a/pynicotine/transfers.py
+++ b/pynicotine/transfers.py
@@ -232,13 +232,14 @@ class Transfers:
         if msg.status == 0:
             self.checkUploadQueue()
 
-    def getFile(self, user, filename, path="", transfer=None, size=None, bitrate=None, length=None):
+    def getFile(self, user, filename, path="", transfer=None, size=None, bitrate=None, length=None, checkduplicate=False):
         path = utils.CleanPath(path, absolute=True)
 
-        for i in self.downloads:
-            if i.user == user and i.filename == filename and i.path == path:
-                # Don't add duplicate downloads
-                return
+        if checkduplicate:
+            for i in self.downloads:
+                if i.user == user and i.filename == filename and i.path == path:
+                    # Don't add duplicate downloads
+                    return
 
         self.transferFile(0, user, filename, path, transfer, size, bitrate, length)
 
@@ -1862,7 +1863,8 @@ class Transfers:
                                 self.FolderDestination(username, directory),
                                 size=file[2],
                                 bitrate=bitrate,
-                                length=length
+                                length=length,
+                                checkduplicate=True
                             )
                         else:
                             self.getFile(
@@ -1871,7 +1873,8 @@ class Transfers:
                                 self.FolderDestination(username, directory),
                                 size=file[2],
                                 bitrate=bitrate,
-                                length=length
+                                length=length,
+                                checkduplicate=True
                             )
 
     def FolderDestination(self, user, directory):


### PR DESCRIPTION
The getFile function is also called when retrying a file download, both automatically and manually. We should not check for duplicate downloads in this case.

Closes https://github.com/Nicotine-Plus/nicotine-plus/issues/312