### PR TITLE
Improvements to distributed searches

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -86,6 +86,7 @@ Bugs closed in GitHub
  * twice downloaded same folder, aborted duplicate files, remove aborted does not remove (#305)
  * downloading folder from user browse doesn't work (#311)
  * cannot connect (#312)
+ * Distrib message type 93 unknown (#322)
 
 Version 1.4.3 (unstable)
 -----------------------------

--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@ Please come and join us in the `#nicotine+` channel on Freenode!
 
 If you'd like to contribute, you have a couple of options to get started. You can [open an issue ticket](https://github.com/Nicotine-Plus/nicotine-plus/issues) on GitHub, discuss in `#nicotine+`, or post to the project [mailing list](mailto:nicotine-team@lists.launchpad.net). Developers are also encouraged to join the [Launchpad Team](https://launchpad.net/~nicotine-team) or subscribe to the mailing list so that they are automatically notified of failed commits.
 
+For (unofficial) documentation of the Soulseek protocol, see [SLSKPROTOCOL.md](doc/SLSKPROTOCOL.md)
+
 There is a current list of things [TODO.md](doc/TODO.md).
 
 If you'd like to translate Nicotine+ into another language it has not been already, see [TRANSLATIONS.md](doc/TRANSLATIONS.md).

--- a/doc/SLSKPROTOCOL.md
+++ b/doc/SLSKPROTOCOL.md
@@ -1,4 +1,8 @@
-# The Soulseek Protocol
+# Soulseek Protocol Documentation
+
+Last updated on 27 June 2020
+
+## Sections
 
 - [Packing](#packing)
 - [Server Messages](#server-messages)
@@ -92,14 +96,18 @@ and callbacks for the messages are set in pynicotine.py.
 | 54   | [Get Recommendations](#server-code-54)            |
 | 56   | [Get Global Recommendations](#server-code-56)     |
 | 57   | [Get User Interests](#server-code-57)             |
+| 60   | [Place In Line Response](#server-code-60)         |
+| 62   | [Room Added](#server-code-62)                     |
+| 63   | [Room Removed](#server-code-63)                   |
 | 64   | [Room List](#server-code-64)                      |
 | 65   | [Exact File Search](#server-code-65)              |
 | 66   | [Global/Admin Message](#server-code-66)           |
+| 67   | [Global User List](#server-code-67)               |
 | 69   | [Privileged Users](#server-code-69)               |
 | 71   | [Have No Parents](#server-code-71)                |
 | 73   | [Parent's IP](#server-code-73)                    |
-| 83   | [ParentMinSpeed](#server-code-83)                 |
-| 84   | [ParentSpeedRatio](#server-code-84)               |
+| 83   | [Parent Min Speed](#server-code-83)               |
+| 84   | [Parent Speed Ratio](#server-code-84)             |
 | 86   | [Parent Inactivity Timeout](#server-code-86)      |
 | 87   | [Search Inactivity Timeout](#server-code-87)      |
 | 88   | [Minimum Parents In Cache](#server-code-88)       |
@@ -138,7 +146,7 @@ and callbacks for the messages are set in pynicotine.py.
 | 139  | [Private Room Added](#server-code-139)            |
 | 140  | [Private Room Removed](#server-code-140)          |
 | 141  | [Private Room Toggle](#server-code-141)           |
-| 142  | [New Password](#server-code-142)     |
+| 142  | [New Password](#server-code-142)                  |
 | 143  | [Private Room Add Operator](#server-code-143)     |
 | 144  | [Private Room Remove Operator](#server-code-144)  |
 | 145  | [Private Room Operator Added](#server-code-145)   |
@@ -147,7 +155,8 @@ and callbacks for the messages are set in pynicotine.py.
 | 149  | [Message Users](#server-code-149)                 |
 | 150  | [Ask Public Chat](#server-code-150)               |
 | 151  | [Stop Public Chat](#server-code-151)              |
-| 152  | [Public Chat](#server-code-152)                   |
+| 152  | [Public Chat Message](#server-code-152)           |
+| 153  | [Related Searches](#server-code-153)              |
 | 1001 | [Cannot Connect](#server-code-1001)               |
 
 ### Server Code 1
@@ -157,7 +166,7 @@ and callbacks for the messages are set in pynicotine.py.
 #### Function Names
 
 Museekd: SLogin  
-Nicotine: **Login**
+Nicotine: Login
 
 #### Description
 
@@ -188,8 +197,8 @@ Send your username, password, and client version.
     1.  **string** <ins>username</ins>
     2.  **string** <ins>password</ins> **A non-empty
         string is required**
-    3.  **uint32** <ins>version number</ins> *182*
-        for Museek+ *181* for Nicotine+
+    3.  **uint32** <ins>version number</ins> *183*
+        for Museek+ *157* for Nicotine+
     4.  **string** <ins>MD5 hex digest of
         concatenated username & password</ins>
     5.  **uint32** <ins>minor version</ins> Minor
@@ -224,7 +233,7 @@ Nicotine: SetWaitPort
 
 #### Description
 
-The port you listen for connections on (2234 by default)
+We send this to the server to indicate the port number that we listen on (2234 by default).
 
 #### Data Order
 
@@ -244,7 +253,7 @@ Nicotine: GetPeerAddress
 
 #### Description
 
-A server for a user's IP Address and port
+We send this to the server to ask for a peer's address (IP address and port), given the peer's username.
 
 #### Data Order
 
@@ -266,7 +275,7 @@ Nicotine: AddUser
 
 #### Description
 
-Watch this user's status
+Used to be kept updated about a user's status.
 
 #### Data Order
 
@@ -294,12 +303,12 @@ Watch this user's status
 
 #### Function Names
 
-Museekd: Not implemented  
-Nicotine: **Not implemented**
+Museekd: Unimplemented  
+Nicotine: Unimplemented
 
 #### Description
 
-Something to do with user status. Usually sent just after SAddUser
+Something to do with user status. Usually sent right after SAddUser.
 
 #### Data Order
 
@@ -318,6 +327,8 @@ Museekd: SGetStatus
 Nicotine: GetUserStatus
 
 #### Description
+
+The server tells us if a user has gone away or has returned.
 
 #### Data Order
 
@@ -340,6 +351,8 @@ Nicotine: SayChatroom
 
 #### Description
 
+Either we want to say something in the chatroom, or someone else did.
+
 #### Data Order
 
   - Send
@@ -360,6 +373,8 @@ Museekd: SJoinRoom
 Nicotine: JoinRoom
 
 #### Description
+
+Server sends us this message when we join a room. Contains users list with data on everyone.
 
 #### Data Order
 
@@ -412,11 +427,13 @@ Nicotine: LeaveRoom
 
 #### Description
 
+We send this to the server when we want to leave a room.
+
 #### Data Order
 
-  - Send (leave room)
+  - Send
     1.  **string** <ins>room</ins>
-  - Receive (left room)
+  - Receive
     1.  **string** <ins>room</ins>
 
 ### Server Code 16
@@ -429,6 +446,8 @@ Museekd: SUserJoinedRoom
 Nicotine: UserJoinedRoom
 
 #### Description
+
+The server tells us someone has just joined a room we're in.
 
 #### Data Order
 
@@ -457,7 +476,7 @@ Nicotine: UserLeftRoom
 
 #### Description
 
-A user (not you) left a room you are in.
+The server tells us someone has just left a room we're in.
 
 #### Data Order
 
@@ -478,8 +497,9 @@ Nicotine: ConnectToPeer
 
 #### Description
 
-A message you send to the server to notify a client that you want to
-connect to it, after direct connection has failed. See also: [Peer
+Either we ask server to tell someone else we want to establish a connection with them, or server tells us someone wants to connect with us. Used when the side that wants a connection can't establish it, and tries to go the other way around (direct connection has failed).
+
+See also: [Peer
 Connection Message
 Order](#peer-connection-message-order)
 
@@ -511,6 +531,8 @@ Nicotine: MessageUser
 
 #### Description
 
+Chat phrase sent to someone or received by us in private.
+
 #### Data Order
 
   - Send
@@ -522,7 +544,7 @@ Nicotine: MessageUser
     3.  **string** <ins>username</ins>
     4.  **string** <ins>message</ins>
     5.  **bool** <ins>isAdmin</ins> **1 if sent by
-        server, elsenot present**
+        server, else not present**
 
 ### Server Code 23
 
@@ -535,9 +557,9 @@ Nicotine: MessageAcked
 
 #### Description
 
-Acknowledge that you received a Private message. If we do not send it,
-the server will keep sending the chat phrase to us. (Museekd also Reset
-timestamps to account for server-time bugginess)
+We send this to the server to confirm that we received a private message. If we don't send it, the server will keep sending the chat phrase to us.
+
+Museekd also resets timestamps to account for server-time bugginess.
 
 #### Data Order
 
@@ -548,13 +570,18 @@ timestamps to account for server-time bugginess)
 
 ### Server Code 26
 
-**File Search** Museekd: SFileSearch  
+**File Search**
+
+#### Function Names
+
+Museekd: SFileSearch  
 Nicotine: FileSearch
 
 #### Description
 
-The ticket is a random number generated by the client and used to track
-the search results.
+We send this to the server when we search for something. Alternatively, the server sends this message to tell us that someone is searching for something.
+
+The ticket/search id is a random number generated by the client and is used to track the search results.
 
 #### Data Order
 
@@ -577,8 +604,12 @@ Nicotine: SetStatus
 
 #### Description
 
-Status is a way to define whether you're available or busy. *1 = Away
-and 2 = Online*
+We send our new status to the server. Status is a way to define whether you're available or busy. 
+
+*-1 = Unknown  
+0 = Offline  
+1 = Away  
+2 = Online*
 
 #### Data Order
 
@@ -598,7 +629,7 @@ Nicotine: ServerPing
 
 #### Description
 
-Test if server responds
+We test if the server responds.
 
 #### Data Order
 
@@ -620,6 +651,8 @@ Nicotine: SendSpeed
 
 **DEPRECIATED**
 
+We used to send this after a finished download to let the server update the speed statistics for a user.
+
 #### Data Order
 
   - Send *average transfer speed*
@@ -639,6 +672,8 @@ Nicotine: SharedFoldersFiles
 
 #### Description
 
+We send this to server to indicate the number of folder and files that we share.
+
 #### Data Order
 
   - Send
@@ -649,9 +684,18 @@ Nicotine: SharedFoldersFiles
 
 ### Server Code 36
 
-**Get User Stats** Museekd: SGetUserStats  
-Nicotine: GetUserStats **This is
-deprecated, see SAddUser.**
+**Get User Stats**
+
+#### Function Names
+
+Museekd: SGetUserStats  
+Nicotine: GetUserStats
+
+#### Description
+
+**This is deprecated (?), see SAddUser.**
+
+The server sends this to indicate a change in a user's statistics.
 
 #### Data Order
 
@@ -670,12 +714,14 @@ deprecated, see SAddUser.**
 
 #### Function Names
 
-Museekd: **Not implemented**  
+Museekd: Unimplemented  
 Nicotine: QueuedDownloads
 
 #### Description
 
 **DEPRECIATED**
+
+The server sends this to indicate if someone has download slots available or not.
 
 #### Data Order
 
@@ -693,20 +739,16 @@ Nicotine: QueuedDownloads
 #### Function Names
 
 Museekd: SKicked  
-Nicotine: \!Relogged
+Nicotine: Relogged
 
 #### Description
 
-You were disconnected (probably by another user with your name
-connecting to the Server) so don't try to reconnect automatically.
+The server sends this if someone else logged in under our nickname, and then disconnects us.
 
 #### Data Order
 
   - Send
-      - Empty Message
-
-<!-- end list -->
-
+      - *No Message*
   - Receive
       - Empty Message
 
@@ -721,7 +763,7 @@ Nicotine: UserSearch
 
 #### Description
 
-Search a specific user's shares
+We send this to the server when we search a specific user's shares. The ticket/search id is a random number generated by the client and is used to track the search results.
 
 #### Data Order
 
@@ -739,9 +781,11 @@ Search a specific user's shares
 #### Function Names
 
 Museekd: SInterestAdd  
-Nicotine: **AddThingILike**
+Nicotine: AddThingILike
 
 #### Description
+
+We send this to the server when we add an item to our likes list.
 
 #### Data Order
 
@@ -757,9 +801,11 @@ Nicotine: **AddThingILike**
 #### Function Names
 
 Museekd: SInterestRemove  
-Nicotine: **RemoveThingILike**
+Nicotine: RemoveThingILike
 
 #### Description
+
+We send this to the server when we remove an item from our likes list.
 
 #### Data Order
 
@@ -775,11 +821,11 @@ Nicotine: **RemoveThingILike**
 #### Function Names
 
 Museekd: SGetRecommendations  
-Nicotine: **Recommendations**
+Nicotine: Recommendations
 
 #### Description
 
-List of recommendations and a number for each
+The server sends us a list of personal recommendations and a number for each.
 
 #### Data Order
 
@@ -812,7 +858,7 @@ Nicotine: GlobalRecommendations
 
 #### Description
 
-List of recommendations and a number for each
+The server sends us a list of global recommendations and a number for each.
 
 #### Data Order
 
@@ -840,12 +886,12 @@ List of recommendations and a number for each
 
 #### Function Names
 
-Museekd:  
+Museekd: SUserInterests  
 Nicotine: UserInterests
 
 #### Description
 
-Get a User's Liked and Hated Interests
+We ask the server for a user's liked and hated interests. The server responds with a list of interests.
 
 #### Data Order
 
@@ -862,6 +908,76 @@ Get a User's Liked and Hated Interests
         interests</ins>
         1.  **string** <ins>interest</ins>
 
+### Server Code 60
+
+**Place In Line Response**
+
+#### Description
+
+**DEPRECIATED**
+
+The server tells us a new room has been added.
+
+#### Function Names
+
+Museekd: Unimplemented  
+Nicotine: PlaceInLineResponse
+
+#### Data Order
+
+  - Send
+    1.  **string** <ins>user</ins>
+    2.  **int** <ins>req</ins>
+    3.  **int** <ins>place</ins>
+  - Receive
+    1.  **string** <ins>user</ins>
+    2.  **int** <ins>req</ins>
+    3.  **int** <ins>place</ins>
+
+### Server Code 62
+
+**Room Added**
+
+#### Description
+
+**DEPRECIATED**
+
+The server tells us a new room has been added.
+
+#### Function Names
+
+Museekd: Unimplemented  
+Nicotine: RoomAdded
+
+#### Data Order
+
+  - Send
+      - *No Message*
+  - Receive
+    1.  **string** <ins>room</ins>
+
+### Server Code 63
+
+**Room Removed**
+
+#### Description
+
+**DEPRECIATED**
+
+The server tells us a room has been removed.
+
+#### Function Names
+
+Museekd: Unimplemented  
+Nicotine: RoomRemoved
+
+#### Data Order
+
+  - Send
+      - *No Message*
+  - Receive
+    1.  **string** <ins>room</ins>
+
 ### Server Code 64
 
 **Room List**
@@ -873,9 +989,7 @@ Nicotine: RoomList
 
 #### Description
 
-List of rooms and the number of users in them. Soulseek has a room size
-requirement of about 50 users when first connecting. Refreshing the list
-will download all rooms.
+The server tells us a list of rooms and the number of users in them. Soulseek has a room size requirement of about 50 users when first connecting. Refreshing the list will download all rooms.
 
 #### Data Order
 
@@ -935,7 +1049,9 @@ Nicotine: ExactFileSearch
 
 #### Description
 
-SEEMS BROKEN (no results even with official client)
+**DEPRECIATED (no results even with official client)**
+
+Someone is searching for a file with an exact name.
 
 #### Data Order
 
@@ -960,7 +1076,7 @@ Nicotine: AdminMessage
 
 #### Description
 
-Admins send this message to all users
+A global message from the server admin has arrived.
 
 #### Data Order
 
@@ -968,6 +1084,46 @@ Admins send this message to all users
       - *No Message*
   - Receive
     1.  **string** <ins>message</ins>
+
+### Server Code 67
+
+**Global User List**
+
+#### Function Names
+
+Museekd: Unimplemented  
+Nicotine: GlobalUserList
+
+#### Description
+
+**DEPRECIATED**
+
+We send this to get a global list of all users online.
+
+#### Data Order
+
+  - Send
+      - Empty Message
+  - Receive
+    1.  **int** <ins>number of users in room</ins>
+    2.  Iterate the <ins>number of users</ins>
+        1.  **string** <ins>user</ins>
+    3.  **int** <ins>number of userdata</ins>
+    4.  Iterate the <ins>number of users</ins>
+        1.  **int** <ins>status</ins>
+    5.  **int** <ins>number of userdata</ins>
+    6.  Iterate the <ins>userdata</ins>
+        1.  **int** <ins>avgspeed</ins>
+        2.  **off\_t** <ins>downloadnum</ins>
+        3.  **int** <ins>files</ins>
+        4.  **int** <ins>dirs</ins>
+    7.  **int** <ins>number of slotsfree</ins>
+    8.  Iterate thru number of slotsfree
+        1.  **int** <ins>slotsfree</ins>
+    9. **int** <ins>number of usercountries</ins>
+    10. Iterate thru number of usercountries
+        1.  **string** <ins>countrycode</ins>
+            **Uppercase country code**
 
 ### Server Code 69
 
@@ -980,7 +1136,7 @@ Nicotine: PrivilegedUsers
 
 #### Description
 
-List of privileged users
+The server sends us a list of privileged users, a.k.a. users who have donated.
 
 #### Data Order
 
@@ -1016,11 +1172,12 @@ Nicotine: HaveNoParent
 
 #### Function Names
 
-Museekd: SParentIP
+Museekd: SParentIP  
+Nicotine: SearchParent
 
 #### Description
 
-Send our parent's IP to the server
+We send the IP address of our parent to the server.
 
 #### Data Order
 
@@ -1031,11 +1188,16 @@ Send our parent's IP to the server
 
 ### Server Code 83
 
-ParentMinSpeed
+**Parent Min Speed**
 
 #### Description
 
-Unknown Purpose
+Unknown purpose
+
+#### Function Names
+
+Museekd: SParentMinSpeed  
+Nicotine: ParentMinSpeed (unused)
 
 #### Data Order
 
@@ -1046,11 +1208,16 @@ Unknown Purpose
 
 ### Server Code 84
 
-ParentSpeedRatio
+**Parent Speed Ratio**
 
 #### Description
 
-Unknown Purpose.
+Unknown purpose
+
+#### Function Names
+
+Museekd: SParentSpeedRatio  
+Nicotine: ParentSpeedRatio (unused)
 
 #### Data Order
 
@@ -1072,8 +1239,6 @@ Unknown Purpose.
 Museekd: SParentInactivityTimeout  
 Nicotine: ParentInactivityTimeout
 
-#### Description
-
 #### Data Order
 
   - Send
@@ -1093,8 +1258,6 @@ Nicotine: ParentInactivityTimeout
 
 Museekd: SSearchInactivityTimeout  
 Nicotine: SearchInactivityTimeout
-
-#### Description
 
 #### Data Order
 
@@ -1158,7 +1321,7 @@ Nicotine: AddToPrivileged
 
 #### Description
 
-Add a new privileged user to your list of global privileged users
+The server sends us the username of a new privileged user, which we add to our list of global privileged users.
 
 #### Data Order
 
@@ -1178,6 +1341,8 @@ Nicotine: CheckPrivileges
 
 #### Description
 
+We ask the server how much time we have left of our privileges. The server responds with the remaining time, in seconds.
+
 #### Data Order
 
   - Send
@@ -1191,16 +1356,17 @@ Nicotine: CheckPrivileges
 
 #### Description
 
-The server sends us search requests from other users
+The server sends us search requests from other users.
 
 #### Function Names
 
-Museekd: SSearchRequest
+Museekd: SSearchRequest  
+Nicotine: SearchRequest
 
 #### Data Order
 
   - Send
-      - No Message
+      - *No Message*
   - Receive
     1.  **uint8** <ins>distributed code
         (DSearchRequest)</ins>
@@ -1215,24 +1381,27 @@ Museekd: SSearchRequest
 
 #### Description
 
-Tell the server if we want to have some children
+We tell the server if we want to accept child nodes.
 
 #### Function Names
 
-Museekd: SAcceptChildren
+Museekd: SAcceptChildren  
+Nicotine: AcceptChildren (not yet used)
 
 #### Data Order
 
   - Send
     1.  **bool** <ins>accept</ins>
   - Receive
-      - No Message
+      - *No Message*
 
 ### Server Code 102
 
 **Net Info**
 
 #### Description
+
+The server send us information about what nodes have been added/removed in the network.
 
 #### Function Names
 
@@ -1242,7 +1411,7 @@ Nicotine: NetInfo
 #### Data Order
 
   - Send
-      - Empty Message
+      - *No Message*
   - Receive *list of search parents*
     1.  **int** <ins>number of parents</ins>
     2.  Iterate for <ins>number of parents</ins>
@@ -1298,6 +1467,8 @@ Nicotine: SimilarUsers
 
 #### Description
 
+The server sends us a list of similar users related to our interests.
+
 #### Data Order
 
   - Send
@@ -1318,6 +1489,8 @@ Museekd: SGetItemRecommendations
 Nicotine: ItemRecommendations
 
 #### Description
+
+The server sends us a list of recommendations related to a specific item, which is usually present in the like/dislike list or an existing recommendation list.
 
 #### Data Order
 
@@ -1344,6 +1517,8 @@ Nicotine: ItemSimilarUsers
 
 #### Description
 
+The server sends us a list of similar users related to a specific item, which is usually present in the like/dislike list or recommendation list.
+
 #### Data Order
 
   - Send
@@ -1365,6 +1540,10 @@ Museekd: SRoomTickers
 Nicotine: RoomTickerState
 
 #### Description
+
+The server returns a list of tickers in a chat room.
+
+Tickers are customizable, user-specific messages that appear in a banner at the top of a chat room.
 
 #### Data Order
 
@@ -1388,6 +1567,10 @@ Nicotine: RoomTickerAdd
 
 #### Description
 
+The server sends us a new ticker that was added to a chat room.
+
+Tickers are customizable, user-specific messages that appear in a banner at the top of a chat room.
+
 #### Data Order
 
   - Send
@@ -1408,6 +1591,10 @@ Nicotine: RoomTickerRemove
 
 #### Description
 
+The server informs us that a ticker was removed from a chat room.
+
+Tickers are customizable, user-specific messages that appear in a banner at the top of a chat room.
+
 #### Data Order
 
   - Send
@@ -1426,6 +1613,10 @@ Museekd: SSetRoomTicker
 Nicotine: RoomTickerSet
 
 #### Description
+
+We send this to the server when we change our own ticker in a chat room.
+
+Tickers are customizable, user-specific messages that appear in a banner at the top of a chat room.
 
 #### Data Order
 
@@ -1446,6 +1637,8 @@ Nicotine: AddThingIHate
 
 #### Description
 
+We send this to the server when we add an item to our hate list.
+
 #### Data Order
 
   - Send
@@ -1463,6 +1656,8 @@ Museekd: SInterestHatedRemove
 Nicotine: RemoveThingIHate
 
 #### Description
+
+We send this to the server when we remove an item from our hate list.
 
 #### Data Order
 
@@ -1497,10 +1692,12 @@ Nicotine: RoomSearch
 
 #### Function Names
 
-Museekd: **SSendUploadSpeed**  
+Museekd: SSendUploadSpeed  
 Nicotine: SendUploadSpeed
 
 #### Description
+
+We send this after a finished upload to let the server update the speed statistics for ourselves.
 
 #### Data Order
 
@@ -1515,10 +1712,12 @@ Nicotine: SendUploadSpeed
 
 #### Function Names
 
-Museekd: **SUserPrivileges**  
-Nicotine: Not implemented
+Museekd: SUserPrivileges  
+Nicotine: UserPrivileged
 
 #### Description
+
+We ask the server whether a user is privileged or not.
 
 #### Data Order
 
@@ -1539,6 +1738,8 @@ Museekd: SGivePrivileges
 Nicotine: GivePrivileges
 
 #### Description
+
+We give (part of) our privileges, specified in days, to another user on the network.
 
 #### Data Order
 
@@ -1593,7 +1794,8 @@ Tell the server what is our position in our branch (xth generation)
 
 #### Function Names
 
-Museekd: **SBranchLevel**
+Museekd: SBranchLevel
+Nicotine: Unimplemented
 
 #### Data Order
 
@@ -1612,7 +1814,8 @@ Tell the server the username of the root of the branch we're in
 
 #### Function Names
 
-Museekd: **SBranchRoot**
+Museekd: SBranchRoot  
+Nicotine: Unimplemented
 
 #### Data Order
 
@@ -1631,7 +1834,8 @@ Tell the server the maximum number of generation of children we have.
 
 #### Function Names
 
-Museekd: **SChildDepth**
+Museekd: SChildDepth  
+Nicotine: Unimplemented
 
 #### Data Order
 
@@ -1642,11 +1846,11 @@ Museekd: **SChildDepth**
 
 ### Server Code 133
 
-**Private Room Users that we can (dis)op/dismember**
+**Private Room Users**
 
 #### Description
 
-We get this when we've created a private room
+The server sends us a list of room users that we can alter (add operator abilities / dismember).
 
 #### Function Names
 
@@ -1669,7 +1873,7 @@ Nicotine: PrivateRoomUsers
 
 #### Description
 
-We get / receive this when we add a user to a private room.
+We send this to inform the server that we've added a user to a private room.
 
 #### Function Names
 
@@ -1691,7 +1895,7 @@ Nicotine: PrivateRoomAddUser
 
 #### Description
 
-We get / send this when we remove a user from a private room
+We send this to inform the server that we've removed a user from a private room.
 
 #### Function Names
 
@@ -1713,7 +1917,7 @@ Nicotine: PrivateRoomRemoveUser
 
 #### Description
 
-We do this to remove our own membership of a private room.
+We send this to the server to remove our own membership of a private room.
 
 #### Function Names
 
@@ -1724,7 +1928,8 @@ Nicotine: PrivateRoomDismember
 
   - Send
     1.  **string** <ins>room</ins>
-  - Not received
+  - Receive
+      - *No Message*
 
 ### Server Code 137
 
@@ -1732,7 +1937,7 @@ Nicotine: PrivateRoomDismember
 
 #### Description
 
-We do this to stop owning a private room.
+We send this to the server to stop owning a private room.
 
 #### Function Names
 
@@ -1743,7 +1948,8 @@ Nicotine: PrivateRoomDisown
 
   - Send
     1.  **string** <ins>room</ins>
-  - Not received
+  - Receive
+      - *No Message*
 
 ### Server Code 138
 
@@ -1751,7 +1957,7 @@ Nicotine: PrivateRoomDisown
 
 #### Description
 
-Undocumented
+Unknown purporse
 
 #### Function Names
 
@@ -1771,7 +1977,7 @@ Nicotine: PrivateRoomSomething
 
 #### Description
 
-We receive this when we are added to a private room.
+The server sends us this message when we are added to a private room.
 
 #### Function Names
 
@@ -1780,7 +1986,8 @@ Nicotine: PrivateRoomAdded
 
 #### Data Order
 
-  - Not sent
+  - Send
+      - *No Message*
   - Receive
     1.  **string** <ins>room</ins>
 
@@ -1790,7 +1997,7 @@ Nicotine: PrivateRoomAdded
 
 #### Description
 
-We receive this when we are removed from a private room.
+The server sends us this message when we are removed from a private room.
 
 #### Function Names
 
@@ -1799,7 +2006,8 @@ Nicotine: PrivateRoomRemoved
 
 #### Data Order
 
-  - Not sent
+  - Send
+      - *No Message*
   - Receive
     1.  **string** <ins>room</ins>
 
@@ -1809,8 +2017,7 @@ Nicotine: PrivateRoomRemoved
 
 #### Description
 
-We send this when we want to enable or disable invitations to private
-rooms
+We send this when we want to enable or disable invitations to private rooms.
 
 #### Function Names
 
@@ -1830,12 +2037,12 @@ Nicotine: PrivateRoomToggle
 
 #### Description
 
-Send the new password. Server sent it back to confirm.
+We send this to the server to change our password. We receive a response if our password changes.
 
 #### Function Names
 
 Museekd: SNewPassword  
-Nicotine: Unimplemented
+Nicotine: ChangePassword
 
 #### Data Order
 
@@ -1850,7 +2057,7 @@ Nicotine: Unimplemented
 
 #### Description
 
-We send this to add private room operator abilities to a user
+We send this to the server to add private room operator abilities to a user.
 
 #### Function Names
 
@@ -1872,11 +2079,11 @@ Nicotine: PrivateRoomAddOperator
 
 #### Description
 
-We send this to remove privateroom operator abilities from a user
+We send this to the server to remove private room operator abilities from a user.
 
 #### Function Names
 
-Museekd: Unimplemented  
+Museekd: SPrivRoomRemoveOperator  
 Nicotine: PrivateRoomRemoveOperator
 
 #### Data Order
@@ -1892,7 +2099,7 @@ Nicotine: PrivateRoomRemoveOperator
 
 #### Description
 
-We receive this when given private room operator abilities
+The server send us this message when we're given operator abilities in a private room.
 
 #### Function Names
 
@@ -1902,7 +2109,7 @@ Nicotine: PrivateRoomOperatorAdded
 #### Data Order
 
   - Send
-    1.  **string** <ins>room</ins>
+      - *No Message*
   - Receive
     1.  **string** <ins>room</ins>
 
@@ -1912,7 +2119,7 @@ Nicotine: PrivateRoomOperatorAdded
 
 #### Description
 
-We receive this when privateroom operator abilities are removed
+The server send us this message when our operator abilities are removed in a private room.
 
 #### Function Names
 
@@ -1921,7 +2128,8 @@ Nicotine: PrivateRoomOperatorRemoved
 
 #### Data Order
 
-  - Not sent
+  - Send
+      - *No Message*
   - Receive
     1.  **string** <ins>room</ins>
 
@@ -1931,7 +2139,7 @@ Nicotine: PrivateRoomOperatorRemoved
 
 #### Description
 
-List of operators of a specific room, that we can disop.
+The server sends us a list of operators in a specific room, that we can remove operator abilities from.
 
 #### Function Names
 
@@ -1940,7 +2148,8 @@ Nicotine: PrivateRoomOwned
 
 #### Data Order
 
-  - Not sent
+  - Send
+      - *No Message*
   - Receive
     1.  **string** <ins>room</ins>
     2.  **int** <ins>number of operators in
@@ -1970,6 +2179,8 @@ Nicotine: Unimplemented
         **museekd uses a vector of strings**
         1.  **string** <ins>user</ins>
     3.  **string** <ins>message</ins>
+  - Receive
+      - *No Message*
 
 ### Server Code 150
 
@@ -1977,17 +2188,19 @@ Nicotine: Unimplemented
 
 #### Description
 
-Ask the server to send us public chat.
+We ask the server to send us messages from all public rooms, also known as public chat.
 
 #### Function Names
 
 Museekd: SAskPublicChat  
-Nicotine: Unimplemented
+Nicotine: JoinPublicRoom
 
 #### Data Order
 
   - Send
       - Empty Message
+  - Receive
+      - *No Message*
 
 ### Server Code 151
 
@@ -1995,38 +2208,65 @@ Nicotine: Unimplemented
 
 #### Description
 
-Ask the server to stop sending us public chat.
+We ask the server to stop sending us messages from all public rooms, also known as public chat.
 
 #### Function Names
 
 Museekd: SStopPublicChat  
-Nicotine: Unimplemented
+Nicotine: LeavePublicRoom
 
 #### Data Order
 
   - Send
       - Empty Message
+  - Receive
+      - *No Message*
 
 ### Server Code 152
 
-**Private Chat**
+**Public Chat Message**
 
 #### Description
 
-Public chat sent by the server (ie every single line written in every
-public room).
+The server sends this when a new message has been written in a public room (every single line written in every public room).
 
 #### Function Names
 
 Museekd: SPublicChat  
-Nicotine: Unimplemented
+Nicotine: PublicRoomMessage
 
 #### Data Order
 
+  - Send
+      - *No Message*
   - Receive
     1.  **string** <ins>room</ins>
     2.  **string** <ins>user</ins>
     3.  **string** <ins>message</ins>
+
+### Server Code 153
+
+**Related Searches**
+
+#### Description
+
+The server returns a list of related search terms for a search query.
+
+#### Function Names
+
+Museekd: SRelatedSearch  
+Nicotine: Unimplemented
+
+#### Data Order
+
+  - Send
+    1.  **string** <ins>query</ins>
+  - Receive
+    1.  **string** <ins>query</ins>
+    2.  **int** <ins>number of terms</ins>
+    3.  Iterate for <ins>number of term</ins>
+        1.  **string** <ins>term</ins>
+        2.  **int** <ins>score</ins>
 
 ### Server Code 1001
 
@@ -2034,10 +2274,12 @@ Nicotine: Unimplemented
 
 #### Function Names
 
-Museekd: **SCannotConnect**  
+Museekd: SCannotConnect  
 Nicotine: CantConnectToPeer
 
 #### Description
+
+We send this to say we can't connect to peer after it has asked us to connect. We receive this if we asked peer to connect and it can't do this. This message means a connection can't be established either way.
 
 See also: [Peer Connection Message
 Order](#peer-connection-message-order)
@@ -2061,6 +2303,8 @@ Order](#peer-connection-message-order)
 In museekd 0.1.13, these messages are sent and received in
 Museek/PeerConnection.cc and defined in Museek/PeerMessages.hh. Since
 museekd 0.2, they are defined in museekd/peermessages.h.
+
+In Nicotine, these messages are matched to their message number in slskproto.py in the SlskProtoThread function, defined in slskmessages.py and callbacks for the messages are set in pynicotine.py.
 
 #### The Peer Init Message format
 
@@ -2097,7 +2341,11 @@ museekd 0.2, they are defined in museekd/peermessages.h.
 
 #### Function Names
 
+Nicotine: PierceFireWall
+
 #### Description
+
+This is the very first message sent by the peer that established a connection, if it has been asked by the other peer to do so. The token is taken from the ConnectToPeer server message.
 
 See also: [Peer Connection Message
 Order](#peer-connection-message-order)
@@ -2115,7 +2363,11 @@ Order](#peer-connection-message-order)
 
 #### Function Names
 
+Nicotine: PeerInit
+
 #### Description
+
+This message is sent by the peer that initiated a connection, not necessarily a peer that actually established it. Token apparently can be anything. Type is 'P' if it's anything but filetransfer, 'F' otherwise.
 
 See also: [Peer Connection Message
 Order](#peer-connection-message-order)
@@ -2147,8 +2399,8 @@ Order](#peer-connection-message-order)
 | 5    | [Shares Reply](#peer-code-5)               |
 | 8    | [Search Request](#peer-code-8)             |
 | 9    | [Search Reply](#peer-code-9)               |
-| 15   | [Info Request](#peer-code-15)              |
-| 16   | [Info Reply](#peer-code-16)                |
+| 15   | [User Info Request](#peer-code-15)         |
+| 16   | [User Info Reply](#peer-code-16)           |
 | 36   | [Folder Contents Request](#peer-code-36)   |
 | 37   | [Folder Contents Reply](#peer-code-37)     |
 | 40   | [Transfer Request](#peer-code-40)          |
@@ -2174,6 +2426,8 @@ Nicotine: GetShareFileList
 
 #### Description
 
+We send this to a peer to ask for a list of shared files.
+
 #### Data Order
 
   - Send
@@ -2191,6 +2445,8 @@ Museekd: PSharesReply
 Nicotine: SharedFileList
 
 #### Description
+
+A peer responds with a list of shared files when we've sent a GetSharedFileList.
 
 #### Data Order
 
@@ -2229,6 +2485,8 @@ Nicotine: FileSearchRequest
 
 #### Description
 
+We send this to the peer when we search for a file. Alternatively, the peer sends this to tell us it is searching for a file.
+
 #### Data Order
 
   - Send
@@ -2248,6 +2506,8 @@ Museekd: PSearchReply
 Nicotine: FileSearchResult
 
 #### Description
+
+The peer sends this when it has a file search match. The token/ticket is taken from original FileSearchRequest message.
 
 #### Data Order
 
@@ -2291,7 +2551,7 @@ Nicotine: FileSearchResult
 
 ### Peer Code 15
 
-**Info Request**
+**User Info Request**
 
 #### Function Names
 
@@ -2299,6 +2559,8 @@ Museekd: PInfoRequest
 Nicotine: UserInfoRequest
 
 #### Description
+
+We ask the other peer to send us their user information, picture and all.
 
 #### Data Order
 
@@ -2309,7 +2571,7 @@ Nicotine: UserInfoRequest
 
 ### Peer Code 16
 
-**Info Reply**
+**User Info Reply**
 
 #### Function Names
 
@@ -2317,6 +2579,8 @@ Museekd: PInfoReply
 Nicotine: UserInfoReply
 
 #### Description
+
+A peer responds with this when we've sent a UserInfoRequest.
 
 #### Data Order
 
@@ -2354,6 +2618,8 @@ Nicotine: FolderContentsRequest
 
 #### Description
 
+We ask the peer to send us the contents of a single folder.
+
 #### Data Order
 
   - Send
@@ -2379,6 +2645,8 @@ Museekd: PFolderContentsReply
 Nicotine: FolderContentsResponse
 
 #### Description
+
+A peer responds with the contents of a particular folder (with all subfolders) when we've sent a FolderContentsRequest.
 
 #### Data Order
 
@@ -2425,6 +2693,8 @@ Nicotine: TransferRequest
 
 #### Description
 
+We request a file from a peer, or tell a peer that we want to send a file to them.
+
 #### Data Order
 
   - Send
@@ -2453,6 +2723,8 @@ Nicotine: TransferResponse
 
 #### Description
 
+Response to TransferRequest - either we (or the other peer) agrees, or tells the reason for rejecting the file transfer.
+
 #### Data Order
 
   - Send
@@ -2477,6 +2749,8 @@ Nicotine: TransferResponse
 
 #### Description
 
+Response to TransferRequest - either we (or the other peer) agrees, or tells the reason for rejecting the file transfer.
+
 #### Data Order
 
   - Send
@@ -2498,6 +2772,8 @@ Museekd: PTransferReply
 Nicotine: TransferResponse
 
 #### Description
+
+Response to TransferRequest - either we (or the other peer) agrees, or tells the reason for rejecting the file transfer.
 
 #### Data Order
 
@@ -2633,7 +2909,7 @@ Nicotine: PlaceInQueueRequest
 #### Function Names
 
 Museekd: PUploadQueueNotification  
-Nicotine: **Not implemented**
+Nicotine: UploadQueueNotification
 
 #### Description
 
@@ -2654,6 +2930,8 @@ In museekd 0.1.13, these messages are sent and received in
 Museek/DistribConnection.cc and defined in Museek/DistribMessages.hh.
 Since museekd 0.2, they are defined in museekd/distributedmessages.h.
 
+In Nicotine, these messages are matched to their message number in slskproto.py in the SlskProtoThread function, defined in slskmessages.py and callbacks for the messages are set in pynicotine.py.
+
 #### The Message format
 
 | Message Length | Code   | Message Contents |
@@ -2669,6 +2947,7 @@ Since museekd 0.2, they are defined in museekd/distributedmessages.h.
 | 4    | [Branch Level](#distributed-code-4)   |
 | 5    | [Branch Root](#distributed-code-5)    |
 | 7    | [Child Depth](#distributed-code-7)    |
+| 93   | [Search Request](#distributed-code-93)|
 
 ### Distributed Code 0
 
@@ -2680,7 +2959,7 @@ Send it every 60 sec.
 
 #### Function Names
 
-Museekd: **DPing**  
+Museekd: DPing  
 Nicotine: DistribAlive
 
 #### Data Order
@@ -2696,13 +2975,14 @@ Nicotine: DistribAlive
 
 #### Description
 
-Transmit the search requests to our children. (Search requests are sent
-to us by the server using SSearchRequest if we're a branch root, or by
-our parent using DSearchRequest)
+Search request that arrives through the distributed network. 
+We transmit the search request to our children.
+
+Search requests are sent to us by the server using SearchRequest if we're a branch root, or by our parent using DistribSearch.
 
 #### Function Names
 
-Museekd: **DSearchRequest**  
+Museekd: DSearchRequest  
 Nicotine: DistribSearch
 
 #### Data Order
@@ -2728,8 +3008,8 @@ See SBranchLevel
 
 #### Function Names
 
-Museekd: **DBranchLevel**  
-Nicotine: DistribUnknown
+Museekd: DBranchLevel  
+Nicotine: Unimplemented
 
 #### Data Order
 
@@ -2748,7 +3028,8 @@ See SBranchRoot
 
 #### Function Names
 
-Museekd: **DBranchRoot**
+Museekd: DBranchRoot  
+Nicotine: Unimplemented
 
 #### Data Order
 
@@ -2767,7 +3048,8 @@ See SChildDepth
 
 #### Function Names
 
-Museekd: **DChildDepth**
+Museekd: DChildDepth  
+Nicotine: Unimplemented
 
 #### Data Order
 
@@ -2775,6 +3057,34 @@ Museekd: **DChildDepth**
     1.  **uint32** <ins>child\_depth</ins>
   - Receive
     1.  **uint32** <ins>child\_depth</ins>
+
+### Distributed Code 93
+
+**Search Request**
+
+#### Description
+
+Search request that arrives through the distributed network. 
+We transmit the search request to our children.
+
+Search requests are sent to us by the server using SearchRequest if we're a branch root, or by our parent using DistribSearch.
+
+#### Function Names
+
+Nicotine: DistribSearch
+
+#### Data Order
+
+  - Send
+    1.  **uint32** <ins>unknown</ins>
+    2.  **string** <ins>user</ins>
+    3.  **uint32** <ins>ticket</ins>
+    4.  **string** <ins>query</ins>
+  - Receive
+    1.  **uint32** <ins>unknown</ins>
+    2.  **string** <ins>user</ins>
+    3.  **uint32** <ins>ticket</ins>
+    4.  **string** <ins>query</ins>
 
 ## Museek Data Types
 

--- a/doc/SLSKPROTOCOL.md
+++ b/doc/SLSKPROTOCOL.md
@@ -1158,6 +1158,8 @@ Nicotine: HaveNoParent
 
 #### Description
 
+We inform the server if we have a distributed parent or not. If not, the server eventually sends us a NetInfo message with a list of 10 possible parents to connect to.
+
 #### Data Order
 
   - Send
@@ -1401,7 +1403,7 @@ Nicotine: AcceptChildren (not yet used)
 
 #### Description
 
-The server send us information about what nodes have been added/removed in the network.
+The server send us information about what nodes have been added/removed in the network. The list contains 10 possible distributed parents to connect to.
 
 #### Function Names
 

--- a/doc/SLSKPROTOCOL.md
+++ b/doc/SLSKPROTOCOL.md
@@ -1708,7 +1708,7 @@ We send this after a finished upload to let the server update the speed statisti
 
 ### Server Code 122
 
-**A user's Soulseek Privileges**
+**User Privileges**
 
 #### Function Names
 
@@ -1730,7 +1730,7 @@ We ask the server whether a user is privileged or not.
 
 ### Server Code 123
 
-**Give Soulseek Privileges to user**
+**Give Privileges**
 
 #### Function Names
 
@@ -1751,7 +1751,7 @@ We give (part of) our privileges, specified in days, to another user on the netw
 
 ### Server Code 124
 
-**Server sends us a Notification about our privileges**
+**Notify Privileges**
 
 #### Function Names
 
@@ -1759,13 +1759,16 @@ Nicotine: NotifyPrivileges
 
 #### Description
 
+The server sends us a notification about our privileges.
+
 #### Data Order
 
   - Send
     1.  **int** <ins>token</ins>
     2.  **string** <ins>user</ins>
   - Receive
-      - *No Message*
+    1.  **int** <ins>token</ins>
+    2.  **string** <ins>user</ins>
 
 ### Server Code 125
 
@@ -1780,7 +1783,7 @@ Nicotine: AckNotifyPrivileges
 #### Data Order
 
   - Send
-      - *No Message*
+    1.  **int** <ins>token</ins>
   - Receive
     1.  **int** <ins>token</ins>
 
@@ -2940,14 +2943,14 @@ In Nicotine, these messages are matched to their message number in slskproto.py 
 
 #### Message Index
 
-| Code | Message                               |
-| ---- | ------------------------------------- |
-| 0    | [Ping](#distributed-code-0)           |
-| 3    | [Search Request](#distributed-code-3) |
-| 4    | [Branch Level](#distributed-code-4)   |
-| 5    | [Branch Root](#distributed-code-5)    |
-| 7    | [Child Depth](#distributed-code-7)    |
-| 93   | [Search Request](#distributed-code-93)|
+| Code | Message                                      |
+| ---- | -------------------------------------------- |
+| 0    | [Ping](#distributed-code-0)                  |
+| 3    | [Search Request](#distributed-code-3)        |
+| 4    | [Branch Level](#distributed-code-4)          |
+| 5    | [Branch Root](#distributed-code-5)           |
+| 7    | [Child Depth](#distributed-code-7)           |
+| 93   | [Server Search Request](#distributed-code-93)|
 
 ### Distributed Code 0
 
@@ -2988,14 +2991,14 @@ Nicotine: DistribSearch
 #### Data Order
 
   - Send
-    1.  **uint32** <ins>unknown</ins>
+    1.  **int** <ins>unknown</ins>
     2.  **string** <ins>user</ins>
-    3.  **uint32** <ins>ticket</ins>
+    3.  **int** <ins>ticket</ins>
     4.  **string** <ins>query</ins>
   - Receive
-    1.  **uint32** <ins>unknown</ins>
+    1.  **int** <ins>unknown</ins>
     2.  **string** <ins>user</ins>
-    3.  **uint32** <ins>ticket</ins>
+    3.  **int** <ins>ticket</ins>
     4.  **string** <ins>query</ins>
 
 ### Distributed Code 4
@@ -3060,7 +3063,7 @@ Nicotine: Unimplemented
 
 ### Distributed Code 93
 
-**Search Request**
+**Server Search Request**
 
 #### Description
 
@@ -3071,19 +3074,20 @@ Search requests are sent to us by the server using SearchRequest if we're a bran
 
 #### Function Names
 
-Nicotine: DistribSearch
+Museekd: Unimplemented  
+Nicotine: DistribServerSearch
 
 #### Data Order
 
   - Send
-    1.  **uint32** <ins>unknown</ins>
+    1.  **off_t** <ins>unknown</ins> *always 210503729152 (?)*
     2.  **string** <ins>user</ins>
-    3.  **uint32** <ins>ticket</ins>
+    3.  **int** <ins>ticket</ins>
     4.  **string** <ins>query</ins>
   - Receive
-    1.  **uint32** <ins>unknown</ins>
+    1.  **off_t** <ins>unknown</ins> *always 210503729152 (?)*
     2.  **string** <ins>user</ins>
-    3.  **uint32** <ins>ticket</ins>
+    3.  **int** <ins>ticket</ins>
     4.  **string** <ins>query</ins>
 
 ## Museek Data Types

--- a/doc/SLSKPROTOCOL.md
+++ b/doc/SLSKPROTOCOL.md
@@ -297,26 +297,6 @@ Used to be kept updated about a user's status.
         6.  **string** <ins>Country Code</ins> (may
             not be implemented)
 
-### Server Code 6
-
-**Unknown**
-
-#### Function Names
-
-Museekd: Unimplemented  
-Nicotine: Unimplemented
-
-#### Description
-
-Something to do with user status. Usually sent right after SAddUser.
-
-#### Data Order
-
-  - Send
-    1.  **string** <ins>username</ins>
-  - Receive
-      - *No Message*
-
 ### Server Code 7
 
 **Get Status**

--- a/pynicotine/pynicotine.py
+++ b/pynicotine/pynicotine.py
@@ -237,10 +237,9 @@ class NetworkEventProcessor:
             slskmessages.ParentMinSpeed: self.DummyMessage,
             slskmessages.ParentSpeedRatio: self.DummyMessage,
             slskmessages.Msg85: self.DummyMessage,
-            slskmessages.Msg12547: self.Msg12547,
-            slskmessages.ParentInactivityTimeout: self.ParentInactivityTimeout,
-            slskmessages.SearchInactivityTimeout: self.SearchInactivityTimeout,
-            slskmessages.MinParentsInCache: self.MinParentsInCache,
+            slskmessages.ParentInactivityTimeout: self.DummyMessage,
+            slskmessages.SearchInactivityTimeout: self.DummyMessage,
+            slskmessages.MinParentsInCache: self.DummyMessage,
             slskmessages.Msg89: self.DummyMessage,
             slskmessages.WishlistInterval: self.WishlistInterval,
             slskmessages.DistribAliveInterval: self.DummyMessage,
@@ -250,7 +249,6 @@ class NetworkEventProcessor:
             slskmessages.DistribChildDepth: self.DistribChildDepth,
             slskmessages.DistribBranchLevel: self.DistribBranchLevel,
             slskmessages.DistribBranchRoot: self.DistribBranchRoot,
-            slskmessages.DistribMessage9: self.DistribMessage9,
             slskmessages.AdminMessage: self.AdminMessage,
             slskmessages.TunneledMessage: self.TunneledMessage,
             slskmessages.IncConn: self.IncConn,
@@ -949,47 +947,31 @@ class NetworkEventProcessor:
         self.logMessage("%s" % (msg.msg))
 
     def ChildDepth(self, msg):
-        # TODO: Distributed search messages need to implemented
+        # TODO: Implement me
         self.logMessage("%s %s" % (msg.__class__, vars(msg)), 4)
 
     def BranchLevel(self, msg):
-        # TODO: Distributed search messages need to implemented
+        # TODO: Implement me
         self.logMessage("%s %s" % (msg.__class__, vars(msg)), 4)
 
     def BranchRoot(self, msg):
-        # TODO: Distributed search messages need to implemented
+        # TODO: Implement me
         self.logMessage("%s %s" % (msg.__class__, vars(msg)), 4)
 
     def DistribChildDepth(self, msg):
-        # TODO: Distributed search messages need to implemented
+        # TODO: Implement me
         self.logMessage("%s %s" % (msg.__class__, vars(msg)), 4)
 
     def DistribBranchLevel(self, msg):
-        # TODO: Distributed search messages need to implemented
+        # TODO: Implement me
         self.logMessage("%s %s" % (msg.__class__, vars(msg)), 4)
 
     def DistribBranchRoot(self, msg):
-        # TODO: Distributed search messages need to implemented
-        self.logMessage("%s %s" % (msg.__class__, vars(msg)), 4)
-
-    def DistribMessage9(self, msg):
-        # TODO: Distributed search messages need to implemented
+        # TODO: Implement me
         self.logMessage("%s %s" % (msg.__class__, vars(msg)), 4)
 
     def DummyMessage(self, msg):
         self.logMessage("%s %s" % (msg.__class__, vars(msg)), 4)
-
-    def Msg12547(self, msg):
-        self.logMessage("%s %s" % (msg.__class__, vars(msg)), 4)
-
-    def ParentInactivityTimeout(self, msg):
-        pass
-
-    def SearchInactivityTimeout(self, msg):
-        pass
-
-    def MinParentsInCache(self, msg):
-        pass
 
     def WishlistInterval(self, msg):
         if self.search is not None:

--- a/pynicotine/pynicotine.py
+++ b/pynicotine/pynicotine.py
@@ -260,6 +260,7 @@ class NetworkEventProcessor:
             slskmessages.NetInfo: self.NetInfo,
             slskmessages.DistribAlive: self.DummyMessage,
             slskmessages.DistribSearch: self.DistribSearch,
+            slskmessages.DistribServerSearch: self.DistribSearch,
             ConnectToPeerTimeout: self.ConnectToPeerTimeout,
             RespondToDistributedSearchesTimeout: self.ToggleRespondDistributed,
             transfers.TransferTimeout: self.TransferTimeout,

--- a/pynicotine/pynicotine.py
+++ b/pynicotine/pynicotine.py
@@ -192,12 +192,12 @@ class NetworkEventProcessor:
             slskmessages.ChangePassword: self.ChangePassword,
             slskmessages.MessageUser: self.MessageUser,
             slskmessages.PMessageUser: self.PMessageUser,
-            slskmessages.ExactFileSearch: self.ExactFileSearch,
+            slskmessages.ExactFileSearch: self.DummyMessage,
             slskmessages.UserJoinedRoom: self.UserJoinedRoom,
             slskmessages.SayChatroom: self.SayChatRoom,
             slskmessages.JoinRoom: self.JoinRoom,
             slskmessages.UserLeftRoom: self.UserLeftRoom,
-            slskmessages.QueuedDownloads: self.QueuedDownloads,
+            slskmessages.QueuedDownloads: self.DummyMessage,
             slskmessages.GetPeerAddress: self.GetPeerAddress,
             slskmessages.OutConn: self.OutConn,
             slskmessages.UserInfoReply: self.UserInfoReply,
@@ -236,11 +236,9 @@ class NetworkEventProcessor:
             slskmessages.ServerPing: self.DummyMessage,
             slskmessages.ParentMinSpeed: self.DummyMessage,
             slskmessages.ParentSpeedRatio: self.DummyMessage,
-            slskmessages.Msg85: self.DummyMessage,
             slskmessages.ParentInactivityTimeout: self.DummyMessage,
             slskmessages.SearchInactivityTimeout: self.DummyMessage,
             slskmessages.MinParentsInCache: self.DummyMessage,
-            slskmessages.Msg89: self.DummyMessage,
             slskmessages.WishlistInterval: self.WishlistInterval,
             slskmessages.DistribAliveInterval: self.DummyMessage,
             slskmessages.ChildDepth: self.ChildDepth,
@@ -252,7 +250,7 @@ class NetworkEventProcessor:
             slskmessages.AdminMessage: self.AdminMessage,
             slskmessages.TunneledMessage: self.TunneledMessage,
             slskmessages.IncConn: self.IncConn,
-            slskmessages.PlaceholdUpload: self.PlaceholdUpload,
+            slskmessages.PlaceholdUpload: self.DummyMessage,
             slskmessages.PlaceInQueueRequest: self.PlaceInQueueRequest,
             slskmessages.UploadQueueNotification: self.UploadQueueNotification,
             slskmessages.SearchRequest: self.SearchRequest,
@@ -260,7 +258,7 @@ class NetworkEventProcessor:
             slskmessages.RoomSearch: self.RoomSearchRequest,
             slskmessages.UserSearch: self.SearchRequest,
             slskmessages.NetInfo: self.NetInfo,
-            slskmessages.DistribAlive: self.DistribAlive,
+            slskmessages.DistribAlive: self.DummyMessage,
             slskmessages.DistribSearch: self.DistribSearch,
             ConnectToPeerTimeout: self.ConnectToPeerTimeout,
             RespondToDistributedSearchesTimeout: self.ToggleRespondDistributed,
@@ -423,6 +421,9 @@ class NetworkEventProcessor:
     def PopupMessage(self, msg):
         self.setStatus(_(msg.title))
         self.frame.PopupMessage(msg)
+
+    def DummyMessage(self, msg):
+        self.logMessage("%s %s" % (msg.__class__, vars(msg)), 4)
 
     def DebugMessage(self, msg):
         self.logMessage(msg.msg, msg.debugLevel)
@@ -970,9 +971,6 @@ class NetworkEventProcessor:
         # TODO: Implement me
         self.logMessage("%s %s" % (msg.__class__, vars(msg)), 4)
 
-    def DummyMessage(self, msg):
-        self.logMessage("%s %s" % (msg.__class__, vars(msg)), 4)
-
     def WishlistInterval(self, msg):
         if self.search is not None:
             self.search.SetInterval(msg)
@@ -1062,9 +1060,6 @@ class NetworkEventProcessor:
             self.chatrooms.roomsctrl.UserLeftRoom(msg)
         else:
             self.logMessage("%s %s" % (msg.__class__, vars(msg)), 4)
-
-    def QueuedDownloads(self, msg):
-        self.logMessage("%s %s" % (msg.__class__, vars(msg)), 4)
 
     def GetPeerAddress(self, msg):
 
@@ -1566,9 +1561,6 @@ class NetworkEventProcessor:
         else:
             self.logMessage("%s %s" % (msg.__class__, vars(msg)), 4)
 
-    def PlaceholdUpload(self, msg):
-        self.logMessage("%s %s" % (msg.__class__, vars(msg)), 4)
-
     def PlaceInQueueRequest(self, msg):
         if self.transfers is not None:
             self.transfers.PlaceInQueueRequest(msg)
@@ -1651,15 +1643,6 @@ class NetworkEventProcessor:
         else:
             self.logMessage(_("Unknown tunneled message: %s") % (vars(msg)), 4)
 
-    def ExactFileSearch(self, msg):
-        ''' Depreciated '''
-
-        self.logMessage("%s %s" % (msg.__class__, vars(msg)), 4)
-        for i in self.peerconns:
-            if i.conn == msg.conn.conn:
-                user = i.username
-                self.shares.processExactSearchRequest(msg.searchterm, user, msg.searchid, direct=1, checksum=msg.checksum)
-
     def FileSearchRequest(self, msg):
         self.logMessage("%s %s" % (msg.__class__, vars(msg)), 4)
         for i in self.peerconns:
@@ -1728,9 +1711,6 @@ class NetworkEventProcessor:
 
                 self.ProcessRequestToPeer(user, slskmessages.DistribConn(), None, addr)
 
-        self.logMessage("%s %s" % (msg.__class__, vars(msg)), 4)
-
-    def DistribAlive(self, msg):
         self.logMessage("%s %s" % (msg.__class__, vars(msg)), 4)
 
     def GetDistribConn(self):

--- a/pynicotine/shares.py
+++ b/pynicotine/shares.py
@@ -324,10 +324,6 @@ class Shares:
 
         self.logMessage("%s %s" % (msg.__class__, vars(msg)), 4)
 
-    def processExactSearchRequest(self, searchterm, user, searchid, direct=0, checksum=None):
-        print(searchterm, user, searchid, checksum)
-        pass
-
     def processSearchRequest(self, searchterm, user, searchid, direct=0):
 
         if not self.config.sections["searches"]["search_results"]:

--- a/pynicotine/slskmessages.py
+++ b/pynicotine/slskmessages.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-#
 # Copyright (C) 2020 Nicotine+ Team
 # Copyright (C) 2007 daelstorm. All rights reserved.
 # Copyright (c) 2003-2004 Hyriand. All rights reserved.
@@ -319,6 +317,7 @@ class DistribMessage(SlskMessage):
 
 
 class Login(ServerMessage):
+    """ Server code: 1 """
     """ We sent this to the server right after the connection has been
     established. Server responds with the greeting message. """
 
@@ -362,8 +361,9 @@ class Login(ServerMessage):
 
 
 class ChangePassword(ServerMessage):
-    """ We sent this to the server to change our password
-    We receive a response if our password changes. """
+    """ Server code: 142 """
+    """ We send this to the server to change our password. We receive a
+    response if our password changes. """
 
     def __init__(self, password=None):
         self.password = password
@@ -376,7 +376,9 @@ class ChangePassword(ServerMessage):
 
 
 class SetWaitPort(ServerMessage):
-    """ Send this to server to indicate port number that we listen on."""
+    """ Server code: 2 """
+    """ We send this to the server to indicate the port number that we
+    listen on (2234 by default). """
     def __init__(self, port=None):
         self.port = port
 
@@ -388,7 +390,9 @@ class SetWaitPort(ServerMessage):
 
 
 class GetPeerAddress(ServerMessage):
-    """ Used to find out a peer's (ip, port) address."""
+    """ Server code: 3 """
+    """ We send this to the server to ask for a peer's address
+    (IP address and port), given the peer's username. """
     def __init__(self, user=None):
         self.user = user
 
@@ -403,7 +407,8 @@ class GetPeerAddress(ServerMessage):
 
 
 class AddUser(ServerMessage):
-    """ Used to be kept updated about a user's status."""
+    """ Server code: 5 """
+    """ Used to be kept updated about a user's status. """
     def __init__(self, user=None):
         self.user = user
         self.status = None
@@ -433,7 +438,8 @@ class AddUser(ServerMessage):
 
 
 class Unknown6(ServerMessage):
-    """ Message 6 """
+    """ Server code: 6 """
+    """ UNKNOWN """
     def __init__(self, user=None):
         self.user = user
 
@@ -446,7 +452,8 @@ class Unknown6(ServerMessage):
 
 
 class RemoveUser(ServerMessage):
-    """ Used when we no longer want to be kept updated about a user's status."""
+    """ Used when we no longer want to be kept updated about a user's status.
+    (is this used anywhere?) """
     def __init__(self, user=None):
         self.user = user
 
@@ -455,7 +462,8 @@ class RemoveUser(ServerMessage):
 
 
 class GetUserStatus(ServerMessage):
-    """ Server tells us if a user has gone away or has returned"""
+    """ Server code: 7 """
+    """ The server tells us if a user has gone away or has returned. """
     def __init__(self, user=None):
         self.user = user
         self.privileged = None
@@ -474,7 +482,15 @@ class GetUserStatus(ServerMessage):
 
 
 class SetStatus(ServerMessage):
-    """ We send our new status to the server """
+    """ Server code: 28 """
+    """ We send our new status to the server. Status is a way to define whether
+    you're available or busy.
+
+    -1 = Unknown
+    0 = Offline
+    1 = Away
+    2 = Online
+    """
     def __init__(self, status=None):
         self.status = status
 
@@ -483,13 +499,14 @@ class SetStatus(ServerMessage):
 
 
 class NotifyPrivileges(ServerMessage):
-    """ Server tells us something about privileges"""
+    """ Server code: 124 """
+    """ Server tells us something about privileges. """
     def __init__(self, token=None, user=None):
         self.token = token
         self.user = user
 
     def parseNetworkMessage(self, message):
-        pos, self.toaken = self.getObject(message, int)
+        pos, self.token = self.getObject(message, int)
         pos, self.user = self.getObject(message, bytes, pos)
 
     def makeNetworkMessage(self):
@@ -497,6 +514,7 @@ class NotifyPrivileges(ServerMessage):
 
 
 class AckNotifyPrivileges(ServerMessage):
+    """ Server code: 125 """
     def __init__(self, token=None):
         self.token = token
 
@@ -508,25 +526,25 @@ class AckNotifyPrivileges(ServerMessage):
 
 
 class JoinPublicRoom(ServerMessage):
-    """We want to join the Public Chat"""
-    def __init__(self, unknown=0):
-        self.unknown = unknown
-
+    """ Server code: 150 """
+    """ We ask the server to send us messages from all public rooms, also
+    known as public chat. """
     def makeNetworkMessage(self):
-        return self.packObject(NetworkIntType(self.unknown))
+        return b""
 
 
 class LeavePublicRoom(ServerMessage):
-    """We want to leave the Public Chat"""
-    def __init__(self, unknown=0):
-        self.unknown = unknown
-
+    """ Server code: 151 """
+    """ We ask the server to stop sending us messages from all public rooms,
+    also known as public chat. """
     def makeNetworkMessage(self):
-        return self.packObject(NetworkIntType(self.unknown))
+        return b""
 
 
 class PublicRoomMessage(ServerMessage):
-    """The server sends us messages from random chatrooms"""
+    """ Server code: 152 """
+    """ The server sends this when a new message has been written in a public
+    room (every single line written in every public room). """
     def parseNetworkMessage(self, message):
         pos, self.room = self.getObject(message, bytes)
         pos, self.user = self.getObject(message, bytes, pos)
@@ -534,7 +552,8 @@ class PublicRoomMessage(ServerMessage):
 
 
 class SayChatroom(ServerMessage):
-    """ Either we want to say something in the chatroom, or someone did."""
+    """ Server code: 13 """
+    """ Either we want to say something in the chatroom, or someone else did. """
     def __init__(self, room=None, msg=None):
         self.room = room
         self.msg = msg
@@ -563,8 +582,9 @@ class UserData:
 
 
 class JoinRoom(ServerMessage):
+    """ Server code: 14 """
     """ Server sends us this message when we join a room. Contains users list
-    with data on everyone."""
+    with data on everyone. """
     def __init__(self, room=None, private=None):
         self.room = room
         self.private = private
@@ -623,7 +643,9 @@ class JoinRoom(ServerMessage):
 
 
 class PrivateRoomUsers(ServerMessage):
-    """ We get this when we've created a private room."""
+    """ Server code: 133 """
+    """ The server sends us a list of room users that we can alter
+    (add operator abilities / dismember). """
     def __init__(self, room=None, numusers=None, users=None):
         self.room = room
         self.numusers = numusers
@@ -639,7 +661,9 @@ class PrivateRoomUsers(ServerMessage):
 
 
 class PrivateRoomOwned(ServerMessage):
-    """ We get this when we've created a private room."""
+    """ Server code: 148 """
+    """ The server sends us a list of operators in a specific room, that we can
+    remove operator abilities from. """
     def __init__(self, room=None, number=None):
         self.room = room
         self.number = number
@@ -654,7 +678,8 @@ class PrivateRoomOwned(ServerMessage):
 
 
 class PrivateRoomAddUser(ServerMessage):
-    """ We get / receive this when we add a user to a private room."""
+    """ Server code: 134 """
+    """ We send this to inform the server that we've added a user to a private room. """
     def __init__(self, room=None, user=None):
         self.room = room
         self.user = user
@@ -668,31 +693,28 @@ class PrivateRoomAddUser(ServerMessage):
 
 
 class PrivateRoomDismember(ServerMessage):
-    """ We do this to remove our own membership of a private room."""
+    """ Server code: 136 """
+    """ We send this to the server to remove our own membership of a private room. """
     def __init__(self, room=None):
         self.room = room
 
     def makeNetworkMessage(self):
         return self.packObject(self.room)
-
-    def parseNetworkMessage(self, message):
-        pos, self.room = self.getObject(message, bytes)
 
 
 class PrivateRoomDisown(ServerMessage):
-    """ We do this to stop owning a private room."""
+    """ Server code: 137 """
+    """ We send this to the server to stop owning a private room. """
     def __init__(self, room=None):
         self.room = room
 
     def makeNetworkMessage(self):
         return self.packObject(self.room)
 
-    def parseNetworkMessage(self, message):
-        pos, self.room = self.getObject(message, bytes)
-
 
 class PrivateRoomSomething(ServerMessage):
-    """Unknown"""
+    """ Server code: 138 """
+    """ UNKNOWN """
     def __init__(self, room=None):
         self.room = room
 
@@ -705,7 +727,8 @@ class PrivateRoomSomething(ServerMessage):
 
 
 class PrivateRoomRemoveUser(ServerMessage):
-    """ We get this when we've removed a user from a private room."""
+    """ Server code: 135 """
+    """ We send this to inform the server that we've removed a user from a private room. """
     def __init__(self, room=None, user=None):
         self.room = room
         self.user = user
@@ -719,31 +742,28 @@ class PrivateRoomRemoveUser(ServerMessage):
 
 
 class PrivateRoomAdded(ServerMessage):
-    """ We are sent this when we are added to a private room."""
+    """ Server code: 139 """
+    """ The server sends us this message when we are added to a private room. """
     def __init__(self, room=None):
         self.room = room
-
-    def makeNetworkMessage(self):
-        return self.packObject(self.room)
 
     def parseNetworkMessage(self, message):
         self.room = self.getObject(message, bytes)[1]
 
 
 class PrivateRoomRemoved(ServerMessage):
-    """ We are sent this when we are removed from a private room."""
+    """ Server code: 140 """
+    """ The server sends us this message when we are removed from a private room. """
     def __init__(self, room=None):
         self.room = room
-
-    def makeNetworkMessage(self):
-        return self.packObject(self.room)
 
     def parseNetworkMessage(self, message):
         self.room = self.getObject(message, bytes)[1]
 
 
 class PrivateRoomToggle(ServerMessage):
-    """ We send this when we want to enable or disable invitations to private rooms"""
+    """ Server code: 141 """
+    """ We send this when we want to enable or disable invitations to private rooms. """
     def __init__(self, enabled=None):
         self.enabled = None if enabled is None else int(enabled)
 
@@ -756,7 +776,8 @@ class PrivateRoomToggle(ServerMessage):
 
 
 class PrivateRoomAddOperator(ServerMessage):
-    """ We send this to add private room operator abilities to a user"""
+    """ Server code: 143 """
+    """ We send this to the server to add private room operator abilities to a user. """
     def __init__(self, room=None, user=None):
         self.room = room
         self.user = user
@@ -770,7 +791,8 @@ class PrivateRoomAddOperator(ServerMessage):
 
 
 class PrivateRoomRemoveOperator(ServerMessage):
-    """ We send this to remove privateroom operator abilities from a user"""
+    """ Server code: 144 """
+    """ We send this to the server to remove private room operator abilities from a user. """
     def __init__(self, room=None, user=None):
         self.room = room
         self.user = user
@@ -784,19 +806,20 @@ class PrivateRoomRemoveOperator(ServerMessage):
 
 
 class PrivateRoomOperatorAdded(ServerMessage):
-    """ We receive this when given privateroom operator abilities"""
+    """ Server code: 145 """
+    """ The server send us this message when we're given operator abilities
+    in a private room. """
     def __init__(self, room=None):
         self.room = room
-
-    def makeNetworkMessage(self):
-        return self.packObject(self.room)
 
     def parseNetworkMessage(self, message):
         pos, self.room = self.getObject(message, bytes)
 
 
 class PrivateRoomOperatorRemoved(ServerMessage):
-    """ We receive this when privateroom operator abilities are removed"""
+    """ Server code: 146 """
+    """ The server send us this message when our operator abilities are removed
+    in a private room. """
     def __init__(self, room=None):
         self.room = room
 
@@ -805,11 +828,11 @@ class PrivateRoomOperatorRemoved(ServerMessage):
 
     def parseNetworkMessage(self, message):
         pos, self.room = self.getObject(message, bytes)
-        # pos, self.username = self.getObject(message, types.StringType, pos)
 
 
 class LeaveRoom(ServerMessage):
-    """ We send this when we want to leave a room."""
+    """ Server code: 15 """
+    """ We send this to the server when we want to leave a room. """
     def __init__(self, room=None):
         self.room = room
 
@@ -821,7 +844,8 @@ class LeaveRoom(ServerMessage):
 
 
 class UserJoinedRoom(ServerMessage):
-    """ Server tells us someone has just joined the room."""
+    """ Server code: 16 """
+    """ The server tells us someone has just joined a room we're in. """
     def parseNetworkMessage(self, message):
         pos, self.room = self.getObject(message, bytes)
         pos, self.username = self.getObject(message, bytes, pos)
@@ -836,14 +860,19 @@ class UserJoinedRoom(ServerMessage):
 
 
 class UserLeftRoom(ServerMessage):
-    """ Server tells us someone has just left the room."""
+    """ Server code: 17 """
+    """ The server tells us someone has just left a room we're in. """
     def parseNetworkMessage(self, message):
         pos, self.room = self.getObject(message, bytes)
         pos, self.username = self.getObject(message, bytes, pos)
 
 
 class RoomTickerState(ServerMessage):
-    """ Message 113 """
+    """ Server code: 113 """
+    """ The server returns a list of tickers in a chat room.
+
+    Tickers are customizable, user-specific messages that appear in a
+    banner at the top of a chat room. """
     def __init__(self):
         self.room = None
         self.user = None
@@ -859,7 +888,11 @@ class RoomTickerState(ServerMessage):
 
 
 class RoomTickerAdd(ServerMessage):
-    """ Message 114 """
+    """ Server code: 114 """
+    """ The server sends us a new ticker that was added to a chat room.
+
+    Tickers are customizable, user-specific messages that appear in a
+    banner at the top of a chat room. """
     def __init__(self):
         self.room = None
         self.user = None
@@ -872,7 +905,11 @@ class RoomTickerAdd(ServerMessage):
 
 
 class RoomTickerRemove(ServerMessage):
-    """ Message 115 """
+    """ Server code: 115 """
+    """ The server informs us that a ticker was removed from a chat room.
+
+    Tickers are customizable, user-specific messages that appear in a
+    banner at the top of a chat room. """
     def __init__(self, room=None):
         self.user = None
         self.room = room
@@ -883,7 +920,12 @@ class RoomTickerRemove(ServerMessage):
 
 
 class RoomTickerSet(ServerMessage):
-    """ Message 116 """
+    """ Server code: 116 """
+    """ We send this to the server when we change our own ticker in
+    a chat room.
+
+    Tickers are customizable, user-specific messages that appear in a
+    banner at the top of a chat room. """
     def __init__(self, room=None, msg=""):
         self.room = room
         self.msg = msg
@@ -893,10 +935,11 @@ class RoomTickerSet(ServerMessage):
 
 
 class ConnectToPeer(ServerMessage):
+    """ Server code: 18 """
     """ Either we ask server to tell someone else we want to establish a
-    connection with him or server tells us someone wants to connect with us.
+    connection with them, or server tells us someone wants to connect with us.
     Used when the side that wants a connection can't establish it, and tries
-    to go the other way around.
+    to go the other way around (direct connection has failed).
     """
     def __init__(self, token=None, user=None, type=None):
         self.token = token
@@ -914,12 +957,12 @@ class ConnectToPeer(ServerMessage):
         pos, self.port = self.getObject(message, int, pos, 1)
         pos, self.token = self.getObject(message, int, pos)
         if len(message[pos:]) > 0:
-            # Don't know what this is, may be some kind of status
-            pos, self.unknown = pos + 1, message[pos]
+            pos, self.privileged = pos + 1, message[pos]
 
 
 class MessageUser(ServerMessage):
-    """ Chat phrase sent to someone or received by us in private"""
+    """ Server code: 22 """
+    """ Chat phrase sent to someone or received by us in private. """
     def __init__(self, user=None, msg=None):
         self.user = user
         self.msg = msg
@@ -935,7 +978,8 @@ class MessageUser(ServerMessage):
 
 
 class MessageAcked(ServerMessage):
-    """ Confirmation of private chat message.
+    """ Server code: 23 """
+    """ We send this to the server to confirm that we received a private message.
     If we don't send it, the server will keep sending the chat phrase to us.
     """
     def __init__(self, msgid=None):
@@ -946,8 +990,13 @@ class MessageAcked(ServerMessage):
 
 
 class FileSearch(ServerMessage):
-    """ We send this to the server when we search for something."""
-    """ Server send this to tell us someone is searching for something."""
+    """ Server code: 26 """
+    """ We send this to the server when we search for something. Alternatively,
+    the server sends this message to tell us that someone is searching for something.
+
+    The search id is a random number generated by the client and is used to track the
+    search results.
+    """
     def __init__(self, requestid=None, text=None):
         self.searchid = requestid
         self.searchterm = text
@@ -964,20 +1013,23 @@ class FileSearch(ServerMessage):
 
 
 class WishlistSearch(FileSearch):
+    """ Server code: 103 """
     pass
 
 
 class QueuedDownloads(ServerMessage):
-    """ Server sends this to indicate if someone has download slots available
-    or not. """
+    """ Server code: 40 """
+    """ The server sends this to indicate if someone has download slots available
+    or not. DEPRECIATED """
     def parseNetworkMessage(self, message):
         pos, self.user = self.getObject(message, bytes)
         pos, self.slotsfull = self.getObject(message, int, pos)
 
 
 class SendSpeed(ServerMessage):
+    """ Server code: 34 """
     """ We used to send this after a finished download to let the server update
-    the speed statistics for a user"""
+    the speed statistics for a user. DEPRECIATED """
     def __init__(self, user=None, speed=None):
         self.user = user
         self.speed = speed
@@ -987,8 +1039,9 @@ class SendSpeed(ServerMessage):
 
 
 class SendUploadSpeed(ServerMessage):
-    """ We now send this after a finished upload to let the server update
-    the speed statistics for a user"""
+    """ Server code: 121 """
+    """ We send this after a finished upload to let the server update the speed
+    statistics for ourselves. """
     def __init__(self, speed=None):
         self.speed = speed
 
@@ -997,8 +1050,9 @@ class SendUploadSpeed(ServerMessage):
 
 
 class SharedFoldersFiles(ServerMessage):
+    """ Server code: 35 """
     """ We send this to server to indicate the number of folder and files
-    that we share """
+    that we share. """
     def __init__(self, folders=None, files=None):
         self.folders = folders
         self.files = files
@@ -1008,7 +1062,8 @@ class SharedFoldersFiles(ServerMessage):
 
 
 class GetUserStats(ServerMessage):
-    """ Server sends this to indicate change in user's statistics"""
+    """ Server code: 36 """
+    """ The server sends this to indicate a change in a user's statistics. """
     def __init__(self, user=None):
         self.user = user
         self.country = None
@@ -1025,16 +1080,17 @@ class GetUserStats(ServerMessage):
 
 
 class Relogged(ServerMessage):
-    """ Message 41 """
-    """ Server sends this if someone else logged in under our nickname
-    and then disconnects us """
+    """ Server code: 41 """
+    """ The server sends this if someone else logged in under our nickname,
+    and then disconnects us. """
     def parseNetworkMessage(self, message):
         pass
 
 
 class PlaceInLineResponse(ServerMessage):
+    """ Server code: 60 """
     """ Server sends this to indicate change in place in queue while we're
-    waiting for files from other peer """
+    waiting for files from other peer. DEPRECIATED """
     def __init__(self, user=None, req=None, place=None):
         self.req = req
         self.user = user
@@ -1050,22 +1106,24 @@ class PlaceInLineResponse(ServerMessage):
 
 
 class RoomAdded(ServerMessage):
-    """ Server tells us a new room has been added"""
+    """ Server code: 62 """
+    """ The server tells us a new room has been added. """
     def parseNetworkMessage(self, message):
         self.room = self.getObject(message, bytes)[1]
 
 
 class RoomRemoved(ServerMessage):
-    """ Server tells us a room has been removed"""
+    """ Server code: 63 """
+    """ The server tells us a room has been removed. """
     def parseNetworkMessage(self, message):
         self.room = self.getObject(message, bytes)[1]
 
 
 class RoomList(ServerMessage):
-    """ Server tells us a list of rooms"""
-    def __init__(self):
-        pass
-
+    """ Server code: 64 """
+    """ The server tells us a list of rooms and the number of users in
+    them. Soulseek has a room size requirement of about 50 users when
+    first connecting. Refreshing the list will download all rooms. """
     def makeNetworkMessage(self):
         return b""
 
@@ -1104,7 +1162,9 @@ class RoomList(ServerMessage):
 
 
 class ExactFileSearch(ServerMessage):
-    """ Someone is searching for a file with an exact name """
+    """ Server code: 65 """
+    """ Someone is searching for a file with an exact name. DEPRECIATED
+    (no results even with official client) """
     def parseNetworkMessage(self, message):
         pos, self.user = self.getObject(message, bytes)
         pos, self.req = self.getObject(message, int, pos)
@@ -1115,16 +1175,15 @@ class ExactFileSearch(ServerMessage):
 
 
 class AdminMessage(ServerMessage):
-    """ A global message from the admin has arrived """
+    """ Server code: 66 """
+    """ A global message from the server admin has arrived. """
     def parseNetworkMessage(self, message):
         self.msg = self.getObject(message, bytes)[1]
 
 
 class GlobalUserList(JoinRoom):
-    """ We send this to get a global list of all users online """
-    def __init__(self):
-        pass
-
+    """ Server code: 67 """
+    """ We send this to get a global list of all users online. DEPRECIATED """
     def makeNetworkMessage(self):
         return b""
 
@@ -1133,6 +1192,8 @@ class GlobalUserList(JoinRoom):
 
 
 class TunneledMessage(ServerMessage):
+    """ Server code: 68 """
+    """ DEPRECIATED """
     def __init__(self, user=None, req=None, code=None, msg=None):
         self.user = user
         self.req = req
@@ -1156,25 +1217,22 @@ class TunneledMessage(ServerMessage):
 
 
 class ParentMinSpeed(ServerMessage):
-    """ Message 83 """
-    def __init__(self):
-        pass
-
+    """ Server code: 83 """
+    """ UNUSED """
     def parseNetworkMessage(self, message):
         pos, self.num = self.getObject(message, int)
 
 
 class ParentSpeedRatio(ParentMinSpeed):
-    """ Message 84 """
-    def __init__(self):
-        pass
-
+    """ Server code: 84 """
+    """ UNUSED """
     def parseNetworkMessage(self, message):
         pos, self.num = self.getObject(message, int)
 
 
 class SearchParent(ServerMessage):
-    """ Message 73 """
+    """ Server code: 73 """
+    """ We send the IP address of our parent to the server. """
     def __init__(self, parentip=None):
         self.parentip = parentip
 
@@ -1184,37 +1242,29 @@ class SearchParent(ServerMessage):
         return self.packObject(ip)
 
 
-class Msg85(ServerMessage):
-    pass
-
-
 class ParentInactivityTimeout(ServerMessage):
-    # 86
-    def __init__(self):
-        pass
-
+    """ Server code: 86 """
+    """ DEPRECIATED """
     def parseNetworkMessage(self, message):
         pos, self.seconds = self.getObject(message, int)
 
 
 class SearchInactivityTimeout(ServerMessage):
-    # 87
-    def __init__(self):
-        pass
-
+    """ Server code: 87 """
+    """ DEPRECIATED """
     def parseNetworkMessage(self, message):
         pos, self.seconds = self.getObject(message, int)
 
 
 class MinParentsInCache(ServerMessage):
-    def __init__(self):
-        pass
-
+    """ Server code: 88 """
+    """ DEPRECIATED """
     def parseNetworkMessage(self, message):
         pos, self.num = self.getObject(message, int)
 
 
 class UploadQueueNotification(PeerMessage):
+    """ Peer code: 52 """
     def __init__(self, conn):
         self.conn = conn
 
@@ -1225,38 +1275,23 @@ class UploadQueueNotification(PeerMessage):
         return b""
 
 
-class Msg89(ServerMessage):
-    def __init__(self):
-        pass
-
-    def parseNetworkMessage(self, message):
-        pass
-
-
 class DistribAliveInterval(ServerMessage):
-    """ Message 90 """
-    def __init__(self):
-        pass
-
+    """ Server code: 90 """
+    """ DEPRECIATED """
     def parseNetworkMessage(self, message):
         pos, self.seconds = self.getObject(message, int)
 
 
 class WishlistInterval(ServerMessage):
-    """ Message 104"""
-    def __init__(self):
-        pass
-
+    """ Server code: 104 """
     def parseNetworkMessage(self, message):
         pos, self.seconds = self.getObject(message, int)
 
 
 class PrivilegedUsers(ServerMessage):
-    """ Message 69 """
-    """ A list of those who made a donation """
-    def __init__(self):
-        pass
-
+    """ Server code: 69 """
+    """ The server sends us a list of privileged users, a.k.a. users who
+    have donated. """
     def parseNetworkMessage(self, message):
         try:
             x = zlib.decompress(message)
@@ -1271,10 +1306,9 @@ class PrivilegedUsers(ServerMessage):
 
 
 class CheckPrivileges(ServerMessage):
-    """ Message 92 """
-    def __init__(self):
-        pass
-
+    """ Server code: 92 """
+    """ We ask the server how much time we have left of our privileges.
+    The server responds with the remaining time, in seconds. """
     def makeNetworkMessage(self):
         return b""
 
@@ -1283,10 +1317,9 @@ class CheckPrivileges(ServerMessage):
 
 
 class AddToPrivileged(ServerMessage):
-    """ Message 91 """
-    def __init__(self):
-        pass
-
+    """ Server code: 91 """
+    """ The server sends us the username of a new privileged user, which we
+    add to our list of global privileged users. """
     def parseNetworkMessage(self, message):
         l2, self.user = self.getObject(message, bytes)
 
@@ -1295,7 +1328,7 @@ class CantConnectToPeer(ServerMessage):
     """ Message 1001 """
     """ We send this to say we can't connect to peer after it has asked us
     to connect. We receive this if we asked peer to connect and it can't do
-    this. So this message means a connection can't be established either way.
+    this. This message means a connection can't be established either way.
     """
     def __init__(self, token=None, user=None):
         self.token = token
@@ -1316,7 +1349,8 @@ class CantConnectToPeer(ServerMessage):
 
 
 class ServerPing(ServerMessage):
-    """ Message 32 """
+    """ Server code: 32 """
+    """ We test if the server responds. """
     def makeNetworkMessage(self):
         return b""
 
@@ -1325,7 +1359,8 @@ class ServerPing(ServerMessage):
 
 
 class AddThingILike(ServerMessage):
-    """ Add item to our likes list """
+    """ Server code: 51 """
+    """ We send this to the server when we add an item to our likes list. """
     def __init__(self, thing=None):
         self.thing = thing
 
@@ -1334,11 +1369,14 @@ class AddThingILike(ServerMessage):
 
 
 class AddThingIHate(AddThingILike):
+    """ Server code: 117 """
+    """ We send this to the server when we add an item to our hate list. """
     pass
 
 
 class RemoveThingILike(ServerMessage):
-    """ Remove item from our likes list """
+    """ Server code: 52 """
+    """ We send this to the server when we remove an item from our likes list. """
     def __init__(self, thing=None):
         self.thing = thing
 
@@ -1347,10 +1385,15 @@ class RemoveThingILike(ServerMessage):
 
 
 class RemoveThingIHate(RemoveThingILike):
+    """ Server code: 118 """
+    """ We send this to the server when we remove an item from our hate list. """
     pass
 
 
 class UserInterests(ServerMessage):
+    """ Server code: 57 """
+    """ We ask the server for a user's liked and hated interests. The server
+    responds with a list of interests. """
     def __init__(self, user=None):
         self.user = user
         self.likes = None
@@ -1377,6 +1420,9 @@ class UserInterests(ServerMessage):
 
 
 class GlobalRecommendations(ServerMessage):
+    """ Server code: 56 """
+    """ The server sends us a list of global recommendations and a number
+    for each. """
     def __init__(self):
         self.recommendations = None
         self.unrecommendations = None
@@ -1407,10 +1453,17 @@ class GlobalRecommendations(ServerMessage):
 
 
 class Recommendations(GlobalRecommendations):
+    """ Server code: 54 """
+    """ The server sends us a list of personal recommendations and a number
+    for each. """
     pass
 
 
 class ItemRecommendations(GlobalRecommendations):
+    """ Server code: 111 """
+    """ The server sends us a list of recommendations related to a specific
+    item, which is usually present in the like/dislike list or an existing
+    recommendation list. """
     def __init__(self, thing=None):
         GlobalRecommendations.__init__(self)
         self.thing = thing
@@ -1424,6 +1477,8 @@ class ItemRecommendations(GlobalRecommendations):
 
 
 class SimilarUsers(ServerMessage):
+    """ Server code: 110 """
+    """ The server sends us a list of similar users related to our interests. """
     def __init__(self):
         self.users = None
 
@@ -1440,6 +1495,9 @@ class SimilarUsers(ServerMessage):
 
 
 class ItemSimilarUsers(ServerMessage):
+    """ Server code: 112 """
+    """ The server sends us a list of similar users related to a specific item,
+    which is usually present in the like/dislike list or recommendation list. """
     def __init__(self, thing=None):
         self.thing = thing
         self.users = None
@@ -1457,6 +1515,7 @@ class ItemSimilarUsers(ServerMessage):
 
 
 class RoomSearch(ServerMessage):
+    """ Server code: 120 """
     def __init__(self, room=None, requestid=None, text=""):
         self.room = room
         self.searchid = requestid
@@ -1477,6 +1536,10 @@ class RoomSearch(ServerMessage):
 
 
 class UserSearch(ServerMessage):
+    """ Server code: 42 """
+    """ We send this to the server when we search a specific user's shares.
+    The ticket/search id is a random number generated by the client and is
+    used to track the search results. """
     def __init__(self, user=None, requestid=None, text=None):
         self.suser = user
         self.searchid = requestid
@@ -1494,9 +1557,9 @@ class UserSearch(ServerMessage):
 
 
 class PierceFireWall(PeerMessage):
-    """ This is the very first message send by peer that established a
-    connection, if it has been asked by other peer to do so. Token is taken
-    from ConnectToPeer server message."""
+    """ This is the very first message sent by the peer that established a
+    connection, if it has been asked by the other peer to do so. The token
+    is taken from the ConnectToPeer server message. """
     def __init__(self, conn, token=None):
         self.conn = conn
         self.token = token
@@ -1509,10 +1572,10 @@ class PierceFireWall(PeerMessage):
 
 
 class PeerInit(PeerMessage):
-    """ This message is sent by peer that initiated a connection, not
-    necessarily a peer that actually established it. Token apparently
-    can be anything. Type is 'P' if it's anything but filetransfer, 'F'
-    otherwise"""
+    """ This message is sent by the peer that initiated a connection,
+    not necessarily a peer that actually established it. Token apparently
+    can be anything. Type is 'P' if it's anything but filetransfer,
+    'F' otherwise. """
     def __init__(self, conn, user=None, type=None, token=None):
         self.conn = conn
         self.user = user
@@ -1551,7 +1614,9 @@ class PMessageUser(PeerMessage):
 
 
 class UserInfoRequest(PeerMessage):
-    """ Ask other peer to send user information, picture and all."""
+    """ Peer code: 15 """
+    """ We ask the other peer to send us their user information, picture
+    and all."""
     def __init__(self, conn):
         self.conn = conn
 
@@ -1563,7 +1628,8 @@ class UserInfoRequest(PeerMessage):
 
 
 class UserInfoReply(PeerMessage):
-    """ Peer responds with this, when asked for user information."""
+    """ Peer code: 16 """
+    """ A peer responds with this when we've sent a UserInfoRequest. """
     def __init__(self, conn, descr=None, pic=None, totalupl=None, queuesize=None, slotsavail=None, uploadallowed=None):
         self.conn = conn
         self.descr = descr
@@ -1600,7 +1666,9 @@ class UserInfoReply(PeerMessage):
 
 
 class SharedFileList(PeerMessage):
-    """ Peer responds with this when asked for a filelist."""
+    """ Peer code: 5 """
+    """ A peer responds with a list of shared files when we've sent
+    a GetSharedFileList. """
     def __init__(self, conn, shares=None):
         self.conn = conn
         self.list = shares
@@ -1665,20 +1733,23 @@ class SharedFileList(PeerMessage):
 
 
 class GetSharedFileList(PeerMessage):
-    """ Ask the peer for a filelist. """
+    """ Peer code: 4 """
+    """ We send this to a peer to ask for a list of shared files. """
     def __init__(self, conn):
         self.conn = conn
-
-    def parseNetworkMessage(self, message):
-        pass
 
     def makeNetworkMessage(self):
         return b""
 
+    def parseNetworkMessage(self, message):
+        pass
+
 
 class FileSearchRequest(PeerMessage):
-    """ We send this to the peer when we search for something."""
-    """ Peer sends this to tell us he is  searching for something."""
+    """ Peer code: 8 """
+    """ We send this to the peer when we search for a file.
+    Alternatively, the peer sends this to tell us it is
+    searching for a file. """
     def __init__(self, conn, requestid=None, text=None):
         self.conn = conn
         self.requestid = requestid
@@ -1693,7 +1764,9 @@ class FileSearchRequest(PeerMessage):
 
 
 class FileSearchResult(PeerMessage):
-    """ Peer sends this when it has a file search match."""
+    """ Peer code: 9 """
+    """ The peer sends this when it has a file search match. The
+    token/ticket is taken from original FileSearchRequest message. """
     def __init__(self, conn, user=None, geoip=None, token=None, shares=None, fileindex=None, freeulslots=None, ulspeed=None, inqueue=None, fifoqueue=None):
         self.conn = conn
         self.user = user
@@ -1776,7 +1849,8 @@ class FileSearchResult(PeerMessage):
 
 
 class FolderContentsRequest(PeerMessage):
-    """ Ask the peer to send us the contents of a single folder. """
+    """ Peer code: 36 """
+    """ We ask the peer to send us the contents of a single folder. """
     def __init__(self, conn, directory=None):
         self.conn = conn
         self.dir = directory
@@ -1790,8 +1864,9 @@ class FolderContentsRequest(PeerMessage):
 
 
 class FolderContentsResponse(PeerMessage):
-    """ Peer tells us the contents of a particular folder (with all subfolders)
-    """
+    """ Peer code: 37 """
+    """ A peer responds with the contents of a particular folder
+    (with all subfolders) when we've sent a FolderContentsRequest. """
     def __init__(self, conn, directory=None, shares=None):
         self.conn = conn
         self.dir = directory
@@ -1844,8 +1919,9 @@ class FolderContentsResponse(PeerMessage):
 
 
 class TransferRequest(PeerMessage):
-    """ Request a file from peer, or tell a peer that we want to send a file to
-    them. """
+    """ Peer code: 40 """
+    """ We request a file from a peer, or tell a peer that we want to send
+    a file to them. """
     def __init__(self, conn, direction=None, req=None, file=None, filesize=None, realfile=None):
         self.conn = conn
         self.direction = direction
@@ -1869,8 +1945,9 @@ class TransferRequest(PeerMessage):
 
 
 class TransferResponse(PeerMessage):
-    """ Response to the TreansferRequest - either we (or other peer) agrees, or
-    tells the reason for rejecting filetransfer. """
+    """ Peer code: 41 """
+    """ Response to TransferRequest - either we (or the other peer) agrees,
+    or tells the reason for rejecting the file transfer. """
     def __init__(self, conn, allowed=None, reason=None, req=None, filesize=None):
         self.conn = conn
         self.allowed = allowed
@@ -1897,6 +1974,8 @@ class TransferResponse(PeerMessage):
 
 
 class PlaceholdUpload(PeerMessage):
+    """ Peer code: 42 """
+    """ DEPRECIATED """
     def __init__(self, conn, file=None):
         self.conn = conn
         self.file = file
@@ -1909,14 +1988,17 @@ class PlaceholdUpload(PeerMessage):
 
 
 class QueueUpload(PlaceholdUpload):
+    """ Peer code: 43 """
     pass
 
 
 class UploadFailed(PlaceholdUpload):
+    """ Peer code: 46 """
     pass
 
 
 class PlaceInQueue(PeerMessage):
+    """ Peer code: 44 """
     def __init__(self, conn, filename=None, place=None):
         self.conn = conn
         self.filename = filename
@@ -1931,10 +2013,12 @@ class PlaceInQueue(PeerMessage):
 
 
 class PlaceInQueueRequest(PlaceholdUpload):
+    """ Peer code: 51 """
     pass
 
 
 class QueueFailed(PeerMessage):
+    """ Peer code: 50 """
     def __init__(self, conn, file=None, reason=None):
         self.conn = conn
         self.file = file
@@ -1960,7 +2044,8 @@ class FileRequest(PeerMessage):
         return msg
 
 
-class HaveNoParent(ServerMessage):  # 71
+class HaveNoParent(ServerMessage):
+    """ Server code: 71 """
     def __init__(self, noparent=None):
         self.noparent = noparent
 
@@ -1969,6 +2054,7 @@ class HaveNoParent(ServerMessage):  # 71
 
 
 class DistribAlive(DistribMessage):
+    """ Distrib code: 0 """
     def __init__(self, conn):
         self.conn = conn
 
@@ -1977,25 +2063,36 @@ class DistribAlive(DistribMessage):
 
 
 class DistribSearch(DistribMessage):
-    """ Search request that arrives through the distributed network """
+    """ Distrib code: 3 or 93 """
+    """
+    Search request that arrives through the distributed network.
+    We transmit the search request to our children.
+
+    Search requests are sent to us by the server using SearchRequest
+    if we're a branch root, or by our parent using DistribSearch.
+    (TODO: check that this works / is implemented)
+    """
     def __init__(self, conn):
         self.conn = conn
 
     def parseNetworkMessage(self, message):
-        try:
-            self._parseNetworkMessage(message)
-        except Exception as error:
-            log.addwarning(_("Exception during parsing %(area)s: %(exception)s") % {'area': 'DistribSearch', 'exception': error})
-            return False
+        # try:
+        self._parseNetworkMessage(message)
+        # except Exception as error:
+        # log.addwarning(_("Exception during parsing %(area)s: %(exception)s") % {'area': 'DistribSearch', 'exception': error})
+        # return False
 
     def _parseNetworkMessage(self, message):
-        pos, self.unknown = self.getObject(message, NetworkLongLongType, printerror=False)
+        print("hit")
+        pos, self.unknown = self.getObject(message, int, printerror=False)
         pos, self.user = self.getObject(message, bytes, pos, printerror=False)
-        pos, self.searchid = self.getObject(message, NetworkLongLongType, pos, printerror=False)
+        pos, self.searchid = self.getObject(message, int, pos, printerror=False)
         pos, self.searchterm = self.getObject(message, bytes, pos, printerror=False)
 
 
 class DistribBranchLevel(DistribMessage):
+    """ Distrib code: 4 """
+    """ TODO: implement fully """
     def __init__(self, conn):
         self.conn = conn
 
@@ -2005,6 +2102,8 @@ class DistribBranchLevel(DistribMessage):
 
 
 class DistribBranchRoot(DistribMessage):
+    """ Distrib code: 5 """
+    """ TODO: implement fully """
     def __init__(self, conn):
         self.conn = conn
 
@@ -2015,6 +2114,8 @@ class DistribBranchRoot(DistribMessage):
 
 
 class DistribChildDepth(DistribMessage):
+    """ Distrib code: 7 """
+    """ TODO: implement fully """
     def __init__(self, conn):
         self.conn = conn
 
@@ -2024,18 +2125,16 @@ class DistribChildDepth(DistribMessage):
 
 
 class BranchLevel(ServerMessage):
-    def __init__(self):
-        pass
-
+    """ Server code: 126 """
+    """ TODO: implement fully """
     def parseNetworkMessage(self, message):
         pos, self.value = self.getObject(message, int)
         # print message.__repr__()
 
 
 class BranchRoot(ServerMessage):
-    def __init__(self):
-        pass
-
+    """ Server code: 127 """
+    """ TODO: implement fully """
     def parseNetworkMessage(self, message):
         # pos, self.value = self.getObject(message, types.IntType)
         pos, self.user = self.getObject(message, bytes)
@@ -2043,6 +2142,9 @@ class BranchRoot(ServerMessage):
 
 
 class AcceptChildren(ServerMessage):
+    """ Server code: 100 """
+    """ We tell the server if we want to accept child nodes.
+    TODO: actually use this somewhere """
     def __init__(self, enabled=None):
         self.enabled = enabled
 
@@ -2051,18 +2153,16 @@ class AcceptChildren(ServerMessage):
 
 
 class ChildDepth(ServerMessage):
-    def __init__(self):
-        pass
-
+    """ Server code: 129 """
+    """ TODO: implement fully """
     def parseNetworkMessage(self, message):
         pos, self.value = self.getObject(message, int)
 
 
 class NetInfo(ServerMessage):
-    """ Information about what nodes have been added/removed in the network """
-    def __init__(self):
-        pass
-
+    """ Server code: 102 """
+    """ The server send us information about what nodes have been
+    added/removed in the network. """
     def parseNetworkMessage(self, message: bytes):
         self.list = {}
         pos, num = self.getObject(message, int)
@@ -2074,10 +2174,8 @@ class NetInfo(ServerMessage):
 
 
 class SearchRequest(ServerMessage):
-    """ Search request that arrives through the server"""
-    def __init__(self):
-        pass
-
+    """ Server code: 93 """
+    """ The server sends us search requests from other users. """
     def parseNetworkMessage(self, message):
         pos, self.code = 1, message[0]
         pos, self.something = self.getObject(message, int, pos)
@@ -2087,7 +2185,8 @@ class SearchRequest(ServerMessage):
 
 
 class UserPrivileged(ServerMessage):
-    """ Discover whether a user is privileged or not """
+    """ Server code: 122 """
+    """ We ask the server whether a user is privileged or not. """
     def __init__(self, user=None):
         self.user = user
         self.privileged = None
@@ -2101,7 +2200,9 @@ class UserPrivileged(ServerMessage):
 
 
 class GivePrivileges(ServerMessage):
-    """ Give (part) of your privileges to another user on the network """
+    """ Server code: 123 """
+    """ We give (part of) our privileges, specified in days, to another
+    user on the network. """
     def __init__(self, user=None, days=None):
         self.user = user
         self.days = days

--- a/pynicotine/slskmessages.py
+++ b/pynicotine/slskmessages.py
@@ -1214,14 +1214,6 @@ class MinParentsInCache(ServerMessage):
         pos, self.num = self.getObject(message, int)
 
 
-class Msg12547(ServerMessage):
-    def __init__(self, conn):
-        self.conn = conn
-
-    def parseNetworkMessage(self, message):
-        pass
-
-
 class UploadQueueNotification(PeerMessage):
     def __init__(self, conn):
         self.conn = conn
@@ -2028,22 +2020,6 @@ class DistribChildDepth(DistribMessage):
 
     def parseNetworkMessage(self, message):
         pos, self.value = self.getObject(message, int)
-        # print self.something, self.user
-
-
-class DistribMessage9(DistribMessage):
-    def __init__(self, conn):
-        self.conn = conn
-
-    def parseNetworkMessage(self, message):
-        # pos, self.value = self.getObject(message, types.IntType)
-        try:
-            x = zlib.decompress(message)  # noqa: F841
-        except Exception:
-            self.debug()
-        # message =  x[4:]
-        # pos, self.user = self.getObject(message, types.StringType)
-        # self.debug()
         # print self.something, self.user
 
 

--- a/pynicotine/slskmessages.py
+++ b/pynicotine/slskmessages.py
@@ -241,8 +241,9 @@ class SlskMessage:
                 else:
                     return intsize + start, struct.unpack("<I", message[start:start + intsize])[0]
             elif type is bytes:
-                length = struct.unpack("<I", message[start:start + intsize])[0]
+                length = struct.unpack("<I", message[start:start + intsize].ljust(intsize, b'\0'))[0]
                 string = message[start + intsize:start + length + intsize]
+                print(string)
 
                 if rawbytes is False:
                     string = findBestEncoding(string, ['utf-8', 'iso-8859-1'])
@@ -1813,6 +1814,7 @@ class FileSearchResult(PeerMessage):
         self.pos, self.inqueue = self.getObject(message, int, self.pos)
 
     def makeNetworkMessage(self):
+        print("hm")
         filelist = []
         for i in self.list:
             try:
@@ -1822,7 +1824,7 @@ class FileSearchResult(PeerMessage):
 
         queuesize = self.inqueue[0]
 
-        print(self.token)
+        print(filelist)
         msg = (self.packObject(self.user) +
                self.packObject(NetworkLongLongType(self.token)) +
                self.packObject(NetworkIntType(len(filelist))))
@@ -1845,6 +1847,8 @@ class FileSearchResult(PeerMessage):
         msg += (bytes([self.freeulslots]) +
                 self.packObject(NetworkIntType(self.ulspeed)) +
                 self.packObject(NetworkIntType(queuesize)))
+        print(msg)
+        print(zlib.compress(msg))
         return zlib.compress(msg)
 
 
@@ -2083,11 +2087,15 @@ class DistribSearch(DistribMessage):
         # return False
 
     def _parseNetworkMessage(self, message):
-        print("hit")
-        pos, self.unknown = self.getObject(message, int, printerror=False)
+        print(message)
+        pos, self.unknown = self.getObject(message, NetworkLongLongType, printerror=False)
+        print(self.unknown)
         pos, self.user = self.getObject(message, bytes, pos, printerror=False)
+        print(self.user)
         pos, self.searchid = self.getObject(message, int, pos, printerror=False)
+        print(self.searchid)
         pos, self.searchterm = self.getObject(message, bytes, pos, printerror=False)
+        print(self.searchterm)
 
 
 class DistribBranchLevel(DistribMessage):
@@ -2177,6 +2185,7 @@ class SearchRequest(ServerMessage):
     """ Server code: 93 """
     """ The server sends us search requests from other users. """
     def parseNetworkMessage(self, message):
+        print(message)
         pos, self.code = 1, message[0]
         pos, self.something = self.getObject(message, int, pos)
         pos, self.user = self.getObject(message, bytes, pos)
@@ -2208,6 +2217,7 @@ class GivePrivileges(ServerMessage):
         self.days = days
 
     def makeNetworkMessage(self):
+        print(self.user)
         return self.packObject(self.user) + self.packObject(self.days)
 
 

--- a/pynicotine/slskmessages.py
+++ b/pynicotine/slskmessages.py
@@ -2045,10 +2045,14 @@ class FileRequest(PeerMessage):
 
 class HaveNoParent(ServerMessage):
     """ Server code: 71 """
+    """ We inform the server if we have a distributed parent or not.
+    If not, the server eventually sends us a NetInfo message with a
+    list of 10 possible parents to connect to. """
     def __init__(self, noparent=None):
         self.noparent = noparent
 
     def makeNetworkMessage(self):
+        print(self.noparent)
         return bytes((self.noparent,))
 
 
@@ -2187,7 +2191,8 @@ class ChildDepth(ServerMessage):
 class NetInfo(ServerMessage):
     """ Server code: 102 """
     """ The server send us information about what nodes have been
-    added/removed in the network. """
+    added/removed in the network. The list contains 10 possible
+    distributed parents to connect to. """
     def parseNetworkMessage(self, message: bytes):
         self.list = {}
         pos, num = self.getObject(message, int)
@@ -2196,6 +2201,7 @@ class NetInfo(ServerMessage):
             pos, self.ip = pos + 4, socket.inet_ntoa(message[pos:pos + 4][::-1])
             pos, port = self.getObject(message, int, pos)
             self.list[username] = (self.ip, port)
+        print(self.list)
 
 
 class SearchRequest(ServerMessage):

--- a/pynicotine/slskmessages.py
+++ b/pynicotine/slskmessages.py
@@ -437,20 +437,6 @@ class AddUser(ServerMessage):
                 pos, self.country = self.getObject(message, bytes, pos)
 
 
-class Unknown6(ServerMessage):
-    """ Server code: 6 """
-    """ UNKNOWN """
-    def __init__(self, user=None):
-        self.user = user
-
-    def makeNetworkMessage(self):
-        return self.packObject(self.user)
-
-    def parseNetworkMessage(self, message):
-        self.debug()
-        pass
-
-
 class RemoveUser(ServerMessage):
     """ Used when we no longer want to be kept updated about a user's status.
     (is this used anywhere?) """
@@ -2052,7 +2038,6 @@ class HaveNoParent(ServerMessage):
         self.noparent = noparent
 
     def makeNetworkMessage(self):
-        print(self.noparent)
         return bytes((self.noparent,))
 
 
@@ -2201,7 +2186,6 @@ class NetInfo(ServerMessage):
             pos, self.ip = pos + 4, socket.inet_ntoa(message[pos:pos + 4][::-1])
             pos, port = self.getObject(message, int, pos)
             self.list[username] = (self.ip, port)
-        print(self.list)
 
 
 class SearchRequest(ServerMessage):

--- a/pynicotine/slskproto.py
+++ b/pynicotine/slskproto.py
@@ -57,6 +57,7 @@ from pynicotine.slskmessages import DistribBranchLevel
 from pynicotine.slskmessages import DistribBranchRoot
 from pynicotine.slskmessages import DistribChildDepth
 from pynicotine.slskmessages import DistribSearch
+from pynicotine.slskmessages import DistribServerSearch
 from pynicotine.slskmessages import DownloadFile
 from pynicotine.slskmessages import ExactFileSearch
 from pynicotine.slskmessages import FileError
@@ -376,7 +377,7 @@ class SlskProtoThread(threading.Thread):
         4: DistribBranchLevel,  # Unimplemented
         5: DistribBranchRoot,  # Unimplemented
         7: DistribChildDepth,  # Unimplemented
-        93: DistribSearch
+        93: DistribServerSearch
     }
 
     IN_PROGRESS_STALE_AFTER = 30

--- a/pynicotine/slskproto.py
+++ b/pynicotine/slskproto.py
@@ -156,7 +156,6 @@ from pynicotine.slskmessages import SimilarUsers
 from pynicotine.slskmessages import TransferRequest
 from pynicotine.slskmessages import TransferResponse
 from pynicotine.slskmessages import TunneledMessage
-from pynicotine.slskmessages import Unknown6
 from pynicotine.slskmessages import UploadFailed
 from pynicotine.slskmessages import UploadFile
 from pynicotine.slskmessages import UploadQueueNotification
@@ -263,7 +262,6 @@ class SlskProtoThread(threading.Thread):
         SetWaitPort: 2,
         GetPeerAddress: 3,
         AddUser: 5,
-        Unknown6: 6,
         GetUserStatus: 7,
         SayChatroom: 13,
         JoinRoom: 14,

--- a/pynicotine/slskproto.py
+++ b/pynicotine/slskproto.py
@@ -1,4 +1,9 @@
+# Copyright (C) 2020 Nicotine+ Team
 # Copyright (C) 2007 daelstorm. All rights reserved.
+# Copyright (c) 2003-2004 Hyriand. All rights reserved.
+#
+# Based on code from PySoulSeek, original copyright note:
+# Copyright (c) 2001-2003 Alexander Kanavin. All rights reserved.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -12,15 +17,9 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
-#
-# Previous copyright below
-# Copyright (c) 2003-2004 Hyriand. All rights reserved.
-#
-# Based on code from PySoulSeek, original copyright note:
-# Copyright (c) 2001-2003 Alexander Kanavin. All rights reserved.
 
 """
-This module implements SoulSeek networking protocol.
+This module implements Soulseek networking protocol.
 """
 
 import codecs
@@ -89,8 +88,6 @@ from pynicotine.slskmessages import Login
 from pynicotine.slskmessages import MessageAcked
 from pynicotine.slskmessages import MessageUser
 from pynicotine.slskmessages import MinParentsInCache
-from pynicotine.slskmessages import Msg85
-from pynicotine.slskmessages import Msg89
 from pynicotine.slskmessages import NetInfo
 from pynicotine.slskmessages import NotifyPrivileges
 from pynicotine.slskmessages import OutConn
@@ -278,10 +275,10 @@ class SlskProtoThread(threading.Thread):
         FileSearch: 26,
         SetStatus: 28,
         ServerPing: 32,
-        SendSpeed: 34,
+        SendSpeed: 34,  # Depreciated
         SharedFoldersFiles: 35,
         GetUserStats: 36,
-        QueuedDownloads: 40,
+        QueuedDownloads: 40,  # Depreciated
         Relogged: 41,
         UserSearch: 42,
         AddThingILike: 51,
@@ -289,25 +286,23 @@ class SlskProtoThread(threading.Thread):
         Recommendations: 54,
         GlobalRecommendations: 56,
         UserInterests: 57,
-        PlaceInLineResponse: 60,  # Depreciated?
-        RoomAdded: 62,
-        RoomRemoved: 63,
+        PlaceInLineResponse: 60,  # Depreciated
+        RoomAdded: 62,  # Depreciated
+        RoomRemoved: 63,  # Depreciated
         RoomList: 64,
-        ExactFileSearch: 65,
+        ExactFileSearch: 65,  # Depreciated
         AdminMessage: 66,
-        GlobalUserList: 67,  # Depreciated?
-        TunneledMessage: 68,  # Depreciated?
+        GlobalUserList: 67,  # Depreciated
+        TunneledMessage: 68,  # Depreciated
         PrivilegedUsers: 69,
         HaveNoParent: 71,
         SearchParent: 73,
-        ParentMinSpeed: 83,
-        ParentSpeedRatio: 84,
-        Msg85: 85,
-        ParentInactivityTimeout: 86,
-        SearchInactivityTimeout: 87,
-        MinParentsInCache: 88,
-        Msg89: 89,
-        DistribAliveInterval: 90,
+        ParentMinSpeed: 83,  # Unused
+        ParentSpeedRatio: 84,  # Unused
+        ParentInactivityTimeout: 86,  # Depreciated
+        SearchInactivityTimeout: 87,  # Depreciated
+        MinParentsInCache: 88,  # Depreciated
+        DistribAliveInterval: 90,  # Depreciated
         AddToPrivileged: 91,
         CheckPrivileges: 92,
         SearchRequest: 93,
@@ -330,10 +325,9 @@ class SlskProtoThread(threading.Thread):
         GivePrivileges: 123,
         NotifyPrivileges: 124,
         AckNotifyPrivileges: 125,
-        BranchLevel: 126,
-        BranchRoot: 127,
-        ChildDepth: 129,
-        # AnotherStatus: 10,
+        BranchLevel: 126,  # Unimplemented
+        BranchRoot: 127,  # Unimplemented
+        ChildDepth: 129,  # Unimplemented
         PrivateRoomUsers: 133,
         PrivateRoomAddUser: 134,
         PrivateRoomRemoveUser: 135,
@@ -367,7 +361,7 @@ class SlskProtoThread(threading.Thread):
         FolderContentsResponse: 37,
         TransferRequest: 40,
         TransferResponse: 41,
-        PlaceholdUpload: 42,
+        PlaceholdUpload: 42,  # Depreciated
         QueueUpload: 43,
         PlaceInQueue: 44,
         UploadFailed: 46,
@@ -379,9 +373,9 @@ class SlskProtoThread(threading.Thread):
     distribclasses = {
         0: DistribAlive,
         3: DistribSearch,
-        4: DistribBranchLevel,
-        5: DistribBranchRoot,
-        7: DistribChildDepth,
+        4: DistribBranchLevel,  # Unimplemented
+        5: DistribBranchRoot,  # Unimplemented
+        7: DistribChildDepth,  # Unimplemented
         93: DistribSearch
     }
 

--- a/pynicotine/slskproto.py
+++ b/pynicotine/slskproto.py
@@ -57,7 +57,6 @@ from pynicotine.slskmessages import DistribAliveInterval
 from pynicotine.slskmessages import DistribBranchLevel
 from pynicotine.slskmessages import DistribBranchRoot
 from pynicotine.slskmessages import DistribChildDepth
-from pynicotine.slskmessages import DistribMessage9
 from pynicotine.slskmessages import DistribSearch
 from pynicotine.slskmessages import DownloadFile
 from pynicotine.slskmessages import ExactFileSearch
@@ -92,7 +91,6 @@ from pynicotine.slskmessages import MessageUser
 from pynicotine.slskmessages import MinParentsInCache
 from pynicotine.slskmessages import Msg85
 from pynicotine.slskmessages import Msg89
-from pynicotine.slskmessages import Msg12547
 from pynicotine.slskmessages import NetInfo
 from pynicotine.slskmessages import NotifyPrivileges
 from pynicotine.slskmessages import OutConn
@@ -375,8 +373,7 @@ class SlskProtoThread(threading.Thread):
         UploadFailed: 46,
         QueueFailed: 50,
         PlaceInQueueRequest: 51,
-        UploadQueueNotification: 52,
-        Msg12547: 12547
+        UploadQueueNotification: 52
     }
 
     distribclasses = {
@@ -385,7 +382,7 @@ class SlskProtoThread(threading.Thread):
         4: DistribBranchLevel,
         5: DistribBranchRoot,
         7: DistribChildDepth,
-        9: DistribMessage9
+        93: DistribSearch
     }
 
     IN_PROGRESS_STALE_AFTER = 30


### PR DESCRIPTION
- Clean up and update Soulseek protocol documentation with newer information
- Clean up protocol message code
- Add distrib type 93 (https://github.com/jpdillingham/Soulseek.NET/issues/228). Closes https://github.com/Nicotine-Plus/nicotine-plus/issues/322
- Add padding to search term bytes when unpacking, if necessary. This prevents the program from breaking if distributed search terms are shorter than 4 characters, since struct.unpack needs exactly 4 bytes.