### PR TITLE
Use long long for file size in file request

### DIFF
--- a/doc/SLSKPROTOCOL.md
+++ b/doc/SLSKPROTOCOL.md
@@ -72,7 +72,6 @@ and callbacks for the messages are set in pynicotine.py.
 | 2    | [Set Listen Port](#server-code-2)                 |
 | 3    | [Get Peer Address](#server-code-3)                |
 | 5    | [Add User](#server-code-5)                        |
-| 6    | [Unknown](#server-code-6)                         |
 | 7    | [Get Status](#server-code-7)                      |
 | 13   | [Say in Chat Room](#server-code-13)               |
 | 14   | [Join Room](#server-code-14)                      |

--- a/pynicotine/slskmessages.py
+++ b/pynicotine/slskmessages.py
@@ -1931,7 +1931,7 @@ class TransferRequest(PeerMessage):
         pos, self.req = self.getObject(message, int, pos)
         pos, self.file = self.getObject(message, bytes, pos)
         if self.direction == 1:
-            pos, self.filesize = self.getObject(message, int, pos)
+            pos, self.filesize = self.getObject(message, NetworkLongLongType, pos)
 
 
 class TransferResponse(PeerMessage):
@@ -1958,7 +1958,7 @@ class TransferResponse(PeerMessage):
         pos, self.allowed = pos + 1, message[pos]
         if message[pos:]:
             if self.allowed:
-                pos, self.filesize = self.getObject(message, int, pos)
+                pos, self.filesize = self.getObject(message, NetworkLongLongType, pos)
             else:
                 pos, self.reason = self.getObject(message, bytes, pos)
 


### PR DESCRIPTION
This allows Nicotine+ to download >2GB files from other Nicotine+ clients by not truncating the file size, but attempting to download a large file from someone using the official SoulseekQt client still results in a 0 byte file size reported from them...