### PR TITLE
Don't request hostname for IP addresses

### DIFF
--- a/pynicotine/gtkgui/frame.py
+++ b/pynicotine/gtkgui/frame.py
@@ -1801,7 +1801,7 @@ class NicotineFrame:
             for i in self.np.config.sections["server"]["userlist"]:
                 if user == i[0] and i[6] is not None:
                     return i[6]
-            return None
+            return "flag_"
         else:
             return self.flag_users[user]
 

--- a/pynicotine/pynicotine.py
+++ b/pynicotine/pynicotine.py
@@ -1141,10 +1141,12 @@ class NetworkEventProcessor:
                 del self.ipignore_requested[msg.user]
                 return
 
-            import socket
-            cn = self.geoip.get_all(msg.ip).country_short
-            if cn != "-":
-                self.frame.HasUserFlag(msg.user, "flag_" + cn)
+            cc = self.geoip.get_all(msg.ip).country_short
+
+            if cc == "-":
+                cc = ""
+
+            self.frame.HasUserFlag(msg.user, "flag_" + cc)
 
             # From this point on all paths should call
             # self.frame.pluginhandler.UserResolveNotification precisely once
@@ -1156,29 +1158,15 @@ class NetworkEventProcessor:
 
             self.ip_requested.remove(msg.user)
 
-            cc = self.geoip.get_all(msg.ip).country_short
-
-            if cc != "-":
+            if cc != "":
                 cc = " (%s)" % cc
-            else:
-                cc = ""
 
-            try:
-                hostname = socket.gethostbyaddr(msg.ip)[0]
-                message = _("IP address of %(user)s is %(ip)s, name %(host)s, port %(port)i%(country)s") % {
-                    'user': msg.user,
-                    'ip': msg.ip,
-                    'host': hostname,
-                    'port': msg.port,
-                    'country': cc
-                }
-            except Exception:
-                message = _("IP address of %(user)s is %(ip)s, port %(port)i%(country)s") % {
-                    'user': msg.user,
-                    'ip': msg.ip,
-                    'port': msg.port,
-                    'country': cc
-                }
+            message = _("IP address of %(user)s is %(ip)s, port %(port)i%(country)s") % {
+                'user': msg.user,
+                'ip': msg.ip,
+                'port': msg.port,
+                'country': cc
+            }
 
             self.logMessage(message)
             self.frame.pluginhandler.UserResolveNotification(msg.user, msg.ip, msg.port, cc)


### PR DESCRIPTION
Requesting the hostname of an IP address could freeze/block the UI for up to 15 seconds in some cases. Also fixed an issue where the worldwide flag image wouldn't show up in the user list, if the user's country is unknown.