### PR TITLE
TreeView tweaks

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -13,6 +13,7 @@ Changes
  * Support for HiDPI displays
  * Search results and transfers can now be grouped by folder
  * Support for transfers larger than 2 GB in size
+ * Transfers and search results now support drag-select
  * Nicotine+ now follows the XDG Base Directory Specification
  * Replaced deprecated dependencies with maintained ones
  * Added unit and DEP-8 continuous integration testing

--- a/pynicotine/gtkgui/chatrooms.py
+++ b/pynicotine/gtkgui/chatrooms.py
@@ -1059,7 +1059,6 @@ class ChatRoom:
         self.UserList.set_model(self.usersmodel)
         self.UserList.enable_model_drag_source(Gdk.ModifierType.BUTTON1_MASK, [('text/plain', 0, 2)], Gdk.DragAction.COPY)
         self.UserList.connect("drag_data_get", self.drag_data_get_data)
-        self.UserList.set_property("rules-hint", True)
 
         self.popup_menu_privaterooms = PopupMenu(self.frame, False)
         self.popup_menu = popup = PopupMenu(self.frame)

--- a/pynicotine/gtkgui/downloads.py
+++ b/pynicotine/gtkgui/downloads.py
@@ -51,7 +51,6 @@ class Downloads(TransferList):
 
         TransferList.__init__(self, frame, frame.DownloadList, type='download')
         self.myvbox = self.frame.downloadsvbox
-        self.frame.DownloadList.set_property("rules-hint", True)
         self.accel_group = gtk.AccelGroup()
 
         self.popup_menu_users = PopupMenu(self.frame, False)

--- a/pynicotine/gtkgui/frame.py
+++ b/pynicotine/gtkgui/frame.py
@@ -908,8 +908,6 @@ class NicotineFrame:
         cols[0].set_sort_column_id(0)
         self.LikesList.set_model(self.likeslist)
 
-        self.RecommendationsList.set_property("rules-hint", True)
-        self.RecommendationUsersList.set_property("rules-hint", True)
         self.RecommendationUsersList.enable_model_drag_source(
             Gdk.ModifierType.BUTTON1_MASK, [('text/plain', 0, 2)], Gdk.DragAction.COPY
         )

--- a/pynicotine/gtkgui/search.py
+++ b/pynicotine/gtkgui/search.py
@@ -586,8 +586,8 @@ class Search:
         self.selected_users = []
 
         self.ResultsList.get_selection().set_mode(gtk.SelectionMode.MULTIPLE)
-        self.ResultsList.set_property("show-expanders", self.directoryGroup.get_active())
-        self.ResultsList.set_property("rules-hint", True)
+        self.ResultsList.set_rubber_banding(True)
+        self.ResultsList.set_show_expanders(self.directoryGroup.get_active())
 
         widths = self.frame.np.config.sections["columns"]["filesearch_widths"]
         cols = InitialiseColumns(
@@ -1528,7 +1528,7 @@ class Search:
 
         self.OnRefilter(widget)
 
-        self.ResultsList.set_property("show-expanders", widget.get_active())
+        self.ResultsList.set_show_expanders(widget.get_active())
 
         self.frame.np.config.sections["searches"]["group_searches"] = self.directoryGroup.get_active()
 

--- a/pynicotine/gtkgui/transferlist.py
+++ b/pynicotine/gtkgui/transferlist.py
@@ -81,6 +81,7 @@ class TransferList:
         self.lastupdate = 0
         self.finalupdatetimerid = None
         widget.get_selection().set_mode(gtk.SelectionMode.MULTIPLE)
+        widget.set_rubber_banding(True)
 
         columntypes = [
             gobject.TYPE_STRING,

--- a/pynicotine/gtkgui/uploads.py
+++ b/pynicotine/gtkgui/uploads.py
@@ -49,7 +49,6 @@ class Uploads(TransferList):
 
         TransferList.__init__(self, frame, frame.UploadList, type='upload')
         self.myvbox = self.frame.uploadsvbox
-        self.frame.UploadList.set_property("rules-hint", True)
 
         self.popup_menu_users = PopupMenu(self.frame, False)
         self.popup_menu_clear = popup2 = PopupMenu(self.frame, False)

--- a/pynicotine/gtkgui/userbrowse.py
+++ b/pynicotine/gtkgui/userbrowse.py
@@ -210,7 +210,7 @@ class UserBrowse:
 
         self.FileTreeView.get_selection().set_mode(gtk.SelectionMode.MULTIPLE)
         self.FileTreeView.set_headers_clickable(True)
-        self.FileTreeView.set_property("rules-hint", True)
+        self.FileTreeView.set_rubber_banding(True)
 
         self.file_popup_menu = PopupMenu(self.frame)
 

--- a/pynicotine/gtkgui/userlist.py
+++ b/pynicotine/gtkgui/userlist.py
@@ -149,7 +149,6 @@ class UserList:
             render.connect('edited', self.cell_edited_callback, self.UserList, 9)
 
         self.UserList.set_model(self.usersmodel)
-        self.UserList.set_property("rules-hint", True)
         self.privileged = []
         self.notify = []
         self.trusted = []

--- a/pynicotine/gtkgui/utils.py
+++ b/pynicotine/gtkgui/utils.py
@@ -217,7 +217,7 @@ def InitialiseColumns(treeview, *args):
         if len(c) > 3 and type(c[3]) is not list:
             column.set_cell_data_func(renderer, c[3])
 
-        column.set_reorderable(True)
+        column.set_reorderable(False)
         column.set_widget(gtk.Label.new(c[0]))
         column.get_widget().show()
 


### PR DESCRIPTION
T.I.L. Nicotine+ allows you to reorder columns... Disable this functionality for now, since the current way of saving column widths isn't designed with this in mind.

Also allow rubber banding (selection of multiple rows by dragging your cursor), and remove the deprecated rules-hint-property.