### PR TITLE
Ensure we don't group downloads under the wrong user

### DIFF
--- a/pynicotine/gtkgui/transferlist.py
+++ b/pynicotine/gtkgui/transferlist.py
@@ -81,6 +81,7 @@ class TransferList:
         self.lastupdate = 0
         self.finalupdatetimerid = None
         widget.get_selection().set_mode(gtk.SelectionMode.MULTIPLE)
+        widget.set_enable_tree_lines(True)
         widget.set_rubber_banding(True)
 
         columntypes = [

--- a/pynicotine/gtkgui/transferlist.py
+++ b/pynicotine/gtkgui/transferlist.py
@@ -576,13 +576,17 @@ class TransferList:
                         [user, "", "", "", "", 0, "", "", "", "", "", 0, 0, 0, False, ""]
                     )
 
-                if transfer.path not in self.paths:
-                    self.paths[transfer.path] = self.transfersmodel.append(
+                """ Paths can be empty if files are downloaded individually, make sure we
+                don't add files to the wrong user in the TreeView """
+                path = user + transfer.path
+
+                if path not in self.paths:
+                    self.paths[path] = self.transfersmodel.append(
                         self.users[user],
                         [user, transfer.path, "", "", "", 0, "", "", "", "", "", 0, 0, 0, False, ""]
                     )
 
-                parent = self.paths[transfer.path]
+                parent = self.paths[path]
             else:
                 parent = None
 


### PR DESCRIPTION
Non-folder downloads currently have an empty path, which resulted in all downloads being added to the first user with an empty path in the downloads TreeView. Make sure downloads are added to the correct user.