### PR TITLE
Improved handling of transfers

### DIFF
--- a/pynicotine/config.py
+++ b/pynicotine/config.py
@@ -128,6 +128,7 @@ class Config:
                 "geoblockcc": [""],
                 "remotedownloads": 1,
                 "uploadallowed": 2,
+                "autoclear_downloads": 0,
                 "autoclear_uploads": 0,
                 "downloads": [],
                 "sharedfiles": {},

--- a/pynicotine/config.py
+++ b/pynicotine/config.py
@@ -129,7 +129,6 @@ class Config:
                 "remotedownloads": 1,
                 "uploadallowed": 2,
                 "autoclear_uploads": 0,
-                "autoretry_downloads": 1,
                 "downloads": [],
                 "sharedfiles": {},
                 "sharedfilesstreams": {},
@@ -524,6 +523,9 @@ class Config:
         self.removeOldOption("columns", "downloads_widths")
         self.removeOldOption("columns", "uploads_columns")
         self.removeOldOption("columns", "uploads_widths")
+
+        # Remove auto-retry failed downloads-option, this is now default behavior
+        self.removeOldOption("transfers", "autoretry_downloads")
 
         # Checking for unknown section/options
         unknown1 = [

--- a/pynicotine/config.py
+++ b/pynicotine/config.py
@@ -129,7 +129,7 @@ class Config:
                 "remotedownloads": 1,
                 "uploadallowed": 2,
                 "autoclear_uploads": 0,
-                "autoretry_downloads": 0,
+                "autoretry_downloads": 1,
                 "downloads": [],
                 "sharedfiles": {},
                 "sharedfilesstreams": {},

--- a/pynicotine/gtkgui/downloads.py
+++ b/pynicotine/gtkgui/downloads.py
@@ -110,9 +110,6 @@ class Downloads(TransferList):
         frame.banDownloadButton.connect("clicked", self.OnBan)
         frame.DownloadList.expand_all()
 
-        self.frame.ToggleAutoRetry.set_active(self.frame.np.config.sections["transfers"]["autoretry_downloads"])
-        frame.ToggleAutoRetry.connect("toggled", self.OnToggleAutoRetry)
-
         self.frame.ToggleTreeDownloads.set_active(self.frame.np.config.sections["transfers"]["groupdownloads"])
         frame.ToggleTreeDownloads.connect("toggled", self.OnToggleTree)
         self.OnToggleTree(None)
@@ -129,9 +126,6 @@ class Downloads(TransferList):
             widths.append(column.get_width())
         self.frame.np.config.sections["columns"]["download_columns"] = columns
         self.frame.np.config.sections["columns"]["download_widths"] = widths
-
-    def OnToggleAutoRetry(self, widget):
-        self.frame.np.config.sections["transfers"]["autoretry_downloads"] = self.frame.ToggleAutoRetry.get_active()
 
     def OnTryClearQueued(self, widget):
 

--- a/pynicotine/gtkgui/downloads.py
+++ b/pynicotine/gtkgui/downloads.py
@@ -110,6 +110,8 @@ class Downloads(TransferList):
         frame.banDownloadButton.connect("clicked", self.OnBan)
         frame.DownloadList.expand_all()
 
+        self.frame.ToggleAutoclearDownloads.set_active(self.frame.np.config.sections["transfers"]["autoclear_downloads"])
+        frame.ToggleAutoclearDownloads.connect("toggled", self.OnToggleAutoclear)
         self.frame.ToggleTreeDownloads.set_active(self.frame.np.config.sections["transfers"]["groupdownloads"])
         frame.ToggleTreeDownloads.connect("toggled", self.OnToggleTree)
         self.OnToggleTree(None)
@@ -153,6 +155,9 @@ class Downloads(TransferList):
 
         self.frame.np.config.sections["transfers"]["downloadsexpanded"] = expanded
         self.frame.np.config.writeConfiguration()
+
+    def OnToggleAutoclear(self, widget):
+        self.frame.np.config.sections["transfers"]["autoclear_downloads"] = self.frame.ToggleAutoclearDownloads.get_active()
 
     def OnToggleTree(self, widget):
 

--- a/pynicotine/gtkgui/downloads.py
+++ b/pynicotine/gtkgui/downloads.py
@@ -495,7 +495,6 @@ class Downloads(TransferList):
                 continue
 
             self.frame.np.transfers.AbortTransfer(transfer)
-            transfer.req = None
             self.frame.np.transfers.getFile(transfer.user, transfer.filename, transfer.path, transfer)
 
         self.frame.np.transfers.SaveDownloads()

--- a/pynicotine/gtkgui/transferlist.py
+++ b/pynicotine/gtkgui/transferlist.py
@@ -60,6 +60,7 @@ class TransferList:
         _("Filtered"),
         _("Download directory error"),
         _("Local file error"),
+        _("Remote file error"),
         _("File not shared"),
         _("Aborted"),
         _("Paused"),
@@ -297,6 +298,8 @@ class TransferList:
             newstatus = _("Download directory error")
         elif status == "Local file error":
             newstatus = _("Local file error")
+        elif status == "Remote file error":
+            newstatus = _("Remote file error")
         else:
             newstatus = status
 
@@ -671,7 +674,7 @@ class TransferList:
         self.ClearTransfers(statuslist)
 
     def OnClearFailed(self, widget):
-        statuslist = ["Cannot connect", "Connection closed by peer", "Local file error", "Getting address", "Waiting for peer to connect", "Initializing transfer"]
+        statuslist = ["Cannot connect", "Connection closed by peer", "Local file error", "Remote file error", "Getting address", "Waiting for peer to connect", "Initializing transfer"]
         self.ClearTransfers(statuslist)
 
     def OnClearPaused(self, widget):
@@ -683,7 +686,7 @@ class TransferList:
         self.ClearTransfers(statuslist)
 
     def OnClearFinishedErred(self, widget):
-        statuslist = ["Aborted", "Cancelled", "Finished", "Filtered", "Cannot connect", "Connection closed by peer", "Local file error"]
+        statuslist = ["Aborted", "Cancelled", "Finished", "Filtered", "Cannot connect", "Connection closed by peer", "Local file error", "Remote file error"]
         self.ClearTransfers(statuslist)
 
     def OnClearQueued(self, widget):

--- a/pynicotine/gtkgui/ui/mainwindow.ui
+++ b/pynicotine/gtkgui/ui/mainwindow.ui
@@ -908,22 +908,6 @@
                               </packing>
                             </child>
                             <child>
-                              <object class="GtkCheckButton" id="ToggleAutoRetry">
-                                <property name="label" translatable="yes">Auto-retry failed</property>
-                                <property name="visible">True</property>
-                                <property name="can_focus">True</property>
-                                <property name="receives_default">False</property>
-                                <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
-                                <property name="tooltip_text" translatable="yes">Every minute</property>
-                                <property name="draw_indicator">True</property>
-                              </object>
-                              <packing>
-                                <property name="expand">False</property>
-                                <property name="fill">False</property>
-                                <property name="position">5</property>
-                              </packing>
-                            </child>
-                            <child>
                               <object class="GtkButton" id="configureTransfers1">
                                 <property name="visible">True</property>
                                 <property name="can_focus">True</property>

--- a/pynicotine/gtkgui/ui/mainwindow.ui
+++ b/pynicotine/gtkgui/ui/mainwindow.ui
@@ -908,6 +908,21 @@
                               </packing>
                             </child>
                             <child>
+                              <object class="GtkCheckButton" id="ToggleAutoclearDownloads">
+                                <property name="label" translatable="yes">Autoclear Finished</property>
+                                <property name="visible">True</property>
+                                <property name="can_focus">True</property>
+                                <property name="receives_default">False</property>
+                                <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
+                                <property name="draw_indicator">True</property>
+                              </object>
+                              <packing>
+                                <property name="expand">False</property>
+                                <property name="fill">False</property>
+                                <property name="position">5</property>
+                              </packing>
+                            </child>
+                            <child>
                               <object class="GtkButton" id="configureTransfers1">
                                 <property name="visible">True</property>
                                 <property name="can_focus">True</property>
@@ -1414,7 +1429,7 @@
                               </packing>
                             </child>
                             <child>
-                              <object class="GtkCheckButton" id="ToggleAutoclear">
+                              <object class="GtkCheckButton" id="ToggleAutoclearUploads">
                                 <property name="label" translatable="yes">Autoclear Finished</property>
                                 <property name="visible">True</property>
                                 <property name="can_focus">True</property>

--- a/pynicotine/gtkgui/ui/mainwindow.ui
+++ b/pynicotine/gtkgui/ui/mainwindow.ui
@@ -1430,7 +1430,7 @@
                             </child>
                             <child>
                               <object class="GtkCheckButton" id="ToggleAutoclearUploads">
-                                <property name="label" translatable="yes">Autoclear finished</property>
+                                <property name="label" translatable="yes">Autoclear finished / aborted</property>
                                 <property name="visible">True</property>
                                 <property name="can_focus">True</property>
                                 <property name="receives_default">False</property>

--- a/pynicotine/gtkgui/ui/mainwindow.ui
+++ b/pynicotine/gtkgui/ui/mainwindow.ui
@@ -909,7 +909,7 @@
                             </child>
                             <child>
                               <object class="GtkCheckButton" id="ToggleAutoclearDownloads">
-                                <property name="label" translatable="yes">Autoclear Finished</property>
+                                <property name="label" translatable="yes">Autoclear finished</property>
                                 <property name="visible">True</property>
                                 <property name="can_focus">True</property>
                                 <property name="receives_default">False</property>
@@ -1430,7 +1430,7 @@
                             </child>
                             <child>
                               <object class="GtkCheckButton" id="ToggleAutoclearUploads">
-                                <property name="label" translatable="yes">Autoclear Finished</property>
+                                <property name="label" translatable="yes">Autoclear finished</property>
                                 <property name="visible">True</property>
                                 <property name="can_focus">True</property>
                                 <property name="receives_default">False</property>

--- a/pynicotine/gtkgui/uploads.py
+++ b/pynicotine/gtkgui/uploads.py
@@ -102,8 +102,8 @@ class Uploads(TransferList):
         frame.banUploadButton.connect("clicked", self.OnBan)
         frame.UploadList.expand_all()
 
-        self.frame.ToggleAutoclear.set_active(self.frame.np.config.sections["transfers"]["autoclear_uploads"])
-        frame.ToggleAutoclear.connect("toggled", self.OnToggleAutoclear)
+        self.frame.ToggleAutoclearUploads.set_active(self.frame.np.config.sections["transfers"]["autoclear_uploads"])
+        frame.ToggleAutoclearUploads.connect("toggled", self.OnToggleAutoclear)
         self.frame.ToggleTreeUploads.set_active(self.frame.np.config.sections["transfers"]["groupuploads"])
         frame.ToggleTreeUploads.connect("toggled", self.OnToggleTree)
 
@@ -171,7 +171,7 @@ class Uploads(TransferList):
         self.frame.np.config.writeConfiguration()
 
     def OnToggleAutoclear(self, widget):
-        self.frame.np.config.sections["transfers"]["autoclear_uploads"] = self.frame.ToggleAutoclear.get_active()
+        self.frame.np.config.sections["transfers"]["autoclear_uploads"] = self.frame.ToggleAutoclearUploads.get_active()
 
     def OnToggleTree(self, widget):
 

--- a/pynicotine/slskproto.py
+++ b/pynicotine/slskproto.py
@@ -906,7 +906,7 @@ class SlskProtoThread(threading.Thread):
                     self._ui_callback([FileError(conn, conn.filedown.file, strerror)])
                 except ValueError:
                     pass
-                self._ui_callback([DownloadFile(conn.conn, len(msgBuffer[:leftbytes]), conn.filedown.file)])
+            self._ui_callback([DownloadFile(conn.conn, len(msgBuffer[:leftbytes]), conn.filedown.file)])
             conn.filereadbytes = conn.filereadbytes + len(msgBuffer[:leftbytes])
             msgBuffer = msgBuffer[leftbytes:]
         elif conn.fileupl is not None:

--- a/pynicotine/transfers.py
+++ b/pynicotine/transfers.py
@@ -108,7 +108,7 @@ class TransferTimeout:
 
 class Transfers:
     """ This is the transfers manager"""
-    FAILED_TRANSFERS = ["Cannot connect", "Connection closed by peer", "Local file error"]
+    FAILED_TRANSFERS = ["Cannot connect", "Connection closed by peer", "Local file error", "Remote file error"]
     COMPLETED_TRANSFERS = ["Finished", "Filtered", "Aborted", "Cancelled"]
     PRE_TRANSFER = ["Queued"]
     TRANSFER = ["Requesting file", "Initializing transfer", "Transferring"]
@@ -1455,13 +1455,12 @@ class Transfers:
     # Find failed downloads and attempt to queue them
     def checkDownloadQueue(self):
 
-        if self.eventprocessor.config.sections["transfers"]["autoretry_downloads"]:
-            statuslist = self.FAILED_TRANSFERS + ["Getting address", "Connecting", "Waiting for peer to connect", "Initializing transfer"]
+        statuslist = self.FAILED_TRANSFERS + ["Getting address", "Connecting", "Waiting for peer to connect", "Initializing transfer"]
 
-            for transfer in self.downloads:
-                if transfer.status in statuslist:
-                    self.AbortTransfer(transfer)
-                    self.getFile(transfer.user, transfer.filename, transfer.path, transfer)
+        for transfer in self.downloads:
+            if transfer.status in statuslist:
+                self.AbortTransfer(transfer)
+                self.getFile(transfer.user, transfer.filename, transfer.path, transfer)
 
         self.startCheckDownloadQueueTimer()
 

--- a/pynicotine/transfers.py
+++ b/pynicotine/transfers.py
@@ -1300,7 +1300,13 @@ class Transfers:
                 )
 
         self.SaveDownloads()
-        self.downloadspanel.update(i)
+
+        # Autoclear this download
+        if self.eventprocessor.config.sections["transfers"]["autoclear_downloads"]:
+            self.downloads.remove(i)
+            self.downloadspanel.update()
+        else:
+            self.downloadspanel.update(i)
 
         if newname and config["transfers"]["afterfinish"]:
             if not executeCommand(config["transfers"]["afterfinish"], newname):
@@ -1718,6 +1724,8 @@ class Transfers:
                     i.status = "User logged off"
                 else:
                     i.status = "Connection closed by peer"
+                    if i in self.downloads:
+                        self.getFile(i.user, i.filename, i.path, i)
 
             curtime = time.time()
             for j in self.uploads:


### PR DESCRIPTION
Several fixes to hopefully resolve https://github.com/Nicotine-Plus/nicotine-plus/issues/336, and some general improvements.
- Hopefully ensure that the UI always shows the correct file percentage
- If a transfer happens to be initiated when the the progress is 100%, move it to the finished downloads folder instead of endlessly trying to download more from the peer
- Remove toggle to disable auto-retry of failed downloads, make this feature mandatory
- Add option to autoclear finished downloads
- Actually display our own uploads aborted by the remote as aborted, and include them in the autoclear uploads-feature, like SoulseekQt does

Don't merge yet, I'm waiting for feedback from @hboetes