### PR TITLE
Bump default megabyte limit for queue

### DIFF
--- a/pynicotine/config.py
+++ b/pynicotine/config.py
@@ -115,7 +115,7 @@ class Config:
                 "usecustomban": 0,
                 "limitby": 1,
                 "customban": "Banned, don't bother retrying",
-                "queuelimit": 100,
+                "queuelimit": 10000,
                 "filelimit": 1000,
                 "friendsonly": 0,
                 "friendsnolimits": 0,


### PR DESCRIPTION
This limit (100 MB) was supposed to represent the size of a full album according to the old Nicotine+ guide, but is pretty low today due to increasing interest in lossless music. Bump it to a generous 10GB to prevent issues where large files can't be shared if a user forgot to modify their limits.