### PR TITLE
Remove redundant links

### DIFF
--- a/pynicotine/gtkgui/frame.py
+++ b/pynicotine/gtkgui/frame.py
@@ -2584,14 +2584,6 @@ class NicotineFrame:
             self.UploadButtons.hide()
             self.DownloadButtons.hide()
 
-    def OnProjectWebsite(self, widget):
-        url = "https://nicotine-plus.org/"
-        OpenUri(url, self.MainWindow)
-
-    def onProjectGithubPage(self, widget):
-        url = "https://github.com/Nicotine-Plus/nicotine-plus"
-        OpenUri(url, self.MainWindow)
-
     def OnCheckLatest(self, widget):
         checklatest(self.MainWindow)
 

--- a/pynicotine/gtkgui/ui/mainwindow.ui
+++ b/pynicotine/gtkgui/ui/mainwindow.ui
@@ -541,7 +541,7 @@
                       <object class="GtkMenuItem" id="check_latest1">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
-                        <property name="label" translatable="yes">Check _latest</property>
+                        <property name="label" translatable="yes">Check _latest version</property>
                         <property name="use_underline">True</property>
                         <signal name="activate" handler="OnCheckLatest" swapped="no"/>
                       </object>

--- a/pynicotine/gtkgui/ui/mainwindow.ui
+++ b/pynicotine/gtkgui/ui/mainwindow.ui
@@ -493,24 +493,6 @@
                   <object class="GtkMenu" id="help1_menu">
                     <property name="can_focus">False</property>
                     <child>
-                      <object class="GtkMenuItem" id="ProjectWebsite">
-                        <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="label" translatable="yes">Project _Website</property>
-                        <property name="use_underline">True</property>
-                        <signal name="activate" handler="OnProjectWebsite" swapped="no"/>
-                      </object>
-                    </child>
-                    <child>
-                      <object class="GtkMenuItem" id="ProjectGithubPage">
-                        <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="label" translatable="yes">Project _Github Page</property>
-                        <property name="use_underline">True</property>
-                        <signal name="activate" handler="onProjectGithubPage" swapped="no"/>
-                      </object>
-                    </child>
-                    <child>
                       <object class="GtkSeparatorMenuItem" id="separator1">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>


### PR DESCRIPTION
I feel like these menu items are a bit redundant, considering we already have a website link in the about-window, and a link to report bugs.