### PR TITLE
Disable a few elements until client is logged in

### DIFF
--- a/pynicotine/gtkgui/frame.py
+++ b/pynicotine/gtkgui/frame.py
@@ -304,6 +304,9 @@ class NicotineFrame:
             except TypeError:
                 pass
 
+        # Disable a few elements until we're logged in (search field, download buttons etc.)
+        self.SetWidgetOnlineStatus(False)
+
         self.MainWindow.set_title(_("Nicotine+") + " " + version)
         self.MainWindow.set_default_icon(self.images["n"])
         self.MainWindow.set_icon(self.images["n"])


### PR DESCRIPTION
There have been times where I accidentally started searching before upnp mapping had finished, and the networking seemed to stall as a result.