### PR TITLE
Don't reset buddy list when moving it

### DIFF
--- a/pynicotine/gtkgui/chatrooms.py
+++ b/pynicotine/gtkgui/chatrooms.py
@@ -151,8 +151,6 @@ class RoomsControl:
         self.frame.roomlist.RoomsList.connect("button_press_event", self.OnListClicked)
         self.frame.roomlist.RoomsList.set_headers_clickable(True)
 
-        self.frame.roomlist.HideRoomList.connect("clicked", self.OnHideRoomList)
-
         self.ChatNotebook.Notebook.connect("switch-page", self.OnSwitchPage)
         self.ChatNotebook.Notebook.connect("page-reordered", self.OnReorderedPage)
 
@@ -276,9 +274,6 @@ class RoomsControl:
         for name, room in list(self.users.items()):
             if room.Main == page:
                 self.frame.Notifications.Clear("rooms", name)
-
-    def OnHideRoomList(self, widget):
-        self.frame.show_room_list1.set_active(0)
 
     def OnListClicked(self, widget, event):
 

--- a/pynicotine/gtkgui/frame.py
+++ b/pynicotine/gtkgui/frame.py
@@ -63,6 +63,7 @@ from pynicotine.gtkgui.entrydialog import QuitBox
 from pynicotine.gtkgui.entrydialog import input_box
 from pynicotine.gtkgui.fastconfigure import FastConfigureAssistant
 from pynicotine.gtkgui.privatechat import PrivateChats
+from pynicotine.gtkgui.roomlist import RoomList
 from pynicotine.gtkgui.search import Searches
 from pynicotine.gtkgui.settingswindow import SettingsWindow
 from pynicotine.gtkgui.uploads import Uploads
@@ -87,78 +88,6 @@ from pynicotine.utils import version
 
 gi.require_version('Gtk', '3.0')
 gi.require_version('Gdk', '3.0')
-
-
-class roomlist:
-
-    def __init__(self, frame):
-
-        # Build the window
-        self.frame = frame
-
-        builder = gtk.Builder()
-
-        builder.set_translation_domain('nicotine')
-        builder.add_from_file(os.path.join(os.path.dirname(os.path.realpath(__file__)), "ui", "roomlist.ui"))
-
-        self.RoomList = builder.get_object("RoomList")
-
-        for i in builder.get_objects():
-            try:
-                self.__dict__[gtk.Buildable.get_name(i)] = i
-            except TypeError:
-                pass
-
-        self.RoomList.remove(self.vbox2)
-        self.RoomList.destroy()
-
-        # self.RoomsList is the TreeView
-        builder.connect_signals(self)
-
-        self.search_iter = None
-        self.query = ""
-        self.room_model = self.RoomsList.get_model()
-
-        self.FindRoom.connect("clicked", self.OnSearchRoom)
-
-    def OnCreateRoom(self, widget):
-
-        room = widget.get_text()
-        if not room:
-            return
-
-        self.frame.np.queue.put(slskmessages.JoinRoom(room))
-        widget.set_text("")
-
-    def OnSearchRoom(self, widget):
-
-        if self.room_model is not self.RoomsList.get_model():
-            self.room_model = self.RoomsList.get_model()
-            self.search_iter = self.room_model.get_iter_first()
-
-        room = self.SearchRooms.get_text().lower()
-
-        if not room:
-            return
-
-        if self.query == room:
-            if self.search_iter is None:
-                self.search_iter = self.room_model.get_iter_first()
-            else:
-                self.search_iter = self.room_model.iter_next(self.search_iter)
-        else:
-            self.search_iter = self.room_model.get_iter_first()
-            self.query = room
-
-        while self.search_iter:
-
-            room_match, size = self.room_model.get(self.search_iter, 0, 1)
-            if self.query in room_match.lower():
-                path = self.room_model.get_path(self.search_iter)
-                self.RoomsList.set_cursor(path)
-                break
-
-            self.search_iter = self.room_model.iter_next(self.search_iter)
 
 
 class BuddiesComboBox:
@@ -290,7 +219,7 @@ class NicotineFrame:
         self.LoadIcons()
 
         self.accel_group = gtk.AccelGroup()
-        self.roomlist = roomlist(self)
+        self.roomlist = RoomList(self)
 
         # Import GtkBuilder widgets
         builder = gtk.Builder()
@@ -2706,13 +2635,8 @@ class NicotineFrame:
             if not chatrooms:
                 self.vpaned3.hide()
 
-        # Reinitialize the userlist to avoid an error that freeze the UI on recent GTK versions
-        # Warning: invalid cast from 'GailPaned' to 'GailNotebook'
-        self.userlist = None
-        self.userlist = UserList(self)
-
         if tab:
-            self.BuddiesTabLabel = ImageLabel(_("Buddy List"), self.images["empty"])
+            self.BuddiesTabLabel = ImageLabel(_("Buddy list"), self.images["empty"])
             self.BuddiesTabLabel.show()
 
             if self.userlist.userlistvbox not in self.MainNotebook.get_children():

--- a/pynicotine/gtkgui/frame.py
+++ b/pynicotine/gtkgui/frame.py
@@ -72,6 +72,7 @@ from pynicotine.gtkgui.userinfo import UserInfo
 from pynicotine.gtkgui.userinfo import UserTabs
 from pynicotine.gtkgui.userlist import UserList
 from pynicotine.gtkgui.utils import AppendLine
+from pynicotine.gtkgui.utils import BuddiesComboBox
 from pynicotine.gtkgui.utils import Humanize
 from pynicotine.gtkgui.utils import HumanSpeed
 from pynicotine.gtkgui.utils import ImageLabel
@@ -88,51 +89,6 @@ from pynicotine.utils import version
 
 gi.require_version('Gtk', '3.0')
 gi.require_version('Gdk', '3.0')
-
-
-class BuddiesComboBox:
-
-    def __init__(self, frame, ComboBox):
-
-        self.frame = frame
-
-        self.items = {}
-
-        self.combobox = ComboBox
-
-        self.store = gtk.ListStore(gobject.TYPE_STRING)
-        self.combobox.set_model(self.store)
-        self.combobox.set_entry_text_column(0)
-
-        self.store.set_default_sort_func(lambda *args: -1)
-        self.store.set_sort_column_id(-1, gtk.SortType.ASCENDING)
-
-        self.combobox.show()
-
-    def Fill(self):
-
-        self.items.clear()
-        self.store.clear()
-
-        self.items[""] = self.store.append([""])
-
-        for user in self.frame.np.config.sections["server"]["userlist"]:
-            self.items[user[0]] = self.store.append([user[0]])
-
-        self.store.set_sort_column_id(0, gtk.SortType.ASCENDING)
-
-    def Append(self, item):
-
-        if item in self.items:
-            return
-
-        self.items[item] = self.combobox.get_model().append([item])
-
-    def Remove(self, item):
-
-        if item in self.items:
-            self.combobox.get_model().remove(self.items[item])
-            del self.items[item]
 
 
 class NicotineFrame:

--- a/pynicotine/gtkgui/roomlist.py
+++ b/pynicotine/gtkgui/roomlist.py
@@ -28,6 +28,7 @@ from gi.repository import Gtk as gtk
 
 from pynicotine import slskmessages
 
+
 class RoomList:
 
     def __init__(self, frame):

--- a/pynicotine/gtkgui/roomlist.py
+++ b/pynicotine/gtkgui/roomlist.py
@@ -1,0 +1,98 @@
+# -*- coding: utf-8 -*-
+#
+# COPYRIGHT (C) 2016-2017 Michael Labouebe <gfarmerfr@free.fr>
+# COPYRIGHT (C) 2016-2018 Mutnick <mutnick@techie.com>
+# COPYRIGHT (C) 2008-2011 Quinox <quinox@users.sf.net>
+# COPYRIGHT (C) 2006-2009 Daelstorm <daelstorm@gmail.com>
+# COPYRIGHT (C) 2009 Hedonist <ak@sensi.org>
+# COPYRIGHT (C) 2003-2004 Hyriand <hyriand@thegraveyard.org>
+#
+# GNU GENERAL PUBLIC LICENSE
+#    Version 3, 29 June 2007
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+import os
+
+from gi.repository import Gtk as gtk
+
+from pynicotine import slskmessages
+
+class RoomList:
+
+    def __init__(self, frame):
+
+        # Build the window
+        self.frame = frame
+
+        builder = gtk.Builder()
+
+        builder.set_translation_domain('nicotine')
+        builder.add_from_file(os.path.join(os.path.dirname(os.path.realpath(__file__)), "ui", "roomlist.ui"))
+
+        self.RoomList = builder.get_object("RoomList")
+
+        for i in builder.get_objects():
+            try:
+                self.__dict__[gtk.Buildable.get_name(i)] = i
+            except TypeError:
+                pass
+
+        self.RoomList.remove(self.vbox2)
+        self.RoomList.destroy()
+
+        # self.RoomsList is the TreeView
+        builder.connect_signals(self)
+
+        self.search_iter = None
+        self.query = ""
+        self.room_model = self.RoomsList.get_model()
+
+    def OnCreateRoom(self, widget):
+
+        room = self.CreateRoomEntry.get_text()
+        if not room:
+            return
+
+        self.frame.np.queue.put(slskmessages.JoinRoom(room))
+        self.CreateRoomEntry.set_text("")
+
+    def OnSearchRoom(self, widget):
+
+        if self.room_model is not self.RoomsList.get_model():
+            self.room_model = self.RoomsList.get_model()
+            self.search_iter = self.room_model.get_iter_first()
+
+        room = self.SearchRooms.get_text().lower()
+
+        if not room:
+            return
+
+        if self.query == room:
+            if self.search_iter is None:
+                self.search_iter = self.room_model.get_iter_first()
+            else:
+                self.search_iter = self.room_model.iter_next(self.search_iter)
+        else:
+            self.search_iter = self.room_model.get_iter_first()
+            self.query = room
+
+        while self.search_iter:
+
+            room_match, size = self.room_model.get(self.search_iter, 0, 1)
+            if self.query in room_match.lower():
+                path = self.room_model.get_path(self.search_iter)
+                self.RoomsList.set_cursor(path)
+                break
+
+            self.search_iter = self.room_model.iter_next(self.search_iter)

--- a/pynicotine/gtkgui/ui/buddylist.ui
+++ b/pynicotine/gtkgui/ui/buddylist.ui
@@ -81,16 +81,17 @@
               </packing>
             </child>
             <child>
-              <object class="GtkButton" id="MoveList">
+              <object class="GtkButton" id="AddUser">
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
                 <property name="receives_default">True</property>
-                <signal name="clicked" handler="OnMoveList" swapped="no"/>
+                <property name="tooltip_text" translatable="yes">Add</property>
+                <signal name="clicked" handler="OnAddUser" swapped="no"/>
                 <child>
                   <object class="GtkImage" id="image1">
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
-                    <property name="stock">gtk-jump-to</property>
+                    <property name="stock">gtk-add</property>
                   </object>
                 </child>
               </object>

--- a/pynicotine/gtkgui/ui/roomlist.ui
+++ b/pynicotine/gtkgui/ui/roomlist.ui
@@ -53,7 +53,7 @@
               <object class="GtkLabel" id="label10">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
-                <property name="label" translatable="yes">Create: </property>
+                <property name="label" translatable="yes">Create room: </property>
               </object>
               <packing>
                 <property name="expand">False</property>
@@ -79,12 +79,13 @@
               </packing>
             </child>
             <child>
-              <object class="GtkButton" id="HideRoomList">
+              <object class="GtkButton" id="CreateRoom">
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
                 <property name="receives_default">True</property>
                 <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
-                <property name="tooltip_text" translatable="yes">Hide room list</property>
+                <property name="tooltip_text" translatable="yes">Create public room</property>
+                <signal name="clicked" handler="OnCreateRoom" swapped="no"/>
                 <child>
                   <object class="GtkAlignment" id="alignment27">
                     <property name="visible">True</property>
@@ -95,7 +96,7 @@
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
                         <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
-                        <property name="stock">gtk-remove</property>
+                        <property name="stock">gtk-add</property>
                       </object>
                     </child>
                   </object>
@@ -124,7 +125,7 @@
               <object class="GtkLabel" id="label1">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
-                <property name="label" translatable="yes">Search: </property>
+                <property name="label" translatable="yes">Find room: </property>
               </object>
               <packing>
                 <property name="expand">False</property>
@@ -156,7 +157,8 @@
                 <property name="receives_default">True</property>
                 <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
                 <property name="has_tooltip">True</property>
-                <property name="tooltip_text" translatable="yes">Hide room list</property>
+                <property name="tooltip_text" translatable="yes">Search for room</property>
+                <signal name="clicked" handler="OnSearchRoom" swapped="no"/>
                 <child>
                   <object class="GtkAlignment" id="alignment1">
                     <property name="visible">True</property>

--- a/pynicotine/gtkgui/userlist.py
+++ b/pynicotine/gtkgui/userlist.py
@@ -226,32 +226,13 @@ class UserList:
     def OnTooltip(self, widget, x, y, keyboard_mode, tooltip):
         return showCountryTooltip(widget, x, y, tooltip, 14, 'flag_')
 
-    def OnMoveList(self, widget):
-
-        tab = always = chatrooms = False
-
-        if self.frame.buddylist_in_tab.get_active():
-            tab = True
-        if self.frame.buddylist_always_visible.get_active():
-            always = True
-        if self.frame.buddylist_in_chatrooms1.get_active():
-            chatrooms = True
-
-        if tab:
-            self.frame.buddylist_in_chatrooms1.set_active(True)
-            self.frame.OnChatRooms(None)
-        if always:
-            self.frame.buddylist_in_tab.set_active(True)
-        if chatrooms:
-            self.frame.buddylist_always_visible.set_active(True)
-
     def OnAddUser(self, widget):
 
-        text = widget.get_text()
+        text = self.AddUserEntry.get_text()
         if not text:
             return
 
-        widget.set_text("")
+        self.AddUserEntry.set_text("")
         self.AddToList(text)
 
     def UpdateColours(self):

--- a/pynicotine/gtkgui/utils.py
+++ b/pynicotine/gtkgui/utils.py
@@ -37,6 +37,7 @@ from gettext import gettext as _
 import gi
 from gi.repository import Gdk
 from gi.repository import GLib
+from gi.repository import GObject as gobject
 from gi.repository import Gtk as gtk
 from gi.repository import Pango as pango
 
@@ -460,6 +461,51 @@ def AppendLine(textview, line, tag=None, timestamp=None, showstamp=True, timesta
         GLib.idle_add(ScrollBottom, scrolledwindow)
 
     return linenr
+
+
+class BuddiesComboBox:
+
+    def __init__(self, frame, ComboBox):
+
+        self.frame = frame
+
+        self.items = {}
+
+        self.combobox = ComboBox
+
+        self.store = gtk.ListStore(gobject.TYPE_STRING)
+        self.combobox.set_model(self.store)
+        self.combobox.set_entry_text_column(0)
+
+        self.store.set_default_sort_func(lambda *args: -1)
+        self.store.set_sort_column_id(-1, gtk.SortType.ASCENDING)
+
+        self.combobox.show()
+
+    def Fill(self):
+
+        self.items.clear()
+        self.store.clear()
+
+        self.items[""] = self.store.append([""])
+
+        for user in self.frame.np.config.sections["server"]["userlist"]:
+            self.items[user[0]] = self.store.append([user[0]])
+
+        self.store.set_sort_column_id(0, gtk.SortType.ASCENDING)
+
+    def Append(self, item):
+
+        if item in self.items:
+            return
+
+        self.items[item] = self.combobox.get_model().append([item])
+
+    def Remove(self, item):
+
+        if item in self.items:
+            self.combobox.get_model().remove(self.items[item])
+            del self.items[item]
 
 
 class ImageLabel(gtk.HBox):


### PR DESCRIPTION
User statuses would reset if you changed the position of the buddy list. The code comment mentions "Reinitialize the userlist to avoid an error that freeze the UI on recent GTK versions", but this doesn't seem to be the case anymore.

Also some minor cleanup, and removal of buttons that were oddly placed.