### PR TITLE
Show correct audio length and bitrate everywhere

### DIFF
--- a/pynicotine/config.py
+++ b/pynicotine/config.py
@@ -216,7 +216,7 @@ class Config:
 
             "columns": {
                 "userbrowse": [1, 1, 1, 1],
-                "userbrowse_widths": [250, 100, 70, 0],
+                "userbrowse_widths": [600, 100, 70, 0],
                 "userlist": [1, 1, 1, 1, 1, 1, 1, 1, 1, 1],
                 "userlist_widths": [0, 25, 120, 0, 0, 0, 0, 0, 160, 0],
                 "chatrooms": {},

--- a/pynicotine/gtkgui/search.py
+++ b/pynicotine/gtkgui/search.py
@@ -53,6 +53,7 @@ from pynicotine.gtkgui.utils import SetTreeviewSelectedRow
 from pynicotine.gtkgui.utils import showCountryTooltip
 from pynicotine.logfacility import log
 from pynicotine.utils import cmp
+from pynicotine.utils import GetResultBitrateLength
 
 gi.require_version('Gtk', '3.0')
 gi.require_version('Gdk', '3.0')
@@ -800,90 +801,11 @@ class Search:
             name = result[1].split('\\')[-1]
             dir = result[1][:-len(name)]
 
-            h_size = HumanSize(result[2])
+            size = result[2]
+            h_size = HumanSize(size)
+            h_bitrate, bitrate, h_length = GetResultBitrateLength(size, result[4])
 
-            bitrate = ""
-            length = ""
-
-            br = 0
-
-            # If there are 3 entries in the last column
-            if len(result[4]) == 3:
-
-                a = result[4]
-
-                # Sometimes the vbr indicator is in third position
-                if a[2] == 0 or a[2] == 1:
-
-                    if a[2] == 1:
-                        bitrate = " (vbr)"
-
-                    bitrate = str(a[0]) + bitrate
-                    br = a[0]
-
-                    length = '%i:%02i' % (a[1] / 60, a[1] % 60)
-
-                # Sometimes the vbr indicator is in second position
-                elif a[1] == 0 or a[1] == 1:
-
-                    if a[1] == 1:
-                        bitrate = " (vbr)"
-
-                    bitrate = str(a[0]) + bitrate
-                    br = a[0]
-
-                    length = '%i:%02i' % (a[2] / 60, a[2] % 60)
-
-                # Lossless audio, length is in first position
-                elif a[2] > 1:
-
-                    # Bitrate = sample rate (Hz) * word length (bits) * channel count
-                    # Bitrate = 44100 * 16 * 2
-                    br = (a[1] * a[2] * 2) / 1000
-                    bitrate = str(br)
-
-                    length = '%i:%02i' % (a[0] / 60, a[0] % 60)
-
-                else:
-
-                    bitrate = str(a[0]) + bitrate
-                    br = a[0]
-
-            # If there are 2 entries in the last column
-            elif len(result[4]) == 2:
-
-                a = result[4]
-
-                # Sometimes the vbr indicator is in second position
-                if a[1] == 0 or a[1] == 1:
-
-                    # If it's a vbr file we can't deduce the length
-                    if a[1] == 1:
-
-                        bitrate = " (vbr)"
-                        bitrate = str(a[0]) + bitrate
-                        br = a[0]
-
-                    # If it's a constant bitrate we can deduce the length
-                    else:
-
-                        bitrate = str(a[0]) + bitrate
-                        br = a[0]
-
-                        # Dividing the file size by the bitrate in Bytes should give us a good enough approximation
-                        l = result[2] / (br / 8 * 1000)  # noqa: E741
-
-                        length = '%i:%02i' % (l / 60, l % 60)
-
-                # Sometimes the bitrate is in first position and the length in second position
-                else:
-
-                    bitrate = str(a[0]) + bitrate
-                    br = a[0]
-
-                    length = '%i:%02i' % (a[1] / 60, a[1] % 60)
-
-            self.append([str(counter), user, self.get_flag(user, country), imdl, h_speed, h_queue, dir, name, h_size, bitrate, length, br, result[1], country, result[2], ulspeed, inqueue, status])
+            self.append([str(counter), user, self.get_flag(user, country), imdl, h_speed, h_queue, dir, name, h_size, h_bitrate, h_length, bitrate, result[1], country, result[2], ulspeed, inqueue, status])
             counter += 1
 
         # Update counter

--- a/pynicotine/gtkgui/userinfo.py
+++ b/pynicotine/gtkgui/userinfo.py
@@ -35,6 +35,7 @@ from gi.repository import Gtk as gtk
 from pynicotine import slskmessages
 from pynicotine.gtkgui.utils import AppendLine
 from pynicotine.gtkgui.utils import Humanize
+from pynicotine.gtkgui.utils import HumanSpeed
 from pynicotine.gtkgui.utils import IconNotebook
 from pynicotine.gtkgui.utils import InitialiseColumns
 from pynicotine.gtkgui.utils import PopupMenu
@@ -78,7 +79,7 @@ class UserTabs(IconNotebook):
 
         if msg.user in self.users:
             tab = self.users[msg.user]
-            tab.speed.set_text(_("Speed: %s") % Humanize(msg.avgspeed))
+            tab.speed.set_text(_("Speed: %s") % HumanSpeed(msg.avgspeed))
             tab.filesshared.set_text(_("Files: %s") % Humanize(msg.files))
             tab.dirsshared.set_text(_("Directories: %s") % Humanize(msg.dirs))
 

--- a/pynicotine/transfers.py
+++ b/pynicotine/transfers.py
@@ -48,6 +48,7 @@ from pynicotine.logfacility import log
 from pynicotine.slskmessages import newId
 from pynicotine.utils import executeCommand
 from pynicotine.utils import CleanFile
+from pynicotine.utils import GetResultBitrateLength
 
 win32 = sys.platform.startswith("win")
 
@@ -1871,27 +1872,17 @@ class Transfers:
                         normalfiles = [x for junk, x in deco]
 
                     for file in priorityfiles + normalfiles:
-                        length = bitrate = None
-                        attrs = file[4]
-
-                        if attrs != []:
-                            bitrate = str(attrs[0])
-                            if attrs[2]:
-                                bitrate += " (vbr)"
-                            try:
-                                rl = int(attrs[1])
-                            except Exception:
-                                rl = 0
-                            length = "%i:%02i" % (rl // 60, rl % 60)
+                        size = file[2]
+                        h_bitrate, bitrate, h_length = GetResultBitrateLength(size, file[4])
 
                         if directory[-1] == '\\':
                             self.getFile(
                                 username,
                                 directory + file[1],
                                 self.FolderDestination(username, directory),
-                                size=file[2],
-                                bitrate=bitrate,
-                                length=length,
+                                size=size,
+                                bitrate=h_bitrate,
+                                length=h_length,
                                 checkduplicate=True
                             )
                         else:
@@ -1899,9 +1890,9 @@ class Transfers:
                                 username,
                                 directory + '\\' + file[1],
                                 self.FolderDestination(username, directory),
-                                size=file[2],
-                                bitrate=bitrate,
-                                length=length,
+                                size=size,
+                                bitrate=h_bitrate,
+                                length=h_length,
                                 checkduplicate=True
                             )
 

--- a/pynicotine/utils.py
+++ b/pynicotine/utils.py
@@ -103,6 +103,95 @@ def GetUserDirectories():
     return config_dir, data_dir
 
 
+def GetResultBitrateLength(filesize, attributes):
+    """ Used to get the audio bitrate and length of search results and
+    user browse files """
+
+    h_bitrate = ""
+    h_length = ""
+
+    bitrate = 0
+
+    # If there are 3 entries in the attribute list
+    if len(attributes) == 3:
+
+        a = attributes
+
+        # Sometimes the vbr indicator is in third position
+        if a[2] == 0 or a[2] == 1:
+
+            if a[2] == 1:
+                h_bitrate = " (vbr)"
+
+            bitrate = a[0]
+            h_bitrate = str(bitrate) + h_bitrate
+
+            h_length = '%i:%02i' % (a[1] / 60, a[1] % 60)
+
+        # Sometimes the vbr indicator is in second position
+        elif a[1] == 0 or a[1] == 1:
+
+            if a[1] == 1:
+                h_bitrate = " (vbr)"
+
+            bitrate = a[0]
+            h_bitrate = str(bitrate) + h_bitrate
+
+            h_length = '%i:%02i' % (a[2] / 60, a[2] % 60)
+
+        # Lossless audio, length is in first position
+        elif a[2] > 1:
+
+            # Bitrate = sample rate (Hz) * word length (bits) * channel count
+            # Bitrate = 44100 * 16 * 2
+            bitrate = (a[1] * a[2] * 2) / 1000
+            h_bitrate = str(bitrate)
+
+            h_length = '%i:%02i' % (a[0] / 60, a[0] % 60)
+
+        else:
+
+            bitrate = a[0]
+            h_bitrate = str(bitrate) + h_bitrate
+
+    # If there are 2 entries in the attribute list
+    elif len(attributes) == 2:
+
+        a = attributes
+
+        # Sometimes the vbr indicator is in second position
+        if a[1] == 0 or a[1] == 1:
+
+            # If it's a vbr file we can't deduce the length
+            if a[1] == 1:
+
+                h_bitrate = " (vbr)"
+
+                bitrate = a[0]
+                h_bitrate = str(bitrate) + h_bitrate
+
+            # If it's a constant bitrate we can deduce the length
+            else:
+
+                bitrate = a[0]
+                h_bitrate = str(bitrate) + h_bitrate
+
+                # Dividing the file size by the bitrate in Bytes should give us a good enough approximation
+                length = filesize / (bitrate / 8 * 1000)
+
+                h_length = '%i:%02i' % (length / 60, length % 60)
+
+        # Sometimes the bitrate is in first position and the length in second position
+        else:
+
+            bitrate = a[0]
+            h_bitrate = str(bitrate) + h_bitrate
+
+            h_length = '%i:%02i' % (a[1] / 60, a[1] % 60)
+
+    return h_bitrate, bitrate, h_length
+
+
 def ApplyTranslation():
     """Function dealing with translations and locales.
 


### PR DESCRIPTION
- There are multiple code snippets for reading audio lengths and bitrates that have been forgotten over the years. Use a unified function instead.
- Show human-readable upload speeds on the user info page
- Show human-readable file sizes on the user browse page