### PR TITLE
Fix for peer message 12547

### DIFF
--- a/pynicotine/pynicotine.py
+++ b/pynicotine/pynicotine.py
@@ -296,7 +296,7 @@ class NetworkEventProcessor:
             slskmessages.PrivateRoomAddOperator: self.PrivateRoomAddOperator,
             slskmessages.PrivateRoomRemoveOperator: self.PrivateRoomRemoveOperator,
             slskmessages.PublicRoomMessage: self.PublicRoomMessage,
-            slskmessages.Unknown: self.DummyMessage,
+            slskmessages.UnknownPeerMessage: self.DummyMessage,
         }
 
     def ProcessRequestToPeer(self, user, message, window=None, address=None):

--- a/pynicotine/pynicotine.py
+++ b/pynicotine/pynicotine.py
@@ -419,7 +419,7 @@ class NetworkEventProcessor:
     # @param self NetworkEventProcessor (Class)
     # @param string a string containing an error message
     def Notify(self, string):
-        self.logMessage("%s" % string)
+        self.logMessage("%s" % string, 4)
 
     def PopupMessage(self, msg):
         self.setStatus(_(msg.title))

--- a/pynicotine/slskmessages.py
+++ b/pynicotine/slskmessages.py
@@ -2144,9 +2144,12 @@ class UploadQueueNotification(PeerMessage):
         return b""
 
 
-class Unknown(PeerMessage):
+class UnknownPeerMessage(PeerMessage):
     """ Peer code: 12547 """
     """ UNKNOWN """
+    def __init__(self, conn):
+        self.conn = conn
+
     def parseNetworkMessage(self, message):
         pass
 

--- a/pynicotine/slskproto.py
+++ b/pynicotine/slskproto.py
@@ -156,7 +156,7 @@ from pynicotine.slskmessages import SimilarUsers
 from pynicotine.slskmessages import TransferRequest
 from pynicotine.slskmessages import TransferResponse
 from pynicotine.slskmessages import TunneledMessage
-from pynicotine.slskmessages import Unknown
+from pynicotine.slskmessages import UnknownPeerMessage
 from pynicotine.slskmessages import UploadFailed
 from pynicotine.slskmessages import UploadFile
 from pynicotine.slskmessages import UploadQueueNotification
@@ -374,7 +374,7 @@ class SlskProtoThread(threading.Thread):
         QueueFailed: 50,
         PlaceInQueueRequest: 51,
         UploadQueueNotification: 52,
-        Unknown: 12547
+        UnknownPeerMessage: 12547
     }
 
     distribclasses = {


### PR DESCRIPTION
This function needs to accept the conn argument. Fixes messages about no handler for class when receiving this message.