### PR TITLE
Multiple transfer list fixes

### DIFF
--- a/pynicotine/gtkgui/downloads.py
+++ b/pynicotine/gtkgui/downloads.py
@@ -365,10 +365,6 @@ class Downloads(TransferList):
 
         return True
 
-    def update(self, transfer=None, forced=False):
-
-        TransferList.update(self, transfer, forced)
-
     def OnGetPlaceInQueue(self, widget):
 
         self.select_transfers()

--- a/pynicotine/gtkgui/search.py
+++ b/pynicotine/gtkgui/search.py
@@ -804,14 +804,15 @@ class Search:
             if counter > self.Searches.maxstoredresults:
                 break
 
-            name = result[1].split('\\')[-1]
-            dir = result[1][:-len(name)]
+            fullpath = result[1]
+            name = fullpath.split('\\')[-1]
+            dir = fullpath[:-len(name)]
 
             size = result[2]
             h_size = HumanSize(size)
             h_bitrate, bitrate, h_length = GetResultBitrateLength(size, result[4])
 
-            self.append([counter, user, self.get_flag(user, country), imdl, h_speed, h_queue, dir, name, h_size, h_bitrate, h_length, bitrate, result[1], country, result[2], ulspeed, inqueue, status])
+            self.append([counter, user, self.get_flag(user, country), imdl, h_speed, h_queue, dir, name, h_size, h_bitrate, h_length, bitrate, fullpath, country, size, ulspeed, inqueue, status])
             counter += 1
 
         # Update counter

--- a/pynicotine/gtkgui/transferlist.py
+++ b/pynicotine/gtkgui/transferlist.py
@@ -273,10 +273,6 @@ class TransferList:
 
         return False  # Stopping timeout
 
-    def remove(self, transfer):
-
-        self.transfersmodel.remove(transfer.iter)
-
     def update(self, transfer=None, forced=False):
 
         current_page = self.frame.MainNotebook.get_current_page()
@@ -544,6 +540,12 @@ class TransferList:
                 path = self.transfersmodel.get_path(iter)
                 self.expand(path)
 
+    def remove_specific(self, transfer, cleartreeviewonly=False):
+        if not cleartreeviewonly:
+            self.list.remove(transfer)
+
+        self.transfersmodel.remove(transfer.iter)
+
     def Clear(self):
         self.users.clear()
         self.paths.clear()
@@ -658,8 +660,7 @@ class TransferList:
                 i.status = "Aborted"
 
             if clear:
-                self.list.remove(i)
-                self.transfersmodel.remove(i.iter)
+                self.remove_specific(i)
 
         self.update()
 
@@ -672,8 +673,7 @@ class TransferList:
             if i.status in status:
                 if i.transfertimer is not None:
                     i.transfertimer.cancel()
-                self.list.remove(i)
-                self.transfersmodel.remove(i.iter)
+                self.remove_specific(i)
 
         self.update()
 

--- a/pynicotine/gtkgui/uploads.py
+++ b/pynicotine/gtkgui/uploads.py
@@ -287,8 +287,6 @@ class Uploads(TransferList):
         self.frame.np.transfers.calcUploadQueueSizes()
         self.frame.np.transfers.checkUploadQueue()
 
-        self.update()
-
     def DoubleClick(self, event):
 
         self.select_transfers()
@@ -313,8 +311,6 @@ class Uploads(TransferList):
         self.frame.np.transfers.calcUploadQueueSizes()
         self.frame.np.transfers.checkUploadQueue()
 
-        self.update()
-
     def OnClearQueued(self, widget):
 
         self.select_transfers()
@@ -323,12 +319,8 @@ class Uploads(TransferList):
         self.frame.np.transfers.calcUploadQueueSizes()
         self.frame.np.transfers.checkUploadQueue()
 
-        self.update()
-
     def OnClearFailed(self, widget):
 
         TransferList.OnClearFailed(self, widget)
         self.frame.np.transfers.calcUploadQueueSizes()
         self.frame.np.transfers.checkUploadQueue()
-
-        self.update()

--- a/pynicotine/gtkgui/uploads.py
+++ b/pynicotine/gtkgui/uploads.py
@@ -282,7 +282,7 @@ class Uploads(TransferList):
             if i.user == user:
                 if i.transfertimer is not None:
                     i.transfertimer.cancel()
-                self.list.remove(i)
+                self.remove_specific(i)
 
         self.frame.np.transfers.calcUploadQueueSizes()
         self.frame.np.transfers.checkUploadQueue()

--- a/pynicotine/gtkgui/userbrowse.py
+++ b/pynicotine/gtkgui/userbrowse.py
@@ -772,6 +772,7 @@ class UserBrowse:
     def OnUploadDirectoryTo(self, widget, recurse=0):
 
         dir = self.selected_folder
+
         if dir is None:
             return
 
@@ -802,6 +803,7 @@ class UserBrowse:
         if dir == "" or dir is None or user is None or user == "":
             return
 
+        realpath = self.frame.np.shares.virtual2real(dir)
         ldir = dir.split("\\")[-1]
 
         for d, f in self.shares:
@@ -811,9 +813,10 @@ class UserBrowse:
                 continue
 
             for file in f:
-                path = "\\".join([dir, file[1]])
+                filename = "\\".join([dir, file[1]])
+                realfilename = "\\".join([realpath, file[1]])
                 size = file[2]
-                self.frame.np.transfers.pushFile(user, path, ldir, size=size)
+                self.frame.np.transfers.pushFile(user, filename, realfilename, ldir, size=size)
                 self.frame.np.transfers.checkUploadQueue()
 
         if not recurse:
@@ -826,6 +829,8 @@ class UserBrowse:
     def OnUploadFiles(self, widget, prefix=""):
 
         dir = self.selected_folder
+        realpath = self.frame.np.shares.virtual2real(dir)
+
         users = []
 
         for entry in self.frame.np.config.sections["server"]["userlist"]:
@@ -845,7 +850,7 @@ class UserBrowse:
         self.frame.np.ProcessRequestToPeer(user, slskmessages.UploadQueueNotification(None))
 
         for fn in self.selected_files:
-            self.frame.np.transfers.pushFile(user, "\\".join([dir, fn]), prefix)
+            self.frame.np.transfers.pushFile(user, "\\".join([dir, fn]), "\\".join([realpath, fn]), prefix)
             self.frame.np.transfers.checkUploadQueue()
 
     def OnPlayFiles(self, widget, prefix=""):

--- a/pynicotine/transfers.py
+++ b/pynicotine/transfers.py
@@ -237,7 +237,7 @@ class Transfers:
                     if i.transfertimer is not None:
                         i.transfertimer.cancel()
                     self.uploads.remove(i)
-                    self.uploadspanel.update()
+                    self.uploadspanel.remove_specific(i, True)
 
         if msg.status == 0:
             self.checkUploadQueue()
@@ -613,7 +613,7 @@ class Transfers:
         for i in self.uploads:
             if i.user == user and i.filename == filename:
                 self.uploads.remove(i)
-                self.uploadspanel.remove(i)
+                self.uploadspanel.remove_specific(i, True)
 
         self.uploads.append(transferobj)
 
@@ -920,7 +920,7 @@ class Transfers:
                         i.transfertimer.cancel()
 
                     self.uploads.remove(i)
-                    self.uploadspanel.update()
+                    self.uploadspanel.remove_specific(i, True)
 
                 elif msg.reason == "Cancelled":
 
@@ -1006,6 +1006,7 @@ class Transfers:
 
         downloaddir = self.eventprocessor.config.sections["transfers"]["downloaddir"]
         incompletedir = self.eventprocessor.config.sections["transfers"]["incompletedir"]
+        needupdate = True
 
         if i.conn is None and i.size is not None:
             i.conn = msg.conn
@@ -1094,9 +1095,12 @@ class Transfers:
                         self.eventprocessor.logTransfer(_("Download started: user %(user)s, file %(file)s") % {'user': i.user, 'file': "%s" % f.name}, 5)
                     else:
                         self.DownloadFinished(f, i)
+                        needupdate = False
 
             self.SetIconDownloads()
-            self.downloadspanel.update(i)
+
+            if needupdate:
+                self.downloadspanel.update(i)
         else:
             self.eventprocessor.logMessage(_("Download error formally known as 'Unknown file request': %(req)s (%(user)s: %(file)s)") % {
                 'req': str(vars(msg)),
@@ -1226,6 +1230,7 @@ class Transfers:
                     i.status = "Transferring"
                 else:
                     self.DownloadFinished(msg.file, i)
+                    needupdate = False
             except IOError as strerror:
                 self.eventprocessor.logMessage(_("Download I/O error: %s") % strerror)
                 i.status = "Local file error"
@@ -1330,7 +1335,7 @@ class Transfers:
         # Autoclear this download
         if self.eventprocessor.config.sections["transfers"]["autoclear_downloads"]:
             self.downloads.remove(i)
-            self.downloadspanel.update()
+            self.downloadspanel.remove_specific(i, True)
         else:
             self.downloadspanel.update(i)
 
@@ -1448,6 +1453,7 @@ class Transfers:
 
                 # Autoclear this upload
                 self.AutoClearUpload(i)
+                needupdate = False
 
             if needupdate:
                 self.uploadspanel.update(i)
@@ -1455,9 +1461,9 @@ class Transfers:
     def AutoClearUpload(self, i):
         if self.eventprocessor.config.sections["transfers"]["autoclear_uploads"]:
             self.uploads.remove(i)
+            self.uploadspanel.remove_specific(i, True)
             self.calcUploadQueueSizes()
             self.checkUploadQueue()
-            self.uploadspanel.update()
 
     def BanUser(self, user, ban_message=None):
         """

--- a/pynicotine/transfers.py
+++ b/pynicotine/transfers.py
@@ -979,8 +979,7 @@ class Transfers:
 
             if i in self.downloads:
                 self.downloadspanel.update(i)
-
-            if i in self.uploads:
+            elif i in self.uploads:
                 self.uploadspanel.update(i)
 
         self.checkUploadQueue()
@@ -1752,8 +1751,12 @@ class Transfers:
             i.requestconn = None
             i.status = "Connection closed by peer"
             i.req = None
-            self.downloadspanel.update(i)
-            self.uploadspanel.update(i)
+
+            if type == "download":
+                self.downloadspanel.update(i)
+            elif type == "upload":
+                self.uploadspanel.update(i)
+
             self.checkUploadQueue()
 
         if i.file is not None:
@@ -1776,8 +1779,12 @@ class Transfers:
                 j.timequeued = curtime
 
         i.conn = None
-        self.downloadspanel.update(i)
-        self.uploadspanel.update(i)
+
+        if type == "download":
+            self.downloadspanel.update(i)
+        elif type == "upload":
+            self.uploadspanel.update(i)
+
         self.checkUploadQueue()
 
     def getRenamed(self, name, originalfile):
@@ -1862,8 +1869,7 @@ class Transfers:
 
             if i in self.downloads:
                 self.downloadspanel.update(i)
-
-            if i in self.uploads:
+            elif i in self.uploads:
                 self.uploadspanel.update(i)
 
             self.checkUploadQueue()

--- a/pynicotine/transfers.py
+++ b/pynicotine/transfers.py
@@ -1974,6 +1974,9 @@ class Transfers:
         transfer.speed = 0
         transfer.timeleft = ""
 
+        if transfer in self.uploads:
+            self.eventprocessor.ProcessRequestToPeer(transfer.user, slskmessages.QueueFailed(None, file=transfer.filename, reason="Aborted"))
+
         if transfer.conn is not None:
             self.queue.put(slskmessages.ConnClose(transfer.conn))
             transfer.conn = None

--- a/pynicotine/transfers.py
+++ b/pynicotine/transfers.py
@@ -255,7 +255,8 @@ class Transfers:
 
     def pushFile(self, user, filename, realfilename, path="", transfer=None, size=None, bitrate=None, length=None):
         if size is None:
-            size = self.getFileSize(filename)
+            size = self.getFileSize(realfilename)
+
         self.transferFile(1, user, filename, path, transfer, size, bitrate, length, realfilename)
 
     def transferFile(self, direction, user, filename, path="", transfer=None, size=None, bitrate=None, length=None, realfilename=None):
@@ -263,7 +264,7 @@ class Transfers:
         not None, update it, otherwise create a new one."""
         if transfer is None:
             transfer = Transfer(
-                user=user, filename=filename, path=path,
+                user=user, filename=filename, realfilename=realfilename, path=path,
                 status="Getting status", size=size, bitrate=bitrate,
                 length=length
             )


### PR DESCRIPTION
- Don't add downloads and uploads to the wrong panels
- Remove transfers properly
- Make direct upload to user feature functional again (found when right-clicking files in your own user share)
- Tell the remote user when we abort our upload