### PR TITLE
Add miniupnp to required dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ $ autopkgtest --shell-fail --apt-upgrade ../nicotine_(...).dsc -- \
 * [gobject-introspection](https://gi.readthedocs.io/en/latest/) for GObject introspection;
 * [gir1.2-gtk-3.0](https://www.gtk.org/) for GObject introspection bindings for GTK;
 * [python3-mutagen](https://mutagen.readthedocs.io/en/latest/) >= 1.36.2 for metadata parsing;
+* [python3-miniupnpc](https://miniupnp.tuxfamily.org/) >= 1.9 for opening ports on your router or `upnpc(1)` if not available;
 * [robotframework](https://robotframework.org/) for CI testing.
 
 ## Optional
@@ -105,7 +106,6 @@ $ autopkgtest --shell-fail --apt-upgrade ../nicotine_(...).dsc -- \
 * [gir1.2-gsound-1.0](https://lazka.github.io/pgi-docs/GSound-1.0/index.html) for sound effects;
 * [gir1.2-gspell-1](https://lazka.github.io/pgi-docs/Gspell-1/index.html) for spell checking in chat;
 * [gir1.2-notify-0.7](https://lazka.github.io/pgi-docs/Notify-0.7/index.html) for desktop notifications;
-* [python3-miniupnpc](https://miniupnp.tuxfamily.org/) >= 1.9 for opening ports on your router or `upnpc(1)` if not available;
 
 # Legal and Privacy
 

--- a/pynicotine/config.py
+++ b/pynicotine/config.py
@@ -91,7 +91,7 @@ class Config:
                 "autosearch": [],
                 "autoreply": "",
                 "portrange": (2234, 2239),
-                "upnp": False,
+                "upnp": True,
                 "userlist": [],
                 "banlist": [],
                 "ignorelist": [],

--- a/pynicotine/gtkgui/fastconfigure.py
+++ b/pynicotine/gtkgui/fastconfigure.py
@@ -152,9 +152,6 @@ class FastConfigureAssistant(object):
         self.kids['upperport'].set_value(
             self.config.sections["server"]["portrange"][1]
         )
-        self.kids['useupnp'].set_active(
-            self.config.sections["server"]["upnp"]
-        )
 
         # sharepage
         if self.config.sections['transfers']['downloaddir']:
@@ -200,7 +197,6 @@ class FastConfigureAssistant(object):
             self.kids['lowerport'].get_value_as_int(),
             self.kids['upperport'].get_value_as_int()
         )
-        self.config.sections['server']['upnp'] = self.kids['useupnp'].get_active()
         self.config.sections['server']['firewalled'] = not self.kids['portopen'].get_active()
 
         # sharepage
@@ -227,7 +223,7 @@ class FastConfigureAssistant(object):
         )
 
         if not self.frame.np.serverconn:
-            self.frame.OnFirstConnect(-1)
+            self.frame.OnConnect(-1)
 
     def OnCancel(self, widget):
         self.window.hide()
@@ -254,12 +250,9 @@ class FastConfigureAssistant(object):
                 complete = True
 
         elif name == 'portpage':
-            if self.kids['useupnp'].get_active():
+            if self.kids['portopen'].get_active() or \
+               self.kids['portclosed'].get_active():
                 complete = True
-            else:
-                if self.kids['portopen'].get_active() or \
-                   self.kids['portclosed'].get_active():
-                    complete = True
 
         elif name == 'sharepage':
             if exists(self.kids['downloaddir'].get_filename()):
@@ -269,8 +262,7 @@ class FastConfigureAssistant(object):
 
             complete = True
             showcpwarning = (
-                self.kids['portclosed'].get_active() and
-                not self.kids['useupnp'].get_active()
+                self.kids['portclosed'].get_active()
             )
 
             if showcpwarning:
@@ -493,27 +485,6 @@ class FastConfigureAssistant(object):
         self.resetcompleteness()
 
     def OnToggled(self, widget):
-
-        name = gtk.Buildable.get_name(widget)
-
-        if name == 'useupnp':
-
-            # Setting active state
-            if widget.get_active():
-                self.kids['portopen'].set_inconsistent(True)
-                self.kids['portclosed'].set_inconsistent(True)
-            else:
-                self.kids['portopen'].set_inconsistent(False)
-                self.kids['portclosed'].set_inconsistent(False)
-
-            # Setting sensitive state
-            inverse = not widget.get_active()
-
-            self.kids['portopen'].set_sensitive(inverse)
-            self.kids['portclosed'].set_sensitive(inverse)
-            self.kids['checkmyport'].set_sensitive(inverse)
-
-            self.resetcompleteness()
 
         if self.initphase:
             return

--- a/pynicotine/gtkgui/frame.py
+++ b/pynicotine/gtkgui/frame.py
@@ -526,6 +526,25 @@ class NicotineFrame:
 
         self.SetTabPositions()
 
+        # Test if we want to do a port mapping
+        if self.np.config.sections["server"]["upnp"]:
+
+            # Initialise a UPnPPortMapping object
+            upnp = UPnPPortMapping()
+
+            # Check if we can do a port mapping
+            (self.upnppossible, errors) = upnp.IsPossible()
+
+            # Test if we are able to do a port mapping
+            if self.upnppossible:
+                # Do the port mapping
+                _thread.start_new_thread(upnp.AddPortMapping, (self, self.np))
+            else:
+                # Display errors
+                if errors is not None:
+                    for err in errors:
+                        log.addwarning(err)
+
         ConfigUnset = self.np.config.needConfig()
         if ConfigUnset:
             if ConfigUnset > 1:
@@ -535,9 +554,9 @@ class NicotineFrame:
                 self.OnFastConfigure(None)
             else:
                 # Connect anyway
-                self.OnFirstConnect(-1)
+                self.OnConnect(-1)
         else:
-            self.OnFirstConnect(-1)
+            self.OnConnect(-1)
 
         self.UpdateDownloadFilters()
 
@@ -1497,33 +1516,6 @@ class NicotineFrame:
 
         # Exiting GTK
         gtk.main_quit()
-
-    def OnFirstConnect(self, widget):
-
-        # Test if we want to do a port mapping
-        if self.np.config.sections["server"]["upnp"]:
-
-            # Initialise a UPnPPortMapping object
-            upnp = UPnPPortMapping()
-
-            # Check if we can do a port mapping
-            (self.upnppossible, errors) = upnp.IsPossible()
-
-            # Test if we are able to do a port mapping
-            if self.upnppossible:
-                # Do the port mapping
-                _thread.start_new_thread(upnp.AddPortMapping, (self, self.np))
-            else:
-                # Display errors
-                if errors is not None:
-                    for err in errors:
-                        log.addwarning(err)
-
-                # If not we connect without changing anything
-                self.OnConnect(-1)
-        else:
-            # If not we connect without changing anything
-            self.OnConnect(-1)
 
     def OnConnect(self, widget):
 

--- a/pynicotine/gtkgui/settingswindow.py
+++ b/pynicotine/gtkgui/settingswindow.py
@@ -158,15 +158,13 @@ class ServerFrame(buildFrame):
             # if the config said so
             self.UseUPnP.set_active(server["upnp"])
             self.UseUPnP.set_sensitive(True)
+            self.labelRequirementsUPnP.hide()
         else:
             # If we cant do a port mapping: highlight the requirements
             # & disable the choice
             self.UseUPnP.set_active(False)
             self.UseUPnP.set_sensitive(False)
-            self.labelRequirementsUPnP.set_sensitive(True)
-
-        # Handle the switch between direct connections and upnp ones
-        self.OnUPnPToggled(None)
+            self.labelRequirementsUPnP.show()
 
     def GetSettings(self):
 
@@ -200,10 +198,7 @@ class ServerFrame(buildFrame):
             )
             raise UserWarning
 
-        if self.UseUPnP.get_active():
-            firewalled = False
-        else:
-            firewalled = not self.DirectConnection.get_active()
+        firewalled = not self.DirectConnection.get_active()
 
         return {
             "server": {
@@ -222,30 +217,6 @@ class ServerFrame(buildFrame):
 
     def OnCheckPort(self, widget):
         OpenUri('='.join(['http://tools.slsknet.org/porttest.php?port', str(self.frame.np.waitport)]), self.p.SettingsWindow)
-
-    def OnUPnPToggled(self, widget):
-
-        if self.UseUPnP.get_active():
-
-            # If we want to use upnp remove hint highlight
-            # since its possible to do it
-            self.labelRequirementsUPnP.set_sensitive(False)
-
-            # We set direct connection to True
-            # since now its possible to establish them
-            self.DirectConnection.set_active(True)
-
-            # Also desactivate direct connections options
-            self.DirectConnection.set_sensitive(False)
-            self.Requirement.set_sensitive(False)
-        else:
-
-            # If we want dont want to use upnp restore the hint for it
-            self.labelRequirementsUPnP.set_sensitive(True)
-
-            # Also activate direct connections
-            self.Requirement.set_sensitive(True)
-            self.DirectConnection.set_sensitive(True)
 
 
 class DownloadsFrame(buildFrame):

--- a/pynicotine/gtkgui/ui/fastconfigure.ui
+++ b/pynicotine/gtkgui/ui/fastconfigure.ui
@@ -314,6 +314,22 @@ If you already have an account at the server fill in those details.</property>
                 <property name="position">2</property>
               </packing>
             </child>
+            <child>
+              <object class="GtkLabel">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="label" translatable="yes">Only select "The page says my port is closed" if all attempts at opening the port were unsuccessful. This can happen if your ISP blocks ports.</property>
+                <property name="justify">center</property>
+                <property name="wrap">True</property>
+                <property name="width_chars">60</property>
+                <property name="max_width_chars">60</property>
+              </object>
+              <packing>
+                <property name="expand">True</property>
+                <property name="fill">True</property>
+                <property name="position">3</property>
+              </packing>
+            </child>
           </object>
           <packing>
             <property name="expand">True</property>
@@ -332,22 +348,6 @@ If you already have an account at the server fill in those details.</property>
             <property name="expand">True</property>
             <property name="fill">True</property>
             <property name="position">1</property>
-          </packing>
-        </child>
-        <child>
-          <object class="GtkCheckButton" id="useupnp">
-            <property name="label" translatable="yes">Use UPnP to map the port on my router</property>
-            <property name="visible">True</property>
-            <property name="can_focus">True</property>
-            <property name="receives_default">False</property>
-            <property name="halign">center</property>
-            <property name="draw_indicator">True</property>
-            <signal name="toggled" handler="OnToggled" swapped="no"/>
-          </object>
-          <packing>
-            <property name="expand">True</property>
-            <property name="fill">True</property>
-            <property name="position">2</property>
           </packing>
         </child>
         <child>

--- a/pynicotine/gtkgui/ui/settingswindow_ServerFrame.ui
+++ b/pynicotine/gtkgui/ui/settingswindow_ServerFrame.ui
@@ -354,13 +354,12 @@
             </child>
             <child>
               <object class="GtkCheckButton" id="UseUPnP">
-                <property name="label" translatable="yes">Use UPnP to fix portmapping (requires MiniUPnPc, preferably with python bindings)</property>
+                <property name="label" translatable="yes">Use UPnP to map the port on my router (requires restart)</property>
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
                 <property name="receives_default">False</property>
                 <property name="use_underline">True</property>
                 <property name="draw_indicator">True</property>
-                <signal name="toggled" handler="OnUPnPToggled" swapped="no"/>
               </object>
               <packing>
                 <property name="expand">False</property>
@@ -405,7 +404,8 @@
                 <property name="can_focus">False</property>
                 <property name="xalign">0</property>
                 <property name="yalign">0</property>
-                <property name="label" translatable="yes">(only use if the above ports are remotely accessible)</property>
+                <property name="label" translatable="yes">Only disable direct connections if the above ports aren't accessible after attempting UPnP and manual port forwarding, if possible. This can happen if your ISP blocks ports.</property>
+                <property name="wrap">True</property>
               </object>
               <packing>
                 <property name="expand">False</property>

--- a/pynicotine/upnp.py
+++ b/pynicotine/upnp.py
@@ -38,9 +38,6 @@ class UPnPPortMapping:
         # Default discovery delay (ms)
         self.discoverdelay = 2000
 
-        # Default requested external WAN port
-        self.externalwanport = 15000
-
         # List of existing port mappings
         self.existingportsmappings = []
 
@@ -161,6 +158,7 @@ class UPnPPortMapping:
 
         # Store the Local LAN port
         self.internallanport = np.protothread._p.getsockname()[1]
+        self.externalwanport = self.internallanport
 
         # The function depends on what method of configuring port mapping is
         # available
@@ -190,9 +188,6 @@ class UPnPPortMapping:
 
         # Set the external WAN port in the GUI
         frame.networkcallback([slskmessages.IncPort(self.externalwanport)])
-
-        # Establish the connection to the slsk network
-        frame.OnConnect(-1)
 
     def AddPortMappingBinary(self):
         """Function to create a Port Mapping via MiniUPnPc binary: upnpc.


### PR DESCRIPTION
- List miniupnp as a required dependency, and enable UPnP by default (like SoulseekQt) to cut down on potential connection issues among new users
- Unlink UPnP and direct connection checkboxes, since UPnP doesn't guarantee that direct connections are possible (e.g. ports blocked on ISP level). UPnP will still help if there are many clients on the same network.