### PR TITLE
Only show new wishlist tabs when supposed to

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -103,6 +103,7 @@ Bugs closed in GitHub
  * Can't find anything from Wu-tang (#343)
  * AttributeError: 'Uploads' object has no attribute 'transfers' (#360)
  * remove filtered files when autoremoving (#374)
+ * wishlist searches should notify on finding a result, not on attempting to find something (#380)
 
 Version 1.4.3 (unstable)
 -----------------------------

--- a/pynicotine/shares.py
+++ b/pynicotine/shares.py
@@ -329,6 +329,10 @@ class Shares:
         if searchterm is None:
             return
 
+        if user != self.config.sections["server"]["login"]:
+            # We shouldn't send a search response if we initiated the search request
+            return
+
         checkuser, reason = self.np.CheckUser(user, None)
         if not checkuser:
             return


### PR DESCRIPTION
- Don't open tabs for wishlist search results if the results won't be added due to being spoofed/incorrect/filtered
- Don't send search responses to our own search requests

Fixes https://github.com/Nicotine-Plus/nicotine-plus/issues/380