### PR TITLE
Add install instructions for Arch and Parabola

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,13 @@ $ sudo apt update
 $ sudo apt install nicotine
 ```
 
+### Arch Linux/Parabola (Stable)
+Nicotine+ is available in the community repository of Arch Linux and Parabola. To install, run the following:
+
+```console
+$ pacman -S nicotine+
+```
+
 ### Other Distributions
 Package maintainers, please insert instructions for users to install pre-compiled packages from your respective repositories here.
 


### PR DESCRIPTION
Don't merge until Nicotine+ 2.0.0 has made it out of Manjaro unstable.