### PR TITLE
Improvements to Windows build

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,10 @@ $ sudo xbps-install -S nicotine+
 Package maintainers, please insert instructions for users to install pre-compiled packages from your respective repositories here.
 
 ## Windows (Stable)
-You can download a Windows package here: [Windows Nicotine+ Installer](https://github.com/Nicotine-Plus/nicotine-plus/releases/download/2.0.1/Nicotine+-2.0.1.exe)
+You can download Windows packages here:
+
+- [64-bit Installer](https://github.com/Nicotine-Plus/nicotine-plus/releases/download/2.0.1/Nicotine+-2.0.1-x86_64.exe)
+- [32-bit Installer](https://github.com/Nicotine-Plus/nicotine-plus/releases/download/2.0.1/Nicotine+-2.0.1-i686.exe)
 
 ## Building from git
 Building from git is described in [RUNFROMGIT.md](doc/RUNFROMGIT.md)

--- a/doc/PACKAGING.md
+++ b/doc/PACKAGING.md
@@ -50,6 +50,8 @@ The RPM package will be located in the `dist` subdirectory of your git repositor
 
 ### Windows
 
+To avoid compatibility issues with older Windows versions, Windows 7 is used to package Nicotine+.
+
 #### Building a frozen application via PyInstaller
 
 First, follow the instructions on installing MSYS2: [https://pygobject.readthedocs.io/en/latest/getting_started.html#windows-logo-windows](https://pygobject.readthedocs.io/en/latest/getting_started.html#windows-logo-windows)
@@ -89,3 +91,9 @@ Extract it in the `files\windows` directory.
 Then via cmd.exe or Powershell go to `files\windows` directory and run `nsis-$(version)/makensis.exe nicotine.nsi`
 
 You should now find a `Nicotine+-$(version).exe` installer in the `files\windows` directory.
+
+#### Building a 32-bit (i686) application and installer
+
+Start a MinGW 32-bit terminal, and follow the above tutorial again, replacing any instance of "x86_64" with "i686" when installing packages.
+
+Preferably, clone a fresh copy of the nicotine-plus git repository before freezing Nicotine+ with PyInstaller again.

--- a/files/windows/nicotine.nsi
+++ b/files/windows/nicotine.nsi
@@ -31,7 +31,8 @@ ReserveFile "shortcuts.ini"
 Name "${PRODUCT_NAME} (${PRODUCT_VERSION})"
 BrandingText "${PRODUCT_NAME}"
 OutFile "${PRODUCT_NAME}-${PRODUCT_VERSION}.exe"
-InstallDir "$PROGRAMFILES\Nicotine+"
+; When creating a 32-bit installer, replace PROGRAMFILES64 with PROGRAMFILES
+InstallDir "$PROGRAMFILES64\Nicotine+"
 InstallDirRegKey HKLM "${PRODUCT_DIR_REGKEY}" ""
 ShowInstDetails show
 ShowUnInstDetails show

--- a/files/windows/nicotine.spec
+++ b/files/windows/nicotine.spec
@@ -1,8 +1,10 @@
 # -*- mode: python ; coding: utf-8 -*-
- 
+
 block_cipher = None
- 
- 
+
+import sys
+sys.modules['FixTk'] = None
+
 # Files to be added to the frozen app
 added_files = [
     #
@@ -15,22 +17,19 @@ added_files = [
     # GeoIP database
     ('../../pynicotine/geoip/ipcountrydb.bin', 'pynicotine/geoip'),
     
-    # Icon
+    # About icon
     ('../../files/org.nicotine_plus.Nicotine.svg', 'share/icons/hicolor/scalable/apps'),
+
+    # Shortcut icon
+    ('nicotine-plus.ico', '.'),
  
     # Translation files
     ('../../languages', 'languages'),
 
     # Sounds
     ('../../sounds', 'share/nicotine/sounds'),
-
-    # License file
-    ('../../COPYING', '.'),
- 
-    # News file
-    ('../../NEWS.md', '.'),
 ]
- 
+
 a = Analysis(['../../nicotine'],
              pathex=['.'],
              binaries=[],
@@ -38,22 +37,17 @@ a = Analysis(['../../nicotine'],
              hiddenimports=[],
              hookspath=[],
              runtime_hooks=[],
-             excludes=[],
+             excludes=['FixTk', 'tcl', 'tk', '_tkinter', 'tkinter', 'Tkinter'],
              win_no_prefer_redirects=False,
              win_private_assemblies=False,
              cipher=block_cipher,
              noarchive=False)
- 
+
 # Removing po files, translation template and translation tools
 a.binaries = [
-    x for x in a.binaries if not x[0].endswith(('.po', '.pot', 'mergeall', 'msgfmtall.py', 'tr_gen.py'))
+    x for x in a.binaries if not x[0].endswith(('.po', '.pot', 'merge_all', 'msgfmtall.py', 'remove_fuzzy', 'remove_mo', 'update_pot.py'))
 ]
- 
-# Removing the changelog and markdown files
-a.binaries = [
-    x for x in a.binaries if not x[0].endswith(('CHANGELOG_DOCS', '.md'))
-]
- 
+
 pyz = PYZ(a.pure, a.zipped_data,
              cipher=block_cipher)
 exe = EXE(pyz,

--- a/pynicotine/utils.py
+++ b/pynicotine/utils.py
@@ -262,10 +262,10 @@ def ApplyTranslation():
         # Locales are in the current dir: install them
         if win32:
 
-            # On windows we use intl.dll: the core DLL of GNU gettext-runtime on Windows
+            # On windows we use libintl-8.dll: the core DLL of GNU gettext-runtime on Windows
             import ctypes
 
-            libintl = ctypes.cdll.LoadLibrary("intl.dll")
+            libintl = ctypes.cdll.LoadLibrary("libintl-8.dll")
 
             libintl.bindtextdomain(PACKAGE, LOCAL_MO_PATH)
             libintl.bind_textdomain_codeset(PACKAGE, "UTF-8")


### PR DESCRIPTION
- Fixed an error that prevented Nicotine+ from starting if translations were requested.
- Cleanups

Corrected 2.0.1 installers to attach to GitHub release:
- 64-bit: https://github.com/mathiascode/nicotine-plus/blob/42b9136bf815f40a90b3c1eee92602a2172ace45/files/windows/Nicotine+-2.0.1-x86_64.exe?raw=true
- 32-bit: https://github.com/mathiascode/nicotine-plus/blob/42b9136bf815f40a90b3c1eee92602a2172ace45/files/windows/Nicotine+-2.0.1-i686.exe?raw=true