### PR TITLE
Remove support for detached tabs 

### DIFF
--- a/pynicotine/gtkgui/about.py
+++ b/pynicotine/gtkgui/about.py
@@ -334,8 +334,6 @@ class AboutRoomsDialog(GenericTableDialog):
         "/clear /cl", _("Clear the chat window"),
         "/tick /t", _("Set your personal ticker"),
         "/tickers", _("Show all the tickers"),
-        "/attach", _("Reattach a chat window to the notebook"),
-        "/detach", _("Detach a chat tab from the notebook"),
         "", "",
         "/me %s" % _("message"), _("Say something in the third-person"),
         "/now", _("Display the Now Playing script's output"),
@@ -384,8 +382,6 @@ class AboutPrivateDialog(GenericTableDialog):
     items = [
         "/close /c", _("Close the current private chat"),
         "/clear /cl", _("Clear the chat window"),
-        "/detach", _("Detach a chat tab from the notebook"),
-        "/attach", _("Reattach a chat window to the notebook"),
         "", "",
         "/me %s" % _("message"), _("Say something in the third-person"),
         "/now", _("Display the Now Playing script's output"),

--- a/pynicotine/gtkgui/search.py
+++ b/pynicotine/gtkgui/search.py
@@ -384,11 +384,8 @@ class Searches(IconNotebook):
             search = self.searches[tab.id]
             search[2] = None
 
-        if self.is_tab_detached(tab.Main):
-            tab.Main.get_parent_window().destroy()
-        else:
-            self.remove_page(tab.Main)
-            tab.Main.destroy()
+        self.remove_page(tab.Main)
+        tab.Main.destroy()
 
     def AutoSearch(self, id):
 
@@ -451,7 +448,6 @@ class Searches(IconNotebook):
 
         popup = PopupMenu(self.frame)
         popup.setup(
-            ("#" + _("Detach this tab"), self.searches[id][2].Detach),
             ("#" + _("Close this tab"), self.searches[id][2].OnClose)
         )
 
@@ -787,18 +783,6 @@ class Search:
                 model.append([text])
             else:
                 model.prepend([text])
-
-    def Attach(self, widget=None):
-        self.Searches.attach_tab(self.Main)
-
-    def Detach(self, widget=None):
-        self.Searches.detach_tab(
-            self.Main,
-            _("Nicotine+ %(mode)s Search: %(term)s") % {
-                'mode': [_("Global"), _("Rooms"), _("Buddies"), self.Searches.GetUserSearchName(self.id)][self.mode],
-                'term': self.text
-            }
-        )
 
     def AddUserResults(self, msg, user, country):
 

--- a/pynicotine/gtkgui/userbrowse.py
+++ b/pynicotine/gtkgui/userbrowse.py
@@ -240,18 +240,6 @@ class UserBrowse:
     def OnPopupMenuDummy(self, widget):
         pass
 
-    def Attach(self, widget=None):
-        self.userbrowses.attach_tab(self.Main)
-
-    def Detach(self, widget=None):
-        self.userbrowses.detach_tab(
-            self.Main,
-            _("Nicotine+ User Browse: %(user)s (%(status)s)") % {
-                'user': self.user,
-                'status': [_("Offline"), _("Away"), _("Online")][self.status]
-            }
-        )
-
     def ConnClose(self):
         pass
 
@@ -933,11 +921,8 @@ class UserBrowse:
         del self.userbrowses.users[self.user]
         self.frame.np.ClosePeerConnection(self.conn)
 
-        if self.userbrowses.is_tab_detached(self.Main):
-            self.Main.get_parent_window().destroy()
-        else:
-            self.userbrowses.remove_page(self.Main)
-            self.Main.destroy()
+        self.userbrowses.remove_page(self.Main)
+        self.Main.destroy()
 
     def OnRefresh(self, widget):
         self.FolderTreeView.set_sensitive(False)

--- a/pynicotine/gtkgui/userinfo.py
+++ b/pynicotine/gtkgui/userinfo.py
@@ -160,7 +160,6 @@ class UserTabs(IconNotebook):
             ("$" + _("Ban this user"), popup.OnBanUser),
             ("$" + _("Ignore this user"), popup.OnIgnoreUser),
             ("", None),
-            ("#" + _("Detach this tab"), self.users[user].Detach),
             ("#" + _("Close this tab"), self.users[user].OnClose)
         )
 
@@ -332,18 +331,6 @@ class UserInfo:
     def ConnClose(self):
         pass
 
-    def Attach(self, widget=None):
-        self.userinfos.attach_tab(self.Main)
-
-    def Detach(self, widget=None):
-        self.userinfos.detach_tab(
-            self.Main,
-            _("Nicotine+ Userinfo: %(user)s (%(status)s)") % {
-                'user': self.user,
-                'status': [_("Offline"), _("Away"), _("Online")][self.status]
-            }
-        )
-
     def CellDataFunc(self, column, cellrenderer, model, iter, dummy="dummy"):
 
         colour = self.frame.np.config.sections["ui"]["search"]
@@ -502,11 +489,8 @@ class UserInfo:
         del self.userinfos.users[self.user]
         self.frame.np.ClosePeerConnection(self.conn)
 
-        if self.userinfos.is_tab_detached(self.Main):
-            self.Main.get_parent_window().destroy()
-        else:
-            self.userinfos.remove_page(self.Main)
-            self.Main.destroy()
+        self.userinfos.remove_page(self.Main)
+        self.Main.destroy()
 
     def OnSavePicture(self, widget):
 

--- a/pynicotine/gtkgui/userinfo.py
+++ b/pynicotine/gtkgui/userinfo.py
@@ -256,7 +256,7 @@ class UserInfo:
         self.tag_local = self.makecolour("chatremote")  # noqa: F821
         self.ChangeColours()
 
-        self.likes_popup_menu = popup = PopupMenu(self)
+        self.likes_popup_menu = popup = PopupMenu(self.frame)
         popup.setup(
             ("$" + _("I _like this"), self.frame.OnLikeRecommendation),
             ("$" + _("I _don't like this"), self.frame.OnDislikeRecommendation),
@@ -266,7 +266,7 @@ class UserInfo:
 
         self.Likes.connect("button_press_event", self.OnPopupLikesMenu)
 
-        self.hates_popup_menu = popup = PopupMenu(self)
+        self.hates_popup_menu = popup = PopupMenu(self.frame)
         popup.setup(
             ("$" + _("I _like this"), self.frame.OnLikeRecommendation),
             ("$" + _("I _don't like this"), self.frame.OnDislikeRecommendation),
@@ -276,7 +276,7 @@ class UserInfo:
 
         self.Hates.connect("button_press_event", self.OnPopupHatesMenu)
 
-        self.image_menu = popup = PopupMenu(self)
+        self.image_menu = popup = PopupMenu(self.frame)
         popup.setup(
             ("#" + _("Zoom 1:1"), self.MakeZoomNormal),
             ("#" + _("Zoom In"), self.MakeZoomIn),


### PR DESCRIPTION
Considering nobody has reported any of the issues associated with detached tabs recently (popups not appearing on the correct window, crammed content, errors when closing windows, a boatload of gtk warnings), and I didn't realize detached tabs were supported until now, I'm going to assume the usage is very low. For now, I don't see a point in maintaining support for detached tabs.