### PR TITLE
Remove Unicode-related Python 2 leftovers

### DIFF
--- a/pynicotine/config.py
+++ b/pynicotine/config.py
@@ -842,7 +842,7 @@ class Config:
         oldumask = os.umask(0o077)
 
         try:
-            f = open(self.filename + ".new", "w")
+            f = open(self.filename + ".new", "w", encoding="utf-8")
         except IOError as e:
             log.addwarning(_("Can't save config file, I/O error: %s") % e)
             self.config_lock.release()

--- a/pynicotine/gtkgui/chatrooms.py
+++ b/pynicotine/gtkgui/chatrooms.py
@@ -47,10 +47,10 @@ from pynicotine.gtkgui.utils import PressHeader
 from pynicotine.gtkgui.utils import ScrollBottom
 from pynicotine.gtkgui.utils import WriteLog
 from pynicotine.gtkgui.utils import expand_alias
-from pynicotine.gtkgui.utils import fixpath
 from pynicotine.gtkgui.utils import is_alias
 from pynicotine.gtkgui.utils import showCountryTooltip
 from pynicotine.logfacility import log
+from pynicotine.utils import CleanFile
 from pynicotine.utils import cmp
 from pynicotine.utils import debug
 
@@ -1129,7 +1129,7 @@ class ChatRoom:
         config = self.frame.np.config.sections
         log = os.path.join(
             config["logging"]["roomlogsdir"],
-            fixpath(self.room.replace(os.sep, "-")) + ".log"
+            CleanFile(self.room.replace(os.sep, "-")) + ".log"
         )
 
         try:

--- a/pynicotine/gtkgui/fastconfigure.py
+++ b/pynicotine/gtkgui/fastconfigure.py
@@ -36,7 +36,6 @@ from pynicotine.gtkgui.utils import HumanSize
 from pynicotine.gtkgui.utils import InitialiseColumns
 from pynicotine.gtkgui.utils import OpenUri
 from pynicotine.gtkgui.utils import popupWarning
-from pynicotine.gtkgui.utils import recode
 
 
 def dirstats(directory):
@@ -336,7 +335,7 @@ class FastConfigureAssistant(object):
 
         self.sharelist.append([
             directory[0],
-            recode(directory[1]),
+            directory[1],
             "",
             "",
             "",
@@ -381,7 +380,7 @@ class FastConfigureAssistant(object):
 
                 self.sharelist.insert(0, [
                     directory[0],
-                    recode(directory[1]),
+                    directory[1],
                     HumanSize(size),
                     str(files),
                     str(subdirs),

--- a/pynicotine/gtkgui/privatechat.py
+++ b/pynicotine/gtkgui/privatechat.py
@@ -41,9 +41,9 @@ from pynicotine.gtkgui.utils import PopupMenu
 from pynicotine.gtkgui.utils import ScrollBottom
 from pynicotine.gtkgui.utils import WriteLog
 from pynicotine.gtkgui.utils import expand_alias
-from pynicotine.gtkgui.utils import fixpath
 from pynicotine.gtkgui.utils import is_alias
 from pynicotine.logfacility import log
+from pynicotine.utils import CleanFile
 from pynicotine.utils import version
 
 
@@ -417,7 +417,7 @@ class PrivateChat:
 
         # Read log file
         config = self.frame.np.config.sections
-        log = os.path.join(config["logging"]["privatelogsdir"], fixpath(self.user.replace(os.sep, "-")) + ".log")
+        log = os.path.join(config["logging"]["privatelogsdir"], CleanFile(self.user.replace(os.sep, "-")) + ".log")
 
         try:
             numlines = int(config["logging"]["readprivatelines"])

--- a/pynicotine/gtkgui/settingswindow.py
+++ b/pynicotine/gtkgui/settingswindow.py
@@ -41,8 +41,6 @@ from pynicotine.gtkgui.utils import InitialiseColumns
 from pynicotine.gtkgui.utils import InputDialog
 from pynicotine.gtkgui.utils import OpenUri
 from pynicotine.gtkgui.utils import popupWarning
-from pynicotine.gtkgui.utils import recode
-from pynicotine.gtkgui.utils import recode2
 from pynicotine.logfacility import log
 from pynicotine.upnp import UPnPPortMapping
 from pynicotine.utils import unescape
@@ -303,7 +301,7 @@ class DownloadsFrame(buildFrame):
             place = "Home"
             homedir = pwd.getpwuid(os.getuid())[5]
 
-        if homedir == recode2(self.DownloadDir.get_file().get_path()) and self.ShareDownloadDir.get_active():
+        if homedir == self.DownloadDir.get_file().get_path() and self.ShareDownloadDir.get_active():
 
             popupWarning(
                 self.p.SettingsWindow,
@@ -316,8 +314,8 @@ class DownloadsFrame(buildFrame):
 
         return {
             "transfers": {
-                "incompletedir": recode2(self.IncompleteDir.get_file().get_path()),
-                "downloaddir": recode2(self.DownloadDir.get_file().get_path()),
+                "incompletedir": self.IncompleteDir.get_file().get_path(),
+                "downloaddir": self.DownloadDir.get_file().get_path(),
                 "sharedownloaddir": self.ShareDownloadDir.get_active(),
                 "downloadfilters": self.GetFilterList(),
                 "enablefilters": self.DownloadFilter.get_active(),
@@ -624,7 +622,7 @@ class SharesFrame(buildFrame):
                 self.shareslist.append(
                     [
                         virtual,
-                        recode(actual),
+                        actual,
                         "",
                         actual
                     ]
@@ -641,7 +639,7 @@ class SharesFrame(buildFrame):
                 self.bshareslist.append(
                     [
                         virtual,
-                        recode(actual),
+                        actual,
                         "",
                         actual
                     ]
@@ -785,7 +783,7 @@ class SharesFrame(buildFrame):
                         self.shareslist.append(
                             [
                                 virtual,
-                                recode(directory),
+                                directory,
                                 "",
                                 directory
                             ]
@@ -843,7 +841,7 @@ class SharesFrame(buildFrame):
                         self.bshareslist.append(
                             [
                                 virtual,
-                                recode(directory),
+                                directory,
                                 "",
                                 directory
                             ]
@@ -1060,7 +1058,7 @@ class TransfersFrame(buildFrame):
                 "prioritize": self.DownloadChecksumsFirst.get_active(),
                 "remotedownloads": self.RemoteDownloads.get_active(),
                 "uploadallowed": uploadallowed,
-                "uploaddir": recode2(self.UploadDir.get_file().get_path())
+                "uploaddir": self.UploadDir.get_file().get_path()
             }
         }
 
@@ -1187,7 +1185,7 @@ class UserinfoFrame(buildFrame):
         descr = buffer.get_text(start, end, True).replace("; ", ", ").__repr__()
 
         if self.ImageChooser.get_filename() is not None:
-            pic = recode2(self.ImageChooser.get_filename())
+            pic = self.ImageChooser.get_filename()
         else:
             pic = ""
 
@@ -1569,7 +1567,7 @@ class SoundsFrame(buildFrame):
     def GetSettings(self):
 
         if self.SoundDir.get_file() is not None:
-            soundtheme = recode2(self.SoundDir.get_file().get_path())
+            soundtheme = self.SoundDir.get_file().get_path()
         else:
             soundtheme = ""
 
@@ -1651,7 +1649,7 @@ class IconsFrame(buildFrame):
                 break
 
         if self.ThemeDir.get_file() is not None:
-            icontheme = recode2(self.ThemeDir.get_file().get_path())
+            icontheme = self.ThemeDir.get_file().get_path()
         else:
             icontheme = ""
 
@@ -2282,9 +2280,9 @@ class LogFrame(buildFrame):
             "logging": {
                 "privatechat": self.LogPrivate.get_active(),
                 "chatrooms": self.LogRooms.get_active(),
-                "logsdir": recode2(self.LogDir.get_file().get_path()),
-                "roomlogsdir": recode2(self.RoomLogDir.get_file().get_path()),
-                "privatelogsdir": recode2(self.PrivateLogDir.get_file().get_path()),
+                "logsdir": self.LogDir.get_file().get_path(),
+                "roomlogsdir": self.RoomLogDir.get_file().get_path(),
+                "privatelogsdir": self.PrivateLogDir.get_file().get_path(),
                 "readroomlogs": self.ReadRoomLogs.get_active(),
                 "readroomlines": self.RoomLogLines.get_value_as_int(),
                 "readprivatelines": self.PrivateLogLines.get_value_as_int(),

--- a/pynicotine/gtkgui/userbrowse.py
+++ b/pynicotine/gtkgui/userbrowse.py
@@ -373,6 +373,7 @@ class UserBrowse:
 
     def MakeNewModel(self, list):
 
+        print(self.shares)
         self.shares = list
         self.selected_folder = None
         self.selected_files = []
@@ -417,6 +418,7 @@ class UserBrowse:
         dirseparator = '\\'
 
         # If there is no share
+        print(self.shares)
         if self.shares == []:
 
             # Set the model of the treeviex
@@ -566,9 +568,11 @@ class UserBrowse:
 
     def ShowInfo(self, msg):
         self.conn = None
+        print("showinfo")
         self.MakeNewModel(msg.list)
 
     def LoadShares(self, list):
+        print("loadshares")
         self.MakeNewModel(list)
 
     def UpdateGauge(self, msg):

--- a/pynicotine/gtkgui/userbrowse.py
+++ b/pynicotine/gtkgui/userbrowse.py
@@ -373,7 +373,6 @@ class UserBrowse:
 
     def MakeNewModel(self, list):
 
-        print(self.shares)
         self.shares = list
         self.selected_folder = None
         self.selected_files = []
@@ -418,7 +417,7 @@ class UserBrowse:
         dirseparator = '\\'
 
         # If there is no share
-        print(self.shares)
+
         if self.shares == []:
 
             # Set the model of the treeviex
@@ -568,11 +567,9 @@ class UserBrowse:
 
     def ShowInfo(self, msg):
         self.conn = None
-        print("showinfo")
         self.MakeNewModel(msg.list)
 
     def LoadShares(self, list):
-        print("loadshares")
         self.MakeNewModel(list)
 
     def UpdateGauge(self, msg):

--- a/pynicotine/pluginsystem.py
+++ b/pynicotine/pluginsystem.py
@@ -50,22 +50,6 @@ returncode = {
 tupletype = type(('', ''))
 
 
-def cast_to_unicode_if_needed(text, logfunc):
-    if isinstance(text, str):
-        return text
-    try:
-        better = str.decode(text, 'utf8')
-        logfunc("Plugin problem: casting '%s' to unicode!" % repr(text))
-        return better
-    except UnicodeError:
-        better = str.decode(text, 'utf8', 'replace')
-        logfunc("Plugin problem: casting '%s' to unicode, losing characters in the process." % repr(text))
-        return better
-    except Exception:
-        logfunc("Plugin problem: failed to completely cast '%s', you're on your own from here on." % repr(text))
-        return text
-
-
 class InvalidPluginError(Exception):
     pass
 
@@ -383,7 +367,6 @@ class PluginHandler(object):
         self.appendqueue({'type': 'logtext', 'text': text})
 
     def saychatroom(self, room, text):
-        text = cast_to_unicode_if_needed(text, log.addwarning)
         self.frame.np.queue.put(slskmessages.SayChatroom(room, text))
 
     def sayprivate(self, user, text):
@@ -533,7 +516,6 @@ class BasePlugin(object):
             room = self.frame.chatrooms.roomsctrl.joinedrooms[room]
         except KeyError:
             return False
-        text = cast_to_unicode_if_needed(text, self.log)
         msg = slskmessages.SayChatroom(room, text)
         msg.user = user
         room.SayChatRoom(msg, text)

--- a/pynicotine/pynicotine.py
+++ b/pynicotine/pynicotine.py
@@ -35,7 +35,6 @@ import logging
 import os
 import queue
 import shutil
-import sys
 import threading
 import time
 from gettext import gettext as _
@@ -1379,12 +1378,7 @@ class NetworkEventProcessor:
             return
 
         try:
-            if sys.platform == "win32":
-                userpic = "%s" % self.config.sections["userinfo"]["pic"]
-                if not os.path.exists(userpic):
-                    userpic = self.config.sections["userinfo"]["pic"]
-            else:
-                userpic = self.config.sections["userinfo"]["pic"]
+            userpic = self.config.sections["userinfo"]["pic"]
 
             f = open(userpic, 'rb')
             pic = f.read()

--- a/pynicotine/transfers.py
+++ b/pynicotine/transfers.py
@@ -787,14 +787,11 @@ class Transfers:
 
     def fileIsShared(self, user, virtualfilename, realfilename):
 
-        u_realfilename = realfilename
-        u_virtualfilename = virtualfilename
-
-        u_realfilename = u_realfilename.replace("\\", os.sep)
-        if not os.access(u_realfilename, os.R_OK):
+        realfilename = realfilename.replace("\\", os.sep)
+        if not os.access(realfilename, os.R_OK):
             return False
 
-        (dir, sep, file) = u_virtualfilename.rpartition('\\')
+        (dir, sep, file) = virtualfilename.rpartition('\\')
 
         if self.eventprocessor.config.sections["transfers"]["enablebuddyshares"]:
             if user in [i[0] for i in self.eventprocessor.config.sections["server"]["userlist"]]:
@@ -1249,22 +1246,19 @@ class Transfers:
         if not os.access(folder, os.F_OK):
             os.makedirs(folder)
 
-        (newname, identicalfile) = self.getRenamed(os.path.join(folder, basename), file.name)
+        newname, identicalfile = self.getRenamed(os.path.join(folder, basename), file.name)
 
         if newname:
             try:
                 shutil.move(file.name, newname)
-            except (IOError, OSError) as inst:  # noqa: F841
-                try:
-                    shutil.move(file.name, "%s" % newname)
-                except (IOError, OSError) as inst:
-                    log.addwarning(
-                        _("Couldn't move '%(tempfile)s' to '%(file)s': %(error)s") % {
-                            'tempfile': file.name,
-                            'file': newname,
-                            'error': inst
-                        }
-                    )
+            except (IOError, OSError) as inst:
+                log.addwarning(
+                    _("Couldn't move '%(tempfile)s' to '%(file)s': %(error)s") % {
+                        'tempfile': "%s" % file.name,
+                        'file': newname,
+                        'error': inst
+                    }
+                )
 
         i.status = "Finished"
         i.speed = 0
@@ -1287,7 +1281,7 @@ class Transfers:
         else:
             self.eventprocessor.logMessage(
                 _("File %(file)s is identical to %(identical)s, not saving.") % {
-                    'file': file.name,
+                    'file': "%s" % file.name,
                     'identical': identicalfile
                 },
                 1

--- a/pynicotine/transfers.py
+++ b/pynicotine/transfers.py
@@ -34,7 +34,6 @@ import os.path
 import re
 import shutil
 import stat
-import sys
 import threading
 import time
 from gettext import gettext as _
@@ -48,8 +47,6 @@ from pynicotine.slskmessages import newId
 from pynicotine.utils import executeCommand
 from pynicotine.utils import CleanFile
 from pynicotine.utils import GetResultBitrateLength
-
-win32 = sys.platform.startswith("win")
 
 
 class Transfer(object):
@@ -790,12 +787,8 @@ class Transfers:
 
     def fileIsShared(self, user, virtualfilename, realfilename):
 
-        if win32:
-            u_realfilename = "%s" % realfilename
-            u_virtualfilename = "%s" % virtualfilename
-        else:
-            u_realfilename = realfilename
-            u_virtualfilename = virtualfilename
+        u_realfilename = realfilename
+        u_virtualfilename = virtualfilename
 
         u_realfilename = u_realfilename.replace("\\", os.sep)
         if not os.access(u_realfilename, os.R_OK):
@@ -870,10 +863,7 @@ class Transfers:
     def getFileSize(self, filename):
 
         try:
-            if win32:
-                size = os.path.getsize("%s" % filename.replace("\\", os.sep))
-            else:
-                size = os.path.getsize(filename.replace("\\", os.sep))
+            size = os.path.getsize(filename.replace("\\", os.sep))
         except Exception:
             # file doesn't exist (remote files are always this)
             size = 0
@@ -1057,10 +1047,7 @@ class Transfers:
                     else:
                         fname = pynewfname
 
-                    if win32:
-                        f = open("%s" % fname, 'ab+')
-                    else:
-                        f = open(fname, 'ab+')
+                    f = open(fname, 'ab+')
 
                 except IOError as strerror:
                     self.eventprocessor.logMessage(_("Download I/O error: %s") % strerror)
@@ -1126,10 +1113,7 @@ class Transfers:
 
             try:
                 # Open File
-                if win32:
-                    filename = "%s" % i.realfilename.replace("\\", os.sep)
-                else:
-                    filename = i.realfilename.replace("\\", os.sep)
+                filename = i.realfilename.replace("\\", os.sep)
 
                 f = open(filename, "rb")
                 self.queue.put(slskmessages.UploadFile(i.conn, file=f, size=i.size))
@@ -1320,10 +1304,7 @@ class Transfers:
         i.conn = None
 
         if newname:
-            if win32:
-                self.addToShared("%s" % newname)
-            else:
-                self.addToShared(newname)
+            self.addToShared(newname)
             self.eventprocessor.shares.sendNumSharedFoldersFiles()
 
             if config["transfers"]["shownotification"]:
@@ -1812,10 +1793,8 @@ class Transfers:
         with the same checksum value already exists as identicalfile, if
         identicalfile is None the file can be saved under newname."""
 
-        if win32 and not os.path.exists("%s" % name) and not os.path.exists(name):
+        if not os.path.exists(name):
             # Filename doesn't exist, good for renaming
-            return (name, None)
-        elif not win32 and not os.path.exists(name):
             return (name, None)
 
         # A file with the same name already exists. First lets check whether it's a duplicate

--- a/pynicotine/utils.py
+++ b/pynicotine/utils.py
@@ -48,8 +48,9 @@ replacementchar = '_'
 
 def CleanFile(filename):
 
-    for char in illegalfilechars:
-        filename = filename.replace(char, replacementchar)
+    if win32:
+        for char in illegalfilechars:
+            filename = filename.replace(char, replacementchar)
 
     return filename
 


### PR DESCRIPTION
Yay to less platform-specific code. :)

Pretty sure none of this is needed in Python 3 anymore. I didn't detect any issues when testing in Windows.

The config is now saved as utf-8 on Windows, to fix problems when using non-latin characters.