### PR TITLE
Improve chat room and user browse UI

### DIFF
--- a/pynicotine/gtkgui/chatrooms.py
+++ b/pynicotine/gtkgui/chatrooms.py
@@ -1296,20 +1296,18 @@ class ChatRoom:
         self.popup_menu.popup(None, None, None, None, event.button, event.time)
 
     def OnShowChatHelp(self, widget):
-        self.frame.OnAboutChatroomCommands(widget, self.frame.MainWindow)
+        self.frame.OnAboutChatroomCommands(widget)
 
     def OnShowChatButtons(self, show=True):
 
-        for widget in self.HideStatusLog, self.HideUserList, self.ShowChatHelp:
+        for widget in self.AutoJoin, self.HideStatusLog, self.HideUserList:
             if show:
                 widget.show()
             else:
                 widget.hide()
 
-        if self.frame.np.config.sections["ui"]["speechenabled"] and show:
+        if self.frame.np.config.sections["ui"]["speechenabled"]:
             self.Speech.show()
-        else:
-            self.Speech.hide()
 
     def OnHideStatusLog(self, widget):
 
@@ -1733,12 +1731,9 @@ class ChatRoom:
     def CountUsers(self):
 
         numusers = len(self.users)
-        if numusers > 1:
+        if numusers > 0:
             self.LabelPeople.show()
-            self.LabelPeople.set_text(_("%i people in room") % numusers)
-        elif numusers == 1:
-            self.LabelPeople.show()
-            self.LabelPeople.set_text(_("You are alone"))
+            self.LabelPeople.set_text(_("User List (%i)") % numusers)
         else:
             self.LabelPeople.hide()
 
@@ -1965,7 +1960,6 @@ class ChatRoom:
         if self.leaving:
             return
 
-        self.Leave.set_sensitive(False)
         self.leaving = 1
 
         config = self.frame.np.config.sections

--- a/pynicotine/gtkgui/frame.py
+++ b/pynicotine/gtkgui/frame.py
@@ -1535,7 +1535,6 @@ class NicotineFrame:
         self.roomlist.CreateRoomEntry.set_sensitive(status)
         self.roomlist.RoomsList.set_sensitive(status)
         self.roomlist.SearchRooms.set_sensitive(status)
-        self.roomlist.FindRoom.set_sensitive(status)
         self.UserPrivateCombo.set_sensitive(status)
         self.sPrivateChatButton.set_sensitive(status)
         self.UserBrowseCombo.set_sensitive(status)
@@ -2439,7 +2438,7 @@ class NicotineFrame:
         self.About.set_version(version)
         self.About.show()
 
-    def OnAboutChatroomCommands(self, widget, parent=None):
+    def OnAboutChatroomCommands(self, widget):
         builder = gtk.Builder()
         builder.set_translation_domain('nicotine')
         builder.add_from_file(os.path.join(os.path.dirname(os.path.realpath(__file__)), "ui", "about", "chatroomcommands.ui"))

--- a/pynicotine/gtkgui/privatechat.py
+++ b/pynicotine/gtkgui/privatechat.py
@@ -506,6 +506,9 @@ class PrivateChat:
     def OnClearChatLog(self, widget):
         self.ChatScroll.get_buffer().set_text("")
 
+    def OnShowChatHelp(self, widget):
+        self.frame.OnAboutPrivateChatCommands(widget)
+
     def ShowMessage(self, text, status=None, timestamp=None):
 
         self.UpdateColours()

--- a/pynicotine/gtkgui/ui/about/privatechatcommands.ui
+++ b/pynicotine/gtkgui/ui/about/privatechatcommands.ui
@@ -3,7 +3,7 @@
   <requires lib="gtk+" version="3.18"/>
   <object class="GtkWindow" id="AboutPrivateChatCommands">
     <property name="can_focus">False</property>
-    <property name="title" translatable="yes">About chat room commands</property>
+    <property name="title" translatable="yes">About private chat commands</property>
     <property name="resizable">False</property>
     <property name="modal">True</property>
     <property name="window_position">center-on-parent</property>

--- a/pynicotine/gtkgui/ui/chatrooms.ui
+++ b/pynicotine/gtkgui/ui/chatrooms.ui
@@ -9,12 +9,10 @@
         <property name="visible">True</property>
         <property name="can_focus">False</property>
         <property name="orientation">vertical</property>
-        <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
         <child>
           <object class="GtkBox">
             <property name="visible">True</property>
             <property name="can_focus">False</property>
-            <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
             <property name="border_width">5</property>
             <property name="spacing">5</property>
             <child>
@@ -33,35 +31,10 @@
               </packing>
             </child>
             <child>
-              <object class="GtkToggleButton" id="HideStatusLog">
-                <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <property name="receives_default">True</property>
-                <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
-                <property name="tooltip_text" translatable="yes">Hide/Show Status log</property>
-                <property name="image">HideStatusLogImage</property>
-                <property name="always_show_image">True</property>
-                <signal name="toggled" handler="OnHideStatusLog" swapped="no"/>
-                <child>
-                  <object class="GtkImage" id="HideStatusLogImage">
-                    <property name="can_focus">False</property>
-                    <property name="icon_name">go-up-symbolic</property>
-                  </object>
-                </child>
-              </object>
-              <packing>
-                <property name="expand">False</property>
-                <property name="fill">False</property>
-                <property name="pack_type">end</property>
-                <property name="position">1</property>
-              </packing>
-            </child>
-            <child>
               <object class="GtkToggleButton" id="HideUserList">
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
                 <property name="receives_default">True</property>
-                <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
                 <property name="tooltip_text" translatable="yes">Hide/Show User list</property>
                 <property name="image">HideUserListImage</property>
                 <property name="always_show_image">True</property>
@@ -76,31 +49,28 @@
               <packing>
                 <property name="expand">False</property>
                 <property name="fill">False</property>
-                <property name="pack_type">end</property>
                 <property name="position">2</property>
               </packing>
             </child>
             <child>
-              <object class="GtkToggleButton" id="Speech">
+              <object class="GtkToggleButton" id="HideStatusLog">
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
                 <property name="receives_default">True</property>
-                <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
-                <property name="tooltip_text" translatable="yes">Toggle Text-To-Speech</property>
-                <property name="image">speech</property>
+                <property name="tooltip_text" translatable="yes">Hide/Show Status log</property>
+                <property name="image">HideStatusLogImage</property>
                 <property name="always_show_image">True</property>
-                <property name="active">True</property>
+                <signal name="toggled" handler="OnHideStatusLog" swapped="no"/>
                 <child>
-                  <object class="GtkImage" id="speech">
+                  <object class="GtkImage" id="HideStatusLogImage">
                     <property name="can_focus">False</property>
-                    <property name="icon_name">multimedia-volume-control-symbolic</property>
+                    <property name="icon_name">go-up-symbolic</property>
                   </object>
                 </child>
               </object>
               <packing>
                 <property name="expand">False</property>
                 <property name="fill">False</property>
-                <property name="pack_type">end</property>
                 <property name="position">3</property>
               </packing>
             </child>
@@ -185,7 +155,6 @@
                       <object class="GtkBox" id="ChatEntryBox">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
-                        <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
                         <property name="border_width">5</property>
                         <property name="spacing">5</property>
                         <child>
@@ -207,11 +176,48 @@
                           </packing>
                         </child>
                         <child>
+                          <object class="GtkCheckButton" id="Log">
+                            <property name="label" translatable="yes">Log</property>
+                            <property name="visible">True</property>
+                            <property name="can_focus">True</property>
+                            <property name="receives_default">False</property>
+                            <property name="use_underline">True</property>
+                            <property name="draw_indicator">True</property>
+                            <signal name="toggled" handler="OnLogToggled" swapped="no"/>
+                          </object>
+                          <packing>
+                            <property name="expand">False</property>
+                            <property name="fill">False</property>
+                            <property name="position">1</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkToggleButton" id="Speech">
+                            <property name="visible">True</property>
+                            <property name="can_focus">True</property>
+                            <property name="receives_default">True</property>
+                            <property name="tooltip_text" translatable="yes">Toggle Text-To-Speech</property>
+                            <property name="image">speech</property>
+                            <property name="always_show_image">True</property>
+                            <property name="active">True</property>
+                            <child>
+                              <object class="GtkImage" id="speech">
+                                <property name="can_focus">False</property>
+                                <property name="icon_name">multimedia-volume-control-symbolic</property>
+                              </object>
+                            </child>
+                          </object>
+                          <packing>
+                            <property name="expand">False</property>
+                            <property name="fill">False</property>
+                            <property name="position">2</property>
+                          </packing>
+                        </child>
+                        <child>
                           <object class="GtkButton" id="ShowChatHelp">
                             <property name="visible">True</property>
                             <property name="can_focus">True</property>
                             <property name="receives_default">True</property>
-                            <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
                             <property name="tooltip_text" translatable="yes">Chat room command help</property>
                             <property name="image">help</property>
                             <property name="always_show_image">True</property>
@@ -226,8 +232,7 @@
                           <packing>
                             <property name="expand">False</property>
                             <property name="fill">False</property>
-                            <property name="pack_type">end</property>
-                            <property name="position">1</property>
+                            <property name="position">3</property>
                           </packing>
                         </child>
                       </object>
@@ -255,27 +260,56 @@
                 <property name="can_focus">False</property>
                 <property name="orientation">vertical</property>
                 <child>
-                  <object class="GtkLabel" id="LabelPeople">
+                  <object class="GtkBox">
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
-                    <property name="label" translatable="yes">0 people in room</property>
+                    <property name="border_width">5</property>
+                    <property name="spacing">15</property>
+                    <child>
+                      <object class="GtkLabel" id="LabelPeople">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="halign">start</property>
+                        <property name="label" translatable="yes">User List</property>
+                        <property name="margin_start">5</property>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">False</property>
+                        <property name="position">0</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkCheckButton" id="AutoJoin">
+                        <property name="label" translatable="yes">Auto-join Room</property>
+                        <property name="visible">True</property>
+                        <property name="can_focus">True</property>
+                        <property name="receives_default">False</property>
+                        <property name="use_underline">True</property>
+                        <property name="draw_indicator">True</property>
+                        <signal name="toggled" handler="OnAutojoin" swapped="no"/>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">False</property>
+                        <property name="pack_type">end</property>
+                        <property name="position">1</property>
+                      </packing>
+                    </child>
                   </object>
                   <packing>
                     <property name="expand">False</property>
                     <property name="fill">False</property>
-                    <property name="padding">2</property>
-                    <property name="position">0</property>
+                    <property name="padding">5</property>
                   </packing>
                 </child>
                 <child>
                   <object class="GtkScrolledWindow">
+                    <property name="width_request">320</property>
                     <property name="visible">True</property>
                     <property name="can_focus">True</property>
                     <property name="hscrollbar_policy">automatic</property>
                     <property name="vscrollbar_policy">automatic</property>
-                    <property name="shadow_type">in</property>
-                    <property name="margin_start">5</property>
-                    <property name="margin_end">5</property>
                     <child>
                       <object class="GtkTreeView" id="UserList">
                         <property name="visible">True</property>
@@ -289,101 +323,6 @@
                     <property name="expand">True</property>
                     <property name="fill">True</property>
                     <property name="position">1</property>
-                  </packing>
-                </child>
-                <child>
-                  <object class="GtkBox">
-                    <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <property name="margin_start">5</property>
-                    <property name="margin_end">5</property>
-                    <property name="margin_top">5</property>
-                    <property name="spacing">5</property>
-                    <child>
-                      <object class="GtkCheckButton" id="Log">
-                        <property name="label" translatable="yes">Log</property>
-                        <property name="visible">True</property>
-                        <property name="can_focus">True</property>
-                        <property name="receives_default">False</property>
-                        <property name="use_underline">True</property>
-                        <property name="draw_indicator">True</property>
-                        <signal name="toggled" handler="OnLogToggled" swapped="no"/>
-                      </object>
-                      <packing>
-                        <property name="expand">False</property>
-                        <property name="fill">False</property>
-                        <property name="position">0</property>
-                      </packing>
-                    </child>
-                  </object>
-                  <packing>
-                    <property name="expand">False</property>
-                    <property name="fill">False</property>
-                    <property name="position">2</property>
-                  </packing>
-                </child>
-                <child>
-                  <object class="GtkBox">
-                    <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <property name="border_width">5</property>
-                    <child>
-                      <object class="GtkCheckButton" id="AutoJoin">
-                        <property name="label" translatable="yes">Auto-join</property>
-                        <property name="visible">True</property>
-                        <property name="can_focus">True</property>
-                        <property name="receives_default">False</property>
-                        <property name="use_underline">True</property>
-                        <property name="draw_indicator">True</property>
-                        <signal name="toggled" handler="OnAutojoin" swapped="no"/>
-                      </object>
-                      <packing>
-                        <property name="expand">False</property>
-                        <property name="fill">False</property>
-                        <property name="position">0</property>
-                      </packing>
-                    </child>
-                    <child>
-                      <object class="GtkButton" id="Leave">
-                        <property name="visible">True</property>
-                        <property name="can_focus">True</property>
-                        <property name="receives_default">False</property>
-                        <signal name="clicked" handler="OnLeave" swapped="no"/>
-                        <child>
-                          <object class="GtkBox">
-                            <property name="visible">True</property>
-                            <property name="can_focus">False</property>
-                            <property name="spacing">5</property>
-                            <child>
-                              <object class="GtkImage">
-                                <property name="visible">True</property>
-                                <property name="can_focus">False</property>
-                                <property name="icon_name">application-exit-symbolic</property>
-                              </object>
-                            </child>
-                            <child>
-                              <object class="GtkLabel">
-                                <property name="visible">True</property>
-                                <property name="can_focus">False</property>
-                                <property name="label" translatable="yes">Leave Room</property>
-                                <property name="use_underline">True</property>
-                              </object>
-                            </child>
-                          </object>
-                        </child>
-                      </object>
-                      <packing>
-                        <property name="expand">False</property>
-                        <property name="fill">False</property>
-                        <property name="pack_type">end</property>
-                        <property name="position">1</property>
-                      </packing>
-                    </child>
-                  </object>
-                  <packing>
-                    <property name="expand">False</property>
-                    <property name="fill">True</property>
-                    <property name="position">3</property>
                   </packing>
                 </child>
               </object>

--- a/pynicotine/gtkgui/ui/mainwindow.ui
+++ b/pynicotine/gtkgui/ui/mainwindow.ui
@@ -2440,6 +2440,7 @@
                                     </child>
                                     <child>
                                       <object class="GtkBox">
+                                        <property name="width_request">280</property>
                                         <property name="visible">True</property>
                                         <property name="can_focus">False</property>
                                         <property name="border_width">5</property>
@@ -2530,7 +2531,7 @@
                                         </child>
                                       </object>
                                       <packing>
-                                        <property name="resize">True</property>
+                                        <property name="resize">False</property>
                                         <property name="shrink">True</property>
                                       </packing>
                                     </child>

--- a/pynicotine/gtkgui/ui/privatechat.ui
+++ b/pynicotine/gtkgui/ui/privatechat.ui
@@ -91,6 +91,28 @@
                 <property name="position">3</property>
               </packing>
             </child>
+            <child>
+              <object class="GtkButton" id="ShowChatHelp">
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <property name="receives_default">True</property>
+                <property name="tooltip_text" translatable="yes">Private chat command help</property>
+                <property name="image">help</property>
+                <property name="always_show_image">True</property>
+                <signal name="clicked" handler="OnShowChatHelp" swapped="no"/>
+                <child>
+                  <object class="GtkImage" id="help">
+                    <property name="can_focus">False</property>
+                    <property name="icon_name">dialog-question-symbolic</property>
+                  </object>
+                </child>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">False</property>
+                <property name="position">4</property>
+              </packing>
+            </child>
           </object>
           <packing>
             <property name="expand">False</property>

--- a/pynicotine/gtkgui/ui/roomlist.ui
+++ b/pynicotine/gtkgui/ui/roomlist.ui
@@ -8,20 +8,47 @@
       <object class="GtkBox" id="vbox2">
         <property name="visible">True</property>
         <property name="can_focus">False</property>
-        <property name="border_width">5</property>
         <property name="orientation">vertical</property>
         <child>
-          <object class="GtkLabel" id="ChatroomsLabel">
+          <object class="GtkBox">
             <property name="visible">True</property>
             <property name="can_focus">False</property>
-            <property name="label" translatable="yes">Chatrooms</property>
-            <property name="use_markup">True</property>
-            <property name="margin_bottom">5</property>
+            <property name="border_width">5</property>
+            <property name="spacing">5</property>
+            <child>
+              <object class="GtkLabel" id="ChatroomsLabel">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="halign">start</property>
+                <property name="label" translatable="yes">Chat Rooms</property>
+                <property name="use_markup">True</property>
+                <property name="margin_start">5</property>
+                <property name="margin_end">10</property>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">0</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkEntry" id="SearchRooms">
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <property name="primary_icon_name">system-search-symbolic</property>
+                <property name="primary_icon_activatable">False</property>
+                <signal name="activate" handler="OnSearchRoom" swapped="no"/>
+              </object>
+              <packing>
+                <property name="expand">True</property>
+                <property name="fill">True</property>
+                <property name="position">1</property>
+              </packing>
+            </child>
           </object>
           <packing>
             <property name="expand">False</property>
-            <property name="fill">True</property>
-            <property name="position">0</property>
+            <property name="fill">False</property>
           </packing>
         </child>
         <child>
@@ -30,7 +57,6 @@
             <property name="can_focus">True</property>
             <property name="hscrollbar_policy">automatic</property>
             <property name="vscrollbar_policy">automatic</property>
-            <property name="shadow_type">in</property>
             <child>
               <object class="GtkTreeView" id="RoomsList">
                 <property name="visible">True</property>
@@ -48,51 +74,65 @@
           <object class="GtkBox">
             <property name="visible">True</property>
             <property name="can_focus">False</property>
+            <property name="border_width">5</property>
             <property name="spacing">5</property>
+            <property name="orientation">vertical</property>
             <child>
-              <object class="GtkLabel">
+              <object class="GtkBox">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
-                <property name="label" translatable="yes">Create room: </property>
-              </object>
-              <packing>
-                <property name="expand">False</property>
-                <property name="fill">True</property>
-                <property name="padding">5</property>
-                <property name="position">0</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkEntry" id="CreateRoomEntry">
-                <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <property name="primary_icon_activatable">False</property>
-                <property name="secondary_icon_activatable">False</property>
-                <property name="primary_icon_sensitive">True</property>
-                <property name="secondary_icon_sensitive">True</property>
-                <signal name="activate" handler="OnCreateRoom" swapped="no"/>
-              </object>
-              <packing>
-                <property name="expand">True</property>
-                <property name="fill">True</property>
-                <property name="position">1</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkButton" id="CreateRoom">
-                <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <property name="receives_default">True</property>
-                <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
-                <property name="tooltip_text" translatable="yes">Create public room</property>
-                <property name="image">add</property>
-                <property name="always_show_image">True</property>
-                <signal name="clicked" handler="OnCreateRoom" swapped="no"/>
+                <property name="spacing">5</property>
                 <child>
-                  <object class="GtkImage" id="add">
-                    <property name="can_focus">False</property>
-                    <property name="icon_name">list-add-symbolic</property>
+                  <object class="GtkEntry" id="CreateRoomEntry">
+                    <property name="visible">True</property>
+                    <property name="can_focus">True</property>
+                    <property name="primary_icon_activatable">False</property>
+                    <property name="secondary_icon_activatable">False</property>
+                    <property name="primary_icon_sensitive">True</property>
+                    <property name="secondary_icon_sensitive">True</property>
+                    <signal name="activate" handler="OnCreateRoom" swapped="no"/>
                   </object>
+                  <packing>
+                    <property name="expand">True</property>
+                    <property name="fill">True</property>
+                    <property name="position">1</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkButton" id="CreateRoom">
+                    <property name="visible">True</property>
+                    <property name="can_focus">True</property>
+                    <property name="receives_default">True</property>
+                    <property name="tooltip_text" translatable="yes">Create public room</property>
+                    <signal name="clicked" handler="OnCreateRoom" swapped="no"/>
+                    <child>
+                      <object class="GtkBox">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="spacing">5</property>
+                        <child>
+                          <object class="GtkImage">
+                            <property name="visible">True</property>
+                            <property name="can_focus">False</property>
+                            <property name="icon_name">list-add-symbolic</property>
+                          </object>
+                        </child>
+                        <child>
+                          <object class="GtkLabel">
+                            <property name="visible">True</property>
+                            <property name="can_focus">False</property>
+                            <property name="label" translatable="yes">Create Room</property>
+                            <property name="use_underline">True</property>
+                          </object>
+                        </child>
+                      </object>
+                    </child>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">2</property>
+                  </packing>
                 </child>
               </object>
               <packing>
@@ -105,73 +145,7 @@
           <packing>
             <property name="expand">False</property>
             <property name="fill">True</property>
-            <property name="padding">5</property>
             <property name="position">2</property>
-          </packing>
-        </child>
-        <child>
-          <object class="GtkBox">
-            <property name="visible">True</property>
-            <property name="can_focus">False</property>
-            <property name="spacing">5</property>
-            <child>
-              <object class="GtkLabel">
-                <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="label" translatable="yes">Find room: </property>
-              </object>
-              <packing>
-                <property name="expand">False</property>
-                <property name="fill">True</property>
-                <property name="padding">5</property>
-                <property name="position">0</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkEntry" id="SearchRooms">
-                <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <property name="primary_icon_activatable">False</property>
-                <property name="secondary_icon_activatable">False</property>
-                <property name="primary_icon_sensitive">True</property>
-                <property name="secondary_icon_sensitive">True</property>
-                <signal name="activate" handler="OnSearchRoom" swapped="no"/>
-              </object>
-              <packing>
-                <property name="expand">True</property>
-                <property name="fill">True</property>
-                <property name="position">1</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkButton" id="FindRoom">
-                <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <property name="receives_default">True</property>
-                <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
-                <property name="has_tooltip">True</property>
-                <property name="tooltip_text" translatable="yes">Search for room</property>
-                <property name="image">search</property>
-                <property name="always_show_image">True</property>
-                <signal name="clicked" handler="OnSearchRoom" swapped="no"/>
-                <child>
-                  <object class="GtkImage" id="search">
-                    <property name="can_focus">False</property>
-                    <property name="icon_name">system-search-symbolic</property>
-                  </object>
-                </child>
-              </object>
-              <packing>
-                <property name="expand">False</property>
-                <property name="fill">True</property>
-                <property name="position">2</property>
-              </packing>
-            </child>
-          </object>
-          <packing>
-            <property name="expand">False</property>
-            <property name="fill">True</property>
-            <property name="position">3</property>
           </packing>
         </child>
       </object>

--- a/pynicotine/gtkgui/ui/userbrowse.ui
+++ b/pynicotine/gtkgui/ui/userbrowse.ui
@@ -10,141 +10,6 @@
         <property name="can_focus">False</property>
         <property name="orientation">vertical</property>
         <child>
-          <object class="GtkBox">
-            <property name="visible">True</property>
-            <property name="can_focus">False</property>
-            <property name="border_width">5</property>
-            <property name="spacing">5</property>
-            <child>
-              <object class="GtkEntry" id="SearchEntry">
-                <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <property name="primary_icon_activatable">False</property>
-                <property name="secondary_icon_activatable">False</property>
-                <property name="primary_icon_sensitive">True</property>
-                <property name="secondary_icon_sensitive">True</property>
-                <property name="tooltip_text" translatable="yes">Search files and folders (exact match)</property>
-                <signal name="activate" handler="OnSearch" swapped="no"/>
-              </object>
-              <packing>
-                <property name="expand">True</property>
-                <property name="fill">True</property>
-                <property name="position">1</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkButton" id="SearchButton">
-                <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <property name="receives_default">False</property>
-                <signal name="clicked" handler="OnSearch" swapped="no"/>
-                <child>
-                  <object class="GtkBox">
-                    <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <property name="spacing">5</property>
-                    <child>
-                      <object class="GtkImage">
-                        <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="icon_name">system-search-symbolic</property>
-                      </object>
-                    </child>
-                    <child>
-                      <object class="GtkLabel">
-                        <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="label" translatable="yes">Search</property>
-                        <property name="use_underline">True</property>
-                      </object>
-                    </child>
-                  </object>
-                </child>
-              </object>
-              <packing>
-                <property name="expand">False</property>
-                <property name="fill">False</property>
-                <property name="position">2</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkButton" id="SaveButton">
-                <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <property name="receives_default">False</property>
-                <signal name="clicked" handler="OnSave" swapped="no"/>
-                <child>
-                  <object class="GtkBox">
-                    <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <property name="spacing">5</property>
-                    <child>
-                      <object class="GtkImage">
-                        <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="icon_name">document-save-symbolic</property>
-                      </object>
-                    </child>
-                    <child>
-                      <object class="GtkLabel">
-                        <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="label" translatable="yes">Save File List</property>
-                        <property name="use_underline">True</property>
-                      </object>
-                    </child>
-                  </object>
-                </child>
-              </object>
-              <packing>
-                <property name="expand">False</property>
-                <property name="fill">False</property>
-                <property name="position">3</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkButton" id="RefreshButton">
-                <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <property name="receives_default">False</property>
-                <signal name="clicked" handler="OnRefresh" swapped="no"/>
-                <child>
-                  <object class="GtkBox">
-                    <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <property name="spacing">5</property>
-                    <child>
-                      <object class="GtkImage">
-                        <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="icon_name">view-refresh-symbolic</property>
-                      </object>
-                    </child>
-                    <child>
-                      <object class="GtkLabel">
-                        <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="label" translatable="yes">Refresh</property>
-                        <property name="use_underline">True</property>
-                      </object>
-                    </child>
-                  </object>
-                </child>
-              </object>
-              <packing>
-                <property name="expand">False</property>
-                <property name="fill">False</property>
-                <property name="position">4</property>
-              </packing>
-            </child>
-          </object>
-          <packing>
-            <property name="expand">False</property>
-            <property name="fill">True</property>
-            <property name="position">0</property>
-          </packing>
-        </child>
-        <child>
           <object class="GtkPaned">
             <property name="visible">True</property>
             <property name="can_focus">True</property>
@@ -158,35 +23,11 @@
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
                     <property name="spacing">10</property>
-                    <property name="border_width">5</property>
-                    <child>
-                      <object class="GtkToggleButton" id="ExpandButton">
-                        <property name="visible">True</property>
-                        <property name="can_focus">True</property>
-                        <property name="receives_default">False</property>
-                        <property name="tooltip_text" translatable="yes">Expand / Collapse all</property>
-                        <property name="image">expand</property>
-                        <property name="always_show_image">True</property>
-                        <signal name="clicked" handler="OnExpand" swapped="no"/>
-                        <child>
-                          <object class="GtkImage" id="expand">
-                            <property name="can_focus">False</property>
-                            <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
-                            <property name="icon_name">list-add-symbolic</property>
-                          </object>
-                        </child>
-                      </object>
-                      <packing>
-                        <property name="expand">False</property>
-                        <property name="fill">False</property>
-                        <property name="position">0</property>
-                      </packing>
-                    </child>
+                    <property name="border_width">10</property>
                     <child>
                       <object class="GtkLabel" id="NumDirectories">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
-                        <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
                         <property name="xalign">0</property>
                         <property name="label" translatable="yes">Dirs: Unknown</property>
                       </object>
@@ -200,7 +41,6 @@
                       <object class="GtkLabel" id="AmountShared">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
-                        <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
                         <property name="xalign">0</property>
                         <property name="label" translatable="yes">Shared: Unknown</property>
                       </object>
@@ -215,27 +55,108 @@
                     <property name="expand">False</property>
                     <property name="fill">False</property>
                     <property name="position">0</property>
+                    <property name="padding">5</property>
                   </packing>
                 </child>
                 <child>
-                <object class="GtkProgressBar" id="progressbar1">
-                  <property name="valign">center</property>
-                  <property name="visible">True</property>
-                  <property name="can_focus">False</property>
-                  <property name="pulse_step">0.10000000149</property>
-                  <property name="margin_start">5</property>
-                  <property name="margin_end">5</property>
-                </object>
-                <packing>
-                  <property name="expand">False</property>
-                  <property name="fill">True</property>
-                  <property name="padding">5</property>
-                  <property name="position">1</property>
-                </packing>
+                  <object class="GtkBox">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="spacing">5</property>
+                    <property name="margin_start">5</property>
+                    <property name="margin_end">5</property>
+                    <property name="margin_bottom">5</property>
+                    <child>
+                      <object class="GtkEntry" id="SearchEntry">
+                        <property name="visible">True</property>
+                        <property name="can_focus">True</property>
+                        <property name="primary_icon_name">system-search-symbolic</property>
+                        <property name="primary_icon_activatable">False</property>
+                        <property name="tooltip_text" translatable="yes">Search files and folders (exact match)</property>
+                        <signal name="activate" handler="OnSearch" swapped="no"/>
+                      </object>
+                      <packing>
+                        <property name="expand">True</property>
+                        <property name="fill">True</property>
+                        <property name="position">0</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkButton" id="RefreshButton">
+                        <property name="visible">True</property>
+                        <property name="can_focus">True</property>
+                        <property name="receives_default">False</property>
+                        <property name="tooltip_text" translatable="yes">Refresh files</property>
+                        <property name="image">refresh</property>
+                        <property name="always_show_image">True</property>
+                        <signal name="clicked" handler="OnRefresh" swapped="no"/>
+                        <child>
+                          <object class="GtkImage" id="refresh">
+                            <property name="can_focus">False</property>
+                            <property name="icon_name">view-refresh-symbolic</property>
+                          </object>
+                        </child>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">False</property>
+                        <property name="position">1</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkButton" id="SaveButton">
+                        <property name="visible">True</property>
+                        <property name="can_focus">True</property>
+                        <property name="receives_default">False</property>
+                        <property name="tooltip_text" translatable="yes">Save file list to disk</property>
+                        <property name="image">save</property>
+                        <property name="always_show_image">True</property>
+                        <signal name="clicked" handler="OnSave" swapped="no"/>
+                        <child>
+                          <object class="GtkImage" id="save">
+                            <property name="can_focus">False</property>
+                            <property name="icon_name">document-save-symbolic</property>
+                          </object>
+                        </child>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">False</property>
+                        <property name="position">2</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkToggleButton" id="ExpandButton">
+                        <property name="visible">True</property>
+                        <property name="can_focus">True</property>
+                        <property name="receives_default">False</property>
+                        <property name="tooltip_text" translatable="yes">Expand / Collapse all</property>
+                        <property name="image">expand</property>
+                        <property name="always_show_image">True</property>
+                        <signal name="clicked" handler="OnExpand" swapped="no"/>
+                        <child>
+                          <object class="GtkImage" id="expand">
+                            <property name="can_focus">False</property>
+                            <property name="icon_name">list-add-symbolic</property>
+                          </object>
+                        </child>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">False</property>
+                        <property name="position">3</property>
+                      </packing>
+                    </child>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">False</property>
+                    <property name="position">1</property>
+                  </packing>
                 </child>
                 <child>
                   <object class="GtkScrolledWindow">
-                    <property name="width_request">250</property>
+                    <property name="width_request">350</property>
                     <property name="visible">True</property>
                     <property name="can_focus">True</property>
                     <property name="hscrollbar_policy">automatic</property>
@@ -253,6 +174,22 @@
                     <property name="expand">True</property>
                     <property name="fill">True</property>
                     <property name="position">2</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkProgressBar" id="progressbar1">
+                    <property name="valign">center</property>
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="pulse_step">0.10000000149</property>
+                    <property name="margin_start">5</property>
+                    <property name="margin_end">5</property>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="padding">5</property>
+                    <property name="position">3</property>
                   </packing>
                 </child>
               </object>


### PR DESCRIPTION
An attempt to reduce the number of vertical elements in the user browse UI to leave more room for files, and just make everything tidier in general.
![s1](https://user-images.githubusercontent.com/8754153/88360310-d10b3480-cd7d-11ea-8102-7c05878a4087.png)
![s2](https://user-images.githubusercontent.com/8754153/88360918-06188680-cd80-11ea-8088-7104c3b41248.png)
