### PR TITLE
Rework confusing enable/disable private rooms option

### DIFF
--- a/pynicotine/gtkgui/chatrooms.py
+++ b/pynicotine/gtkgui/chatrooms.py
@@ -119,15 +119,13 @@ class RoomsControl:
 
         self.popup_room = None
         self.popup_menu = PopupMenu(self.frame).setup(
-            ("#" + _("Join room"), self.OnPopupJoin),
-            ("#" + _("Leave room"), self.OnPopupLeave),
-            ("", None),
-            ("#" + _("Enable Private Rooms"), self.OnEnablePrivateRooms),
-            ("#" + _("Disable Private Rooms"), self.OnDisablePrivateRooms),
+            ("#" + _("Join Room"), self.OnPopupJoin),
+            ("#" + _("Leave Room"), self.OnPopupLeave),
+            ("#" + _("Create Room"), self.OnPopupCreatePublicRoom),
             ("", None),
             ("#" + _("Create Private Room"), self.OnPopupCreatePrivateRoom),
             ("#" + _("Disown Private Room"), self.OnPopupPrivateRoomDisown),
-            ("#" + _("Cancel room membership"), self.OnPopupPrivateRoomDismember),
+            ("#" + _("Cancel Room Membership"), self.OnPopupPrivateRoomDismember),
             ("", None),
             ("#" + _("Join Public Room"), self.OnJoinPublicRoom),
             ("", None),
@@ -135,11 +133,7 @@ class RoomsControl:
         )
 
         items = self.popup_menu.get_children()
-        self.Menu_Join, self.Menu_Leave, self.Menu_Empty1, self.Menu_PrivateRoom_Enable, self.Menu_PrivateRoom_Disable, self.Menu_Empty2, self.Menu_PrivateRoom_Create, self.Menu_PrivateRoom_Disown, self.Menu_PrivateRoom_Dismember, self.Menu_Empty3, self.Menu_JoinPublicRoom, self.Menu_Empty4, self.Menu_Refresh = items
-
-        self.Menu_PrivateRoom_Enable.set_sensitive(False)
-        self.Menu_PrivateRoom_Disable.set_sensitive(False)
-        self.Menu_PrivateRoom_Create.set_sensitive(False)
+        self.Menu_Join, self.Menu_Leave, self.Menu_Create_Room, self.Menu_Empty1, self.Menu_PrivateRoom_Create, self.Menu_PrivateRoom_Disown, self.Menu_PrivateRoom_Dismember, self.Menu_Empty2, self.Menu_JoinPublicRoom, self.Menu_Empty3, self.Menu_Refresh = items
 
         self.frame.roomlist.RoomsList.connect("button_press_event", self.OnListClicked)
         self.frame.roomlist.RoomsList.set_headers_clickable(True)
@@ -148,7 +142,6 @@ class RoomsControl:
         self.ChatNotebook.Notebook.connect("page-reordered", self.OnReorderedPage)
 
         self.frame.SetTextBG(self.frame.roomlist.RoomsList)
-        self.frame.SetTextBG(self.frame.roomlist.CreateRoomEntry)
         self.frame.SetTextBG(self.frame.roomlist.SearchRooms)
 
     def IsPrivateRoomOwned(self, room):
@@ -319,8 +312,16 @@ class RoomsControl:
     def OnPopupJoin(self, widget):
         self.frame.np.queue.put(slskmessages.JoinRoom(self.popup_room))
 
-    def OnEnablePrivateRooms(self, widget):
-        self.frame.np.queue.put(slskmessages.PrivateRoomToggle(True))
+    def OnPopupCreatePublicRoom(self, widget):
+
+        room = input_box(
+            self.frame,
+            title=_('Nicotine+:') + " " + _("Create Public Room"),
+            message=_('Enter the name of the public room you wish to create')
+        )
+
+        if room:
+            self.frame.np.queue.put(slskmessages.JoinRoom(room))
 
     def OnJoinPublicRoom(self, widget):
 
@@ -344,9 +345,6 @@ class RoomsControl:
         room.CountUsers()
 
         self.frame.np.queue.put(slskmessages.JoinPublicRoom())
-
-    def OnDisablePrivateRooms(self, widget):
-        self.frame.np.queue.put(slskmessages.PrivateRoomToggle(False))
 
     def OnPopupCreatePrivateRoom(self, widget):
 
@@ -609,10 +607,6 @@ class RoomsControl:
 
         self.frame.np.config.sections["server"]["private_chatrooms"] = enabled
 
-        self.Menu_PrivateRoom_Enable.set_sensitive(not enabled)
-        self.Menu_PrivateRoom_Disable.set_sensitive(enabled)
-        self.Menu_PrivateRoom_Create.set_sensitive(enabled)
-
     def PrivateRoomDisown(self, msg):
         if msg.room in self.PrivateRooms:
             if self.PrivateRooms[msg.room]["owner"] == self.frame.np.config.sections["server"]["login"]:
@@ -680,7 +674,6 @@ class RoomsControl:
     def UpdateColours(self):
 
         self.frame.SetTextBG(self.frame.roomlist.RoomsList)
-        self.frame.SetTextBG(self.frame.roomlist.CreateRoomEntry)
         self.frame.SetTextBG(self.frame.roomlist.SearchRooms)
 
         for room in list(self.joinedrooms.values()):
@@ -1087,7 +1080,6 @@ class ChatRoom:
         self.UserList.connect("button_press_event", self.OnPopupMenu)
 
         self.ChatEntry.grab_focus()
-        self.ChatEntryBox.set_focus_child(self.ChatEntry)
 
         self.logpopupmenu = PopupMenu(self.frame).setup(
             ("#" + _("Find"), self.OnFindLogWindow),

--- a/pynicotine/gtkgui/frame.py
+++ b/pynicotine/gtkgui/frame.py
@@ -1531,10 +1531,10 @@ class NicotineFrame:
         self.awayreturn1.set_sensitive(status)
         self.check_privileges1.set_sensitive(status)
         self.get_privileges1.set_sensitive(status)
-
-        self.roomlist.CreateRoomEntry.set_sensitive(status)
         self.roomlist.RoomsList.set_sensitive(status)
         self.roomlist.SearchRooms.set_sensitive(status)
+        self.roomlist.RefreshButton.set_sensitive(status)
+        self.roomlist.AcceptPrivateRoom.set_sensitive(status)
         self.UserPrivateCombo.set_sensitive(status)
         self.sPrivateChatButton.set_sensitive(status)
         self.UserBrowseCombo.set_sensitive(status)

--- a/pynicotine/gtkgui/roomlist.py
+++ b/pynicotine/gtkgui/roomlist.py
@@ -58,14 +58,7 @@ class RoomList:
         self.query = ""
         self.room_model = self.RoomsList.get_model()
 
-    def OnCreateRoom(self, widget):
-
-        room = self.CreateRoomEntry.get_text()
-        if not room:
-            return
-
-        self.frame.np.queue.put(slskmessages.JoinRoom(room))
-        self.CreateRoomEntry.set_text("")
+        self.AcceptPrivateRoom.set_active(self.frame.np.config.sections["server"]["private_chatrooms"])
 
     def OnSearchRoom(self, widget):
 
@@ -96,3 +89,10 @@ class RoomList:
                 break
 
             self.search_iter = self.room_model.iter_next(self.search_iter)
+
+    def OnRefresh(self, widget):
+        self.frame.np.queue.put(slskmessages.RoomList())
+
+    def OnToggleAcceptPrivateRoom(self, widget):
+        value = self.AcceptPrivateRoom.get_active()
+        self.frame.np.queue.put(slskmessages.PrivateRoomToggle(value))

--- a/pynicotine/gtkgui/ui/mainwindow.ui
+++ b/pynicotine/gtkgui/ui/mainwindow.ui
@@ -860,7 +860,7 @@
                             <child>
                               <object class="GtkComboBox" id="ToggleTreeDownloads">
                                 <property name="visible">True</property>
-                                <property name="can_focus">True</property>
+                                <property name="can_focus">False</property>
                                 <property name="tooltip_text" translatable="yes">File grouping mode</property>
                               </object>
                               <packing>
@@ -1248,7 +1248,7 @@
                             <child>
                               <object class="GtkComboBox" id="ToggleTreeUploads">
                                 <property name="visible">True</property>
-                                <property name="can_focus">True</property>
+                                <property name="can_focus">False</property>
                                 <property name="tooltip_text" translatable="yes">File grouping mode</property>
                               </object>
                               <packing>

--- a/pynicotine/gtkgui/ui/roomlist.ui
+++ b/pynicotine/gtkgui/ui/roomlist.ui
@@ -45,6 +45,28 @@
                 <property name="position">1</property>
               </packing>
             </child>
+            <child>
+              <object class="GtkButton" id="RefreshButton">
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <property name="receives_default">False</property>
+                <property name="tooltip_text" translatable="yes">Refresh room list</property>
+                <property name="image">refresh</property>
+                <property name="always_show_image">True</property>
+                <signal name="clicked" handler="OnRefresh" swapped="no"/>
+                <child>
+                  <object class="GtkImage" id="refresh">
+                    <property name="can_focus">False</property>
+                    <property name="icon_name">view-refresh-symbolic</property>
+                  </object>
+                </child>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">False</property>
+                <property name="position">2</property>
+              </packing>
+            </child>
           </object>
           <packing>
             <property name="expand">False</property>
@@ -78,67 +100,19 @@
             <property name="spacing">5</property>
             <property name="orientation">vertical</property>
             <child>
-              <object class="GtkBox">
+              <object class="GtkCheckButton" id="AcceptPrivateRoom">
+                <property name="label" translatable="yes">Accept private room invitations</property>
                 <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="spacing">5</property>
-                <child>
-                  <object class="GtkEntry" id="CreateRoomEntry">
-                    <property name="visible">True</property>
-                    <property name="can_focus">True</property>
-                    <property name="primary_icon_activatable">False</property>
-                    <property name="secondary_icon_activatable">False</property>
-                    <property name="primary_icon_sensitive">True</property>
-                    <property name="secondary_icon_sensitive">True</property>
-                    <signal name="activate" handler="OnCreateRoom" swapped="no"/>
-                  </object>
-                  <packing>
-                    <property name="expand">True</property>
-                    <property name="fill">True</property>
-                    <property name="position">1</property>
-                  </packing>
-                </child>
-                <child>
-                  <object class="GtkButton" id="CreateRoom">
-                    <property name="visible">True</property>
-                    <property name="can_focus">True</property>
-                    <property name="receives_default">True</property>
-                    <property name="tooltip_text" translatable="yes">Create public room</property>
-                    <signal name="clicked" handler="OnCreateRoom" swapped="no"/>
-                    <child>
-                      <object class="GtkBox">
-                        <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="spacing">5</property>
-                        <child>
-                          <object class="GtkImage">
-                            <property name="visible">True</property>
-                            <property name="can_focus">False</property>
-                            <property name="icon_name">list-add-symbolic</property>
-                          </object>
-                        </child>
-                        <child>
-                          <object class="GtkLabel">
-                            <property name="visible">True</property>
-                            <property name="can_focus">False</property>
-                            <property name="label" translatable="yes">Create Room</property>
-                            <property name="use_underline">True</property>
-                          </object>
-                        </child>
-                      </object>
-                    </child>
-                  </object>
-                  <packing>
-                    <property name="expand">False</property>
-                    <property name="fill">True</property>
-                    <property name="position">2</property>
-                  </packing>
-                </child>
+                <property name="can_focus">True</property>
+                <property name="receives_default">False</property>
+                <property name="use_underline">True</property>
+                <property name="draw_indicator">True</property>
+                <signal name="toggled" handler="OnToggleAcceptPrivateRoom" swapped="no"/>
               </object>
               <packing>
                 <property name="expand">False</property>
-                <property name="fill">True</property>
-                <property name="position">2</property>
+                <property name="fill">False</property>
+                <property name="position">0</property>
               </packing>
             </child>
           </object>
@@ -146,6 +120,7 @@
             <property name="expand">False</property>
             <property name="fill">True</property>
             <property name="position">2</property>
+            <property name="padding">5</property>
           </packing>
         </child>
       </object>

--- a/pynicotine/gtkgui/ui/search.ui
+++ b/pynicotine/gtkgui/ui/search.ui
@@ -88,7 +88,7 @@
             <child>
               <object class="GtkComboBox" id="ResultGrouping">
                 <property name="visible">True</property>
-                <property name="can_focus">True</property>
+                <property name="can_focus">False</property>
                 <property name="tooltip_text" translatable="yes">Result grouping mode</property>
               </object>
               <packing>


### PR DESCRIPTION
At the protocol level, enabling/disabling private rooms doesn't disable the whole private rooms feature, it just toggles your ability to be added to a private room. Update the UI to make this clear.