### PR TITLE
Port most dialogs to GtkMessageDialog

### DIFF
--- a/pynicotine/gtkgui/chatrooms.py
+++ b/pynicotine/gtkgui/chatrooms.py
@@ -36,7 +36,8 @@ from gi.repository import Pango as pango
 
 from pynicotine import slskmessages
 from pynicotine.gtkgui import nowplaying
-from pynicotine.gtkgui.entrydialog import input_box
+from pynicotine.gtkgui.dialogs import EntryDialog
+from pynicotine.gtkgui.dialogs import TickerDialog
 from pynicotine.gtkgui.utils import AppendLine
 from pynicotine.gtkgui.utils import Humanize
 from pynicotine.gtkgui.utils import HumanSpeed
@@ -348,9 +349,9 @@ class RoomsControl:
 
     def OnPopupCreatePrivateRoom(self, widget):
 
-        room = input_box(
-            self.frame,
-            title=_('Nicotine+:') + " " + _("Create Private Room"),
+        room = EntryDialog(
+            self.frame.MainWindow,
+            title=_("Create Private Room"),
             message=_('Enter the name of the private room you wish to create')
         )
 
@@ -821,65 +822,6 @@ class Ticker:
         GLib.source_remove(self.source)
 
         self.source = None
-
-
-def TickDialog(parent, default=""):
-
-    dlg = gtk.Dialog(
-        title=_("Nicotine+: Set ticker message"),
-        transient_for=parent
-    )
-    dlg.add_buttons(gtk.STOCK_CANCEL, gtk.ResponseType.CANCEL, gtk.STOCK_OK, gtk.ResponseType.OK)
-    dlg.set_default_response(gtk.ResponseType.OK)
-
-    t = 0
-
-    dlg.set_border_width(10)
-    dlg.vbox.set_spacing(15)
-
-    l = gtk.Label.new(_("Set room ticker message:"))  # noqa: E741
-    l.set_alignment(0, 0.5)
-    dlg.vbox.pack_start(l, False, False, 0)
-
-    entry = gtk.Entry()
-    entry.set_activates_default(True)
-    entry.set_text(default)
-    dlg.vbox.pack_start(entry, True, True, 0)
-
-    v = gtk.Box.new(gtk.Orientation.VERTICAL, False)
-    v.set_spacing(5)
-    r1 = gtk.RadioButton().new_from_widget(None)
-    r1.set_label(_("Just this time"))
-    r1.set_active(True)
-    v.pack_start(r1, False, False, 0)
-
-    r2 = gtk.RadioButton().new_from_widget(r1)
-    r2.set_label(_("Always for this channel"))
-    v.pack_start(r2, False, False, 0)
-
-    r3 = gtk.RadioButton().new_from_widget(r1)
-    r3.set_label(_("Default for all channels"))
-    v.pack_start(r3, False, False, 0)
-
-    dlg.vbox.pack_start(v, True, True, 0)
-
-    dlg.vbox.show_all()
-
-    result = None
-    if dlg.run() == gtk.ResponseType.OK:
-
-        if r1.get_active():
-            t = 0
-        elif r2.get_active():
-            t = 1
-        elif r3.get_active():
-            t = 2
-
-        result = entry.get_text()
-
-    dlg.destroy()
-
-    return [t, result]
 
 
 class ChatRoom:
@@ -2268,7 +2210,12 @@ class ChatRoom:
         else:
             old = ""
 
-        t, result = TickDialog(self.frame.MainWindow, old)
+        t, result = TickerDialog(
+            parent=self.frame.MainWindow,
+            title="Set ticker message",
+            message="Set room ticker message:",
+            default_text=old
+        )
 
         if result is not None:
 

--- a/pynicotine/gtkgui/chatrooms.py
+++ b/pynicotine/gtkgui/chatrooms.py
@@ -315,9 +315,9 @@ class RoomsControl:
 
     def OnPopupCreatePublicRoom(self, widget):
 
-        room = input_box(
-            self.frame,
-            title=_('Nicotine+:') + " " + _("Create Public Room"),
+        room = EntryDialog(
+            self.frame.MainWindow,
+            title=_("Create Public Room"),
             message=_('Enter the name of the public room you wish to create')
         )
 

--- a/pynicotine/gtkgui/checklatest.py
+++ b/pynicotine/gtkgui/checklatest.py
@@ -18,10 +18,12 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 import json
 import urllib.error
 import urllib.parse
 import urllib.request
+
 from gettext import gettext as _
 
 from gi.repository import Gtk as gtk
@@ -66,44 +68,39 @@ def checklatest(frame):
         date = data['created_at']
     except Exception as m:
         dlg = gtk.MessageDialog(
-            frame,
-            0,
-            gtk.MessageType.ERROR,
-            gtk.ButtonsType.OK,
-            _("Could not retrieve version information!\nError: %s") % m
-        )
-        dlg.set_title(_("Check Latest Version"))
-        dlg.run()
-        dlg.destroy()
-        return
-
-    myversion = makeversion(version)
-
-    if latest > myversion:
-        dlg = gtk.MessageDialog(
-            frame,
-            0,
-            gtk.MessageType.WARNING,
-            gtk.ButtonsType.OK,
-            _("A newer version %s is available, released on %s.") % (hlatest, date)
-        )
-    elif myversion > latest:
-        dlg = gtk.MessageDialog(
-            frame,
-            0,
-            gtk.MessageType.WARNING,
-            gtk.ButtonsType.OK,
-            _("You appear to be using a development version of Nicotine+.")
+            transient_for=frame,
+            flags=0,
+            type=gtk.MessageType.ERROR,
+            buttons=gtk.ButtonsType.OK,
+            text=_("Could not retrieve version information!\nError: %s") % m
         )
     else:
-        dlg = gtk.MessageDialog(
-            frame,
-            0,
-            gtk.MessageType.INFO,
-            gtk.ButtonsType.OK,
-            _("You are using the latest version of Nicotine+.")
-        )
+        myversion = makeversion(version)
 
-    dlg.set_title(_("Check Latest Version"))
+        if latest > myversion:
+            dlg = gtk.MessageDialog(
+                transient_for=frame,
+                flags=0,
+                type=gtk.MessageType.INFO,
+                buttons=gtk.ButtonsType.OK,
+                text=_("A newer version %s is available, released on %s.") % (hlatest, date)
+            )
+        elif myversion > latest:
+            dlg = gtk.MessageDialog(
+                transient_for=frame,
+                flags=0,
+                type=gtk.MessageType.INFO,
+                buttons=gtk.ButtonsType.OK,
+                text=_("You appear to be using a development version of Nicotine+.")
+            )
+        else:
+            dlg = gtk.MessageDialog(
+                transient_for=frame,
+                flags=0,
+                type=gtk.MessageType.INFO,
+                buttons=gtk.ButtonsType.OK,
+                text=_("You are using the latest version of Nicotine+.")
+            )
+
     dlg.run()
     dlg.destroy()

--- a/pynicotine/gtkgui/dialogs.py
+++ b/pynicotine/gtkgui/dialogs.py
@@ -26,6 +26,166 @@ from gi.repository import GObject as gobject
 from gi.repository import Gtk as gtk
 
 
+def ComboBoxDialog(parent, title, message, default_text="",
+                   option=False, optionmessage="",
+                   optionvalue=False, droplist=[]):
+
+    self = gtk.MessageDialog(
+        transient_for=parent,
+        flags=0,
+        type=gtk.MessageType.QUESTION,
+        buttons=(gtk.STOCK_CANCEL, gtk.ResponseType.CANCEL, gtk.STOCK_OK, gtk.ResponseType.OK),
+        text=title
+    )
+    self.set_default_size(500, -1)
+    self.set_modal(True)
+    self.format_secondary_text(message)
+
+    self.gotoption = option
+
+    self.combo_list = gtk.ListStore(gobject.TYPE_STRING)
+    self.combo = gtk.ComboBox.new_with_model_and_entry(model=self.combo_list)
+    self.combo.set_entry_text_column(0)
+
+    for i in droplist:
+        self.combo_list.append([i])
+
+    self.combo.get_child().set_text(default_text)
+
+    self.get_message_area().pack_start(self.combo, False, False, 0)
+
+    self.combo.show()
+    self.combo.grab_focus()
+
+    if self.gotoption:
+
+        self.option = gtk.CheckButton()
+        self.option.set_active(optionvalue)
+        self.option.set_label(optionmessage)
+        self.option.show()
+
+        self.get_message_area().pack_start(self.option, False, False, 0)
+
+    result = None
+    if self.run() == gtk.ResponseType.OK:
+        if self.gotoption:
+            result = [self.combo.get_child().get_text(), self.option.get_active()]
+        else:
+            result = self.combo.get_child().get_text()
+
+    self.destroy()
+
+    return result
+
+
+def EntryDialog(parent, title, message, default=""):
+
+    self = gtk.MessageDialog(
+        transient_for=parent,
+        flags=0,
+        type=gtk.MessageType.QUESTION,
+        buttons=(gtk.STOCK_CANCEL, gtk.ResponseType.CANCEL, gtk.STOCK_OK, gtk.ResponseType.OK),
+        text=title
+    )
+    self.set_default_size(500, -1)
+    self.set_modal(True)
+    self.format_secondary_text(message)
+
+    entry = gtk.Entry()
+    entry.set_activates_default(True)
+    entry.set_text(default)
+    self.get_message_area().pack_start(entry, True, True, 0)
+    entry.show()
+
+    result = None
+    if self.run() == gtk.ResponseType.OK:
+        result = entry.get_text()
+
+    self.destroy()
+
+    return result
+
+
+def OptionDialog(parent, title, message, callback, callback_data=None, checkbox_label="", third=""):
+
+    self = gtk.MessageDialog(
+        transient_for=parent,
+        flags=0,
+        type=gtk.MessageType.QUESTION,
+        buttons=(gtk.STOCK_CANCEL, gtk.ResponseType.CANCEL, gtk.STOCK_OK, gtk.ResponseType.OK),
+        text=title
+    )
+    self.connect("response", callback, callback_data)
+    self.set_modal(True)
+    self.format_secondary_text(message)
+
+    if checkbox_label:
+        self.checkbox = gtk.CheckButton(checkbox_label)
+        self.get_message_area().pack_start(self.checkbox, False, False, 0)
+        self.checkbox.show()
+
+    if third:
+        third_button = self.add_button(third, gtk.ResponseType.REJECT)
+
+    self.show()
+
+
+def TickerDialog(parent, title, message, default_text=""):
+
+    self = gtk.MessageDialog(
+        transient_for=parent,
+        flags=0,
+        type=gtk.MessageType.QUESTION,
+        buttons=(gtk.STOCK_CANCEL, gtk.ResponseType.CANCEL, gtk.STOCK_OK, gtk.ResponseType.OK),
+        text=title
+    )
+    self.set_default_size(600, -1)
+    self.set_modal(True)
+    self.format_secondary_text(message)
+
+    entry = gtk.Entry()
+    entry.set_activates_default(True)
+    entry.set_text(default_text)
+    self.get_message_area().pack_start(entry, True, True, 0)
+
+    box = gtk.Box.new(gtk.Orientation.VERTICAL, False)
+    box.set_spacing(5)
+
+    radio1 = gtk.RadioButton().new_from_widget(None)
+    radio1.set_label(_("Just this time"))
+    radio1.set_active(True)
+    box.pack_start(radio1, False, False, 0)
+
+    radio2 = gtk.RadioButton().new_from_widget(radio1)
+    radio2.set_label(_("Always for this channel"))
+    box.pack_start(radio2, False, False, 0)
+
+    radio3 = gtk.RadioButton().new_from_widget(radio1)
+    radio3.set_label(_("Default for all channels"))
+    box.pack_start(radio3, False, False, 0)
+
+    self.get_message_area().pack_start(box, True, True, 0)
+
+    self.vbox.show_all()
+
+    result = None
+    t = 0
+    if self.run() == gtk.ResponseType.OK:
+
+        if radio1.get_active():
+            t = 0
+        elif radio2.get_active():
+            t = 1
+        elif radio3.get_active():
+            t = 2
+
+        result = entry.get_text()
+
+    self.destroy()
+
+    return t, result
+
+
 class MetaDialog(gtk.Dialog):
 
     def __init__(self, frame, message="", data=None, modal=True, Search=True):
@@ -439,113 +599,6 @@ class MetaDialog(gtk.Dialog):
         return label, entry
 
 
-class EntryDialog(gtk.Dialog):
-
-    def __init__(self, frame, message="", default_text="",
-                 option=False, optionmessage="",
-                 optionvalue=False, droplist=[]):
-
-        gtk.Dialog.__init__(self)
-
-        self.connect("destroy", self.quit)
-        self.connect("delete-event", self.quit)
-
-        self.set_transient_for(frame.MainWindow)
-
-        self.gotoption = option
-
-        box = gtk.VBox(spacing=10)
-        box.set_border_width(10)
-        self.vbox.pack_start(box, False, False, 0)
-        box.show()
-
-        if message:
-            label = gtk.Label.new(message)
-            box.pack_start(label, False, False, 0)
-            label.set_line_wrap(True)
-            label.show()
-
-        self.combo_List = gtk.ListStore(gobject.TYPE_STRING)
-        self.combo = gtk.ComboBox.new_with_model_and_entry(model=self.combo_List)
-        self.combo.set_entry_text_column(0)
-
-        for i in droplist:
-            self.combo_List.append([i])
-
-        self.combo.get_child().set_text(default_text)
-
-        box.pack_start(self.combo, False, False, 0)
-
-        self.combo.show()
-        self.combo.grab_focus()
-
-        if self.gotoption:
-
-            self.option = gtk.CheckButton()
-            self.option.set_active(optionvalue)
-            self.option.set_label(optionmessage)
-            self.option.show()
-
-            box.pack_start(self.option, False, False, 0)
-
-        button = gtk.Button(_("Cancel"))
-        button.connect("clicked", self.quit)
-        button.props.can_default = True
-        self.action_area.pack_start(button, False, False, 0)
-
-        button.show()
-
-        button = gtk.Button(_("OK"))
-        button.connect("clicked", self.click)
-        button.props.can_default = True
-        self.action_area.pack_start(button, False, False, 0)
-
-        button.show()
-        button.grab_default()
-
-        # Set modal to True to avoid wrong window having the focus
-        self.set_modal(True)
-
-        self.ret = None
-
-    def quit(self, w=None, event=None):
-        self.hide()
-        self.destroy()
-        gtk.main_quit()
-
-    def click(self, button):
-
-        if self.gotoption:
-            self.ret = [self.combo.get_child().get_text(), self.option.get_active()]
-        else:
-            self.ret = self.combo.get_child().get_text()
-
-        self.quit()
-
-
-def input_box(frame, title="Input Box", message="", default_text="",
-              modal=True, option=False, optionmessage="",
-              optionvalue=False, droplist=[]):
-
-    win = EntryDialog(
-        frame, message, default_text,
-        option=option, optionmessage=optionmessage,
-        optionvalue=optionvalue, droplist=droplist
-    )
-
-    win.set_title(title)
-    win.set_icon(frame.images["n"])
-
-    hints_geometry = Gdk.Geometry()
-    hints_geometry.min_width = 300
-    win.set_geometry_hints(None, hints_geometry, Gdk.WindowHints(Gdk.WindowHints.MIN_SIZE))
-    win.show()
-
-    gtk.main()
-
-    return win.ret
-
-
 class FindDialog(gtk.Dialog):
 
     def __init__(self, frame, message="", default_text='',
@@ -640,160 +693,3 @@ class FindDialog(gtk.Dialog):
     def destroy(self, w=None, event=None):
         if "FindDialog" in self.nicotine.__dict__:
             del self.nicotine.FindDialog
-
-
-def FolderDownload(frame, title="Option Box", message="", default_text='',
-                   modal=True, data=None, callback=None):
-
-    win = FolderDownloadDialog(frame, message, modal=modal)
-    win.connect("response", callback, data)
-    win.set_title(title)
-    win.set_icon(frame.images["n"])
-    win.show()
-
-
-class FolderDownloadDialog(gtk.Dialog):
-
-    def __init__(self, frame, message="", modal=False, ):
-
-        gtk.Dialog.__init__(self)
-
-        self.connect("destroy", self.quit)
-        self.connect("delete-event", self.quit)
-
-        self.nicotine = frame
-
-        self.set_modal(modal)
-        self.set_transient_for(frame.MainWindow)
-
-        box = gtk.VBox(spacing=10)
-        box.set_border_width(10)
-        self.vbox.pack_start(box, False, False, 0)
-        box.show()
-        hbox = gtk.HBox(spacing=5)
-        hbox.set_border_width(5)
-        hbox.show()
-        box.pack_start(hbox, False, False, 0)
-
-        image = gtk.Image()
-        image.set_padding(0, 0)
-        icon = gtk.STOCK_DIALOG_QUESTION
-        image.set_from_stock(icon, 4)
-        image.show()
-        hbox.pack_start(image, False, False, 0)
-
-        if message:
-            label = gtk.Label.new(message)
-            hbox.pack_start(label, False, False, 0)
-            label.set_line_wrap(True)
-            label.show()
-
-        hbox2 = gtk.HBox(spacing=5)
-        hbox2.set_border_width(5)
-        hbox2.show()
-        box.pack_start(hbox2, False, False, 0)
-
-        cancel_button = self.add_button(gtk.STOCK_CANCEL, gtk.ResponseType.CANCEL)  # noqa: F841
-        ok_button = self.add_button(gtk.STOCK_OK, gtk.ResponseType.OK)
-        ok_button.grab_default()
-
-    def quit(self, *args):
-        self.destroy()
-
-
-def QuitBox(frame, title="Option Box", message="", default_text='',
-            modal=True, status=None, tray=False, third=""):
-
-    win = OptionDialog(frame, message, modal=modal, status=status,
-                       option=tray, third=third, rememberbox=True)
-    win.connect("response", frame.on_quit_response)
-    win.set_title(title)
-    win.set_icon(frame.images["n"])
-    win.show()
-    return win
-
-
-class OptionDialog(gtk.Dialog):
-
-    def __init__(self, frame, message="", modal=False, status=None,
-                 option=False, third="", rememberbox=False):
-
-        gtk.Dialog.__init__(self)
-
-        self.connect("destroy", self.quit)
-        self.connect("delete-event", self.quit)
-
-        self.nicotine = frame
-
-        self.set_modal(modal)
-        self.set_transient_for(frame.MainWindow)
-
-        box = gtk.VBox(spacing=10)
-        box.set_border_width(10)
-        self.vbox.pack_start(box, False, False, 0)
-        box.show()
-        hbox = gtk.HBox(spacing=5)
-        hbox.set_border_width(5)
-        hbox.show()
-        box.pack_start(hbox, False, False, 0)
-
-        if status:
-            image = gtk.Image()
-            image.set_padding(0, 0)
-            if status == "warning":
-                icon = gtk.STOCK_DIALOG_WARNING
-            else:
-                icon = gtk.STOCK_DIALOG_QUESTION
-            image.set_from_stock(icon, 4)
-            image.show()
-            hbox.pack_start(image, False, False, 0)
-
-        if message:
-            label = gtk.Label.new(message)
-            hbox.pack_start(label, False, False, 0)
-            label.set_line_wrap(True)
-            label.show()
-
-        hbox2 = gtk.HBox(spacing=5)
-        hbox2.set_border_width(5)
-        hbox2.show()
-        box.pack_start(hbox2, False, False, 0)
-
-        # Storing under self. so we can find it easily later
-        if rememberbox:
-            self.checkbox = gtk.CheckButton("Remember choice")
-            box.pack_start(self.checkbox, False, False, 0)
-            self.checkbox.show()
-
-        if option:
-            Alignment = gtk.Alignment(xalign=0.5, yalign=0.5, xscale=0, yscale=0)
-            Alignment.show()
-
-            Hbox = gtk.HBox(False, 2)
-            Hbox.show()
-            Hbox.set_spacing(2)
-
-            image = gtk.Image()
-            image.set_padding(0, 0)
-
-            image.set_from_stock(gtk.STOCK_GO_DOWN, 4)
-            image.show()
-            Hbox.pack_start(image, False, False, 0)
-            Alignment.add(Hbox)
-
-            if label:
-                Label = gtk.Label.new(third)
-                Label.set_padding(0, 0)
-                Label.show()
-                Hbox.pack_start(Label, False, False, 0)
-
-            tray_button = self.add_button("", gtk.ResponseType.REJECT)
-            tray_button.remove(tray_button.get_child())
-            tray_button.add(Alignment)
-
-        cancel_button = self.add_button(gtk.STOCK_CANCEL, gtk.ResponseType.CANCEL)  # noqa: F841
-        ok_button = self.add_button(gtk.STOCK_OK, gtk.ResponseType.OK)
-        ok_button.grab_default()
-
-    def quit(self, *args):
-        self.destroy()

--- a/pynicotine/gtkgui/dialogs.py
+++ b/pynicotine/gtkgui/dialogs.py
@@ -21,7 +21,6 @@
 
 from gettext import gettext as _
 
-from gi.repository import Gdk
 from gi.repository import GObject as gobject
 from gi.repository import Gtk as gtk
 
@@ -125,7 +124,7 @@ def OptionDialog(parent, title, message, callback, callback_data=None, checkbox_
         self.checkbox.show()
 
     if third:
-        third_button = self.add_button(third, gtk.ResponseType.REJECT)
+        self.add_button(third, gtk.ResponseType.REJECT)
 
     self.show()
 

--- a/pynicotine/gtkgui/downloads.py
+++ b/pynicotine/gtkgui/downloads.py
@@ -30,8 +30,8 @@ from gi.repository import Gtk as gtk
 
 from _thread import start_new_thread
 from pynicotine import slskmessages
-from pynicotine.gtkgui.entrydialog import MetaDialog
-from pynicotine.gtkgui.entrydialog import OptionDialog
+from pynicotine.gtkgui.dialogs import MetaDialog
+from pynicotine.gtkgui.dialogs import OptionDialog
 from pynicotine.gtkgui.transferlist import TransferList
 from pynicotine.gtkgui.utils import CollapseTreeview
 from pynicotine.gtkgui.utils import FillFileGroupingCombobox
@@ -103,10 +103,9 @@ class Downloads(TransferList):
     def OnTryClearQueued(self, widget):
 
         direction = "down"
-        win = OptionDialog(self.frame, _("Clear All Queued Downloads?"), modal=True, status=None, option=False, third="")
+        win = OptionDialog(self.frame, _("Clear All Queued Downloads?"), modal=True, option=False, third="")
         win.connect("response", self.frame.on_clear_response, direction)
         win.set_title(_("Nicotine+") + ": " + _("Clear Queued Transfers"))
-        win.set_icon(self.frame.images["n"])
         win.show()
 
     def expand(self, path):
@@ -147,7 +146,6 @@ class Downloads(TransferList):
 
         win = MetaDialog(self.frame, message, data, modal, Search=Search)
         win.set_title(title)
-        win.set_icon(self.frame.images["n"])
         win.show()
         gtk.main()
 

--- a/pynicotine/gtkgui/fastconfigure.py
+++ b/pynicotine/gtkgui/fastconfigure.py
@@ -30,11 +30,10 @@ from gi.repository import Gtk as gtk
 
 import _thread
 from pynicotine.gtkgui.dirchooser import ChooseDir
-from pynicotine.gtkgui.entrydialog import input_box
+from pynicotine.gtkgui.dialogs import ComboBoxDialog
 from pynicotine.gtkgui.utils import HumanSize
 from pynicotine.gtkgui.utils import InitialiseColumns
 from pynicotine.gtkgui.utils import OpenUri
-from pynicotine.gtkgui.utils import popupWarning
 
 
 def dirstats(directory):
@@ -419,8 +418,8 @@ class FastConfigureAssistant(object):
 
                 for directory in selected:
 
-                    virtual = input_box(
-                        self.frame,
+                    virtual = ComboBoxDialog(
+                        parent=self.frame.MainWindow,
                         title=_("Virtual name"),
                         message=_("Enter virtual name for '%(dir)s':") % {'dir': directory}
                     )
@@ -428,12 +427,16 @@ class FastConfigureAssistant(object):
                     # If the virtual name is empty
                     if virtual == '' or virtual is None:
 
-                        popupWarning(
-                            self.window,
-                            _("Warning"),
-                            _("The chosen virtual name is empty"),
-                            self.frame.images["n"]
+                        dlg = gtk.MessageDialog(
+                            transient_for=self.window,
+                            flags=0,
+                            type=gtk.MessageType.WARNING,
+                            buttons=gtk.ButtonsType.OK,
+                            text=_("Warning")
                         )
+                        dlg.format_secondary_text(_("The chosen virtual name is empty"))
+                        dlg.run()
+                        dlg.destroy()
                         pass
 
                     else:
@@ -447,23 +450,31 @@ class FastConfigureAssistant(object):
                             # We reject the share if the virtual share name is already used
                             if virtual == model.get_value(iter, 0):
 
-                                popupWarning(
-                                    self.window,
-                                    _("Warning"),
-                                    _("The chosen virtual name already exist"),
-                                    self.frame.images["n"]
+                                dlg = gtk.MessageDialog(
+                                    transient_for=self.window,
+                                    flags=0,
+                                    type=gtk.MessageType.WARNING,
+                                    buttons=gtk.ButtonsType.OK,
+                                    text=_("Warning")
                                 )
+                                dlg.format_secondary_text(_("The chosen virtual name already exists"))
+                                dlg.run()
+                                dlg.destroy()
                                 return
 
                             # We also reject the share if the directory is already used
                             elif directory == model.get_value(iter, 6):
 
-                                popupWarning(
-                                    self.window,
-                                    _("Warning"),
-                                    _("The chosen directory is already shared"),
-                                    self.frame.images["n"]
+                                dlg = gtk.MessageDialog(
+                                    transient_for=self.window,
+                                    flags=0,
+                                    type=gtk.MessageType.WARNING,
+                                    buttons=gtk.ButtonsType.OK,
+                                    text=_("Warning")
                                 )
+                                dlg.format_secondary_text(_("The chosen directory is already shared"))
+                                dlg.run()
+                                dlg.destroy()
                                 return
 
                             else:

--- a/pynicotine/gtkgui/nowplaying.py
+++ b/pynicotine/gtkgui/nowplaying.py
@@ -57,7 +57,6 @@ class NowPlaying:
             except TypeError:
                 pass
 
-        self.NowPlaying.set_icon(self.frame.images["n"])
         self.NowPlaying.set_transient_for(self.frame.MainWindow)
         self.NowPlaying.add_accel_group(self.accel_group)
 

--- a/pynicotine/gtkgui/search.py
+++ b/pynicotine/gtkgui/search.py
@@ -35,7 +35,8 @@ from gi.repository import Gtk as gtk
 
 from pynicotine import slskmessages
 from pynicotine.gtkgui.dirchooser import ChooseDir
-from pynicotine.gtkgui.entrydialog import MetaDialog
+from pynicotine.gtkgui.dialogs import EntryDialog
+from pynicotine.gtkgui.dialogs import MetaDialog
 from pynicotine.gtkgui.utils import CollapseTreeview
 from pynicotine.gtkgui.utils import FillFileGroupingCombobox
 from pynicotine.gtkgui.utils import Humanize
@@ -43,7 +44,6 @@ from pynicotine.gtkgui.utils import HumanSize
 from pynicotine.gtkgui.utils import HumanSpeed
 from pynicotine.gtkgui.utils import IconNotebook
 from pynicotine.gtkgui.utils import InitialiseColumns
-from pynicotine.gtkgui.utils import InputDialog
 from pynicotine.gtkgui.utils import PopupMenu
 from pynicotine.gtkgui.utils import PressHeader
 from pynicotine.gtkgui.utils import SelectUserRowIter
@@ -1340,7 +1340,6 @@ class Search:
 
         win = MetaDialog(self.frame, message, data, modal)
         win.set_title(title)
-        win.set_icon(self.frame.images["n"])
         win.show()
         gtk.main()
 
@@ -1600,7 +1599,6 @@ class WishList(gtk.Dialog):
         gtk.Dialog.__init__(self)
 
         self.set_title(_("Nicotine+: Search Wishlist"))
-        self.set_icon(frame.images["n"])
         self.connect("destroy", self.quit)
         self.connect("destroy-event", self.quit)
         self.connect("delete-event", self.quit)
@@ -1660,7 +1658,7 @@ class WishList(gtk.Dialog):
 
     def OnAddWish(self, widget):
 
-        wish = InputDialog(self.vbox.get_toplevel(), _("Add Wish..."), _("Wish:"))
+        wish = EntryDialog(self.vbox.get_toplevel(), _("Add Wish..."), _("Wish:"))
 
         if wish and wish not in self.wishes:
             self.wishes[wish] = self.store.append([wish])

--- a/pynicotine/gtkgui/search.py
+++ b/pynicotine/gtkgui/search.py
@@ -35,7 +35,6 @@ from gi.repository import Gtk as gtk
 
 from pynicotine import slskmessages
 from pynicotine.gtkgui.dirchooser import ChooseDir
-from pynicotine.gtkgui.dialogs import EntryDialog
 from pynicotine.gtkgui.dialogs import MetaDialog
 from pynicotine.gtkgui.utils import CollapseTreeview
 from pynicotine.gtkgui.utils import FillFileGroupingCombobox
@@ -1592,55 +1591,31 @@ class Search:
                 CollapseTreeview(self.ResultsList, self.ResultGrouping.get_active())
 
 
-class WishList(gtk.Dialog):
+class WishList:
 
     def __init__(self, frame):
 
-        gtk.Dialog.__init__(self)
+        builder = gtk.Builder()
 
-        self.set_title(_("Nicotine+: Search Wishlist"))
-        self.connect("destroy", self.quit)
-        self.connect("destroy-event", self.quit)
-        self.connect("delete-event", self.quit)
-        self.connect("delete_event", self.quit)
+        builder.set_translation_domain('nicotine')
+        builder.add_from_file(os.path.join(os.path.dirname(os.path.realpath(__file__)), "ui", "wishlist.ui"))
 
-        self.nicotine = frame
-        self.set_modal(True)
-        self.set_size_request(600, 600)
-        self.set_transient_for(frame.MainWindow)
-        self.mainHbox = gtk.Box.new(gtk.Orientation.HORIZONTAL, 5)
-        self.mainHbox.set_border_width(10)
-        self.mainHbox.show()
+        self.WishList = builder.get_object("WishList")
+        builder.connect_signals(self)
 
-        self.WishScrollWin = gtk.ScrolledWindow()
-        self.WishScrollWin.set_policy(gtk.PolicyType.AUTOMATIC, gtk.PolicyType.AUTOMATIC)
-        self.WishScrollWin.show()
-        self.WishScrollWin.set_shadow_type(gtk.ShadowType.IN)
+        for i in builder.get_objects():
+            try:
+                self.__dict__[gtk.Buildable.get_name(i)] = i
+            except TypeError:
+                pass
 
-        self.WishlistView = gtk.TreeView()
-        self.WishlistView.show()
-        self.WishlistView.set_headers_visible(False)
-        self.WishScrollWin.add(self.WishlistView)
+        self.WishList.set_transient_for(frame.MainWindow)
 
-        self.mainHbox.pack_start(self.WishScrollWin, True, True, 0)
-        self.mainVbox = gtk.Box.new(gtk.Orientation.VERTICAL, 5)
-        self.mainHbox.pack_start(self.mainVbox, False, False, 0)
-        self.mainVbox.show()
-        self.mainVbox.set_spacing(5)
-
-        self.AddWishButton = self.nicotine.CreateIconButton(gtk.STOCK_ADD, "stock", self.OnAddWish, _("Add..."))
-        self.mainVbox.pack_start(self.AddWishButton, False, False, 0)
-
-        self.RemoveWishButton = self.nicotine.CreateIconButton(gtk.STOCK_REMOVE, "stock", self.OnRemoveWish, _("Remove"))
-        self.mainVbox.pack_start(self.RemoveWishButton, False, False, 0)
-
-        self.SelectAllWishesButton = self.nicotine.CreateIconButton(gtk.STOCK_DND_MULTIPLE, "stock", self.OnSelectAllWishes, _("Select all"))
-        self.mainVbox.pack_start(self.SelectAllWishesButton, False, False, 0)
-
-        self.CloseButton = self.nicotine.CreateIconButton(gtk.STOCK_CLOSE, "stock", self.quit, _("Close"))
-        self.mainVbox.pack_end(self.CloseButton, False, False, 0)
-
-        self.vbox.pack_start(self.mainHbox, True, True, 0)
+        self.frame = frame
+        self.WishList.connect("destroy", self.quit)
+        self.WishList.connect("destroy-event", self.quit)
+        self.WishList.connect("delete-event", self.quit)
+        self.WishList.connect("delete_event", self.quit)
 
         self.store = gtk.ListStore(gobject.TYPE_STRING)
 
@@ -1653,48 +1628,18 @@ class WishList(gtk.Dialog):
         self.store.set_sort_column_id(0, gtk.SortType.ASCENDING)
         self.wishes = {}
 
-        for wish in self.nicotine.np.config.sections["server"]["autosearch"]:
+        for wish in self.frame.np.config.sections["server"]["autosearch"]:
             self.wishes[wish] = self.store.append([wish])
 
     def OnAddWish(self, widget):
-
-        wish = EntryDialog(self.vbox.get_toplevel(), _("Add Wish..."), _("Wish:"))
+        wish = self.AddWishEntry.get_text()
+        self.AddWishEntry.set_text("")
 
         if wish and wish not in self.wishes:
             self.wishes[wish] = self.store.append([wish])
-            self.nicotine.Searches.NewWish(wish)
-
-    def _RemoveWish(self, model, path, iter, line):
-        line.append(iter)
-
-    def removeWish(self, wish):
-
-        if wish in self.wishes:
-            self.store.remove(self.wishes[wish])
-            del self.wishes[wish]
-
-        if wish in self.nicotine.np.config.sections["server"]["autosearch"]:
-
-            self.nicotine.np.config.sections["server"]["autosearch"].remove(wish)
-
-            for number, search in list(self.nicotine.Searches.searches.items()):
-
-                if search[1] == wish and search[4] == 1:
-
-                    search[4] = 0
-                    self.nicotine.Searches.searches[number] = search
-
-                    if search[2] is not None:
-                        search[2].RememberCheckButton.set_active(False)
-
-                    break
-
-    def addWish(self, wish):
-        if wish and wish not in self.wishes:
-            self.wishes[wish] = self.store.append([wish])
+            self.frame.Searches.NewWish(wish)
 
     def OnRemoveWish(self, widget):
-
         iters = []
         self.WishlistView.get_selection().selected_foreach(self._RemoveWish, iters)
 
@@ -1702,16 +1647,45 @@ class WishList(gtk.Dialog):
             wish = self.store.get_value(iter, 0)
             self.removeWish(wish)
 
+    def _RemoveWish(self, model, path, iter, line):
+        line.append(iter)
+
     def OnSelectAllWishes(self, widget):
         self.WishlistView.get_selection().select_all()
 
+    def addWish(self, wish):
+        if wish and wish not in self.wishes:
+            self.wishes[wish] = self.store.append([wish])
+
+    def removeWish(self, wish):
+
+        if wish in self.wishes:
+            self.store.remove(self.wishes[wish])
+            del self.wishes[wish]
+
+        if wish in self.frame.np.config.sections["server"]["autosearch"]:
+
+            self.frame.np.config.sections["server"]["autosearch"].remove(wish)
+
+            for number, search in list(self.frame.Searches.searches.items()):
+
+                if search[1] == wish and search[4] == 1:
+
+                    search[4] = 0
+                    self.frame.Searches.searches[number] = search
+
+                    if search[2] is not None:
+                        search[2].RememberCheckButton.set_active(False)
+
+                    break
+
     def quit(self, w=None, event=None):
-        self.hide()
+        self.WishList.hide()
         return True
 
     def Toggle(self, widget):
 
-        if self.get_property("visible"):
-            self.hide()
+        if self.WishList.get_property("visible"):
+            self.WishList.hide()
         else:
-            self.show()
+            self.WishList.show()

--- a/pynicotine/gtkgui/settingswindow.py
+++ b/pynicotine/gtkgui/settingswindow.py
@@ -35,12 +35,11 @@ from gi.repository import Gtk as gtk
 
 import _thread
 from pynicotine.gtkgui.dirchooser import ChooseDir
-from pynicotine.gtkgui.entrydialog import input_box
+from pynicotine.gtkgui.dialogs import ComboBoxDialog
+from pynicotine.gtkgui.dialogs import EntryDialog
 from pynicotine.gtkgui.utils import HumanSize
 from pynicotine.gtkgui.utils import InitialiseColumns
-from pynicotine.gtkgui.utils import InputDialog
 from pynicotine.gtkgui.utils import OpenUri
-from pynicotine.gtkgui.utils import popupWarning
 from pynicotine.logfacility import log
 from pynicotine.upnp import UPnPPortMapping
 from pynicotine.utils import unescape
@@ -174,12 +173,16 @@ class ServerFrame(buildFrame):
             server = None
 
         if str(self.Login.get_text()) == "None":
-            popupWarning(
-                self.p.SettingsWindow,
-                _("Warning: Bad Username"),
-                _("Username 'None' is not a good one, please pick another."),
-                self.frame.images["n"]
+            dlg = gtk.MessageDialog(
+                transient_for=self.p.SettingsWindow,
+                flags=0,
+                type=gtk.MessageType.WARNING,
+                buttons=gtk.ButtonsType.OK,
+                text=_("Warning: Bad Username")
             )
+            dlg.format_secondary_text(_("Username 'None' is not a good one, please pick another."))
+            dlg.run()
+            dlg.destroy()
             raise UserWarning
 
         try:
@@ -188,12 +191,16 @@ class ServerFrame(buildFrame):
             portrange = (firstport, lastport)
         except Exception:
             portrange = None
-            popupWarning(
-                self.p.SettingsWindow,
-                _("Warning: Invalid ports"),
-                _("Client ports are invalid."),
-                self.frame.images["n"]
+            dlg = gtk.MessageDialog(
+                transient_for=self.p.SettingsWindow,
+                flags=0,
+                type=gtk.MessageType.WARNING,
+                buttons=gtk.ButtonsType.OK,
+                text=_("Warning: Invalid ports")
             )
+            dlg.format_secondary_text(_("Client ports are invalid."))
+            dlg.run()
+            dlg.destroy()
             raise UserWarning
 
         firewalled = not self.DirectConnection.get_active()
@@ -303,12 +310,16 @@ class DownloadsFrame(buildFrame):
 
         if homedir == self.DownloadDir.get_file().get_path() and self.ShareDownloadDir.get_active():
 
-            popupWarning(
-                self.p.SettingsWindow,
-                _("Warning"),
-                _("Security Risk: you should not share your %s directory!") % place,
-                self.frame.images["n"]
+            dlg = gtk.MessageDialog(
+                transient_for=self.p.SettingsWindow,
+                flags=0,
+                type=gtk.MessageType.WARNING,
+                buttons=gtk.ButtonsType.OK,
+                text=_("Warning")
             )
+            dlg.format_secondary_text(_("Security Risk: you should not share your %s directory!") % place)
+            dlg.run()
+            dlg.destroy()
 
             raise UserWarning
 
@@ -363,9 +374,9 @@ class DownloadsFrame(buildFrame):
 
     def OnAddFilter(self, widget):
 
-        response = input_box(
-            self.frame,
-            title=_('Nicotine+: Add a download filter'),
+        response = ComboBoxDialog(
+            parent=self.p.SettingsWindow,
+            title=_('Add a download filter'),
             message=_('Enter a new download filter:'),
             option=True,
             optionvalue=True,
@@ -409,9 +420,9 @@ class DownloadsFrame(buildFrame):
             iter = self.filtersiters[dfilter]
             escapedvalue = self.filterlist.get_value(iter, 1)
 
-            response = input_box(
-                self.frame,
-                title=_('Nicotine+: Edit a download filter'),
+            response = ComboBoxDialog(
+                parent=self.p.SettingsWindow,
+                title=_('Edit a download filter'),
                 message=_('Modify this download filter:'),
                 default_text=dfilter,
                 option=True,
@@ -663,12 +674,16 @@ class SharesFrame(buildFrame):
 
         for share in self.shareddirs + self.bshareddirs:
             if homedir == share:
-                popupWarning(
-                    self.p.SettingsWindow,
-                    _("Warning"),
-                    _("Security Risk: you should not share your %s directory!") % place,
-                    self.frame.images["n"]
+                dlg = gtk.MessageDialog(
+                    transient_for=self.p.SettingsWindow,
+                    flags=0,
+                    type=gtk.MessageType.WARNING,
+                    buttons=gtk.ButtonsType.OK,
+                    text=_("Warning")
                 )
+                dlg.format_secondary_text(_("Security Risk: you should not share your %s directory!") % place)
+                dlg.run()
+                dlg.destroy()
                 raise UserWarning
 
         # Buddy shares related menus are activated if needed
@@ -751,18 +766,22 @@ class SharesFrame(buildFrame):
                 # If the directory is already shared
                 if directory in [x[1] for x in self.shareddirs + self.bshareddirs]:
 
-                    popupWarning(
-                        self.p.SettingsWindow,
-                        _("Warning"),
-                        _("The chosen directory is already shared"),
-                        self.frame.images["n"]
+                    dlg = gtk.MessageDialog(
+                        transient_for=self.p.SettingsWindow,
+                        flags=0,
+                        type=gtk.MessageType.WARNING,
+                        buttons=gtk.ButtonsType.OK,
+                        text=_("Warning")
                     )
+                    dlg.format_secondary_text(_("The chosen directory is already shared"))
+                    dlg.run()
+                    dlg.destroy()
                     pass
 
                 else:
 
-                    virtual = input_box(
-                        self.frame,
+                    virtual = ComboBoxDialog(
+                        parent=self.p.SettingsWindow,
                         title=_("Virtual name"),
                         message=_("Enter virtual name for '%(dir)s':") % {'dir': directory}
                     )
@@ -770,12 +789,16 @@ class SharesFrame(buildFrame):
                     # If the virtual share name is not already used
                     if virtual == '' or virtual is None or virtual in [x[0] for x in self.shareddirs + self.bshareddirs]:
 
-                        popupWarning(
-                            self.p.SettingsWindow,
-                            _("Warning"),
-                            _("The chosen virtual name is either empty or already exist"),
-                            self.frame.images["n"]
+                        dlg = gtk.MessageDialog(
+                            transient_for=self.p.SettingsWindow,
+                            flags=0,
+                            type=gtk.MessageType.WARNING,
+                            buttons=gtk.ButtonsType.OK,
+                            text=_("Warning")
                         )
+                        dlg.format_secondary_text(_("The chosen virtual name is either empty or already exists"))
+                        dlg.run()
+                        dlg.destroy()
                         pass
 
                     else:
@@ -809,18 +832,22 @@ class SharesFrame(buildFrame):
                 # If the directory is already shared
                 if directory in [x[1] for x in self.shareddirs + self.bshareddirs]:
 
-                    popupWarning(
-                        self.p.SettingsWindow,
-                        _("Warning"),
-                        _("The chosen directory is already shared"),
-                        self.frame.images["n"]
+                    dlg = gtk.MessageDialog(
+                        transient_for=self.p.SettingsWindow,
+                        flags=0,
+                        type=gtk.MessageType.WARNING,
+                        buttons=gtk.ButtonsType.OK,
+                        text=_("Warning")
                     )
+                    dlg.format_secondary_text(_("The chosen directory is already shared"))
+                    dlg.run()
+                    dlg.destroy()
                     pass
 
                 else:
 
-                    virtual = input_box(
-                        self.frame,
+                    virtual = ComboBoxDialog(
+                        parent=self.p.SettingsWindow,
                         title=_("Virtual name"),
                         message=_("Enter virtual name for '%(dir)s':") % {'dir': directory}
                     )
@@ -828,12 +855,16 @@ class SharesFrame(buildFrame):
                     # If the virtual share name is not already used
                     if virtual == '' or virtual is None or virtual in [x[0] for x in self.shareddirs + self.bshareddirs]:
 
-                        popupWarning(
-                            self.p.SettingsWindow,
-                            _("Warning"),
-                            _("The chosen virtual name is either empty or already exist"),
-                            self.frame.images["n"]
+                        dlg = gtk.MessageDialog(
+                            transient_for=self.p.SettingsWindow,
+                            flags=0,
+                            type=gtk.MessageType.WARNING,
+                            buttons=gtk.ButtonsType.OK,
+                            text=_("Warning")
                         )
+                        dlg.format_secondary_text(_("The chosen virtual name is either empty or already exists"))
+                        dlg.run()
+                        dlg.destroy()
                         pass
 
                     else:
@@ -866,8 +897,8 @@ class SharesFrame(buildFrame):
             directory = self.shareslist.get_value(iter, 3)
             oldmapping = (oldvirtual, directory)
 
-            virtual = input_box(
-                self.frame,
+            virtual = ComboBoxDialog(
+                parent=self.p.SettingsWindow,
                 title=_("Virtual name"),
                 message=_("Enter new virtual name for '%(dir)s':") % {'dir': directory}
             )
@@ -891,8 +922,8 @@ class SharesFrame(buildFrame):
             directory = self.bshareslist.get_value(iter, 3)
             oldmapping = (oldvirtual, directory)
 
-            virtual = input_box(
-                self.frame,
+            virtual = ComboBoxDialog(
+                parent=self.p.SettingsWindow,
                 title=_("Virtual name"),
                 message=_("Enter new virtual name for '%(dir)s':") % {'dir': directory}
             )
@@ -1265,7 +1296,7 @@ class IgnoreFrame(buildFrame):
 
     def OnAddIgnored(self, widget):
 
-        user = InputDialog(
+        user = EntryDialog(
             self.Main.get_toplevel(),
             _("Ignore user..."),
             _("User:")
@@ -1289,7 +1320,7 @@ class IgnoreFrame(buildFrame):
 
     def OnAddIgnoredIP(self, widget):
 
-        ip = InputDialog(
+        ip = EntryDialog(
             self.Main.get_toplevel(),
             _("Ignore IP Address..."),
             _("IP:") + " " + _("* is a wildcard")
@@ -1401,7 +1432,7 @@ class BanFrame(buildFrame):
 
     def OnAddBanned(self, widget):
 
-        user = InputDialog(
+        user = EntryDialog(
             self.Main.get_toplevel(),
             _("Ban user..."),
             _("User:")
@@ -1431,7 +1462,7 @@ class BanFrame(buildFrame):
 
     def OnAddBlocked(self, widget):
 
-        ip = InputDialog(
+        ip = EntryDialog(
             self.Main.get_toplevel(),
             _("Block IP Address..."),
             _("IP:") + " " + _("* is a wildcard")
@@ -2939,7 +2970,6 @@ class buildDialog(gtk.Dialog):
 
         builder.connect_signals(self)
 
-        self.PluginProperties.set_icon(self.settings.frame.images["n"])
         self.PluginProperties.set_transient_for(self.settings.SettingsWindow)
         self.tw = {}
         self.options = {}

--- a/pynicotine/gtkgui/tray.py
+++ b/pynicotine/gtkgui/tray.py
@@ -22,7 +22,7 @@ import os
 from gettext import gettext as _
 
 from pynicotine import slskmessages
-from pynicotine.gtkgui.entrydialog import input_box
+from pynicotine.gtkgui.dialogs import ComboBoxDialog
 from pynicotine.gtkgui.utils import PopupMenu
 from pynicotine.logfacility import log
 from pynicotine.utils import installPrefix
@@ -81,9 +81,9 @@ class TrayApp:
             users.append(entry[0])
 
         users.sort()
-        user = input_box(
-            self.frame,
-            title=_('Nicotine+:') + " " + _("Start Message"),
+        user = ComboBoxDialog(
+            parent=self.frame.MainWindow,
+            title=_('Nicotine+') + ": " + _("Start Messaging"),
             message=_('Enter the User who you wish to send a private message:'),
             droplist=users
         )
@@ -100,9 +100,9 @@ class TrayApp:
             users.append(entry[0])
 
         users.sort()
-        user = input_box(
-            self.frame,
-            title=_('Nicotine+: Get User Info'),
+        user = ComboBoxDialog(
+            parent=self.frame.MainWindow,
+            title=_('Nicotine+') + ": " + _("Get User Info"),
             message=_('Enter the User whose User Info you wish to receive:'),
             droplist=users
         )
@@ -117,9 +117,9 @@ class TrayApp:
         for entry in self.frame.np.config.sections["server"]["userlist"]:
             users.append(entry[0])
         users.sort()
-        user = input_box(
-            self.frame,
-            title=_("Nicotine+: Get A User's IP"),
+        user = ComboBoxDialog(
+            parent=self.frame.MainWindow,
+            title=_('Nicotine+') + ": " + _("Get A User's IP"),
             message=_('Enter the User whose IP Address you wish to receive:'),
             droplist=users
         )
@@ -133,9 +133,9 @@ class TrayApp:
         for entry in self.frame.np.config.sections["server"]["userlist"]:
             users.append(entry[0])
         users.sort()
-        user = input_box(
-            self.frame,
-            title=_("Nicotine+: Get A User's Shares List"),
+        user = ComboBoxDialog(
+            parent=self.frame.MainWindow,
+            title=_('Nicotine+') + ": " + _("Get A User's Shares List"),
             message=_('Enter the User whose Shares List you wish to receive:'),
             droplist=users
         )

--- a/pynicotine/gtkgui/ui/nowplaying.ui
+++ b/pynicotine/gtkgui/ui/nowplaying.ui
@@ -5,7 +5,7 @@
     <property name="border_width">10</property>
     <property name="width_request">800</property>
     <property name="can_focus">False</property>
-    <property name="title" translatable="yes">Nicotine+: Configure Now Playing</property>
+    <property name="title" translatable="yes">Configure Now Playing</property>
     <property name="resizable">False</property>
     <property name="modal">True</property>
     <property name="window_position">center-on-parent</property>

--- a/pynicotine/gtkgui/ui/wishlist.ui
+++ b/pynicotine/gtkgui/ui/wishlist.ui
@@ -1,0 +1,168 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<interface>
+  <requires lib="gtk+" version="3.18"/>
+  <object class="GtkDialog" id="WishList">
+    <property name="can_focus">False</property>
+    <property name="title" translatable="yes">Search Wishlist</property>
+    <property name="resizable">False</property>
+    <property name="modal">True</property>
+    <property name="window_position">center-on-parent</property>
+    <property name="default_width">600</property>
+    <property name="default_height">600</property>
+    <child internal-child="vbox">
+      <object class="GtkBox">
+        <property name="visible">True</property>
+        <property name="can_focus">False</property>
+        <property name="orientation">vertical</property>
+        <child>
+          <object class="GtkScrolledWindow">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <child>
+              <object class="GtkTreeView" id="WishlistView">
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+              </object>
+            </child>
+          </object>
+          <packing>
+            <property name="expand">True</property>
+            <property name="fill">True</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkBox">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <property name="border_width">5</property>
+            <property name="spacing">5</property>
+            <child>
+              <object class="GtkEntry" id="AddWishEntry">
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <signal name="activate" handler="OnAddWish" swapped="no"/>
+              </object>
+              <packing>
+                <property name="expand">True</property>
+                <property name="fill">True</property>
+                <property name="position">0</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkButton">
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <property name="receives_default">False</property>
+                <property name="margin_end">30</property>
+                <signal name="clicked" handler="OnAddWish" swapped="no"/>
+                <child>
+                  <object class="GtkBox">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="spacing">5</property>
+                    <child>
+                      <object class="GtkImage">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="icon_name">list-add-symbolic</property>
+                      </object>
+                    </child>
+                    <child>
+                      <object class="GtkLabel">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="label" translatable="yes">Add...</property>
+                        <property name="use_underline">True</property>
+                      </object>
+                    </child>
+                  </object>
+                </child>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">False</property>
+                <property name="position">1</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkButton">
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <property name="receives_default">False</property>
+                <signal name="clicked" handler="OnRemoveWish" swapped="no"/>
+                <child>
+                  <object class="GtkBox">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="spacing">5</property>
+                    <child>
+                      <object class="GtkImage">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="icon_name">edit-clear-symbolic</property>
+                      </object>
+                    </child>
+                    <child>
+                      <object class="GtkLabel">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="label" translatable="yes">Remove</property>
+                        <property name="use_underline">True</property>
+                      </object>
+                    </child>
+                  </object>
+                </child>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">False</property>
+                <property name="position">2</property>
+                <property name="pack_type">end</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkButton">
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <property name="receives_default">False</property>
+                <signal name="clicked" handler="OnSelectAllWishes" swapped="no"/>
+                <child>
+                  <object class="GtkBox">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="spacing">5</property>
+                    <child>
+                      <object class="GtkImage">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="icon_name">object-select-symbolic</property>
+                      </object>
+                    </child>
+                    <child>
+                      <object class="GtkLabel">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="label" translatable="yes">Select All</property>
+                        <property name="use_underline">True</property>
+                      </object>
+                    </child>
+                  </object>
+                </child>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">False</property>
+                <property name="position">3</property>
+                <property name="pack_type">end</property>
+              </packing>
+            </child>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+          </packing>
+        </child>
+      </object>
+    </child>
+  </object>
+</interface>

--- a/pynicotine/gtkgui/uploads.py
+++ b/pynicotine/gtkgui/uploads.py
@@ -30,7 +30,7 @@ from gi.repository import Gtk as gtk
 
 from _thread import start_new_thread
 from pynicotine import slskmessages
-from pynicotine.gtkgui.entrydialog import OptionDialog
+from pynicotine.gtkgui.dialogs import OptionDialog
 from pynicotine.gtkgui.transferlist import TransferList
 from pynicotine.gtkgui.utils import CollapseTreeview
 from pynicotine.gtkgui.utils import FillFileGroupingCombobox
@@ -97,10 +97,9 @@ class Uploads(TransferList):
 
         direction = "up"
 
-        win = OptionDialog(self.frame, _("Clear All Queued Uploads?"), modal=True, status=None, option=False, third="")
+        win = OptionDialog(self.frame, _("Clear All Queued Uploads?"), modal=True, option=False, third="")
         win.connect("response", self.frame.on_clear_response, direction)
         win.set_title(_("Nicotine+") + ": " + _("Clear Queued Transfers"))
-        win.set_icon(self.frame.images["n"])
 
         win.show()
 

--- a/pynicotine/gtkgui/userbrowse.py
+++ b/pynicotine/gtkgui/userbrowse.py
@@ -31,7 +31,7 @@ from gi.repository import Gtk as gtk
 from _thread import start_new_thread
 from pynicotine import slskmessages
 from pynicotine.gtkgui.dirchooser import ChooseDir
-from pynicotine.gtkgui.entrydialog import input_box
+from pynicotine.gtkgui.dialogs import ComboBoxDialog
 from pynicotine.gtkgui.utils import HumanSize
 from pynicotine.gtkgui.utils import InitialiseColumns
 from pynicotine.gtkgui.utils import PopupMenu
@@ -765,9 +765,9 @@ class UserBrowse:
             users.append(entry[0])
 
         users.sort()
-        user = input_box(
-            self.frame,
-            title=_("Nicotine+: Upload Directory's Contents"),
+        user = ComboBoxDialog(
+            parent=self.frame.MainWindow,
+            title=_("Upload Directory's Contents"),
             message=_('Enter the User you wish to upload to:'),
             droplist=users
         )
@@ -821,9 +821,9 @@ class UserBrowse:
             users.append(entry[0])
 
         users.sort()
-        user = input_box(
-            self.frame,
-            title=_('Nicotine+: Upload File(s)'),
+        user = ComboBoxDialog(
+            parent=self.frame.MainWindow,
+            title=_('Upload File(s)'),
             message=_('Enter the User you wish to upload to:'),
             droplist=users
         )

--- a/pynicotine/gtkgui/userlist.py
+++ b/pynicotine/gtkgui/userlist.py
@@ -31,10 +31,10 @@ from gi.repository import GObject as gobject
 from gi.repository import Gtk as gtk
 
 from pynicotine import slskmessages
+from pynicotine.gtkgui.dialogs import EntryDialog
 from pynicotine.gtkgui.utils import Humanize
 from pynicotine.gtkgui.utils import HumanSpeed
 from pynicotine.gtkgui.utils import InitialiseColumns
-from pynicotine.gtkgui.utils import InputDialog
 from pynicotine.gtkgui.utils import PopupMenu
 from pynicotine.gtkgui.utils import PressHeader
 from pynicotine.gtkgui.utils import showCountryTooltip
@@ -464,7 +464,7 @@ class UserList:
         else:
             comments = ""
 
-        comments = InputDialog(self.frame.MainWindow, _("Edit comments") + "...", _("Comments") + ":", comments)
+        comments = EntryDialog(self.frame.MainWindow, _("Edit comments") + "...", _("Comments") + ":", comments)
 
         if comments is not None:
             for i in self.userlist:

--- a/pynicotine/gtkgui/utils.py
+++ b/pynicotine/gtkgui/utils.py
@@ -523,7 +523,7 @@ class ImageLabel(gtk.Box):
         self.Box = gtk.Box()
 
         if self.angle in (90, -90):
-            self.Box.set_orientation(vertical)
+            self.Box.set_orientation(gtk.Orientation.VERTICAL)
         else:
             self.angle = 0
 

--- a/pynicotine/pynicotine.py
+++ b/pynicotine/pynicotine.py
@@ -1592,7 +1592,7 @@ class NetworkEventProcessor:
                     if os.path.commonprefix([i, j]) == j:
                         files = msg.list[i][j]
                         numfiles = len(files)
-                        if numfiles > 0:
+                        if numfiles > 100:
                             many = True
                             folder = j
 

--- a/pynicotine/pynicotine.py
+++ b/pynicotine/pynicotine.py
@@ -1592,7 +1592,7 @@ class NetworkEventProcessor:
                     if os.path.commonprefix([i, j]) == j:
                         files = msg.list[i][j]
                         numfiles = len(files)
-                        if numfiles > 100:
+                        if numfiles > 0:
                             many = True
                             folder = j
 


### PR DESCRIPTION
Painstaking work, but almost every small dialog should now use the GtkMessageDialog GTK 3 style. The only two dialogs that still contain deprecated elements are the find and metadata ones. Still not entirely sure what to do with find, and the metadata dialog should preferably be ported to a ui file.