### PR TITLE
Further file scanning optimizations

### DIFF
--- a/pynicotine/config.py
+++ b/pynicotine/config.py
@@ -990,8 +990,16 @@ class Config:
                 self.sections["transfers"][destination].close()
                 self.sections["transfers"][destination] = shelve.open(os.path.join(self.data_dir, filename), flag='n', protocol=pickle.HIGHEST_PROTOCOL)
 
-                for key in source:
-                    self.sections["transfers"][destination][key] = source[key]
+                if "fileindex" in destination:
+                    index = 0
+
+                    for value in source:
+                        # The file index db is a list
+                        self.sections["transfers"][destination][str(index)] = value
+                        index += 1
+                else:
+                    for key in source:
+                        self.sections["transfers"][destination][key] = source[key]
             except Exception as e:
                 log.addwarning(_("Can't save %s: %s") % (filename, e))
                 return

--- a/pynicotine/gtkgui/frame.py
+++ b/pynicotine/gtkgui/frame.py
@@ -2024,6 +2024,7 @@ class NicotineFrame:
         self.logMessage(_("Rescanning Buddy Shares finished"))
 
         self.BuddySharesProgress.hide()
+
         self.np.shares.CompressShares("buddy")
 
     def _RescanFinished(self, files, streams, wordindex, fileindex, mtimes):
@@ -2039,6 +2040,7 @@ class NicotineFrame:
         self.logMessage(_("Rescanning finished"))
 
         self.SharesProgress.hide()
+
         self.np.shares.CompressShares("normal")
 
         if self.np.transfers is not None:

--- a/pynicotine/gtkgui/frame.py
+++ b/pynicotine/gtkgui/frame.py
@@ -2011,7 +2011,6 @@ class NicotineFrame:
     def _BuddyRescanFinished(self, files, streams, wordindex, fileindex, mtimes):
 
         self.np.config.setBuddyShares(files, streams, wordindex, fileindex, mtimes)
-        self.np.config.writeShares()
 
         if self.np.config.sections["transfers"]["enablebuddyshares"]:
             self.rescan_buddy.set_sensitive(True)
@@ -2030,7 +2029,6 @@ class NicotineFrame:
     def _RescanFinished(self, files, streams, wordindex, fileindex, mtimes):
 
         self.np.config.setShares(files, streams, wordindex, fileindex, mtimes)
-        self.np.config.writeShares()
 
         if self.np.config.sections["transfers"]["shared"]:
             self.rescan_public.set_sensitive(True)

--- a/pynicotine/gtkgui/frame.py
+++ b/pynicotine/gtkgui/frame.py
@@ -2035,14 +2035,14 @@ class NicotineFrame:
             self.rescan_public.set_sensitive(True)
             self.browse_public_shares.set_sensitive(True)
 
-        if self.np.transfers is not None:
-            self.np.shares.sendNumSharedFoldersFiles()
-
         self.rescanning = 0
         self.logMessage(_("Rescanning finished"))
 
         self.SharesProgress.hide()
         self.np.shares.CompressShares("normal")
+
+        if self.np.transfers is not None:
+            self.np.shares.sendNumSharedFoldersFiles()
 
     def RescanFinished(self, files, streams, wordindex, fileindex, mtimes, type):
         if type == "buddy":


### PR DESCRIPTION
- Send number of files and folders a bit later, to ensure that the shares db is open. Should fix https://github.com/Nicotine-Plus/nicotine-plus/issues/454
- Remove pointless creation of list
- No need to sync shelves, as we're not in writeback mode
- Compress file share response in a new thread, to get consistent startup times no matter how large your file share is
- Remove unneeded code
- A whole lot of changes according to profiling results