### PR TITLE
Clarify that Mutagen has been replaced

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -20,6 +20,7 @@ Changes
  * The Windows installer now removes old Nicotine+ system files before updating installations
  * Added quick-access checkbox for enabling/disabling private room invitations
  * Removed support for detachable tabs due to low usage and bugs
+ * Replaced Mutagen with pytaglib for audio file metadata scanning due to performance issues
 
 Issues closed on GitHub
 


### PR DESCRIPTION
So we hopefully don't have packages still including Mutagen as a dependency after 2.1.0 is released.