### PR TITLE
Use different icon for room wall button

### DIFF
--- a/pynicotine/gtkgui/ui/chatrooms.ui
+++ b/pynicotine/gtkgui/ui/chatrooms.ui
@@ -153,7 +153,7 @@
                             <child>
                               <object class="GtkImage" id="list">
                                 <property name="can_focus">False</property>
-                                <property name="icon_name">format-unordered-list-symbolic</property>
+                                <property name="icon_name">view-list-symbolic</property>
                               </object>
                             </child>
                           </object>


### PR DESCRIPTION
Use an icon that's more widely recognized on systems.