### PR TITLE
Downgrade PyInstaller to 3.6 for now

### DIFF
--- a/files/windows/dependencies.sh
+++ b/files/windows/dependencies.sh
@@ -18,7 +18,7 @@ pacman --noconfirm -S --needed \
 
 # pip should not pick up our setup.cfg
 cd ..
-pip install plyer pyinstaller
+pip install plyer pyinstaller==3.6
 
 # pytaglib
 wget https://github.com/supermihi/pytaglib/archive/v1.4.6.tar.gz


### PR DESCRIPTION
Temporarily fixes Windows packaging.