### PR TITLE
Update list of active developers

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -3,11 +3,6 @@ This is a somewhat up-to-date list of current Nicotine+ maintainers. For inquiri
 
 ### Active
 
-Mutnick
-- Created Nicotine+ GitHub Organization
-- Developer
-- [muhing(at)yahoo(dot)com]
-
 eLvErDe
 - Provides Nicotine+ Website
 - Migrated source code from SVN to Github
@@ -16,6 +11,7 @@ eLvErDe
 
 Kip Warner
 - Developer
+- Debianization
 - [kip(at)thevertigo(dot)com]
 
 Lene Preuss
@@ -68,6 +64,11 @@ osiris
 Michael Labouebe (aka gfarmerfr)
 - Developer
 - [gfarmerfr(at)free(dot)fr]
+
+Mutnick
+- Created Nicotine+ GitHub Organization
+- Developer
+- [muhing(at)yahoo(dot)com]
 
 ---
 

--- a/pynicotine/gtkgui/ui/about/about.ui
+++ b/pynicotine/gtkgui/ui/about/about.ui
@@ -19,11 +19,6 @@ https://www.ip2location.com</property>
 
 ### Active
 
-Mutnick
-- Created Nicotine+ GitHub Organization
-- Developer
-- [mutnick(at)techie(dot)com]
-
 eLvErDe
 - Provides Nicotine+ Website
 - Migrated source code from SVN to Github
@@ -88,6 +83,11 @@ osiris
 Michael Labouebe (aka gfarmerfr)
 - Developer
 - [gfarmerfr(at)free(dot)fr
+
+Mutnick
+- Created Nicotine+ GitHub Organization
+- Developer
+- [mutnick(at)techie(dot)com]
 
 # Nicotine MAINTAINERS
 


### PR DESCRIPTION
@Mutnick If you're still around, and ever feel like contributing to Nicotine+ again, feel free to add yourself back to the list of active devs.