### PR TITLE
Use PyInstaller 3.6 on macOS for now

### DIFF
--- a/files/macos/dependencies.sh
+++ b/files/macos/dependencies.sh
@@ -14,5 +14,5 @@ brew install \
 
 # pip should not pick up our setup.cfg
 cd pynicotine
-pip3 install flake8 pyinstaller pytaglib pytest
+pip3 install flake8 pyinstaller==3.6 pytaglib pytest
 cd ..


### PR DESCRIPTION
PyInstaller 4.0 is adding around 1GB of unnecessary files to the MacOS builds... 