### PR TITLE
Only allow one instance of Nicotine+ to be open at a time

### DIFF
--- a/nicotine
+++ b/nicotine
@@ -238,7 +238,7 @@ def run():
 
             profiler.dump_stats(dumpfile)
         else:
-            app.MainLoop()
+            app.run(None)
     else:
         print(result)
 

--- a/pynicotine/gtkgui/frame.py
+++ b/pynicotine/gtkgui/frame.py
@@ -33,6 +33,7 @@ from urllib.parse import urlencode
 import gi
 from gi.repository import Gdk
 from gi.repository import GdkPixbuf
+from gi.repository import Gio
 from gi.repository import GLib
 from gi.repository import GObject as gobject
 from gi.repository import Gtk as gtk
@@ -81,7 +82,7 @@ from pynicotine.utils import version
 
 class NicotineFrame:
 
-    def __init__(self, data_dir, config, plugins, use_trayicon, start_hidden=False, bindip=None, port=None):
+    def __init__(self, data_dir, config, plugins, use_trayicon, bindip=None, port=None):
 
         self.clip_data = ""
         self.data_dir = data_dir
@@ -190,15 +191,10 @@ class NicotineFrame:
         if maximized == "True":
             self.MainWindow.maximize()
 
-        self.MainWindow.show()
-
         # Initialize these windows/dialogs later when necessary
         self.fastconfigure = None
         self.now = None
         self.settingswindow = None
-
-        if start_hidden:
-            self.MainWindow.hide()
 
         self.minimized = False
         self.HiddenTabs = {}
@@ -927,8 +923,6 @@ class NicotineFrame:
 
             self.MainWindow.destroy()
 
-            gtk.main_quit()
-
         elif response == gtk.ResponseType.CANCEL:
             pass
 
@@ -1391,9 +1385,6 @@ class NicotineFrame:
             "bfileindex", "bsharedmtimes"
         ]:
             self.np.config.sections["transfers"][db].close()
-
-        # Exiting GTK
-        gtk.main_quit()
 
     def OnConnect(self, widget):
 
@@ -3145,10 +3136,37 @@ class NicotineFrame:
         self.ChangeMainPage(widget, "userlist")
 
 
-class MainApp:
-
+class MainApp(gtk.Application):
     def __init__(self, data_dir, config, plugins, trayicon, start_hidden, bindip, port):
-        self.frame = NicotineFrame(data_dir, config, plugins, trayicon, start_hidden, bindip, port)
+        gtk.Application.__init__(self, application_id="org.nicotine_plus.Nicotine",
+                                 flags=Gio.ApplicationFlags.FLAGS_NONE)
 
-    def MainLoop(self):
-        gtk.main()
+        self.connect(
+            "activate",
+            self.OnActivate,
+            data_dir,
+            config,
+            plugins,
+            trayicon,
+            start_hidden,
+            bindip,
+            port
+        )
+
+    def OnActivate(self, data, data_dir, config, plugins, trayicon, start_hidden, bindip, port):
+        if not self.get_windows():
+            # Only allow one instance of the main window
+
+            self.frame = NicotineFrame(
+                data_dir,
+                config,
+                plugins,
+                trayicon,
+                bindip,
+                port
+            )
+
+            self.add_window(self.frame.MainWindow)
+
+        if not start_hidden:
+            self.frame.MainWindow.show()


### PR DESCRIPTION
We can't handle multiple instances of Nicotine+. Ensure users don't open multiple windows by mistake.