### PR TITLE
Allow users to change the server in the settings

### DIFF
--- a/pynicotine/gtkgui/ui/settings/server.ui
+++ b/pynicotine/gtkgui/ui/settings/server.ui
@@ -68,10 +68,9 @@
               </packing>
             </child>
             <child>
-              <object class="GtkLabel" id="Server">
+              <object class="GtkEntry" id="Server">
                 <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="xalign">0</property>
+                <property name="can_focus">True</property>
               </object>
               <packing>
                 <property name="left_attach">1</property>
@@ -95,9 +94,6 @@
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
                 <property name="max_length">28</property>
-                <property name="width_chars">29</property>
-                <property name="primary_icon_activatable">False</property>
-                <property name="secondary_icon_activatable">False</property>
               </object>
               <packing>
                 <property name="left_attach">1</property>
@@ -127,7 +123,6 @@
                     <property name="can_focus">True</property>
                     <property name="visibility">False</property>
                     <property name="invisible_char">•</property>
-                    <property name="width_chars">10</property>
                   </object>
                   <packing>
                     <property name="expand">True</property>
@@ -208,7 +203,6 @@
         </child>
         <child>
           <object class="GtkBox">
-            <property name="width_request">114</property>
             <property name="visible">True</property>
             <property name="can_focus">False</property>
             <property name="spacing">5</property>
@@ -226,7 +220,6 @@
             </child>
             <child>
               <object class="GtkLabel">
-                <property name="width_request">0</property>
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <property name="label" translatable="yes">to</property>

--- a/pynicotine/gtkgui/ui/settings/settingswindow.ui
+++ b/pynicotine/gtkgui/ui/settings/settingswindow.ui
@@ -7,7 +7,7 @@
     <property name="title" translatable="yes">Nicotine+ Settings</property>
     <property name="window_position">center</property>
     <property name="default_width">1200</property>
-    <property name="default_height">800</property>
+    <property name="default_height">750</property>
     <child internal-child="vbox">
       <object class="GtkBox" id="Main">
         <property name="visible">True</property>


### PR DESCRIPTION
In my opinion, reduced lock-in is a good idea for Nicotine+. If people want to change the port of the official server, or host their own Soulfind server, let them do so.