### PR TITLE
Make distributed searches more reliable

### DIFF
--- a/pynicotine/pynicotine.py
+++ b/pynicotine/pynicotine.py
@@ -1724,10 +1724,11 @@ class NetworkEventProcessor:
                     """ We previously attempted to connect to all potential parents. Since we now
                     have a parent, stop connecting to the others. """
 
-                    if i.conn is not None and i.conn != msg.conn.conn:
-                        self.queue.put(slskmessages.ConnClose(i.conn))
+                    if i.conn != msg.conn.conn:
+                        if i.conn is not None:
+                            self.queue.put(slskmessages.ConnClose(i.conn))
 
-                    self.peerconns.remove(i)
+                        self.peerconns.remove(i)
 
             self.queue.put(slskmessages.HaveNoParent(0))
             self.queue.put(slskmessages.SearchParent(msg.conn.addr[0]))


### PR DESCRIPTION
Previously, it could take a long time to find a working parent connection to send us search requests, since in the worst case scenario we connected to a potential parent, waited for a response or timeout, and then proceeded to the next parent in the list. I noticed that SoulseekQt connects to all 10 potential parents at once, and adapted the same behavior in Nicotine+. As a result, distributed searches should be up and running within a minute of starting Nicotine+.