### PR TITLE
Rename NetInfo message

### DIFF
--- a/doc/SLSKPROTOCOL.md
+++ b/doc/SLSKPROTOCOL.md
@@ -1,6 +1,6 @@
 # Soulseek Protocol Documentation
 
-Last updated on 27 June 2020
+Last updated on 12 August 2020
 
 ## Sections
 
@@ -116,7 +116,7 @@ and callbacks for the messages are set in pynicotine.py.
 | 92   | [Check Privileges](#server-code-92)               |
 | 93   | [Search Request](#server-code-93)                 |
 | 100  | [Accept Children](#server-code-100)               |
-| 102  | [Net Info](#server-code-102)                      |
+| 102  | [Possible Parents](#server-code-102)              |
 | 103  | [Wishlist Search](#server-code-103)               |
 | 104  | [Wishlist Interval](#server-code-104)             |
 | 110  | [Get Similar Users](#server-code-110)             |
@@ -299,7 +299,7 @@ Used to be kept updated about a user's stats. When a user's stats have changed, 
 
 ### Server Code 6
 
-**Add User**
+**Remove User**
 
 #### Function Names
 
@@ -1156,7 +1156,7 @@ Nicotine: HaveNoParent
 
 #### Description
 
-We inform the server if we have a distributed parent or not. If not, the server eventually sends us a NetInfo message with a list of 10 possible parents to connect to.
+We inform the server if we have a distributed parent or not. If not, the server eventually sends us a PossibleParents message with a list of 10 possible parents to connect to.
 
 #### Data Order
 
@@ -1397,16 +1397,16 @@ Nicotine: AcceptChildren (not yet used)
 
 ### Server Code 102
 
-**Net Info**
+**Possible Parents**
 
 #### Description
 
-The server send us information about what nodes have been added/removed in the network. The list contains 10 possible distributed parents to connect to.
+The server send us a list of 10 possible distributed parents to connect to. Messages of this type are sent to us at regular intervals, until we tell the server we don't need more possible parents with a HaveNoParent message.
 
 #### Function Names
 
 Museekd: SNetInfo  
-Nicotine: NetInfo
+Nicotine: PossibleParents
 
 #### Data Order
 

--- a/pynicotine/pynicotine.py
+++ b/pynicotine/pynicotine.py
@@ -257,7 +257,7 @@ class NetworkEventProcessor:
             slskmessages.FileSearch: self.SearchRequest,
             slskmessages.RoomSearch: self.RoomSearchRequest,
             slskmessages.UserSearch: self.SearchRequest,
-            slskmessages.NetInfo: self.NetInfo,
+            slskmessages.PossibleParents: self.PossibleParents,
             slskmessages.DistribAlive: self.DummyMessage,
             slskmessages.DistribSearch: self.DistribSearch,
             slskmessages.DistribServerSearch: self.DistribSearch,
@@ -1689,7 +1689,7 @@ class NetworkEventProcessor:
             self.shares.processSearchRequest(msg.searchterm, msg.user, msg.searchid, 0)
         self.frame.pluginhandler.DistribSearchNotification(msg.searchterm, msg.user, msg.searchid)
 
-    def NetInfo(self, msg):
+    def PossibleParents(self, msg):
 
         self.distribcache.update(msg.list)
 

--- a/pynicotine/slskmessages.py
+++ b/pynicotine/slskmessages.py
@@ -1003,7 +1003,7 @@ class PrivilegedUsers(ServerMessage):
 class HaveNoParent(ServerMessage):
     """ Server code: 71 """
     """ We inform the server if we have a distributed parent or not.
-    If not, the server eventually sends us a NetInfo message with a
+    If not, the server eventually sends us a PossibleParents message with a
     list of 10 possible parents to connect to. """
     def __init__(self, noparent=None):
         self.noparent = noparent
@@ -1107,11 +1107,11 @@ class AcceptChildren(ServerMessage):
         return bytes([self.enabled])
 
 
-class NetInfo(ServerMessage):
+class PossibleParents(ServerMessage):
     """ Server code: 102 """
-    """ The server send us information about what nodes have been
-    added/removed in the network. The list contains 10 possible
-    distributed parents to connect to. """
+    """ The server send us a list of 10 possible distributed parents to connect to.
+    This message is sent to us at regular intervals until we tell the server we don't
+    need more possible parents, through a HaveNoParent message. """
     def parseNetworkMessage(self, message: bytes):
         self.list = {}
         pos, num = self.getObject(message, int)

--- a/pynicotine/slskproto.py
+++ b/pynicotine/slskproto.py
@@ -87,7 +87,7 @@ from pynicotine.slskmessages import Login
 from pynicotine.slskmessages import MessageAcked
 from pynicotine.slskmessages import MessageUser
 from pynicotine.slskmessages import MinParentsInCache
-from pynicotine.slskmessages import NetInfo
+from pynicotine.slskmessages import PossibleParents
 from pynicotine.slskmessages import NotifyPrivileges
 from pynicotine.slskmessages import OutConn
 from pynicotine.slskmessages import ParentInactivityTimeout
@@ -313,7 +313,7 @@ class SlskProtoThread(threading.Thread):
         CheckPrivileges: 92,
         SearchRequest: 93,
         AcceptChildren: 100,
-        NetInfo: 102,
+        PossibleParents: 102,
         WishlistSearch: 103,
         WishlistInterval: 104,
         SimilarUsers: 110,


### PR DESCRIPTION
The "NetInfo" name is misleading. The only purpose of this server message is to send us a list of parents to connect to.