### PR TITLE
Remove variable bitrate information

### DIFF
--- a/pynicotine/shares.py
+++ b/pynicotine/shares.py
@@ -542,11 +542,8 @@ class Shares:
                 except IOError:
                     pass
 
-            if audio is not None:
-                # TODO: Variable bitrate is always set to false now, perhaps detect it somehow
-                vbr = False
-                bitrateinfo = (int(audio.bitrate), int(vbr))
-                fileinfo = (name, size, bitrateinfo, int(audio.length))
+            if audio is not None and audio.length > 0:
+                fileinfo = (name, size, int(audio.bitrate), int(audio.length))
             else:
                 fileinfo = (name, size, None, None)
 
@@ -636,22 +633,19 @@ class Shares:
         if fileinfo[2] is not None:
             try:
                 msgbytes = bytearray()
-                msgbytes.extend(message.packObject('mp3') + message.packObject(3))
+                msgbytes.extend(message.packObject('mp3') + message.packObject(2))
                 msgbytes.extend(
                     message.packObject(0) +
-                    message.packObject(NetworkIntType(fileinfo[2][0])) +
+                    message.packObject(NetworkIntType(fileinfo[2])) +
                     message.packObject(1) +
-                    message.packObject(NetworkIntType(fileinfo[3])) +
-                    message.packObject(2) +
-                    message.packObject(NetworkIntType(fileinfo[2][1]))
+                    message.packObject(NetworkIntType(fileinfo[3]))
                 )
                 stream.extend(msgbytes)
             except Exception:
-                log.addwarning(_("Found meta data that couldn't be encoded, possible corrupt file: '%(file)s' has a bitrate of %(bitrate)s kbs, a length of %(length)s seconds and a VBR of %(vbr)s" % {
+                log.addwarning(_("Found meta data that couldn't be encoded, possible corrupt file: '%(file)s' has a bitrate of %(bitrate)s kbs and a length of %(length)s seconds" % {
                     'file': fileinfo[0],
-                    'bitrate': fileinfo[2][0],
-                    'length': fileinfo[3],
-                    'vbr': fileinfo[2][1]
+                    'bitrate': fileinfo[2],
+                    'length': fileinfo[3]
                 }))
                 stream.extend(message.packObject('') + message.packObject(0))
         else:

--- a/pynicotine/slskmessages.py
+++ b/pynicotine/slskmessages.py
@@ -1870,14 +1870,12 @@ class FileSearchResult(PeerMessage):
                 msg.extend(self.packObject('') + self.packObject(0))
             else:
                 # FileExtension, NumAttributes,
-                msg.extend(self.packObject("mp3") + self.packObject(3))
+                msg.extend(self.packObject("mp3") + self.packObject(2))
                 msg.extend(
                     self.packObject(0) +
-                    self.packObject(NetworkIntType(i[2][0])) +
+                    self.packObject(NetworkIntType(i[2])) +
                     self.packObject(1) +
-                    self.packObject(NetworkIntType(i[3])) +
-                    self.packObject(2) +
-                    self.packObject(i[2][1])
+                    self.packObject(NetworkIntType(i[3]))
                 )
         msg.extend(
             bytes([self.freeulslots]) +
@@ -2027,8 +2025,8 @@ class FolderContentsResponse(PeerMessage):
             if i[2] is None:
                 msg = msg + self.packObject('') + self.packObject(0)
             else:
-                msg = msg + self.packObject("mp3") + self.packObject(3)
-                msg = msg + self.packObject(0) + self.packObject(i[2][0]) + self.packObject(1) + self.packObject(i[3]) + self.packObject(2) + self.packObject(i[2][1])
+                msg = msg + self.packObject("mp3") + self.packObject(2)
+                msg = msg + self.packObject(0) + self.packObject(i[2]) + self.packObject(1) + self.packObject(i[3])
         return zlib.compress(msg)
 
 

--- a/pynicotine/utils.py
+++ b/pynicotine/utils.py
@@ -159,7 +159,7 @@ def GetResultBitrateLength(filesize, attributes):
         a = attributes
 
         # Sometimes the vbr indicator is in second position
-        if a[1] == 0 or a[1] == 1:
+        if a[0] > 0 and (a[1] == 0 or a[1] == 1):
 
             # If it's a vbr file we can't deduce the length
             if a[1] == 1:


### PR DESCRIPTION
Turns out SoulseekQt also switched to TagLib a few years ago, and dropped variable bitrate information for tracks, as TagLib doesn't provide it.