### PR TITLE
Check earlier if wordindex is closed before processing search request

### DIFF
--- a/pynicotine/shares.py
+++ b/pynicotine/shares.py
@@ -328,17 +328,17 @@ class Shares:
         terms = searchterm.lower().translate(self.translatepunctuation).split()
         length = 0
 
-        for i in terms:
-            if i in wordindex:
-                length += 1
-
-        if length == 0 or length != len(terms):
-            return
-
         try:
+            for i in terms:
+                if i in wordindex:
+                    length += 1
+
+            if length == 0 or length != len(terms):
+                return
+
             list = [wordindex[i] for i in terms if i in wordindex]
         except ValueError:
-            # Shelf is probably closed, perhaps when rescanning share
+            # DB is closed, perhaps when rescanning share or closing Nicotine+
             return
 
         shortest = min(list, key=len)


### PR DESCRIPTION
After the changes in https://github.com/Nicotine-Plus/nicotine-plus/pull/494, the check has to go higher up in the code. It can happen quite frequently when Nicotine+ is shutting down and we're receiving a search request.

Fixes https://github.com/Nicotine-Plus/nicotine-plus/issues/545#issuecomment-674294623