### PR TITLE
Fix issue where we don't get a new parent after previous disconnected

### DIFF
--- a/pynicotine/pynicotine.py
+++ b/pynicotine/pynicotine.py
@@ -1700,8 +1700,9 @@ class NetworkEventProcessor:
         We attempt to connect to them all at once, since connection errors are fairly common. """
 
         potential_parents = msg.list
+        print(msg.list)
 
-        if self.GetParentConn() is None and potential_parents:
+        if potential_parents:
 
             for user in potential_parents:
                 addr = potential_parents[user]
@@ -1713,6 +1714,7 @@ class NetworkEventProcessor:
     def GetParentConn(self):
         for i in self.peerconns:
             if i.init.type == 'D':
+                print(i)
                 return i
 
         return None
@@ -1742,6 +1744,10 @@ class NetworkEventProcessor:
 
             self.queue.put(slskmessages.HaveNoParent(0))
             self.queue.put(slskmessages.SearchParent(msg.conn.addr[0]))
+            print("parent found!")
+        else:
+            print("distribbranchlevel fail")
+            self.ParentConnClosed()
 
         self.logMessage("%s %s" % (msg.__class__, vars(msg)), 4)
 


### PR DESCRIPTION
By the time our old parent disconnects, the connection stored in parentconn has most likely become out of sync with the one in the peer conn list, which leads to Nicotine+ never asking the server for a new parent. Revert to the old way of getting our parent connection.