### PR TITLE
Minor UI improvements and corrections

### DIFF
--- a/pynicotine/gtkgui/chatrooms.py
+++ b/pynicotine/gtkgui/chatrooms.py
@@ -144,7 +144,6 @@ class RoomsControl:
         self.ChatNotebook.Notebook.connect("switch-page", self.OnSwitchPage)
         self.ChatNotebook.Notebook.connect("page-reordered", self.OnReorderedPage)
 
-        self.frame.SetTextBG(self.frame.roomlist.RoomsList)
         self.frame.SetTextBG(self.frame.roomlist.SearchRooms)
 
     def IsPrivateRoomOwned(self, room):
@@ -675,7 +674,6 @@ class RoomsControl:
 
     def UpdateColours(self):
 
-        self.frame.SetTextBG(self.frame.roomlist.RoomsList)
         self.frame.SetTextBG(self.frame.roomlist.SearchRooms)
 
         for room in list(self.joinedrooms.values()):
@@ -1705,13 +1703,8 @@ class ChatRoom:
         logbuffer = self.RoomLog.get_buffer()
         self.tag_log = self.makecolour(logbuffer, "chatremote")
 
-        self.frame.SetTextBG(self.ChatScroll)
-        self.frame.SetTextBG(self.RoomLog)
-        self.frame.SetTextBG(self.UserList)
-
         self.frame.SetTextBG(self.ChatEntry)
-        self.frame.SetTextBG(self.AutoJoin)
-        self.frame.SetTextBG(self.Log)
+        self.frame.SetTextBG(self.RoomWall.RoomWallEntry)
 
     def getUserStatusColor(self, status):
 
@@ -1770,12 +1763,8 @@ class ChatRoom:
         for user in self.tag_users:
             self.getUserTag(user)
 
-        self.frame.SetTextBG(self.ChatScroll)
-        self.frame.SetTextBG(self.RoomLog)
-        self.frame.SetTextBG(self.UserList)
         self.frame.SetTextBG(self.ChatEntry)
-        self.frame.SetTextBG(self.AutoJoin)
-        self.frame.SetTextBG(self.Log)
+        self.frame.SetTextBG(self.RoomWall.RoomWallEntry)
         self.frame.ChangeListFont(self.UserList, self.frame.np.config.sections["ui"]["listfont"])
 
     def OnLeave(self, widget=None):

--- a/pynicotine/gtkgui/frame.py
+++ b/pynicotine/gtkgui/frame.py
@@ -442,6 +442,7 @@ class NicotineFrame:
         self.tray_tooltip_template = _("Nicotine+ Transfers: %(speeddown).1f KB/s Down, %(speedup).1f KB/s Up")
 
         self.UpdateBandwidth()
+        self.ShowTransferButtons.set_active(self.np.config.sections["transfers"]["enabletransferbuttons"])
         self.UpdateTransferButtons()
 
         # Search Methods
@@ -1223,8 +1224,6 @@ class NicotineFrame:
         font = self.np.config.sections["ui"]["chatfont"]
         self.tag_log.set_property("font", font)
 
-        self.SetTextBG(self.LogWindow)
-        self.SetTextBG(self.userlist.UserList)
         # self.ChangeListFont( self.UserList, self.frame.np.config.sections["ui"]["listfont"])
         for listview in [
             self.userlist.UserList,
@@ -1237,15 +1236,12 @@ class NicotineFrame:
         ]:
             self.ChangeListFont(listview, self.np.config.sections["ui"]["listfont"])
 
-        self.SetTextBG(self.RecommendationsList)
-        self.SetTextBG(self.UnrecommendationsList)
-        self.SetTextBG(self.RecommendationUsersList)
-        self.SetTextBG(self.LikesList)
-        self.SetTextBG(self.DislikesList)
         self.SetTextBG(self.UserPrivateCombo.get_child())
         self.SetTextBG(self.UserInfoCombo.get_child())
         self.SetTextBG(self.UserBrowseCombo.get_child())
         self.SetTextBG(self.SearchEntry)
+        self.SetTextBG(self.AddLikeEntry)
+        self.SetTextBG(self.AddDislikeEntry)
 
     def SetTextBG(self, widget, bgcolor="", fgcolor=""):
         if bgcolor == "" and self.np.config.sections["ui"]["textbg"] == "":
@@ -2115,8 +2111,6 @@ class NicotineFrame:
         if self.np.transfers is not None:
             self.np.transfers.checkUploadQueue()
 
-        self.UpdateTransferButtons()
-
         if needrescan:
             self.needrescan = True
 
@@ -2395,6 +2389,14 @@ class NicotineFrame:
             self.np.config.sections["columns"]["chatrooms"][room][1] = int(show)
         self.userlist.cols[1].set_visible(show)
         self.np.config.sections["columns"]["userlist"][1] = int(show)
+        self.np.config.writeConfiguration()
+
+    def OnShowTransferButtons(self, widget):
+
+        show = widget.get_active()
+
+        self.np.config.sections["transfers"]["enabletransferbuttons"] = show
+        self.UpdateTransferButtons()
         self.np.config.writeConfiguration()
 
     def OnShowRoomList(self, widget):

--- a/pynicotine/gtkgui/privatechat.py
+++ b/pynicotine/gtkgui/privatechat.py
@@ -843,9 +843,7 @@ class PrivateChat:
             self.tag_username.set_property("underline", pango.Underline.NONE)
             self.tag_my_username.set_property("underline", pango.Underline.NONE)
 
-        self.frame.SetTextBG(self.ChatScroll)
         self.frame.SetTextBG(self.ChatLine)
-        self.frame.SetTextBG(self.Log)
         self.frame.SetTextBG(self.PeerPrivateMessages)
 
     def changecolour(self, tag, colour):
@@ -897,7 +895,6 @@ class PrivateChat:
         else:
             self.changecolour(self.tag_my_username, "useroffline")
 
-        self.frame.SetTextBG(self.ChatScroll)
         self.frame.SetTextBG(self.ChatLine)
 
     def getUserStatusColor(self, status):

--- a/pynicotine/gtkgui/search.py
+++ b/pynicotine/gtkgui/search.py
@@ -416,7 +416,7 @@ class Searches(IconNotebook):
                 continue
             id[2].ChangeColours()
 
-        self.frame.SetTextBG(self.WishListDialog.WishlistView)
+        self.frame.SetTextBG(self.WishListDialog.AddWishEntry)
 
     def saveColumns(self):
 
@@ -1108,14 +1108,11 @@ class Search:
 
     def ChangeColours(self):
 
-        self.frame.SetTextBG(self.ResultsList)
         self.frame.SetTextBG(self.FilterIn.get_child())
         self.frame.SetTextBG(self.FilterOut.get_child())
         self.frame.SetTextBG(self.FilterSize.get_child())
         self.frame.SetTextBG(self.FilterBitrate.get_child())
         self.frame.SetTextBG(self.FilterCountry.get_child())
-        self.frame.SetTextBG(self.RememberCheckButton)
-        self.frame.SetTextBG(self.FilterFreeSlot)
 
         font = self.frame.np.config.sections["ui"]["searchfont"]
 

--- a/pynicotine/gtkgui/settingswindow.py
+++ b/pynicotine/gtkgui/settingswindow.py
@@ -2092,9 +2092,6 @@ class FontsFrame(buildFrame):
                 "transfersfont": self.SelectTransfersFont,
                 "browserfont": self.SelectBrowserFont,
                 "decimalsep": self.DecimalSep
-            },
-            "transfers": {
-                "enabletransferbuttons": self.ShowTransferButtons
             }
         }
 
@@ -2131,15 +2128,8 @@ class FontsFrame(buildFrame):
                 "searchfont": self.SelectSearchFont.get_font(),
                 "transfersfont": self.SelectTransfersFont.get_font(),
                 "browserfont": self.SelectBrowserFont.get_font()
-            },
-            "transfers": {
-                "enabletransferbuttons": self.ShowTransferButtons.get_active()
             }
         }
-
-    def OnTranslationCheckToggled(self, widget):
-        sensitive = widget.get_active()
-        self.TranslationCombo.set_sensitive(sensitive)
 
     def OnDefaultFont(self, widget):
         self.SelectChatFont.set_font_name("")
@@ -3406,7 +3396,7 @@ class SettingsWindow:
 
     def ColourWidgets(self, widget):
 
-        if type(widget) in (gtk.Entry, gtk.SpinButton, gtk.TextView, gtk.TreeView, gtk.CheckButton, gtk.RadioButton):
+        if type(widget) in (gtk.Entry, gtk.SpinButton):
             self.SetTextBG(widget)
         if type(widget) is gtk.TreeView:
             self.frame.ChangeListFont(widget, self.frame.np.config.sections["ui"]["listfont"])

--- a/pynicotine/gtkgui/transferlist.py
+++ b/pynicotine/gtkgui/transferlist.py
@@ -128,7 +128,6 @@ class TransferList:
         self.frame.np.config.sections["columns"][self.type + "_widths"] = widths
 
     def UpdateColours(self):
-        self.frame.SetTextBG(self.widget)
         self.frame.ChangeListFont(self.widget, self.frame.np.config.sections["ui"]["transfersfont"])
 
     def CellDataFunc(self, column, cellrenderer, model, iter, dummy="dummy"):

--- a/pynicotine/gtkgui/ui/mainwindow.ui
+++ b/pynicotine/gtkgui/ui/mainwindow.ui
@@ -209,6 +209,16 @@
                       </object>
                     </child>
                     <child>
+                      <object class="GtkCheckMenuItem" id="ShowTransferButtons">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="label" translatable="yes">Show _buttons in transfer tabs</property>
+                        <property name="use_underline">True</property>
+                        <signal name="toggled" handler="OnShowTransferButtons" swapped="no"/>
+                        <accelerator key="b" signal="activate" modifiers="GDK_MOD1_MASK"/>
+                      </object>
+                    </child>
+                    <child>
                       <object class="GtkSeparatorMenuItem">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>

--- a/pynicotine/gtkgui/ui/settings/downloads.ui
+++ b/pynicotine/gtkgui/ui/settings/downloads.ui
@@ -523,7 +523,7 @@
                               <object class="GtkImage">
                                 <property name="visible">True</property>
                                 <property name="can_focus">False</property>
-                                <property name="icon_name">edit-symbolic</property>
+                                <property name="icon_name">document-edit-symbolic</property>
                               </object>
                               <packing>
                                 <property name="expand">False</property>

--- a/pynicotine/gtkgui/ui/settings/fonts.ui
+++ b/pynicotine/gtkgui/ui/settings/fonts.ui
@@ -10,20 +10,6 @@
         <property name="spacing">15</property>
         <property name="orientation">vertical</property>
         <child>
-          <object class="GtkCheckButton" id="ShowTransferButtons">
-            <property name="label" translatable="yes">Show Buttons in Transfers Tabs</property>
-            <property name="visible">True</property>
-            <property name="can_focus">True</property>
-            <property name="receives_default">False</property>
-            <property name="draw_indicator">True</property>
-          </object>
-          <packing>
-            <property name="expand">False</property>
-            <property name="fill">False</property>
-            <property name="position">1</property>
-          </packing>
-        </child>
-        <child>
           <object class="GtkGrid">
             <property name="visible">True</property>
             <property name="can_focus">False</property>
@@ -470,7 +456,7 @@
           <packing>
             <property name="expand">False</property>
             <property name="fill">True</property>
-            <property name="position">2</property>
+            <property name="position">0</property>
           </packing>
         </child>
       </object>

--- a/pynicotine/gtkgui/ui/settings/shares.ui
+++ b/pynicotine/gtkgui/ui/settings/shares.ui
@@ -35,7 +35,7 @@
           <packing>
             <property name="expand">False</property>
             <property name="fill">False</property>
-            <property name="position">0</property>
+            <property name="position">1</property>
           </packing>
         </child>
         <child>
@@ -156,7 +156,7 @@
                           <object class="GtkImage">
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
-                            <property name="icon_name">edit-symbolic</property>
+                            <property name="icon_name">document-edit-symbolic</property>
                           </object>
                         </child>
                         <child>
@@ -187,7 +187,7 @@
           <packing>
             <property name="expand">True</property>
             <property name="fill">True</property>
-            <property name="position">1</property>
+            <property name="position">2</property>
           </packing>
         </child>
         <child>
@@ -233,7 +233,7 @@
           <packing>
             <property name="expand">False</property>
             <property name="fill">True</property>
-            <property name="position">2</property>
+            <property name="position">3</property>
           </packing>
         </child>
         <child>
@@ -247,7 +247,7 @@
           <packing>
             <property name="expand">False</property>
             <property name="fill">False</property>
-            <property name="position">3</property>
+            <property name="position">4</property>
           </packing>
         </child>
         <child>
@@ -368,7 +368,7 @@
                           <object class="GtkImage">
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
-                            <property name="icon_name">edit-symbolic</property>
+                            <property name="icon_name">document-edit-symbolic</property>
                           </object>
                         </child>
                         <child>
@@ -399,7 +399,7 @@
           <packing>
             <property name="expand">True</property>
             <property name="fill">True</property>
-            <property name="position">4</property>
+            <property name="position">5</property>
           </packing>
         </child>
       </object>

--- a/pynicotine/gtkgui/userbrowse.py
+++ b/pynicotine/gtkgui/userbrowse.py
@@ -258,8 +258,6 @@ class UserBrowse:
         return True
 
     def ChangeColours(self):
-        self.frame.SetTextBG(self.FileTreeView)
-        self.frame.SetTextBG(self.FolderTreeView)
         self.frame.SetTextBG(self.SearchEntry)
 
         self.frame.ChangeListFont(self.FolderTreeView, self.frame.np.config.sections["ui"]["browserfont"])

--- a/pynicotine/gtkgui/userinfo.py
+++ b/pynicotine/gtkgui/userinfo.py
@@ -375,10 +375,6 @@ class UserInfo:
 
         self.changecolour(self.tag_local, "chatremote")
 
-        self.frame.SetTextBG(self.descr)
-        self.frame.SetTextBG(self.Likes)
-        self.frame.SetTextBG(self.Hates)
-
         self.frame.ChangeListFont(self.Likes, self.frame.np.config.sections["ui"]["listfont"])
         self.frame.ChangeListFont(self.Hates, self.frame.np.config.sections["ui"]["listfont"])
 


### PR DESCRIPTION
- Use icon name "document-edit-symbolic", which is more common, instead of "edit-symbolic"
- Remove option to set background color on lists for now, since it breaks item highlights and usability
- Move option to hide transfer buttons out of font settings