### PR TITLE
Minor fixes related to uploads

### DIFF
--- a/pynicotine/gtkgui/uploads.py
+++ b/pynicotine/gtkgui/uploads.py
@@ -181,7 +181,7 @@ class Uploads(TransferList):
                 continue
 
             self.frame.np.ProcessRequestToPeer(user, slskmessages.UploadQueueNotification(None))
-            self.frame.np.transfers.pushFile(user, filename, path, transfer)
+            self.frame.np.transfers.pushFile(user, filename, path, transfer=transfer)
 
         self.frame.np.transfers.checkUploadQueue()
 
@@ -297,6 +297,8 @@ class Uploads(TransferList):
             self.OnClearTransfer(None)
 
     def OnAbortTransfer(self, widget, remove=False, clear=False):
+
+        self.select_transfers()
 
         TransferList.OnAbortTransfer(self, widget, remove, clear)
         self.frame.np.transfers.calcUploadQueueSizes()

--- a/pynicotine/transfers.py
+++ b/pynicotine/transfers.py
@@ -475,7 +475,7 @@ class Transfers:
     def TransferRequestDownloads(self, msg, user, conn, addr):
 
         for i in self.downloads:
-            if i.filename == msg.file and user == i.user and i.status == "Queued":
+            if i.filename == msg.file and user == i.user:
                 # Remote peer is signalling a tranfer is ready, attempting to download it
 
                 """ If the file is larger than 2GB, the SoulseekQt client seems to
@@ -517,8 +517,7 @@ class Transfers:
                     self.queue.put(slskmessages.AddUser(user))
 
                 self.queue.put(slskmessages.GetUserStatus(user))
-                if user != self.eventprocessor.config.sections["server"]["login"]:
-                    response = slskmessages.TransferResponse(conn, 0, reason="Queued", req=transfer.req)
+                response = slskmessages.TransferResponse(conn, 0, reason="Queued", req=transfer.req)
                 self.downloadspanel.update(transfer)
             else:
                 response = slskmessages.TransferResponse(conn, 0, reason="Cancelled", req=msg.req)


### PR DESCRIPTION
Makes the retry and abort buttons on the uploads page functional again, and fixes a small issue with duplicate downloads I discovered when downloading my own files.