### PR TITLE
checklatest.py: check against tag name instead of release name

### DIFF
--- a/pynicotine/gtkgui/checklatest.py
+++ b/pynicotine/gtkgui/checklatest.py
@@ -63,7 +63,7 @@ def checklatest(frame):
         response = urllib.request.urlopen(latesturl)
         data = json.loads(response.read())
         response.close()
-        hlatest = data['name']
+        hlatest = data['tag_name']
         latest = makeversion(hlatest)
         date = data['created_at']
     except Exception as m:


### PR DESCRIPTION
Makes more sense to get the version from the tag instead of the release title.