### PR TITLE
Properly cancel uploads if we can't connect to user

### DIFF
--- a/pynicotine/pynicotine.py
+++ b/pynicotine/pynicotine.py
@@ -505,7 +505,7 @@ class NetworkEventProcessor:
         else:
             self.logMessage("%s %s %s" % (msg.err, msg.__class__, vars(msg)), 4)
 
-            self.ClosedConnection(msg.connobj.conn, msg.connobj.addr)
+            self.ClosedConnection(msg.connobj.conn, msg.connobj.addr, msg.err)
 
     def IncPort(self, msg):
         self.waitport = msg.port
@@ -559,7 +559,7 @@ class NetworkEventProcessor:
     def ConnClose(self, msg):
         self.ClosedConnection(msg.conn, msg.addr)
 
-    def ClosedConnection(self, conn, addr):
+    def ClosedConnection(self, conn, addr, error=None):
 
         if conn == self.serverconn:
 
@@ -599,7 +599,7 @@ class NetworkEventProcessor:
                         i.conntimer.cancel()
 
                     if self.transfers is not None:
-                        self.transfers.ConnClose(conn, addr)
+                        self.transfers.ConnClose(conn, addr, i.username, error)
 
                     if i == self.GetParentConn():
                         self.ParentConnClosed()

--- a/pynicotine/transfers.py
+++ b/pynicotine/transfers.py
@@ -1707,7 +1707,7 @@ class Transfers:
         else:
             return False
 
-    def ConnClose(self, conn, addr):
+    def ConnClose(self, conn, addr, user, error):
         """ The remote user has closed the connection either because
         he logged off, or because there's a network problem. """
 
@@ -1718,7 +1718,10 @@ class Transfers:
             self._ConnClose(conn, addr, i, "download")
 
         for i in self.uploads:
-            if i.conn != conn:
+            if type(error) is not ConnectionRefusedError and i.conn != conn:
+                continue
+            elif i.user != user:
+                # Connection refused, cancel all of user's transfers
                 continue
 
             self._ConnClose(conn, addr, i, "upload")


### PR DESCRIPTION
If we attempt to transfer a file to a user from our end, but the connection to the user doesn't go through for some reason (most likely firewall issues), the uploads are now cancelled instead of being stuck in a connecting state.

Closes https://github.com/Nicotine-Plus/nicotine-plus/issues/564