### PR TITLE
Regularly ask for queue position of downloads

### DIFF
--- a/pynicotine/gtkgui/downloads.py
+++ b/pynicotine/gtkgui/downloads.py
@@ -29,7 +29,6 @@ from gi.repository import Gdk
 from gi.repository import Gtk as gtk
 
 from _thread import start_new_thread
-from pynicotine import slskmessages
 from pynicotine.gtkgui.dialogs import MetaDialog
 from pynicotine.gtkgui.dialogs import OptionDialog
 from pynicotine.gtkgui.transferlist import TransferList
@@ -61,8 +60,6 @@ class Downloads(TransferList):
 
         self.popup_menu = popup = PopupMenu(frame)
         popup.setup(
-            ("#" + _("Get place in _queue"), self.OnGetPlaceInQueue),
-            ("", None),
             ("#" + _("Copy _URL"), self.OnCopyURL),
             ("#" + _("Copy folder URL"), self.OnCopyDirURL),
             ("#" + _("Send to _player"), self.OnPlayFiles),
@@ -359,15 +356,6 @@ class Downloads(TransferList):
             widget.stop_emission_by_name("button_press_event")
 
         return True
-
-    def OnGetPlaceInQueue(self, widget):
-
-        self.select_transfers()
-
-        for i in self.selected_transfers:
-            if i.status != "Queued":
-                continue
-            self.frame.np.ProcessRequestToPeer(i.user, slskmessages.PlaceInQueueRequest(None, i.filename))
 
     def OnRetryTransfer(self, widget):
 

--- a/pynicotine/transfers.py
+++ b/pynicotine/transfers.py
@@ -1465,7 +1465,8 @@ class Transfers:
     def startCheckDownloadQueueTimer(self):
         GLib.timeout_add(60000, self.checkDownloadQueue)
 
-    # Find failed or stuck downloads and attempt to queue them
+    # Find failed or stuck downloads and attempt to queue them.
+    # Also ask for the queue position of downloads.
     def checkDownloadQueue(self):
 
         statuslist = self.FAILED_TRANSFERS + \
@@ -1475,6 +1476,8 @@ class Transfers:
             if transfer.status in statuslist:
                 self.AbortTransfer(transfer)
                 self.getFile(transfer.user, transfer.filename, transfer.path, transfer)
+            elif transfer.status == "Queued":
+                self.eventprocessor.ProcessRequestToPeer(transfer.user, slskmessages.PlaceInQueueRequest(None, transfer.filename))
 
         self.startCheckDownloadQueueTimer()
 


### PR DESCRIPTION
The queue position is currently only updated when adding a download or manually requesting the position. Request the queue position regularly instead.