### PR TITLE
Revert "Close stale connections more frequently"

### DIFF
--- a/pynicotine/slskproto.py
+++ b/pynicotine/slskproto.py
@@ -386,8 +386,11 @@ class SlskProtoThread(threading.Thread):
         93: DistribServerSearch
     }
 
-    IN_PROGRESS_STALE_AFTER = 5
-    CONNECTION_MAX_IDLE = 5
+    IN_PROGRESS_STALE_AFTER = 30
+    # The value of 30 was pulled out of thin air. When we let the OS handle this:
+    # - Linux seems okay, stale in progress conns get killed after a minute or two
+    # - With Windows, based on #473, it would seem these connections are never removed
+    CONNECTION_MAX_IDLE = 60
     CONNCOUNT_UI_INTERVAL = 0.5
 
     def __init__(self, ui_callback, queue, bindip, port, config, eventprocessor):


### PR DESCRIPTION
Reverts Nicotine-Plus/nicotine-plus#543

This change is too dangerous. It caused uploads to cancel if the user limited their download speed.