### PR TITLE
Select "I can receive direct connections" by default

### DIFF
--- a/pynicotine/config.py
+++ b/pynicotine/config.py
@@ -100,7 +100,7 @@ class Config:
                 "server": ('server.slsknet.org', 2242),
                 "login": '',
                 "passw": '',
-                "firewalled": 1,
+                "firewalled": 0,
                 "ctcpmsgs": 0,
                 "autosearch": [],
                 "autoreply": "",


### PR DESCRIPTION
The ideal solution would be to get rid of this option completely in favor of automatically figuring out what the situation is some day.

Closes https://github.com/Nicotine-Plus/nicotine-plus/issues/564