### PR TITLE
Config: remove everything ticker-related

### DIFF
--- a/pynicotine/config.py
+++ b/pynicotine/config.py
@@ -371,12 +371,6 @@ class Config:
                 "dislikes": []
             },
 
-            "ticker": {
-                "default": "",
-                "rooms": {},
-                "hide": False
-            },
-
             "players": {
                 "default": "xdg-open $",
                 "npothercommand": "",
@@ -460,7 +454,7 @@ class Config:
                         continue
 
                     if self.sections[i][j] is None or self.sections[i][j] == '' \
-                       and i not in ("userinfo", "ui", "ticker", "players") \
+                       and i not in ("userinfo", "ui", "players") \
                        and j not in ("incompletedir", "autoreply", 'afterfinish', 'afterfolder', 'geoblockcc', 'downloadregexp'):
 
                         # Repair options set to None with defaults
@@ -587,6 +581,9 @@ class Config:
 
         # Seems to be superseded by ("server", "private_chatrooms")
         self.removeOldOption("private_rooms", "enabled")
+
+        # Remove everything ticker-related, no longer necessary after the introduction of room walls
+        self.removeOldSection("ticker")
 
         # Checking for unknown section/options
         unknown1 = [

--- a/pynicotine/gtkgui/roomwall.py
+++ b/pynicotine/gtkgui/roomwall.py
@@ -58,14 +58,6 @@ class RoomWall:
         config = self.frame.np.config.sections
         room_name = self.room.room
 
-        if not result:
-            if room_name in config["ticker"]["rooms"]:
-                del config["ticker"]["rooms"][room_name]
-        else:
-            config["ticker"]["rooms"][room_name] = result
-
-        self.frame.np.config.writeConfiguration()
-
         self.frame.np.queue.put(slskmessages.RoomTickerSet(room_name, result))
 
         self.RoomWallList.get_buffer().set_text("")

--- a/pynicotine/pynicotine.py
+++ b/pynicotine/pynicotine.py
@@ -753,13 +753,6 @@ class NetworkEventProcessor:
         if self.chatrooms is not None:
 
             self.chatrooms.roomsctrl.JoinRoom(msg)
-            ticker = ""
-
-            if msg.room in self.config.sections["ticker"]["rooms"]:
-                ticker = self.config.sections["ticker"]["rooms"][msg.room]
-
-            if ticker:
-                self.queue.put(slskmessages.RoomTickerSet(msg.room, ticker))
 
         self.logMessage("%s %s" % (msg.__class__, vars(msg)), 4)
 


### PR DESCRIPTION
We have no reason to remember our ticker messages anymore, since they are always per-room now and remembered by the server.