### PR TITLE
Optimize string translation access in a few cases

### DIFF
--- a/pynicotine/gtkgui/downloads.py
+++ b/pynicotine/gtkgui/downloads.py
@@ -202,7 +202,7 @@ class Downloads(TransferList):
         self.widget.get_selection().selected_foreach(self.SelectedResultsAllData, data)
 
         if data != {}:
-            self.MetaBox(title=_("Nicotine+:") + " " + _("Downloads Metadata"), message=_("<b>Metadata</b> for Downloads"), data=data, modal=True, Search=False)
+            self.MetaBox(title=_("Downloads Metadata"), message=_("<b>Metadata</b> for Downloads"), data=data, modal=True, Search=False)
 
     def OnOpenDirectory(self, widget):
 

--- a/pynicotine/gtkgui/fastconfigure.py
+++ b/pynicotine/gtkgui/fastconfigure.py
@@ -410,7 +410,7 @@ class FastConfigureAssistant(object):
 
             selected = ChooseDir(
                 self.window.get_toplevel(),
-                title=_("Nicotine+") + ": " + _("Add a shared directory")
+                title=_("Add a shared directory")
             )
 
             if selected:

--- a/pynicotine/gtkgui/frame.py
+++ b/pynicotine/gtkgui/frame.py
@@ -157,7 +157,7 @@ class NicotineFrame:
         # Disable a few elements until we're logged in (search field, download buttons etc.)
         self.SetWidgetOnlineStatus(False)
 
-        self.MainWindow.set_title(_("Nicotine+") + " " + version)
+        self.MainWindow.set_title("Nicotine+" + " " + version)
         self.MainWindow.set_default_icon(self.images["n"])
         self.MainWindow.set_icon(self.images["n"])
         # self.MainWindow.selection_add_target("PRIMARY", "STRING", 1)
@@ -264,6 +264,8 @@ class NicotineFrame:
             self.InterestsTabLabel: "interestsvbox"
         }
 
+        hide_tab_template = _("Hide %(tab)s")
+
         # Initialize tabs labels
         for label_tab in [
             self.ChatTabLabel,
@@ -296,7 +298,7 @@ class NicotineFrame:
 
             popup.setup(
                 (
-                    "#" + _("Hide %(tab)s") % {"tab": translated_tablabels[label_tab]}, self.HideTab, [label_tab, map_tablabels_to_box[label_tab]]
+                    "#" + hide_tab_template % {"tab": translated_tablabels[label_tab]}, self.HideTab, [label_tab, map_tablabels_to_box[label_tab]]
                 )
             )
 
@@ -466,8 +468,9 @@ class NicotineFrame:
         # Space after Joined Rooms is important, so it doesn't conflict
         # with any possible real room, but if it's not translated with the space
         # nothing awful will happen
-        self.searchroomslist[_("Joined Rooms ")] = self.RoomSearchCombo_List.append([_("Joined Rooms ")])
-        self.RoomSearchCombo.set_active_iter(self.searchroomslist[_("Joined Rooms ")])
+        joined_rooms = _("Joined Rooms ")
+        self.searchroomslist[joined_rooms] = self.RoomSearchCombo_List.append([joined_rooms])
+        self.RoomSearchCombo.set_active_iter(self.searchroomslist[joined_rooms])
 
         for method in [_("Global"), _("Buddies"), _("Rooms"), _("User")]:
             self.searchmethods[method] = self.SearchMethod_List.append([method])

--- a/pynicotine/gtkgui/notifications.py
+++ b/pynicotine/gtkgui/notifications.py
@@ -99,25 +99,25 @@ class Notifications:
 
         if self.frame.hilites["rooms"] == [] and self.frame.hilites["private"] == []:
             # Reset Title
-            if self.frame.MainWindow.get_title() != _("Nicotine+") + " " + version:
-                self.frame.MainWindow.set_title(_("Nicotine+") + " " + version)
+            if self.frame.MainWindow.get_title() != "Nicotine+" + " " + version:
+                self.frame.MainWindow.set_title("Nicotine+" + " " + version)
         elif self.frame.np.config.sections["notifications"]["notification_window_title"]:
             # Private Chats have a higher priority
             if len(self.frame.hilites["private"]) > 0:
                 user = self.frame.hilites["private"][-1]
                 self.frame.MainWindow.set_title(
-                    _("Nicotine+") + " " + version + " :: " + _("Private Message from %(user)s") % {'user': user}
+                    "Nicotine+" + " " + version + " :: " + _("Private Message from %(user)s") % {'user': user}
                 )
             # Allow for the possibility the username is not available
             elif len(self.frame.hilites["rooms"]) > 0:
                 room = self.frame.hilites["rooms"][-1]
                 if user is None:
                     self.frame.MainWindow.set_title(
-                        _("Nicotine+") + " " + version + " :: " + _("You've been mentioned in the %(room)s room") % {'room': room}
+                        "Nicotine+" + " " + version + " :: " + _("You've been mentioned in the %(room)s room") % {'room': room}
                     )
                 else:
                     self.frame.MainWindow.set_title(
-                        _("Nicotine+") + " " + version + " :: " + _("%(user)s mentioned you in the %(room)s room") % {'user': user, 'room': room}
+                        "Nicotine+" + " " + version + " :: " + _("%(user)s mentioned you in the %(room)s room") % {'user': user, 'room': room}
                     )
 
     def new_tts(self, message):

--- a/pynicotine/gtkgui/search.py
+++ b/pynicotine/gtkgui/search.py
@@ -1165,7 +1165,7 @@ class Search:
         self.ResultsList.get_selection().selected_foreach(self.SelectedResultsAllData, data)
 
         if data != {}:
-            self.MetaBox(title=_("Nicotine+: Search Results"), message=_("<b>Metadata</b> for Search Query: <i>%s</i>") % self.text, data=data, modal=True)
+            self.MetaBox(title=_("Search Results"), message=_("<b>Metadata</b> for Search Query: <i>%s</i>") % self.text, data=data, modal=True)
 
     def OnDownloadFiles(self, widget, prefix=""):
 

--- a/pynicotine/gtkgui/settingswindow.py
+++ b/pynicotine/gtkgui/settingswindow.py
@@ -788,7 +788,7 @@ class SharesFrame(buildFrame):
 
         dir1 = ChooseDir(
             self.Main.get_toplevel(),
-            title=_("Nicotine+") + ": " + _("Add a shared directory")
+            title=_("Add a shared directory")
         )
 
         if dir1 is not None:
@@ -854,7 +854,7 @@ class SharesFrame(buildFrame):
 
         dir1 = ChooseDir(
             self.Main.get_toplevel(),
-            title=_("Nicotine+") + ": " + _("Add a shared buddy directory")
+            title=_("Add a shared buddy directory")
         )
 
         if dir1 is not None:

--- a/pynicotine/gtkgui/ui/about/about.ui
+++ b/pynicotine/gtkgui/ui/about/about.ui
@@ -7,7 +7,7 @@
     <property name="modal">True</property>
     <property name="window_position">center-on-parent</property>
     <property name="logo_icon_name">org.nicotine_plus.Nicotine</property>
-    <property name="program_name" translatable="yes">Nicotine+</property>
+    <property name="program_name">Nicotine+</property>
     <property name="comments" translatable="yes">A graphical client for the Soulseek peer-to-peer system
 Based on code from Nicotine and PySoulSeek
 


### PR DESCRIPTION
- Cache a few strings that are used often, to prevent requesting them from disk every time.
- Status strings that are sent to other clients should not be translated. The translation of the "geoip" string was needlessly requested from disk every time we received a search request (10-20 times a second).
- Consistency improvements for dialog titles