### PR TITLE
Transfer list improvements

### DIFF
--- a/pynicotine/gtkgui/utils.py
+++ b/pynicotine/gtkgui/utils.py
@@ -184,9 +184,6 @@ def InitialiseColumns(treeview, *args):
 
             column = gtk.TreeViewColumn(c[0], renderer, text=i)
             column.set_alignment(0.9)
-        elif c[2] == "colored":
-            renderer = gtk.CellRendererText()
-            column = gtk.TreeViewColumn(c[0], renderer, text=i, foreground=c[3][0], background=c[3][1])
         elif c[2] == "edit":
             renderer = gtk.CellRendererText()
             renderer.set_property('editable', True)
@@ -221,6 +218,19 @@ def InitialiseColumns(treeview, *args):
 
         if len(c) > 3 and type(c[3]) is not list:
             column.set_cell_data_func(renderer, c[3])
+
+        if len(c) > 4:
+            foreground = c[4][0]
+            background = c[4][1]
+
+            if foreground == "":
+                foreground = None
+
+            if background == "":
+                background = None
+
+            renderer.set_property("foreground", foreground)
+            renderer.set_property("background", background)
 
         column.set_reorderable(False)
         column.set_widget(gtk.Label.new(c[0]))

--- a/pynicotine/slskproto.py
+++ b/pynicotine/slskproto.py
@@ -594,7 +594,7 @@ class SlskProtoThread(threading.Thread):
 
             for part in parts:
                 # Stop if there's no wildcard or matching string number
-                if part not in (s_address[seg], "*"):
+                if part != s_address[seg] and part != "*":
                     break
 
                 seg += 1
@@ -1160,22 +1160,22 @@ class SlskProtoThread(threading.Thread):
                 conns, connsinprogress, server_socket = self.process_queue(queue, conns, connsinprogress, server_socket)
                 self._server_socket = server_socket
 
-            outsocks = [i for i in conns if len(conns[i].obuf) > 0 or (i is not server_socket and conns[i].fileupl is not None and conns[i].fileupl.offset is not None)]
             outsock = []
 
             self._limits = {}
             self._dlimits = {}
 
-            for i in outsocks:
-                if self._isUpload(conns[i]):
-                    limit = self._uploadlimit[0](conns, conns[i])
+            for i in conns:
+                if len(conns[i].obuf) > 0 or (i is not server_socket and conns[i].fileupl is not None and conns[i].fileupl.offset is not None):
+                    if self._isUpload(conns[i]):
+                        limit = self._uploadlimit[0](conns, conns[i])
 
-                    if limit is None or limit > 0:
-                        self._limits[i] = limit
+                        if limit is None or limit > 0:
+                            self._limits[i] = limit
+                            outsock.append(i)
+
+                    else:
                         outsock.append(i)
-
-                else:
-                    outsock.append(i)
 
             try:
                 # Select Networking Input and Output sockets


### PR DESCRIPTION
- Simplify code a bit
- Cache status strings to prevent requesting translations too often
- Reduce stress from updating transfer list text color
- When removing all transfers under a folder or user, there is no longer a delay before the folder and user rows are removed
- Don't create useless outsocks list