### PR TITLE
Don't let PeerConnection objects exist indefinitely

### DIFF
--- a/pynicotine/slskproto.py
+++ b/pynicotine/slskproto.py
@@ -982,6 +982,8 @@ class SlskProtoThread(threading.Thread):
 
                             self._ui_callback([ConnectError(msgObj, err)])
                             conn.close()
+                    else:
+                        self._ui_callback([ConnectError(msgObj)])
 
                 elif msgObj.__class__ is DownloadFile and msgObj.conn in conns:
                     conns[msgObj.conn].filedown = msgObj
@@ -1207,14 +1209,17 @@ class SlskProtoThread(threading.Thread):
 
             for connection_in_progress in connsinprogress.copy():
 
+                msgObj = connsinprogress[connection_in_progress].msgObj
+
                 if (curtime - connsinprogress[connection_in_progress].lastactive) > self.IN_PROGRESS_STALE_AFTER:
+
+                    self._ui_callback([ConnClose(msgObj.conn, msgObj.addr)])
 
                     connection_in_progress.close()
                     del connsinprogress[connection_in_progress]
                     continue
 
                 try:
-                    msgObj = connsinprogress[connection_in_progress].msgObj
                     if connection_in_progress in input:
                         connection_in_progress.recv(0)
 


### PR DESCRIPTION
There were two cases where a UI callback was missing in the network thread: when removing stale connections that timed out, and when the connection count limit was exceeded. This caused PeerConnection objects to stay around in the UI thread's peerconns list (https://github.com/Nicotine-Plus/nicotine-plus/issues/416#issuecomment-666034572). It was quite common for the peerconns list to grow quite large when repeatedly searching for popular search terms.