### PR TITLE
Fix minor issues in older GTK versions

### DIFF
--- a/pynicotine/gtkgui/dirchooser.py
+++ b/pynicotine/gtkgui/dirchooser.py
@@ -39,7 +39,8 @@ def ChooseDir(parent=None, initialdir="~", title=None, multichoice=True):
     except AttributeError:
         dialog = gtk.FileChooserDialog(
             title,
-            parent
+            parent,
+            gtk.FileChooserAction.SELECT_FOLDER
         )
         dialog.add_buttons(_("_Cancel"), gtk.ResponseType.CANCEL, _("_Open"), gtk.ResponseType.ACCEPT)
 

--- a/pynicotine/gtkgui/ui/about/chatroomcommands.ui
+++ b/pynicotine/gtkgui/ui/about/chatroomcommands.ui
@@ -4,7 +4,6 @@
   <object class="GtkDialog" id="AboutChatRoomCommands">
     <property name="can_focus">False</property>
     <property name="title" translatable="yes">About chat room commands</property>
-    <property name="resizable">False</property>
     <property name="modal">True</property>
     <property name="window_position">center-on-parent</property>
     <property name="default_width">650</property>

--- a/pynicotine/gtkgui/ui/about/privatechatcommands.ui
+++ b/pynicotine/gtkgui/ui/about/privatechatcommands.ui
@@ -4,7 +4,6 @@
   <object class="GtkDialog" id="AboutPrivateChatCommands">
     <property name="can_focus">False</property>
     <property name="title" translatable="yes">About private chat commands</property>
-    <property name="resizable">False</property>
     <property name="modal">True</property>
     <property name="window_position">center-on-parent</property>
     <property name="default_width">650</property>

--- a/pynicotine/gtkgui/ui/about/searchfilters.ui
+++ b/pynicotine/gtkgui/ui/about/searchfilters.ui
@@ -5,7 +5,6 @@
     <property name="border_width">10</property>
     <property name="can_focus">False</property>
     <property name="title" translatable="yes">About search filters</property>
-    <property name="resizable">False</property>
     <property name="modal">True</property>
     <property name="window_position">center-on-parent</property>
     <child internal-child="vbox">

--- a/pynicotine/gtkgui/ui/fastconfigure.ui
+++ b/pynicotine/gtkgui/ui/fastconfigure.ui
@@ -14,9 +14,9 @@
   <object class="GtkAssistant" id="FastConfigureAssistant">
     <property name="can_focus">False</property>
     <property name="modal">True</property>
-    <property name="window_position">center</property>
+    <property name="window_position">center-on-parent</property>
     <property name="default_width">900</property>
-    <property name="default_height">400</property>
+    <property name="default_height">450</property>
     <property name="type_hint">dialog</property>
     <property name="gravity">center</property>
     <signal name="apply" handler="OnApply" swapped="no"/>
@@ -230,7 +230,7 @@ Please keep in mind that more common usernames may be taken. If you're unable to
         <property name="margin_top">5</property>
         <property name="margin_bottom">5</property>
         <property name="orientation">vertical</property>
-        <property name="spacing">15</property>
+        <property name="spacing">20</property>
         <child>
           <object class="GtkBox" id="portselection">
             <property name="visible">True</property>
@@ -493,6 +493,7 @@ Please keep in mind that more common usernames may be taken. If you're unable to
               <object class="GtkScrolledWindow">
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
+                <property name="height_request">150</property>
                 <property name="shadow_type">in</property>
                 <child>
                   <object class="GtkTreeView" id="shareddirectoriestree">

--- a/pynicotine/gtkgui/ui/mainwindow.ui
+++ b/pynicotine/gtkgui/ui/mainwindow.ui
@@ -1611,7 +1611,7 @@
                                       <object class="GtkImage">
                                         <property name="visible">True</property>
                                         <property name="can_focus">False</property>
-                                        <property name="icon_name">document-edit-symbolic</property>
+                                        <property name="icon_name">text-editor-symbolic</property>
                                       </object>
                                     </child>
                                     <child>

--- a/pynicotine/gtkgui/ui/nowplaying.ui
+++ b/pynicotine/gtkgui/ui/nowplaying.ui
@@ -6,7 +6,6 @@
     <property name="width_request">800</property>
     <property name="can_focus">False</property>
     <property name="title" translatable="yes">Configure Now Playing</property>
-    <property name="resizable">False</property>
     <property name="modal">True</property>
     <property name="window_position">center-on-parent</property>
     <child internal-child="vbox">

--- a/pynicotine/gtkgui/ui/roomwall.ui
+++ b/pynicotine/gtkgui/ui/roomwall.ui
@@ -4,7 +4,6 @@
   <object class="GtkDialog" id="RoomWall">
     <property name="can_focus">False</property>
     <property name="title" translatable="yes">Room Wall</property>
-    <property name="resizable">False</property>
     <property name="modal">True</property>
     <property name="window_position">center-on-parent</property>
     <property name="default_width">900</property>
@@ -93,7 +92,7 @@
                       <object class="GtkImage">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
-                        <property name="icon_name">chat-message-new</property>
+                        <property name="icon_name">list-add-symbolic</property>
                       </object>
                     </child>
                     <child>

--- a/pynicotine/gtkgui/ui/settings/downloads.ui
+++ b/pynicotine/gtkgui/ui/settings/downloads.ui
@@ -523,7 +523,7 @@
                               <object class="GtkImage">
                                 <property name="visible">True</property>
                                 <property name="can_focus">False</property>
-                                <property name="icon_name">document-edit-symbolic</property>
+                                <property name="icon_name">text-editor-symbolic</property>
                               </object>
                               <packing>
                                 <property name="expand">False</property>

--- a/pynicotine/gtkgui/ui/settings/shares.ui
+++ b/pynicotine/gtkgui/ui/settings/shares.ui
@@ -156,7 +156,7 @@
                           <object class="GtkImage">
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
-                            <property name="icon_name">document-edit-symbolic</property>
+                            <property name="icon_name">text-editor-symbolic</property>
                           </object>
                         </child>
                         <child>
@@ -368,7 +368,7 @@
                           <object class="GtkImage">
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
-                            <property name="icon_name">document-edit-symbolic</property>
+                            <property name="icon_name">text-editor-symbolic</property>
                           </object>
                         </child>
                         <child>

--- a/pynicotine/gtkgui/ui/wishlist.ui
+++ b/pynicotine/gtkgui/ui/wishlist.ui
@@ -4,7 +4,6 @@
   <object class="GtkDialog" id="WishList">
     <property name="can_focus">False</property>
     <property name="title" translatable="yes">Search Wishlist</property>
-    <property name="resizable">False</property>
     <property name="modal">True</property>
     <property name="window_position">center-on-parent</property>
     <property name="default_width">600</property>

--- a/pynicotine/gtkgui/utils.py
+++ b/pynicotine/gtkgui/utils.py
@@ -186,10 +186,12 @@ def InitialiseColumns(treeview, *args):
             column.set_alignment(0.9)
         elif c[2] == "edit":
             renderer = gtk.CellRendererText()
+            renderer.set_padding(10, 3)
             renderer.set_property('editable', True)
             column = gtk.TreeViewColumn(c[0], renderer, text=i)
         elif c[2] == "combo":
             renderer = gtk.CellRendererCombo()
+            renderer.set_padding(10, 3)
             renderer.set_property('text-column', 0)
             renderer.set_property('editable', True)
             column = gtk.TreeViewColumn(c[0], renderer, text=i)


### PR DESCRIPTION
Fixes a few issues I found when using older GTK3 versions (Ubuntu 16.04, GTK 3.18)..For some strange reason, a few elements had a negative height when dialogs weren't resizable. 