### PR TITLE
Drop urllib.requests import

### DIFF
--- a/pynicotine/gtkgui/frame.py
+++ b/pynicotine/gtkgui/frame.py
@@ -23,11 +23,8 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 import os
 import re
-import urllib.error
 import urllib.parse
-import urllib.request
 from gettext import gettext as _
-from urllib.parse import urlencode
 
 import gi
 from gi.repository import Gdk
@@ -777,9 +774,7 @@ class NicotineFrame:
 
     def OnGetPrivileges(self, widget):
         url = "%(url)s" % {
-            'url': 'https://www.slsknet.org/userlogin.php?' + urlencode({
-                'username': self.np.config.sections["server"]["login"]
-            })
+            'url': 'https://www.slsknet.org/userlogin.php?username=' + urllib.parse.quote(self.np.config.sections["server"]["login"])
         }
         OpenUri(url, self.MainWindow)
 
@@ -2526,7 +2521,7 @@ class NicotineFrame:
 
     def OnSoulSeek(self, url):
         try:
-            user, file = urllib.request.url2pathname(url[7:]).split("/", 1)
+            user, file = urllib.parse.unquote(url[7:]).split("/", 1)
             if file[-1] == "/":
                 self.np.ProcessRequestToPeer(user, slskmessages.FolderContentsRequest(None, file[:-1].replace("/", "\\")))
             else:
@@ -2535,8 +2530,8 @@ class NicotineFrame:
             self.logMessage(_("Invalid SoulSeek meta-url: %s") % url)
 
     def SetClipboardURL(self, user, path):
-        self.clip.set_text("slsk://" + urllib.request.pathname2url("%s/%s" % (user, path.replace("\\", "/"))), -1)
-        self.clip_data = "slsk://" + urllib.request.pathname2url("%s/%s" % (user, path.replace("\\", "/")))
+        self.clip.set_text("slsk://" + urllib.parse.quote("%s/%s" % (user, path.replace("\\", "/"))), -1)
+        self.clip_data = "slsk://" + urllib.parse.quote("%s/%s" % (user, path.replace("\\", "/")))
 
     def OnSelectionGet(self, widget, data, info, timestamp):
         data.set_text(self.clip_data, -1)

--- a/pynicotine/gtkgui/nowplaying.py
+++ b/pynicotine/gtkgui/nowplaying.py
@@ -640,7 +640,7 @@ class NowPlaying:
         import json
 
         try:
-            conn = http.client.HTTPConnection("ws.audioscrobbler.com")
+            conn = http.client.HTTPSConnection("ws.audioscrobbler.com")
         except Exception as error:
             log.addwarning(_("ERROR: lastfm: Could not connect to audioscrobbler: %(error)s") % {"error": error})
             return None
@@ -651,9 +651,9 @@ class NowPlaying:
             log.addwarning(_("ERROR: lastfm: Please provide both your lastfm username and API key"))
             return None
 
-        conn.request("GET", "/2.0/?method=user.getrecenttracks&user=" + user + "&api_key=" + apikey + "&format=json")
+        conn.request("GET", "/2.0/?method=user.getrecenttracks&user=" + user + "&api_key=" + apikey + "&format=json", headers={"User-Agent": "Nicotine+"})
         resp = conn.getresponse()
-        data = resp.read()
+        data = resp.read().decode("utf-8")
 
         if resp.status != 200 or resp.reason != "OK":
             log.addwarning(_("ERROR: lastfm: Could not get recent track from audioscrobbler: %(error)s") % {"error": str(data)})

--- a/pynicotine/gtkgui/search.py
+++ b/pynicotine/gtkgui/search.py
@@ -1241,13 +1241,13 @@ class Search:
                 self.frame.np.ProcessRequestToPeer(user, slskmessages.FolderContentsRequest(None, folder))
 
     def OnCopyURL(self, widget):
-        user, path = self.selected_results[0][:2]
+        user, path = next(iter(self.selected_results))[:2]
         self.frame.SetClipboardURL(user, path)
 
     def OnCopyDirURL(self, widget):
 
-        user, path = self.selected_results[0][:2]
-        path = "\\".join(path.split("\\")[:-1]) + "\\"
+        user, path = next(iter(self.selected_results))[:2]
+        path = "\\".join(path.split("\\")[:-1])
 
         if path[:-1] != "/":
             path += "/"

--- a/pynicotine/gtkgui/utils.py
+++ b/pynicotine/gtkgui/utils.py
@@ -27,9 +27,7 @@ import re
 import sys
 import time
 import types
-import urllib.error
 import urllib.parse
-import urllib.request
 import webbrowser
 from gettext import gettext as _
 
@@ -485,7 +483,7 @@ def AppendLine(textview, line, tag=None, timestamp=None, showstamp=True, timesta
         line = line[match.end():]
 
         if url.startswith("slsk://") and HUMANIZE_URLS:
-            url = urllib.request.url2pathname(url)
+            url = urllib.parse.unquote(url)
 
         _append(buffer, url, urltag)
         # Match remaining url

--- a/pynicotine/utils.py
+++ b/pynicotine/utils.py
@@ -26,13 +26,9 @@ This module contains utility functions.
 """
 
 import gettext
-import json
 import locale
 import os
 import sys
-import urllib.error
-import urllib.parse
-import urllib.request
 
 from codecs import encode, decode
 from subprocess import PIPE
@@ -83,11 +79,15 @@ def CleanPath(path, absolute=False):
 
 
 def get_latest_version():
-    latesturl = 'https://api.github.com/repos/Nicotine-Plus/nicotine-plus/releases/latest'
 
-    response = urllib.request.urlopen(latesturl)
-    data = json.loads(response.read().decode('utf-8'))
-    response.close()
+    import http.client
+    import json
+
+    conn = http.client.HTTPSConnection("api.github.com")
+    conn.request("GET", "/repos/Nicotine-Plus/nicotine-plus/releases/latest", headers={"User-Agent": "Nicotine+"})
+    resp = conn.getresponse()
+    data = json.loads(resp.read().decode("utf-8"))
+
     hlatest = data['tag_name']
     latest = int(make_version(hlatest))
     date = data['created_at']


### PR DESCRIPTION
For the small number of http-related features we need, importing urllib.request is overkill. Since version checking is not done often, we can also cut down on startup import time a bit by importing http.client on demand.