### PR TITLE
Open log files as UTF-8

### DIFF
--- a/pynicotine/gtkgui/chatrooms.py
+++ b/pynicotine/gtkgui/chatrooms.py
@@ -969,7 +969,7 @@ class ChatRoom:
             numlines = 15
 
         try:
-            with open(log, 'r') as lines:
+            with open(log, 'r', encoding='utf-8') as lines:
                 # Only show as many log lines as specified in config
                 lines = deque(lines, numlines)
 

--- a/pynicotine/gtkgui/privatechat.py
+++ b/pynicotine/gtkgui/privatechat.py
@@ -431,7 +431,7 @@ class PrivateChat:
             numlines = 15
 
         try:
-            with open(log, 'r') as lines:
+            with open(log, 'r', encoding='utf-8') as lines:
                 # Only show as many log lines as specified in config
                 lines = deque(lines, numlines)
 


### PR DESCRIPTION
Since utf-8 isn't default on Windows. Luckily the log files have been saved as utf-8 for a long time, so there's no need to convert anything.