### PR TITLE
Update transfer status on queue failure in more cases

### DIFF
--- a/pynicotine/gtkgui/transferlist.py
+++ b/pynicotine/gtkgui/transferlist.py
@@ -67,6 +67,7 @@ class TransferList:
         self.statuses["Filtered"] = _("Filtered")
         self.statuses["Connection closed by peer"] = _("Connection closed by peer")
         self.statuses["File not shared"] = _("File not shared")
+        self.statuses["File not shared."] = _("File not shared")  # The official client sends a variant containing a dot
         self.statuses["Establishing connection"] = _("Establishing connection")
         self.statuses["Download directory error"] = _("Download directory error")
         self.statuses["Local file error"] = _("Local file error")

--- a/pynicotine/transfers.py
+++ b/pynicotine/transfers.py
@@ -803,7 +803,7 @@ class Transfers:
                 break
 
         for i in self.downloads:
-            if i.user == user and i.filename == msg.file and i.status == "Queued":
+            if i.user == user and i.filename == msg.file and i.status not in ["Aborted", "Paused"]:
                 i.status = msg.reason
                 self.downloadspanel.update(i)
                 break


### PR DESCRIPTION
Sometimes queue failure messages will be sent when the transfer status is not "Queued". If you tried to download files from a SoulseekQt user who had unshared their files, the transfer status would be stuck on "Getting address".

I suspect this could "solve" a few cases where downloads can seem stuck when adding them.