### PR TITLE
Add 2.1.0 to appdata

### DIFF
--- a/files/appdata/org.nicotine_plus.Nicotine.appdata.xml
+++ b/files/appdata/org.nicotine_plus.Nicotine.appdata.xml
@@ -45,6 +45,7 @@
     <content_attribute id="social-info">mild</content_attribute>
   </content_rating>
   <releases>
+    <release version="2.1.0" date="2020-09-12" />
     <release version="2.0.1" date="2020-07-16" />
     <release version="2.0.0" date="2020-07-14" />
   </releases>


### PR DESCRIPTION
Necessary for Flathub, unfortunately I forgot to do this. I think I'll just bump the commit used for building the Flatpak once this is merged.