### PR TITLE
Don't update room username styles in vain

### DIFF
--- a/pynicotine/gtkgui/chatrooms.py
+++ b/pynicotine/gtkgui/chatrooms.py
@@ -1565,9 +1565,9 @@ class ChatRoom:
 
     def UserColumnDraw(self, column, cellrenderer, model, iter, dummy="dummy"):
 
-        user = self.usersmodel.get_value(iter, 2)
-
         if self.room in self.roomsctrl.PrivateRooms:
+            user = self.usersmodel.get_value(iter, 2)
+
             if user == self.roomsctrl.PrivateRooms[self.room]["owner"]:
                 cellrenderer.set_property("underline", pango.Underline.SINGLE)
                 cellrenderer.set_property("weight", pango.Weight.BOLD)
@@ -1577,9 +1577,6 @@ class ChatRoom:
             else:
                 cellrenderer.set_property("weight", pango.Weight.NORMAL)
                 cellrenderer.set_property("underline", pango.Underline.NONE)
-        else:
-            cellrenderer.set_property("weight", pango.Weight.NORMAL)
-            cellrenderer.set_property("underline", pango.Underline.NONE)
 
         self.frame.CellDataFunc(column, cellrenderer, model, iter)
 

--- a/pynicotine/gtkgui/userlist.py
+++ b/pynicotine/gtkgui/userlist.py
@@ -342,12 +342,11 @@ class UserList:
 
     def GetIter(self, user):
 
-        iters = [i.iter for i in self.usersmodel if i[2] == user]
+        for i in self.usersmodel:
+            if i[2] == user:
+                return i.iter
 
-        if iters:
-            return iters[0]
-        else:
-            return None
+        return None
 
     def GetUserStatus(self, msg):
 


### PR DESCRIPTION
These were some low-hanging fruit I noticed in py-spy.

Since usernames in public rooms never have a special style, and private rooms can't be converted to public rooms, there doesn't seem to be a point in constantly setting the cell properties to the defaults.