### PR TITLE
Add option to copy a previous search term

### DIFF
--- a/pynicotine/gtkgui/search.py
+++ b/pynicotine/gtkgui/search.py
@@ -349,6 +349,8 @@ class Searches(IconNotebook):
 
         popup = PopupMenu(self.frame)
         popup.setup(
+            ("#" + _("Copy search term"), self.searches[id][2].OnCopySearchTerm),
+            ("", None),
             ("#" + _("Close this tab"), self.searches[id][2].OnClose)
         )
 
@@ -1324,6 +1326,9 @@ class Search:
                 self.OnIgnore(widget)
 
         self.Searches.RemoveTab(self)
+
+    def OnCopySearchTerm(self, widget):
+        self.frame.clip.set_text(self.text, -1)
 
     def OnToggleRemember(self, widget):
 


### PR DESCRIPTION
This would be an easy way to get a full search term from a previous tab and easily make changes to it.
Closes https://github.com/Nicotine-Plus/nicotine-plus/issues/383