### PR TITLE
Make sure transfer speed limit can't be bypassed

### DIFF
--- a/pynicotine/gtkgui/utils.py
+++ b/pynicotine/gtkgui/utils.py
@@ -1312,7 +1312,7 @@ speed_suffixes = ['B/s', 'KiB/s', 'MiB/s', 'GiB/s', 'TiB/s', 'PiB/s', 'EiB/s', '
 
 def HumanSpeed(filesize):
     try:
-        step_unit = 1000.0
+        step_unit = 1024.0
 
         for i in speed_suffixes:
             if filesize < step_unit:


### PR DESCRIPTION
If our transfer speed limit is set too low while we have too many concurrent downloads, the limit can become negative, effectively bypassing the max limit. Cap the min speed per transfer to 1 KB/s.