### PR TITLE
Refactor code related to shares

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+nicotine (2.1.2-dev1) focal; urgency=medium
+
+  * Development version.
+
+ -- Mat <mail@mathias.is>  Sat, 26 Sep 2020 19:58:58 +0300
+
 nicotine (2.1.1-1) focal; urgency=medium
 
   * Latest upstream.

--- a/files/windows/nicotine.nsi
+++ b/files/windows/nicotine.nsi
@@ -1,5 +1,5 @@
 !define PRODUCT_NAME "Nicotine+"
-!define PRODUCT_VERSION "2.1.1"
+!define PRODUCT_VERSION "2.1.2-dev1"
 !define PRODUCT_PUBLISHER "Nicotine+ Team"
 !define PRODUCT_WEB_SITE "https://nicotine-plus.org"
 !define PRODUCT_DIR_REGKEY "Software\Nicotine+"

--- a/pynicotine/gtkgui/frame.py
+++ b/pynicotine/gtkgui/frame.py
@@ -1966,7 +1966,7 @@ class NicotineFrame:
         elif type == "normal":
             GLib.idle_add(self._RescanFinished)
 
-    def _BuddyRescanFinished(self, files, streams, wordindex, fileindex, mtimes):
+    def _BuddyRescanFinished(self):
 
         if self.np.config.sections["transfers"]["enablebuddyshares"]:
             self.rescan_buddy.set_sensitive(True)

--- a/pynicotine/gtkgui/frame.py
+++ b/pynicotine/gtkgui/frame.py
@@ -998,13 +998,7 @@ class NicotineFrame:
 
         self.logMessage(_("Rescanning started"))
 
-        shared = self.np.config.sections["transfers"]["shared"][:]
-
-        if self.np.config.sections["transfers"]["sharedownloaddir"]:
-            shared.append((_('Downloaded'), self.np.config.sections["transfers"]["downloaddir"]))
-
-        msg = slskmessages.RescanShares(shared, None)
-        _thread.start_new_thread(self.np.shares.RescanShares, (msg, rebuild))
+        _thread.start_new_thread(self.np.shares.RescanShares, (rebuild,))
 
     def OnBuddyRescan(self, widget=None, rebuild=False):
 
@@ -1018,13 +1012,7 @@ class NicotineFrame:
 
         self.logMessage(_("Rescanning Buddy Shares started"))
 
-        shared = self.np.config.sections["transfers"]["buddyshared"][:] + self.np.config.sections["transfers"]["shared"][:]
-
-        if self.np.config.sections["transfers"]["sharedownloaddir"]:
-            shared.append((_('Downloaded'), self.np.config.sections["transfers"]["downloaddir"]))
-
-        msg = slskmessages.RescanBuddyShares(shared, None)
-        _thread.start_new_thread(self.np.shares.RescanBuddyShares, (msg, rebuild))
+        _thread.start_new_thread(self.np.shares.RescanBuddyShares, (rebuild,))
 
     def OnBrowsePublicShares(self, widget):
         """ Browse your own public shares """
@@ -1972,33 +1960,24 @@ class NicotineFrame:
 
     """ Scanning """
 
-    def RescanFinished(self, files, streams, wordindex, fileindex, mtimes, type):
+    def RescanFinished(self, type):
         if type == "buddy":
-            GLib.idle_add(self._BuddyRescanFinished, files, streams, wordindex, fileindex, mtimes)
+            GLib.idle_add(self._BuddyRescanFinished)
         elif type == "normal":
-            GLib.idle_add(self._RescanFinished, files, streams, wordindex, fileindex, mtimes)
+            GLib.idle_add(self._RescanFinished)
 
     def _BuddyRescanFinished(self, files, streams, wordindex, fileindex, mtimes):
-
-        self.np.config.setBuddyShares(files, streams, wordindex, fileindex, mtimes)
 
         if self.np.config.sections["transfers"]["enablebuddyshares"]:
             self.rescan_buddy.set_sensitive(True)
             self.browse_buddy_shares.set_sensitive(True)
-
-        if self.np.transfers is not None:
-            self.np.shares.sendNumSharedFoldersFiles()
 
         self.brescanning = False
         self.logMessage(_("Rescanning Buddy Shares finished"))
 
         self.BuddySharesProgress.hide()
 
-        self.np.shares.CompressShares("buddy")
-
-    def _RescanFinished(self, files, streams, wordindex, fileindex, mtimes):
-
-        self.np.config.setShares(files, streams, wordindex, fileindex, mtimes)
+    def _RescanFinished(self):
 
         if self.np.config.sections["transfers"]["shared"]:
             self.rescan_public.set_sensitive(True)
@@ -2008,11 +1987,6 @@ class NicotineFrame:
         self.logMessage(_("Rescanning finished"))
 
         self.SharesProgress.hide()
-
-        self.np.shares.CompressShares("normal")
-
-        if self.np.transfers is not None:
-            self.np.shares.sendNumSharedFoldersFiles()
 
     """ Search """
 

--- a/pynicotine/pynicotine.py
+++ b/pynicotine/pynicotine.py
@@ -272,8 +272,6 @@ class NetworkEventProcessor:
             ConnectToPeerTimeout: self.ConnectToPeerTimeout,
             RespondToDistributedSearchesTimeout: self.ToggleRespondDistributed,
             transfers.TransferTimeout: self.TransferTimeout,
-            slskmessages.RescanShares: self.shares.RescanShares,
-            slskmessages.RescanBuddyShares: self.shares.RescanBuddyShares,
             str: self.Notify,
             slskmessages.PopupMessage: self.PopupMessage,
             slskmessages.SetCurrentConnectionCount: self.SetCurrentConnectionCount,

--- a/pynicotine/pynicotine.py
+++ b/pynicotine/pynicotine.py
@@ -637,7 +637,7 @@ class NetworkEventProcessor:
             self.privatechat, self.chatrooms, self.userinfo, self.userbrowse, self.search, downloads, uploads, self.userlist = self.frame.InitInterface(msg)
 
             self.transfers.setTransferPanels(downloads, uploads)
-            self.shares.sendNumSharedFoldersFiles()
+            self.shares.send_num_shared_folders_files()
             self.queue.put(slskmessages.SetStatus((not self.frame.away) + 1))
 
             for thing in self.config.sections["interests"]["likes"]:
@@ -1649,17 +1649,17 @@ class NetworkEventProcessor:
         for i in self.peerconns:
             if i.conn == msg.conn.conn:
                 user = i.username
-                self.shares.processSearchRequest(msg.searchterm, user, msg.searchid, direct=1)
+                self.shares.process_search_request(msg.searchterm, user, msg.searchid, direct=1)
                 break
 
     def SearchRequest(self, msg):
         self.logMessage("%s %s" % (msg.__class__, vars(msg)), 4)
-        self.shares.processSearchRequest(msg.searchterm, msg.user, msg.searchid, direct=0)
+        self.shares.process_search_request(msg.searchterm, msg.user, msg.searchid, direct=0)
         self.frame.pluginhandler.SearchRequestNotification(msg.searchterm, msg.user, msg.searchid)
 
     def RoomSearchRequest(self, msg):
         self.logMessage("%s %s" % (msg.__class__, vars(msg)), 4)
-        self.shares.processSearchRequest(msg.searchterm, msg.room, msg.searchid, direct=0)
+        self.shares.process_search_request(msg.searchterm, msg.room, msg.searchid, direct=0)
 
     def ToggleRespondDistributed(self, msg, settings=False):
         """
@@ -1693,7 +1693,7 @@ class NetworkEventProcessor:
 
     def DistribSearch(self, msg):
         if self.respondDistributed:  # set in ToggleRespondDistributed
-            self.shares.processSearchRequest(msg.searchterm, msg.user, msg.searchid, 0)
+            self.shares.process_search_request(msg.searchterm, msg.user, msg.searchid, 0)
         self.frame.pluginhandler.DistribSearchNotification(msg.searchterm, msg.user, msg.searchid)
 
     def PossibleParents(self, msg):

--- a/pynicotine/pynicotine.py
+++ b/pynicotine/pynicotine.py
@@ -134,7 +134,7 @@ class NetworkEventProcessor:
         self.users = {}
         self.user_addr_requested = set()
         self.queue = queue.Queue(0)
-        self.shares = Shares(self)
+        self.shares = Shares(self, self.config, self.queue, self.logMessage)
 
         script_dir = os.path.dirname(__file__)
         file_path = os.path.join(script_dir, "geoip/ipcountrydb.bin")

--- a/pynicotine/shares.py
+++ b/pynicotine/shares.py
@@ -21,7 +21,9 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import os
+import pickle
 import re
+import shelve
 import stat
 import string
 import sys
@@ -36,12 +38,48 @@ from pynicotine import slskmessages
 from pynicotine.logfacility import log
 from pynicotine.utils import GetUserDirectories
 
+if sys.platform == "win32":
+    # Use semidbm for faster shelves on Windows
+
+    def shelve_open_semidbm(filename, flag='c', protocol=None, writeback=False):
+        import semidbm
+        return shelve.Shelf(semidbm.open(filename, flag), protocol, writeback)
+
+    shelve.open = shelve_open_semidbm
+
 
 class Shares:
 
     def __init__(self, np):
         self.np = np
         self.config = self.np.config
+
+        # Convert fs-based shared to virtual shared (pre 1.4.0)
+        def _convert_to_virtual(x):
+            if isinstance(x, tuple):
+                return x
+            virtual = x.replace('/', '_').replace('\\', '_').strip('_')
+            log.addwarning("Renaming shared folder '%s' to '%s'. A rescan of your share is required." % (x, virtual))
+            return (virtual, x)
+
+        self.config.sections["transfers"]["shared"] = [_convert_to_virtual(x) for x in self.config.sections["transfers"]["shared"]]
+        self.config.sections["transfers"]["buddyshared"] = [_convert_to_virtual(x) for x in self.config.sections["transfers"]["buddyshared"]]
+
+        self.load_shares(
+            [
+                os.path.join(self.config.data_dir, "files.db"),
+                os.path.join(self.config.data_dir, "buddyfiles.db"),
+                os.path.join(self.config.data_dir, "streams.db"),
+                os.path.join(self.config.data_dir, "buddystreams.db"),
+                os.path.join(self.config.data_dir, "wordindex.db"),
+                os.path.join(self.config.data_dir, "buddywordindex.db"),
+                os.path.join(self.config.data_dir, "fileindex.db"),
+                os.path.join(self.config.data_dir, "buddyfileindex.db"),
+                os.path.join(self.config.data_dir, "mtimes.db"),
+                os.path.join(self.config.data_dir, "buddymtimes.db")
+            ]
+        )
+
         self.queue = self.np.queue
         self.LogMessage = self.np.logMessage
         self.CompressedSharesBuddy = self.CompressedSharesNormal = None
@@ -49,6 +87,43 @@ class Shares:
         self.CompressShares("buddy")
         self.newbuddyshares = self.newnormalshares = False
         self.translatepunctuation = str.maketrans(dict.fromkeys(string.punctuation, ' '))
+
+    def load_shares(self, dbs):
+        opened_shelves = []
+        errors = []
+
+        for shelvefile in dbs:
+            try:
+                opened_shelves.append(shelve.open(shelvefile, protocol=pickle.HIGHEST_PROTOCOL))
+            except Exception:
+                errors.append(shelvefile)
+                try:
+                    os.unlink(shelvefile)
+                    opened_shelves.append(shelve.open(shelvefile, flag='n', protocol=pickle.HIGHEST_PROTOCOL))
+                except Exception as ex:
+                    print(("Failed to unlink %s: %s" % (shelvefile, ex)))
+
+        self.config.sections["transfers"]["sharedfiles"] = opened_shelves.pop(0)
+        self.config.sections["transfers"]["bsharedfiles"] = opened_shelves.pop(0)
+        self.config.sections["transfers"]["sharedfilesstreams"] = opened_shelves.pop(0)
+        self.config.sections["transfers"]["bsharedfilesstreams"] = opened_shelves.pop(0)
+        self.config.sections["transfers"]["wordindex"] = opened_shelves.pop(0)
+        self.config.sections["transfers"]["bwordindex"] = opened_shelves.pop(0)
+        self.config.sections["transfers"]["fileindex"] = opened_shelves.pop(0)
+        self.config.sections["transfers"]["bfileindex"] = opened_shelves.pop(0)
+        self.config.sections["transfers"]["sharedmtimes"] = opened_shelves.pop(0)
+        self.config.sections["transfers"]["bsharedmtimes"] = opened_shelves.pop(0)
+
+        if errors:
+            log.addwarning(_("Failed to process the following databases: %(names)s") % {'names': '\n'.join(errors)})
+
+            self.setShares(type="normal", files={}, streams={}, mtimes={}, wordindex={}, fileindex={})
+            self.setShares(type="buddy", files={}, streams={}, mtimes={}, wordindex={}, fileindex={})
+
+            self.load_shares(dbs)
+
+            log.addwarning(_("Shared files database seems to be corrupted, rescan your shares"))
+            return
 
     def real2virtual(self, path):
         path = os.path.normpath(path)
@@ -116,47 +191,61 @@ class Shares:
 
         self.queue.put(slskmessages.SharedFoldersFiles(sharedfolders, sharedfiles))
 
-    def RebuildShares(self, msg):
-        self._RescanShares(msg, "normal", rebuild=True)
+    def RebuildShares(self):
+        self._RescanShares("normal", rebuild=True)
 
-    def RescanShares(self, msg, rebuild=False):
-        self._RescanShares(msg, "normal", rebuild)
+    def RescanShares(self, rebuild=False):
+        self._RescanShares("normal", rebuild)
 
-    def RebuildBuddyShares(self, msg):
-        self._RescanShares(msg, "buddy", rebuild=True)
+    def RebuildBuddyShares(self):
+        self._RescanShares("buddy", rebuild=True)
 
-    def RescanBuddyShares(self, msg, rebuild=False):
-        self._RescanShares(msg, "buddy", rebuild)
+    def RescanBuddyShares(self, rebuild=False):
+        self._RescanShares("buddy", rebuild)
 
-    def _RescanShares(self, msg, type, rebuild=False):
+    def _RescanShares(self, type, rebuild=False):
 
         if type == "normal":
             name = _("Shares")
             mtimes = self.config.sections["transfers"]["sharedmtimes"]
             files = self.config.sections["transfers"]["sharedfiles"]
             filesstreams = self.config.sections["transfers"]["sharedfilesstreams"]
+
+            shared_folders = self.config.sections["transfers"]["shared"][:]
+
+            if self.config.sections["transfers"]["sharedownloaddir"]:
+                shared_folders.append((_('Downloaded'), self.config.sections["transfers"]["downloaddir"]))
+
         else:
             name = _("Buddy Shares")
             mtimes = self.config.sections["transfers"]["bsharedmtimes"]
             files = self.config.sections["transfers"]["bsharedfiles"]
             filesstreams = self.config.sections["transfers"]["bsharedfilesstreams"]
 
+            shared_folders = self.config.sections["transfers"]["buddyshared"][:] + self.config.sections["transfers"]["shared"][:]
+
+            if self.config.sections["transfers"]["sharedownloaddir"]:
+                shared_folders.append((_('Downloaded'), self.config.sections["transfers"]["downloaddir"]))
+
         try:
-            files, streams, wordindex, fileindex, mtimes = self.rescandirs(
-                msg.shared,
+            self.rescandirs(
+                type,
+                shared_folders,
                 mtimes,
                 files,
                 filesstreams,
-                msg.yieldfunction,
                 self.np.frame.SharesProgress,
                 name=name,
                 rebuild=rebuild
             )
 
-            self.np.frame.RescanFinished(
-                files, streams, wordindex, fileindex, mtimes,
-                type
-            )
+            self.np.frame.RescanFinished(type)
+
+            self.CompressShares(type)
+
+            if self.np.transfers is not None:
+                self.np.shares.sendNumSharedFoldersFiles()
+
         except Exception as ex:
             config_dir, data_dir = GetUserDirectories()
             log.addwarning(
@@ -422,7 +511,7 @@ class Shares:
                     }, 2)
 
     # Rescan directories in shared databases
-    def rescandirs(self, shared, oldmtimes, oldfiles, sharedfilesstreams, yieldfunction, progress=None, name="", rebuild=False):
+    def rescandirs(self, type, shared, oldmtimes, oldfiles, sharedfilesstreams, progress=None, name="", rebuild=False):
         """
         Check for modified or new files via OS's last mtime on a directory,
         or, if rebuild is True, all directories
@@ -441,28 +530,28 @@ class Shares:
 
         self.logMessage(_("%(num)s folders found before rescan, rebuilding...") % {"num": num_folders})
 
-        newmtimes = self.getDirsMtimes(shared_directories, yieldfunction)
+        newmtimes = self.getDirsMtimes(shared_directories)
 
         # Get list of files
         # returns dict in format { Directory : { File : metadata, ... }, ... }
-        newsharedfiles = self.getFilesList(newmtimes, oldmtimes, oldfiles, yieldfunction, progress, rebuild)
+        newsharedfiles = self.getFilesList(newmtimes, oldmtimes, oldfiles, progress, rebuild)
 
         # Pack shares data
         # returns dict in format { Directory : hex string of files+metadata, ... }
-        newsharedfilesstreams = self.getFilesStreams(newmtimes, oldmtimes, sharedfilesstreams, newsharedfiles, rebuild, yieldfunction)
+        newsharedfilesstreams = self.getFilesStreams(newmtimes, oldmtimes, sharedfilesstreams, newsharedfiles, rebuild)
+
+        # Save data to shelves
+        self.setShares(type=type, files=newsharedfiles, streams=newsharedfilesstreams, mtimes=newmtimes)
 
         # Update Search Index
-        # newwordindex is a dict in format {word: [num, num, ..], ... } with num matching
-        # keys in newfileindex
-        # newfileindex is a dict in format { num: (path, size, (bitrate, vbr), length), ... }
-        newwordindex, newfileindex = self.getFilesIndex(newmtimes, newsharedfiles, yieldfunction, progress)
+        # wordindex is a dict in format {word: [num, num, ..], ... } with num matching keys in newfileindex
+        # fileindex is a dict in format { num: (path, size, (bitrate, vbr), length), ... }
+        self.getFilesIndex(type, newsharedfiles, progress)
 
-        self.logMessage(_("%(num)s folders found after rescan") % {"num": len(newmtimes)})
-
-        return newsharedfiles, newsharedfilesstreams, newwordindex, newfileindex, newmtimes
+        self.logMessage(_("%(num)s folders found after rescan") % {"num": len(newsharedfiles)})
 
     # Get Modification Times
-    def getDirsMtimes(self, dirs, yieldcall=None):
+    def getDirsMtimes(self, dirs):
 
         list = {}
 
@@ -497,8 +586,6 @@ class Shares:
                         for k in dircontents:
                             list[k] = dircontents[k]
 
-                    if yieldcall is not None:
-                        yieldcall()
             except OSError as errtuple:
                 message = _("Error while scanning folder %(path)s: %(error)s") % {'path': folder, 'error': errtuple}
                 print(str(message))
@@ -508,7 +595,7 @@ class Shares:
         return list
 
     # Check for new files
-    def getFilesList(self, mtimes, oldmtimes, oldlist, yieldcall=None, progress=None, rebuild=False):
+    def getFilesList(self, mtimes, oldmtimes, oldlist, progress=None, rebuild=False):
         """ Get a list of files with their filelength, bitrate and track length in seconds """
 
         list = {}
@@ -560,8 +647,6 @@ class Shares:
                         if data is not None:
                             list[virtualdir].append(data)
 
-                    if yieldcall is not None:
-                        yieldcall()
             except OSError as errtuple:
                 message = _("Error while scanning folder %(path)s: %(error)s") % {'path': folder, 'error': errtuple}
                 print(str(message))
@@ -596,7 +681,7 @@ class Shares:
             self.logMessage(message)
 
     # Get streams of files
-    def getFilesStreams(self, mtimes, oldmtimes, oldstreams, newsharedfiles, rebuild=False, yieldcall=None):
+    def getFilesStreams(self, mtimes, oldmtimes, oldstreams, newsharedfiles, rebuild=False):
 
         streams = {}
 
@@ -622,9 +707,6 @@ class Shares:
                         continue
 
             streams[virtualdir] = self.getDirStream(newsharedfiles[virtualdir])
-
-            if yieldcall is not None:
-                yieldcall()
 
         return streams
 
@@ -690,34 +772,46 @@ class Shares:
         return stream
 
     # Update Search index with new files
-    def getFilesIndex(self, mtimes, newsharedfiles, yieldcall=None, progress=None):
+    def getFilesIndex(self, type, sharedfiles, progress=None):
 
+        """ We dump data directly into the file index shelf to save memory """
+        if type == "normal":
+            section = "fileindex"
+        else:
+            section = "bfileindex"
+
+        self.config.sections["transfers"][section].close()
+
+        fileindex = self.config.sections["transfers"][section] = \
+            shelve.open(os.path.join(self.config.data_dir, section + ".db"), flag='n', protocol=pickle.HIGHEST_PROTOCOL)
+
+        """ For the word index, we can't use the same approach as above, as we need
+        to access dict elements frequently. This would take too long on a shelf. """
         wordindex = {}
-        fileindex = []
+
         index = 0
-        count = len(mtimes)
+        count = len(sharedfiles)
         lastpercent = 0.0
 
-        for folder in mtimes:
-
-            virtualdir = self.real2virtual(folder)
+        for folder in sharedfiles:
             count += 1
 
             if progress:
                 # Truncate the percentage to two decimal places to avoid sending data to the GUI thread too often
-                percent = float("%.2f" % (float(count) / len(mtimes) * 0.75))
+                percent = float("%.2f" % (float(count) / len(sharedfiles) * 0.75))
 
                 if percent > lastpercent and percent <= 1.0:
                     GLib.idle_add(progress.set_fraction, percent)
                     lastpercent = percent
 
-            for j in newsharedfiles[virtualdir]:
+            for j in sharedfiles[folder]:
                 file = j[0]
-                fileindex.append((virtualdir + '\\' + file,) + j[1:])
+
+                fileindex[repr(index)] = (folder + '\\' + file, *j[1:])
 
                 # Collect words from filenames for Search index
                 # Use set to prevent duplicates
-                for k in set((virtualdir + " " + file).lower().translate(self.translatepunctuation).split()):
+                for k in set((folder + " " + file).lower().translate(self.translatepunctuation).split()):
                     try:
                         wordindex[k].append(index)
                     except KeyError:
@@ -725,10 +819,7 @@ class Shares:
 
                 index += 1
 
-            if yieldcall is not None:
-                yieldcall()
-
-        return wordindex, fileindex
+        self.setShares(type=type, wordindex=wordindex)
 
     def addToShared(self, name):
         """ Add a file to the normal shares database """
@@ -806,3 +897,37 @@ class Shares:
             else:
                 wordindex[i] = wordindex[i] + [index]
         fileindex.append((os.path.join(dir, fileinfo[0]),) + fileinfo[1:])
+
+    def setShares(self, type="normal", files=None, streams=None, mtimes=None, wordindex=None, fileindex=None):
+
+        if type == "normal":
+            storable_objects = [
+                (files, "sharedfiles", "files.db"),
+                (streams, "sharedfilesstreams", "streams.db"),
+                (mtimes, "sharedmtimes", "mtimes.db"),
+                (wordindex, "wordindex", "wordindex.db"),
+                (fileindex, "fileindex", "fileindex.db")
+            ]
+        else:
+            storable_objects = [
+                (files, "bsharedfiles", "buddyfiles.db"),
+                (streams, "bsharedfilesstreams", "buddystreams.db"),
+                (mtimes, "bsharedmtimes", "buddymtimes.db"),
+                (wordindex, "bwordindex", "buddywordindex.db"),
+                (fileindex, "bfileindex", "buddyfileindex.db")
+            ]
+
+        self.storeObjects(storable_objects)
+
+    def storeObjects(self, storable_objects):
+
+        for source, destination, filename in storable_objects:
+            if source is not None:
+                try:
+                    self.config.sections["transfers"][destination].close()
+                    self.config.sections["transfers"][destination] = shelve.open(os.path.join(self.config.data_dir, filename), flag='n', protocol=pickle.HIGHEST_PROTOCOL)
+                    self.config.sections["transfers"][destination].update(source)
+
+                except Exception as e:
+                    log.addwarning(_("Can't save %s: %s") % (filename, e))
+                    return

--- a/pynicotine/slskmessages.py
+++ b/pynicotine/slskmessages.py
@@ -157,20 +157,6 @@ class SetGeoBlock(InternalMessage):
         self.config = config
 
 
-class RescanShares(InternalMessage):
-    """ Sent by the GUI thread to itself to indicate the need to rescan shares in the background"""
-    def __init__(self, shared, yieldfunction):
-        self.shared = shared
-        self.yieldfunction = yieldfunction
-
-
-class RescanBuddyShares(InternalMessage):
-    """ Sent by the GUI thread to itself to indicate the need to rescan shares in the background"""
-    def __init__(self, shared, yieldfunction):
-        self.shared = shared
-        self.yieldfunction = yieldfunction
-
-
 class DistribConn(InternalMessage):
     def __init__(self):
         pass
@@ -1938,7 +1924,7 @@ class FileSearchResult(PeerMessage):
 
         for index in islice(self.list, self.numresults):
             try:
-                fileinfo = self.fileindex[str(index)]
+                fileinfo = self.fileindex[repr(index)]
             except Exception:
                 continue
 

--- a/pynicotine/slskmessages.py
+++ b/pynicotine/slskmessages.py
@@ -1809,7 +1809,7 @@ class SharedFileList(PeerMessage):
                     pos, attr = self.getObject(message, int, pos, printerror=False)
                     attrs.append(attr)
 
-                files.append([code, name, size, ext, attrs])
+                files.append((code, name, size, ext, attrs))
 
             shares.append((directory, files))
 

--- a/pynicotine/transfers.py
+++ b/pynicotine/transfers.py
@@ -42,7 +42,6 @@ from time import sleep
 
 from pynicotine import slskmessages
 from pynicotine import utils
-from pynicotine.logfacility import log
 from pynicotine.slskmessages import newId
 from pynicotine.utils import executeCommand
 from pynicotine.utils import CleanFile
@@ -1286,12 +1285,13 @@ class Transfers:
         try:
             shutil.move(file.name, newname)
         except (IOError, OSError) as inst:
-            log.addwarning(
+            self.eventprocessor.logMessage(
                 _("Couldn't move '%(tempfile)s' to '%(file)s': %(error)s") % {
                     'tempfile': "%s" % file.name,
                     'file': newname,
                     'error': inst
-                }
+                },
+                1
             )
 
         i.status = "Finished"
@@ -1317,7 +1317,7 @@ class Transfers:
         i.conn = None
 
         self.addToShared(newname)
-        self.eventprocessor.shares.sendNumSharedFoldersFiles()
+        self.eventprocessor.shares.send_num_shared_folders_files()
 
         if config["notifications"]["notification_popup_file"]:
             self.eventprocessor.frame.Notifications.NewNotificationPopup(
@@ -1366,7 +1366,7 @@ class Transfers:
     def addToShared(self, name):
         """ Add a file to the normal shares database """
 
-        self.eventprocessor.shares.addToShared(name)
+        self.eventprocessor.shares.add_file_to_shared(name)
 
     def FileUpload(self, msg):
         """ A file upload is in progress """

--- a/pynicotine/utils.py
+++ b/pynicotine/utils.py
@@ -36,7 +36,7 @@ from gettext import gettext as _
 from subprocess import PIPE
 from subprocess import Popen
 
-version = "2.1.1"
+version = "2.1.2.dev1"
 
 win32 = sys.platform.startswith("win")
 


### PR DESCRIPTION
- When rescanning shares, save a lot of memory by writing data directly into the file index db. This also reduces GUI freezes.
- Fix "add downloads to share"-feature, which was calling a removed function
- Use the correct progress bar when rescanning buddy shares
- Remove everything shares-related from config.py, simplify shares loading code
- Remove unnecessary code, move code not related to GUI to shares.py