### PR TITLE
Properly display messages sent to you while offline

### DIFF
--- a/doc/SLSKPROTOCOL.md
+++ b/doc/SLSKPROTOCOL.md
@@ -1,6 +1,6 @@
 # Soulseek Protocol Documentation
 
-Last updated on 2 September 2020
+Last updated on 28 September 2020
 
 ## Sections
 
@@ -543,8 +543,7 @@ Chat phrase sent to someone or received by us in private.
     2.  **int** <ins>timestamp</ins>
     3.  **string** <ins>username</ins>
     4.  **string** <ins>message</ins>
-    5.  **bool** <ins>isAdmin</ins> **1 if sent by
-        server, else not present**
+    5.  **bool** <ins>new message</ins> **1 if message is new, 0 if message is re-sent (e.g. if recipient was offline)**
 
 ### Server Code 23
 

--- a/pynicotine/gtkgui/privatechat.py
+++ b/pynicotine/gtkgui/privatechat.py
@@ -211,7 +211,7 @@ class PrivateChats(IconNotebook):
 
         return False
 
-    def ShowMessage(self, msg, text, status=None):
+    def ShowMessage(self, msg, text, newmessage=True):
 
         if msg.user in self.frame.np.config.sections["server"]["ignorelist"]:
             return
@@ -220,7 +220,7 @@ class PrivateChats(IconNotebook):
             ip, port = self.frame.np.users[msg.user].addr
             if self.frame.np.ipIgnored(ip):
                 return
-        else:
+        elif newmessage:
             self.frame.np.queue.put(slskmessages.GetPeerAddress(msg.user))
             self.frame.np.PrivateMessageQueueAdd(msg, text)
             return
@@ -257,7 +257,7 @@ class PrivateChats(IconNotebook):
             ctcpversion = 1
             text = "CTCP VERSION"
 
-        self.users[msg.user].ShowMessage(text, status, msg.timestamp)
+        self.users[msg.user].ShowMessage(text, newmessage, msg.timestamp)
 
         if ctcpversion and self.frame.np.config.sections["server"]["ctcpmsgs"] == 0:
             self.SendMessage(msg.user, "Nicotine+ %s" % version)
@@ -514,7 +514,7 @@ class PrivateChat:
     def OnShowChatHelp(self, widget):
         self.frame.OnAboutPrivateChatCommands(widget)
 
-    def ShowMessage(self, text, status=None, timestamp=None):
+    def ShowMessage(self, text, newmessage=True, timestamp=None):
 
         self.UpdateColours()
 
@@ -528,7 +528,7 @@ class PrivateChat:
             tag = self.tag_remote
 
         timestamp_format = self.frame.np.config.sections["logging"]["private_timestamp"]
-        if status and not self.offlinemessage:
+        if not newmessage and not self.offlinemessage:
             AppendLine(
                 self.ChatScroll,
                 _("* Message(s) sent while you were offline. Timestamps are reported by the server and can be off."),
@@ -537,10 +537,11 @@ class PrivateChat:
             )
             self.offlinemessage = 1
 
-        if not status and self.offlinemessage:
+        if newmessage and self.offlinemessage:
             self.offlinemessage = False
 
-        if status:
+        if not newmessage:
+
             # The timestamps from the server are off by a lot, so we'll only use them when this is an offline message
             # Also, they are in UTC so we need to correct them
             if daylight:

--- a/pynicotine/pynicotine.py
+++ b/pynicotine/pynicotine.py
@@ -169,7 +169,6 @@ class NetworkEventProcessor:
         self.search = None
         self.transfers = None
         self.userlist = None
-        self.logintime = None
         self.ipaddress = None
         self.privileges_left = None
         self.servertimer = None
@@ -624,7 +623,6 @@ class NetworkEventProcessor:
 
     def Login(self, msg):
 
-        self.logintime = time.time()
         conf = self.config.sections
 
         if msg.success:
@@ -719,19 +717,14 @@ class NetworkEventProcessor:
 
     def MessageUser(self, msg):
 
-        status = 0
-        if self.logintime:
-            if time.time() <= self.logintime + 2:
-                # Offline message
-                status = 1
-
         if self.privatechat is not None:
 
             tuple = self.frame.pluginhandler.IncomingPrivateChatEvent(msg.user, msg.msg)
 
             if tuple is not None:
                 (u, msg.msg) = tuple
-                self.privatechat.ShowMessage(msg, msg.msg, status=status)
+                self.privatechat.ShowMessage(msg, msg.msg, msg.newmessage)
+
                 self.frame.pluginhandler.IncomingPrivateChatNotification(msg.user, msg.msg)
 
             self.queue.put(slskmessages.MessageAcked(msg.msgid))
@@ -845,7 +838,7 @@ class NetworkEventProcessor:
             for data in self.PrivateMessageQueue[user][:]:
                 msg, text = data
                 self.PrivateMessageQueue[user].remove(data)
-                self.privatechat.ShowMessage(msg, text, status=0)
+                self.privatechat.ShowMessage(msg, text)
 
     def ipIgnored(self, address):
 

--- a/pynicotine/slskmessages.py
+++ b/pynicotine/slskmessages.py
@@ -612,6 +612,11 @@ class MessageUser(ServerMessage):
         pos, self.user = self.getObject(message, bytes, pos)
         pos, self.msg = self.getObject(message, bytes, pos)
 
+        if len(message[pos:]) > 0:
+            pos, self.newmessage = pos + 1, message[pos]
+        else:
+            self.newmessage = 1
+
 
 class MessageAcked(ServerMessage):
     """ Server code: 23 """


### PR DESCRIPTION
The server sends us a boolean value that we can use to figure out if a private message was sent to us while we were offline. Use this value instead of our previous calculation, and don't display offline messages as new ones (small error on line 223 in privatemessages.py).

The server value was previously assumed to indicate whether a private message was sent by an admin or not, but this turned out to be incorrect.