### PR TITLE
Remove GLib import from non-GUI code

### DIFF
--- a/pynicotine/gtkgui/frame.py
+++ b/pynicotine/gtkgui/frame.py
@@ -2701,6 +2701,24 @@ class NicotineFrame:
         self.SocketStatus.pop(self.socket_context_id)
         self.SocketStatus.push(self.socket_context_id, self.socket_template % {'current': status, 'limit': slskproto.MAXFILELIMIT})
 
+    def ShowScanProgress(self, sharestype):
+        if sharestype == "normal":
+            GLib.idle_add(self.np.frame.SharesProgress.show)
+        else:
+            GLib.idle_add(self.np.frame.BuddySharesProgress.show)
+
+    def SetScanProgress(self, sharestype, value):
+        if sharestype == "normal":
+            GLib.idle_add(self.np.frame.SharesProgress.set_fraction, value)
+        else:
+            GLib.idle_add(self.np.frame.BuddySharesProgress.set_fraction, value)
+
+    def HideScanProgress(self, sharestype):
+        if sharestype == "normal":
+            GLib.idle_add(self.np.frame.SharesProgress.hide)
+        else:
+            GLib.idle_add(self.np.frame.BuddySharesProgress.hide)
+
     def UpdateBandwidth(self):
 
         def _bandwidth(line):

--- a/pynicotine/pynicotine.py
+++ b/pynicotine/pynicotine.py
@@ -134,7 +134,7 @@ class NetworkEventProcessor:
         self.users = {}
         self.user_addr_requested = set()
         self.queue = queue.Queue(0)
-        self.shares = Shares(self, self.config, self.queue, self.logMessage)
+        self.shares = Shares(self, self.config, self.queue, self.logMessage, self.frame)
 
         script_dir = os.path.dirname(__file__)
         file_path = os.path.join(script_dir, "geoip/ipcountrydb.bin")


### PR DESCRIPTION
This should fix the build issues. I'll do similar cleanups in the transfers.py file later, as there's some UI-related code that shouldn't be there.