### PR TITLE
Remove MediaDefender bots from default block list

### DIFF
--- a/pynicotine/config.py
+++ b/pynicotine/config.py
@@ -96,7 +96,7 @@ class Config:
                 "banlist": [],
                 "ignorelist": [],
                 "ipignorelist": {},
-                "ipblocklist": {"72.172.88.*": "MediaDefender Bots"},
+                "ipblocklist": {},
                 "autojoin": ["nicotine"],
                 "autoaway": 15,
                 "private_chatrooms": False


### PR DESCRIPTION
MediaDefender is defunct since 2009.