### PR TITLE
Set logging levels on startup

### DIFF
--- a/pynicotine/pynicotine.py
+++ b/pynicotine/pynicotine.py
@@ -121,7 +121,10 @@ class NetworkEventProcessor:
 
         self.bindip = bindip
         self.port = port
+
         self.config.read_config()
+        log.set_log_levels(self.config.sections["logging"]["debugmodes"])
+
         self.peerconns = []
         self.watchedusers = []
         self.ipblock_requested = {}


### PR DESCRIPTION
Set our custom log levels on startup, otherwise only messages in level 0 and 1 (defaults) will be logged until we modify our level list.