### PR TITLE
Don't include invalid data in folder contents response

### DIFF
--- a/pynicotine/pynicotine.py
+++ b/pynicotine/pynicotine.py
@@ -1649,9 +1649,9 @@ class NetworkEventProcessor:
             return
 
         if checkuser == 1:
-            shares = self.config.sections["transfers"]["sharedfiles"]
+            shares = self.config.sections["transfers"]["sharedfilesstreams"]
         elif checkuser == 2:
-            shares = self.config.sections["transfers"]["bsharedfiles"]
+            shares = self.config.sections["transfers"]["bsharedfilesstreams"]
         else:
             self.queue.put(slskmessages.TransferResponse(msg.conn.conn, 0, reason=reason, req=0))
             shares = {}
@@ -1663,7 +1663,7 @@ class NetworkEventProcessor:
                 self.queue.put(slskmessages.FolderContentsResponse(msg.conn.conn, msg.dir, shares[msg.dir.rstrip('\\')]))
             else:
                 if checkuser == 2:
-                    shares = self.config.sections["transfers"]["sharedfiles"]
+                    shares = self.config.sections["transfers"]["sharedfilesstreams"]
                     if msg.dir in shares:
                         self.queue.put(slskmessages.FolderContentsResponse(msg.conn.conn, msg.dir, shares[msg.dir]))
                     elif msg.dir.rstrip("\\") in shares:

--- a/pynicotine/shares.py
+++ b/pynicotine/shares.py
@@ -311,7 +311,7 @@ class Shares:
         """
 
         # returns dict in format:  { Directory : mtime, ... }
-        shared_directories = [x[1] for x in shared]
+        shared_directories = (x[1] for x in shared)
 
         try:
             num_folders = len(oldmtimes)
@@ -615,7 +615,7 @@ class Shares:
 
         message = slskmessages.SlskMessage()
         stream = bytearray()
-        stream.extend(message.pack_object(len(folder)))
+        stream.extend(message.pack_object(len(folder), unsignedint=True))
 
         for fileinfo in folder:
             stream.extend(bytes([1]))
@@ -628,9 +628,9 @@ class Shares:
                     stream.extend(message.pack_object(3))
 
                     stream.extend(message.pack_object(0))
-                    stream.extend(message.pack_object(fileinfo[2][0]))
+                    stream.extend(message.pack_object(fileinfo[2][0], unsignedint=True))
                     stream.extend(message.pack_object(1))
-                    stream.extend(message.pack_object(fileinfo[3]))
+                    stream.extend(message.pack_object(fileinfo[3], unsignedint=True))
                     stream.extend(message.pack_object(2))
                     stream.extend(message.pack_object(fileinfo[2][1]))
                 except Exception:

--- a/pynicotine/slskmessages.py
+++ b/pynicotine/slskmessages.py
@@ -2152,27 +2152,9 @@ class FolderContentsResponse(PeerMessage):
         msg.extend(self.pack_object(self.dir))
         msg.extend(self.pack_object(1))
         msg.extend(self.pack_object(self.dir))
-        msg.extend(self.pack_object(len(self.list), unsignedint=True))
 
-        for fileinfo in self.list:
-            msg.extend(bytes([1]))
-            msg.extend(self.pack_object(fileinfo[0]))
-            msg.extend(self.pack_object(fileinfo[1], unsignedlonglong=True))
-            msg.extend(self.pack_object(0))
-
-            if fileinfo[2] is None:
-                msg.extend(self.pack_object(''))
-                msg.extend(self.pack_object(0))
-            else:
-                msg.extend(self.pack_object("mp3"))
-                msg.extend(self.pack_object(3))
-
-                msg.extend(self.pack_object(0))
-                msg.extend(self.pack_object(fileinfo[2][0], unsignedint=True))
-                msg.extend(self.pack_object(1))
-                msg.extend(self.pack_object(fileinfo[3], unsignedint=True))
-                msg.extend(self.pack_object(2))
-                msg.extend(self.pack_object(fileinfo[2][1]))
+        # We already saved the folder contents as a bytearray when scanning our shares
+        msg.extend(self.list)
 
         return zlib.compress(msg)
 


### PR DESCRIPTION
This is a fix for a regression in https://github.com/Nicotine-Plus/nicotine-plus/commit/9b527ce709f7aa09eab9ba584dfce244e9fde973#diff-686974e33d233586bc64ec1e339db17b.

Before we started packing the file size as a long long (8 bytes), it seems like Nicotine+ sent the file size as an integer (4 bytes), and some dummy content (4 bytes) to take up the 8 bytes required by the protocol (slskmessages.py, line 2161). Since I didn't remove this dummy content, we now inserted 4 unwanted bytes between the file size and file extension.

The folder contents are also identical to the ones we saved while rescanning our shares, so use our cached data instead.