### PR TITLE
Always use correct data directory on Windows

### DIFF
--- a/nicotine
+++ b/nicotine
@@ -36,9 +36,6 @@ from pynicotine.utils import get_user_directories
 # Setting gettext and locale
 apply_translation()
 
-# Detect if we're running on Windows
-win32 = platform.system().startswith("Win")
-
 
 def checkenv():
 
@@ -199,16 +196,8 @@ def run():
         usage()
         sys.exit(2)
 
-    if win32:
-        try:
-            data_dir = os.path.join(os.environ['APPDATA'], 'nicotine')
-        except KeyError:
-            data_dir, x = os.path.split(sys.argv[0])
-
-        config = os.path.join(data_dir, "config", "config")
-    else:
-        config_dir, data_dir = get_user_directories()
-        config = os.path.join(config_dir, 'config')
+    config_dir, data_dir = get_user_directories()
+    config = os.path.join(config_dir, 'config')
 
     plugins = os.path.join(data_dir, 'plugins')
 

--- a/pynicotine/gtkgui/frame.py
+++ b/pynicotine/gtkgui/frame.py
@@ -2104,7 +2104,7 @@ class NicotineFrame:
                 if not isinstance(mylist, (list, dict)):
                     raise TypeError("Bad data in file %(sharesdb)s" % {'sharesdb': share})
 
-                username = share.split(os.sep)[-1]
+                username = share.replace('\\', os.sep).split(os.sep)[-1]
                 self.userbrowse.init_window(username, None)
 
                 if username in self.userbrowse.users:

--- a/pynicotine/gtkgui/userbrowse.py
+++ b/pynicotine/gtkgui/userbrowse.py
@@ -41,14 +41,12 @@ from pynicotine.gtkgui.utils import set_treeview_selected_row
 from pynicotine.logfacility import log
 from pynicotine.utils import clean_file
 from pynicotine.utils import execute_command
-from pynicotine.utils import get_user_directories
 from pynicotine.utils import get_result_bitrate_length
 
 
 class UserBrowse:
 
     def __init__(self, userbrowses, user, conn):
-        _config_dir, self.data_dir = get_user_directories()
 
         # Build the window
         builder = Gtk.Builder()
@@ -531,7 +529,7 @@ class UserBrowse:
                 log.add(_("Error while attempting to display folder '%(folder)s', reported error: %(error)s"), {'folder': directory, 'error': msg})
 
     def on_save(self, widget):
-        sharesdir = os.path.join(self.data_dir, "usershares")
+        sharesdir = os.path.join(self.frame.data_dir, "usershares")
 
         try:
             if not os.path.exists(sharesdir):
@@ -545,6 +543,8 @@ class UserBrowse:
             sharesfile = bz2.BZ2File(os.path.join(sharesdir, clean_file(self.user)), 'w')
             mypickle.dump(self.shares, sharesfile, protocol=mypickle.HIGHEST_PROTOCOL)
             sharesfile.close()
+            log.add(_("Saved list of shared files for user '%(user)s' to %(dir)s"), {'user': self.user, 'dir': sharesdir})
+
         except Exception as msg:
             log.add(_("Can't save shares, '%(user)s', reported error: %(error)s"), {'user': self.user, 'error': msg})
 

--- a/pynicotine/upnp.py
+++ b/pynicotine/upnp.py
@@ -92,7 +92,7 @@ class UPnPPortMapping:
         else:
             # If the python binding import is successful we define the
             # resulting mode
-            self.mode = 'Module'
+            self.mode = '_module'
             return (True, None)
 
     def add_port_mapping(self, np):

--- a/pynicotine/utils.py
+++ b/pynicotine/utils.py
@@ -116,6 +116,16 @@ def get_user_directories():
     """Returns a tuple:
     - the config directory
     - the data directory"""
+
+    if win32:
+        try:
+            data_dir = os.path.join(os.environ['APPDATA'], 'nicotine')
+        except KeyError:
+            data_dir, x = os.path.split(sys.argv[0])
+
+        config_dir = os.path.join(data_dir, "config")
+        return config_dir, data_dir
+
     home = os.path.expanduser("~")
 
     legacy_dir = os.path.join(home, '.nicotine')


### PR DESCRIPTION
There were two cases where Nicotine+ incorrectly attempted to use the XDG dirs on Windows.