### PR TITLE
Always rescan buddy shares when enabling them

### DIFF
--- a/pynicotine/gtkgui/settingswindow.py
+++ b/pynicotine/gtkgui/settingswindow.py
@@ -743,6 +743,7 @@ class SharesFrame(BuildFrame):
 
     def on_enabled_buddy_shares_toggled(self, widget):
         self.on_friends_only_toggled(widget)
+        self.needrescan = True
 
     def on_friends_only_toggled(self, widget):
 

--- a/pynicotine/shares.py
+++ b/pynicotine/shares.py
@@ -72,8 +72,13 @@ class Shares:
         )
 
         self.compressed_shares_buddy = self.compressed_shares_normal = None
-        self.compress_shares("normal")
-        self.compress_shares("buddy")
+
+        if not self.config.sections["transfers"]["friendsonly"]:
+            self.compress_shares("normal")
+
+        if self.config.sections["transfers"]["enablebuddyshares"]:
+            self.compress_shares("buddy")
+
         self.newbuddyshares = self.newnormalshares = False
 
     """ Shares-related actions """


### PR DESCRIPTION
Let's say we have shared and scanned a bunch of normal folders. If we then enable buddy shares without modifying the folders, the buddy share list will be empty, even though it should contain the normal shares too. Make sure buddy shares are automatically rescanned if they are enabled.

Also prevent compressing shares if not necessary.