### PR TITLE
AUTHORS.md: add PySoulSeek authors

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -1,10 +1,11 @@
-# Nicotine+ Maintainers
-This is a somewhat up-to-date list of current Nicotine+ maintainers. For inquiries, it is recommended to [open an issue ticket](https://github.com/Nicotine-Plus/nicotine-plus/issues) on GitHub.
+# Nicotine+ Contributors
+
+Have you done something for Nicotine+, and your name is missing? Please [let us know](README.md#getting-involved).
 
 ### Active
 
 eLvErDe
-- Provides Nicotine+ Website
+- Provided Nicotine+ Trac instance
 - Migrated source code from SVN to Github
 - python3-miniupnpc bindings
 - Developer
@@ -31,21 +32,21 @@ daelstorm
 
 gallows (aka 'burp O')
 - Developer, Packager
-- [g4ll0ws(at)gmail(dot)com]
 - Submitted Slack.Build file
+- [g4ll0ws(at)gmail(dot)com]
 
 QuinoX
 - Developer
 
 hedonist (formerly known as alexbk)
 - OS X nicotine.app maintainer / developer
-- [ak(at)sensi(dot)org]
 - Author of original pyslsk, which is used for nicotine core
+- [ak(at)sensi(dot)org]
 
 lee8oi
 - Bash Commander
-- [winslaya(at)gmail(dot)com]
 - New and updated /alias
+- [winslaya(at)gmail(dot)com]
 
 INMCM
 - Nicotine+ topic maintainer on ubuntuforums.org
@@ -57,7 +58,10 @@ suser-guru
 - Nicotine+ RPM's for Suse 9.1, 9.2, 9.3, 10.0, 10.1
 
 osiris
-- handy-man, documentation, some GNU/Linux packaging, Nicotine+ on win32
+- handy-man
+- documentation
+- some GNU/Linux packaging
+- Nicotine+ on win32
 - Author of Nicotine+ Guide
 - [osiris.contact(at)gmail(dot)com]
 
@@ -72,7 +76,7 @@ Mutnick
 
 ---
 
-# Nicotine Maintainers
+# Nicotine Contributors
 
 ### Retired
 
@@ -100,8 +104,8 @@ sierracat
 - Developed soulseeX
 
 Gustavo
-- [gjc(at)inescporto(dot)pt]
 - Made the exception dialog
+- [gjc(at)inescporto(dot)pt]
 
 SeeSchloss
 - Developer
@@ -110,10 +114,61 @@ SeeSchloss
 
 vasi
 - Mac developer
-- [djvasi(at)gmail(dot)com]
 - Packaged nicotine on OSX PowerPc
+- [djvasi(at)gmail(dot)com]
 
+---
 
-# Contact Info
-Have you done something for Nicotine or Nicotine+ and your name is forgotten?
-Please [let us know](https://github.com/Nicotine-Plus/nicotine-plus/issues).
+# PySoulSeek Contributors
+
+### Retired
+
+Alexander Kanavin
+- Created PySoulSeek
+- [ak(at)sensi(dot)org]
+
+Nir Arbel
+- Helped with many protocol questions I had, and of
+  course he designed and impemented the whole
+  system.
+- [nir(at)slsk(dot)org]
+			    
+Zip (Brett W. Thompson)
+- I used his client code to get an initial impression
+  of how the system works.
+- Supplied the patch for logging chat conversations.
+- [brettt(at)tfn(dot)net]
+
+Josselin Mouette
+- official Debian package maintainer
+- [joss(at)debian(dot)org]
+
+blueboy
+- former unofficial Debian package maintainer
+- [bluegeek(at)eresmas(dot)com]
+
+Christian Swinehart
+- Fink package maintainer
+- [cswinehart(at)users(dot)sourceforge(dot)net]
+
+Hyriand
+- Patches for upload bandwidth management, banning,
+  various UI improvements and more
+- [hyriand(at)thegraveyard(dot)org]
+
+Geert Kloosterman
+- a script for importing windows soulseek configuration
+- [geertk(at)ai(dot)rug(dot)nl]
+
+Joe Halliwell
+- Submitted a patch for optionally discarding search
+  results after closing a search tab
+- [s9900164(at)sms(dot)ed(dot)ac(dot)uk]
+
+Alexey Vyskubov
+- Code cleanups
+- [alexey(dot)vyskubov(at)nokia(dot)com]
+
+Jason Green
+- Ignore list and auto-join checkbox, wishlists
+- [smacklefunky(at)optusnet(dot)com(dot)au]

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ If you'd like to contribute, you have a couple of options to get started:
 * Developers are also encouraged to join the [Launchpad Team](https://launchpad.net/~nicotine-team) or subscribe to the mailing list so that they are automatically notified of failed commits.
 * For (unofficial) documentation of the Soulseek protocol, see [SLSKPROTOCOL.md](doc/SLSKPROTOCOL.md)
 * For a current list of things to do, see the [issue tracker](https://github.com/Nicotine-Plus/nicotine-plus/issues).
-* If you want to contact someone, see [MAINTAINERS.md](AUTHORS.md).
+* For a list of contributors to Nicotine+ and its predecessors, see [AUTHORS.md](AUTHORS.md).
 
 # Continuous Integration Testing
 

--- a/pynicotine/gtkgui/ui/about/about.ui
+++ b/pynicotine/gtkgui/ui/about/about.ui
@@ -10,11 +10,11 @@
     <property name="program_name">Nicotine+</property>
     <property name="comments" translatable="yes">A graphical client for the Soulseek file sharing network</property>
     <property name="website">https://nicotine-plus.org</property>
-    <property name="copyright">© 2001 Alexander Kanavin
+    <property name="copyright">© 2001 PySoulSeek Contributors
 © 2003 Nicotine Team
 © 2006 Nicotine+ Team</property>
     <property name="license_type">GTK_LICENSE_GPL_3_0</property>
-    <property name="authors"># ATTRIBUTIONS
+    <property name="authors"># Attributions
 
 - This product includes IP2Location LITE data,
   available from:
@@ -24,12 +24,12 @@
   Copyright (c) 2013 Panayiotis Lipiridis
   https://github.com/lipis/flag-icon-css
 
-# Nicotine+ MAINTAINERS
+# Nicotine+ Contributors
 
 ### Active
 
 eLvErDe
-- Provides Nicotine+ Website
+- Provided Nicotine+ Trac instance
 - Migrated source code from SVN to Github
 - python3-miniupnpc bindings
 - Developer
@@ -56,30 +56,30 @@ daelstorm
 
 gallows (aka 'burp O')
 - Developer, Packager
-- [g4ll0ws(at)gmail(dot)com]
 - Submitted Slack.Build file
+- [g4ll0ws(at)gmail(dot)com]
 
 QuinoX
 - Developer
 
 hedonist (formerly known as alexbk)
 - OS X nicotine.app maintainer / developer
-- [ak(at)sensi(dot)org]
 - Author of original pyslsk, which is used for
   nicotine core
+- [ak(at)sensi(dot)org]
 
 lee8oi
 - Bash Commander
-- [winslaya(at)gmail(dot)com]
 - New and updated /alias
+- [winslaya(at)gmail(dot)com]
 
 INMCM
 - Nicotine+ topic maintainer on ubuntuforums.org
-- ubuntuforums.org/showthread.php?t=196835
+  https://ubuntuforums.org/showthread.php?t=196835
 
 suser-guru
 - Suse Linux packager
-- dev-loki.blogspot.fr
+  https://dev-loki.blogspot.fr/
 - Nicotine+ RPM's for Suse 9.1, 9.2, 9.3, 10.0, 10.1
 
 osiris
@@ -92,14 +92,14 @@ osiris
 
 Michael Labouebe (aka gfarmerfr)
 - Developer
-- [gfarmerfr(at)free(dot)fr
+- [gfarmerfr(at)free(dot)fr]
 
 Mutnick
 - Created Nicotine+ GitHub Organization
 - Developer
-- [mutnick(at)techie(dot)com]
+- [muhing(at)yahoo(dot)com]
 
-# Nicotine MAINTAINERS
+# Nicotine Contributors
 
 ### Retired
 
@@ -121,25 +121,81 @@ Wretched
 (va)\\*10^3
 - Beta tester
 - Designer of the old nicotine homepage and artwork
+  (logos)
 
 sierracat
 - MacOSX tester
 - Developed soulseeX
 
 Gustavo
-- [gjc(at)inescporto(dot)pt]
 - Made the exception dialog
+- [gjc(at)inescporto(dot)pt]
 
 SeeSchloss
 - Developer
 - Made 1.0.8 win32 installer
-- Created Soulfind github.com/seeschloss/soulfind,
+- Created Soulfind,
   opensource Soulseek Server written in D
+  https://github.com/seeschloss/soulfind
 
 vasi
 - Mac developer
-- [djvasi@gmail.com]
-- Packaged nicotine on OSX PowerPc</property>
+- Packaged nicotine on OSX PowerPc
+- [djvasi(at)gmail(dot)com]
+
+# PySoulSeek Contributors
+
+### Retired
+
+Alexander Kanavin
+- Created PySoulSeek
+- [ak(at)sensi(dot)org]
+
+Nir Arbel
+- Helped with many protocol questions I had, and of
+  course he designed and impemented the whole
+  system.
+- [nir(at)slsk(dot)org]
+			    
+Zip (Brett W. Thompson)
+- I used his client code to get an initial impression
+  of how the system works.
+- Supplied the patch for logging chat conversations.
+- [brettt(at)tfn(dot)net]
+
+Josselin Mouette
+- official Debian package maintainer
+- [joss(at)debian(dot)org]
+
+blueboy
+- former unofficial Debian package maintainer
+- [bluegeek(at)eresmas(dot)com]
+
+Christian Swinehart
+- Fink package maintainer
+- [cswinehart(at)users(dot)sourceforge(dot)net]
+
+Hyriand
+- Patches for upload bandwidth management, banning,
+  various UI improvements and more
+- [hyriand(at)thegraveyard(dot)org]
+
+Geert Kloosterman
+- a script for importing windows soulseek configuration
+- [geertk(at)ai(dot)rug(dot)nl]
+
+Joe Halliwell
+- Submitted a patch for optionally discarding search
+  results after closing a search tab
+- [s9900164(at)sms(dot)ed(dot)ac(dot)uk]
+
+Alexey Vyskubov
+- Code cleanups
+- [alexey(dot)vyskubov(at)nokia(dot)com]
+
+Jason Green
+- Ignore list and auto-join checkbox, wishlists
+- [smacklefunky(at)optusnet(dot)com(dot)au]</property>
     <property name="translator_credits">Dutch
  * nince78 (2007)
  * hyriand


### PR DESCRIPTION
Since Nicotine was based on PySoulSeek, I feel it would be a kind gesture to also credit the people who made PySoulSeek possible. The author list is taken from PySoulSeek 1.2.4, the last version Nicotine used code from.