### PR TITLE
Debian: install to /usr/lib/python3/dist-packages

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -22,10 +22,11 @@ Rules-Requires-Root: no
 Package: nicotine
 Architecture: all
 Depends:
+    $(python3:Depends},
+    ${misc:Depends},
     python3-miniupnpc | miniupnpc (>= 1.9),
     gobject-introspection,
     gir1.2-gtk-3.0,
-    python3 (>= 3.5),
     python3-dbus,
     python3-gi,
     python3-taglib,


### PR DESCRIPTION
This seems to be the way to go to install Nicotine+ to the more generic /usr/lib/python3/dist-packages folder, instead of /usr/lib/python3.X/dist-packages. We want to avoid installing files to a minor version folder, as it breaks our deb packages on Debian installations if the minor Python 3 version doesn't match, and most other Python-based packages don't install their files here.