### PR TITLE
Debian: install to /usr/lib/python3/dist-packages

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -22,6 +22,8 @@ Rules-Requires-Root: no
 Package: nicotine
 Architecture: all
 Depends:
+    ${python3:Depends},
+    ${misc:Depends},
     python3-miniupnpc | miniupnpc (>= 1.9),
     gobject-introspection,
     gir1.2-gtk-3.0,


### PR DESCRIPTION
This seems to be the way to go to install Nicotine+ to the more generic /usr/lib/python3/dist-packages folder, instead of /usr/lib/python3.X/dist-packages. We want to avoid installing files to a minor version folder, as it breaks our deb packages on Debian installations if the minor Python 3 version doesn't match, and almost every other Python-based package doesn't install its files here.