### PR TITLE
Reuse spell checker object for every chat

### DIFF
--- a/pynicotine/gtkgui/chatrooms.py
+++ b/pynicotine/gtkgui/chatrooms.py
@@ -786,10 +786,10 @@ class ChatRoom:
         TextSearchBar(self.ChatScroll, self.ChatSearchBar, self.ChatSearchEntry)
 
         # Spell Check
-        if self.frame.gspell and self.frame.np.config.sections["ui"]["spellcheck"]:
+        if self.frame.spell_checker and self.frame.np.config.sections["ui"]["spellcheck"]:
             from gi.repository import Gspell
             spell_buffer = Gspell.EntryBuffer.get_from_gtk_entry_buffer(self.ChatEntry.get_buffer())
-            spell_buffer.set_spell_checker(Gspell.Checker.new())
+            spell_buffer.set_spell_checker(self.frame.spell_checker)
             spell_view = Gspell.Entry.get_from_gtk_entry(self.ChatEntry)
             spell_view.set_inline_spell_checking(True)
 

--- a/pynicotine/gtkgui/frame.py
+++ b/pynicotine/gtkgui/frame.py
@@ -109,10 +109,10 @@ class NicotineFrame:
         try:
             # Spell checking support
             gi.require_version('Gspell', '1')
-            from gi.repository import Gspell  # noqa: F401
-            self.gspell = True
+            from gi.repository import Gspell
+            self.spell_checker = Gspell.Checker.new()
         except (ImportError, ValueError):
-            self.gspell = False
+            self.spell_checker = None
 
         self.np = NetworkEventProcessor(
             self,

--- a/pynicotine/gtkgui/privatechat.py
+++ b/pynicotine/gtkgui/privatechat.py
@@ -362,10 +362,10 @@ class PrivateChat:
         TextSearchBar(self.ChatScroll, self.SearchBar, self.SearchEntry)
 
         # Spell Check
-        if self.frame.gspell and self.frame.np.config.sections["ui"]["spellcheck"]:
+        if self.frame.spell_checker and self.frame.np.config.sections["ui"]["spellcheck"]:
             from gi.repository import Gspell
             spell_buffer = Gspell.EntryBuffer.get_from_gtk_entry_buffer(self.ChatLine.get_buffer())
-            spell_buffer.set_spell_checker(Gspell.Checker.new())
+            spell_buffer.set_spell_checker(self.frame.spell_checker)
             spell_view = Gspell.Entry.get_from_gtk_entry(self.ChatLine)
             spell_view.set_inline_spell_checking(True)
 

--- a/pynicotine/gtkgui/settingswindow.py
+++ b/pynicotine/gtkgui/settingswindow.py
@@ -2867,7 +2867,7 @@ class CompletionFrame(BuildFrame):
     def set_settings(self, config):
         self.needcompletion = 0
 
-        self.SpellCheck.set_sensitive(self.frame.gspell)
+        self.SpellCheck.set_sensitive(True if self.frame.spell_checker else False)
 
         self.p.set_widgets_data(config, self.options)
 


### PR DESCRIPTION
A spell checker object seems to take up quite a lot of memory, so reuse it across chats instead of creating new ones.

master branch: 200MB memory usage after joining 20 rooms
this PR: 62MB memory usage after joining 20 rooms