### PR TITLE
Migrate from libnotify to GNotification

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -35,7 +35,6 @@ Depends:
 Recommends:
     gir1.2-ayatanaappindicator3-0.1 | gir1.2-appindicator3-0.1,
     gir1.2-gspell-1,
-    gir1.2-notify-0.7,
     python3-miniupnpc
 Description: graphical client for Soulseek P2P network
  Nicotine+ is a graphical client for the Soulseek peer-to-peer

--- a/doc/DEPENDENCIES.md
+++ b/doc/DEPENDENCIES.md
@@ -14,7 +14,6 @@
 
 * [gir1.2-appindicator3-0.1](https://lazka.github.io/pgi-docs/AppIndicator3-0.1/index.html) or [gir1.2-ayatanaappindicator3-0.1](https://lazka.github.io/pgi-docs/AyatanaAppIndicator3-0.1/index.html) for tray icon;
 * [gir1.2-gspell-1](https://lazka.github.io/pgi-docs/Gspell-1/index.html) for spell checking in chat;
-* [gir1.2-notify-0.7](https://lazka.github.io/pgi-docs/Notify-0.7/index.html) for popup notifications and sounds;
 
 ## Installing dependencies
 ### GNU/Linux

--- a/files/macos/dependencies.sh
+++ b/files/macos/dependencies.sh
@@ -29,7 +29,6 @@ brew install \
   gobject-introspection \
   gspell \
   gtk+3 \
-  libnotify \
   librsvg \
   pygobject3 \
   taglib \

--- a/pynicotine/config.py
+++ b/pynicotine/config.py
@@ -378,7 +378,7 @@ class Config:
                 "notification_window_title": True,
                 "notification_tab_colors": False,
                 "notification_tab_icons": True,
-                "notification_popup_sound": True,
+                "notification_popup_sound": False,
                 "notification_popup_file": True,
                 "notification_popup_folder": True,
                 "notification_popup_private_message": True,

--- a/pynicotine/gtkgui/chatrooms.py
+++ b/pynicotine/gtkgui/chatrooms.py
@@ -29,6 +29,7 @@ from gettext import gettext as _
 from os.path import commonprefix
 
 from gi.repository import Gdk
+from gi.repository import Gio
 from gi.repository import GLib
 from gi.repository import GObject
 from gi.repository import Gtk
@@ -1141,8 +1142,7 @@ class ChatRoom:
                     self.frame.notifications.new_notification(
                         text,
                         title=_("%s mentioned you in the %s room") % (user, self.room),
-                        soundnamenotify="bell-window-system",
-                        soundnamewin="SystemExclamation"
+                        priority=Gio.NotificationPriority.HIGH
                     )
 
             else:
@@ -1161,7 +1161,8 @@ class ChatRoom:
                 elif self.frame.np.config.sections["notifications"]["notification_popup_chatroom"]:
                     self.frame.notifications.new_notification(
                         text,
-                        title=_("Message by %s in the %s room") % (user, self.room)
+                        title=_("Message by %s in the %s room") % (user, self.room),
+                        priority=Gio.NotificationPriority.HIGH
                     )
 
         if text[:4] == "/me ":

--- a/pynicotine/gtkgui/privatechat.py
+++ b/pynicotine/gtkgui/privatechat.py
@@ -27,6 +27,7 @@ from time import altzone
 from time import daylight
 
 from gi.repository import Gdk
+from gi.repository import Gio
 from gi.repository import GLib
 from gi.repository import GObject
 from gi.repository import Gtk
@@ -246,7 +247,8 @@ class PrivateChats(IconNotebook):
             if self.frame.np.config.sections["notifications"]["notification_popup_private_message"]:
                 self.frame.notifications.new_notification(
                     text,
-                    title=_("Private message from %s") % msg.user
+                    title=_("Private message from %s") % msg.user,
+                    priority=Gio.NotificationPriority.HIGH
                 )
 
         # SEND CLIENT VERSION to user if the following string is sent

--- a/pynicotine/gtkgui/settingswindow.py
+++ b/pynicotine/gtkgui/settingswindow.py
@@ -3126,21 +3126,6 @@ class NotificationsFrame(BuildFrame):
 
     def set_settings(self, config):
 
-        if self.frame.notifications.notification_provider is not None:
-            self.NotificationPopupSound.set_sensitive(True)
-            self.NotificationPopupFile.set_sensitive(True)
-            self.NotificationPopupFolder.set_sensitive(True)
-            self.NotificationPopupPrivateMessage.set_sensitive(True)
-            self.NotificationPopupChatroom.set_sensitive(True)
-            self.NotificationPopupChatroomMention.set_sensitive(True)
-        else:
-            self.NotificationPopupSound.set_sensitive(False)
-            self.NotificationPopupFile.set_sensitive(False)
-            self.NotificationPopupFolder.set_sensitive(False)
-            self.NotificationPopupPrivateMessage.set_sensitive(False)
-            self.NotificationPopupChatroom.set_sensitive(False)
-            self.NotificationPopupChatroomMention.set_sensitive(False)
-
         self.p.set_widgets_data(config, self.options)
 
     def get_settings(self):

--- a/pynicotine/transfers.py
+++ b/pynicotine/transfers.py
@@ -1303,8 +1303,7 @@ class Transfers:
                     'user': i.user,
                     'file': newname.rsplit(os.sep, 1)[1]
                 },
-                title=_("File downloaded"),
-                soundnamenotify="complete-download"
+                title=_("File downloaded")
             )
 
         self.save_downloads()
@@ -1332,8 +1331,7 @@ class Transfers:
                             'user': i.user,
                             'folder': folder
                         },
-                        title=_("Folder downloaded"),
-                        soundnamenotify="complete-download"
+                        title=_("Folder downloaded")
                     )
                 if config["transfers"]["afterfolder"]:
                     if not execute_command(config["transfers"]["afterfolder"], folder):

--- a/setup.cfg
+++ b/setup.cfg
@@ -5,7 +5,6 @@ requires =
     gspell
     gtk3
     libappindicator-gtk3
-    libnotify
     python3 >= 3.5
     python3-dbus
     python3-gobject


### PR DESCRIPTION
This seems to be the logical step going forward, see https://developer.gnome.org/GNotification/.

As a side effect, we now support notifications on macOS. A Windows backend isn't present yet, but there's an open issue for it: https://gitlab.gnome.org/GNOME/glib/-/issues/1234