### PR TITLE
Disable tray icon on macOS

### DIFF
--- a/pynicotine/config.py
+++ b/pynicotine/config.py
@@ -396,6 +396,10 @@ class Config:
         if sys.platform.startswith('win'):
             self.sections['ui']['filemanager'] = 'explorer $'
 
+        if sys.platform == "darwin":
+            # Non-functional tray icon is disabled on macOS
+            self.sections['ui']['exitdialog'] = 0
+
         self.defaults = {}
         for key, value in self.sections.items():
             if isinstance(value, dict):

--- a/pynicotine/gtkgui/frame.py
+++ b/pynicotine/gtkgui/frame.py
@@ -23,6 +23,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 import os
 import re
+import sys
 import urllib.parse
 
 from gettext import gettext as _
@@ -400,7 +401,9 @@ class NicotineFrame:
         }
 
         # Create the trayicon if needed
-        if use_trayicon and config["ui"]["trayicon"]:
+        # Tray icons don't work as expected on macOS
+        if sys.platform != "darwin" and \
+                use_trayicon and config["ui"]["trayicon"]:
             self.tray_app.create()
 
         """ Connect """

--- a/pynicotine/gtkgui/settingswindow.py
+++ b/pynicotine/gtkgui/settingswindow.py
@@ -1577,6 +1577,11 @@ class IconsFrame(BuildFrame):
         if ui["icontheme"]:
             self.ThemeDir.set_current_folder(ui["icontheme"])
 
+        if sys.platform == "darwin":
+            # Tray icons don't work as expected on macOS
+            self.hide_tray_icon_settings()
+            return
+
         if ui["exitdialog"] is not None:
 
             exitdialog = int(ui["exitdialog"])
@@ -1587,6 +1592,24 @@ class IconsFrame(BuildFrame):
                 self.SendToTrayOnClose.set_active(True)
             elif exitdialog == 0:
                 self.QuitOnClose.set_active(True)
+
+    def hide_tray_icon_settings(self):
+
+        # Hide widgets
+        self.TraySettings.hide()
+
+        self.Trayicon_Label.hide()
+        self.Trayicon_Away.hide()
+        self.Trayicon_Away_Label.hide()
+        self.Trayicon_Connect.hide()
+        self.Trayicon_Online_Label.hide()
+        self.Trayicon_Disconnect.hide()
+        self.Trayicon_Offline_Label.hide()
+        self.Trayicon_Msg.hide()
+        self.Trayicon_Hilite_Label.hide()
+
+        # Always exit on close, since there's no tray icon
+        self.QuitOnClose.set_active(True)
 
     def on_default_theme(self, widget):
         self.ThemeDir.unselect_all()

--- a/pynicotine/gtkgui/ui/settings/icons.ui
+++ b/pynicotine/gtkgui/ui/settings/icons.ui
@@ -10,7 +10,7 @@
         <property name="spacing">15</property>
         <property name="orientation">vertical</property>
         <child>
-          <object class="GtkBox">
+          <object class="GtkBox" id="TraySettings">
             <property name="visible">True</property>
             <property name="can_focus">False</property>
             <property name="spacing">10</property>
@@ -196,7 +196,7 @@
                 <property name="column_spacing">10</property>
                 <property name="column_homogeneous">True</property>
                 <child>
-                  <object class="GtkLabel">
+                  <object class="GtkLabel" id="Trayicon_Label">
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
                     <property name="label" translatable="yes">&lt;b&gt;Trayicon&lt;/b&gt;</property>
@@ -209,7 +209,7 @@
                   </packing>
                 </child>
                 <child>
-                  <object class="GtkLabel">
+                  <object class="GtkLabel" id="Trayicon_Online_Label">
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
                     <property name="label" translatable="yes">Online:</property>
@@ -221,7 +221,7 @@
                   </packing>
                 </child>
                 <child>
-                  <object class="GtkLabel">
+                  <object class="GtkLabel" id="Trayicon_Away_Label">
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
                     <property name="label" translatable="yes">Away:</property>
@@ -233,7 +233,7 @@
                   </packing>
                 </child>
                 <child>
-                  <object class="GtkLabel">
+                  <object class="GtkLabel" id="Trayicon_Offline_Label">
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
                     <property name="label" translatable="yes">Offline:</property>
@@ -241,7 +241,7 @@
                   </object>
                   <packing>
                     <property name="left_attach">2</property>
-          Z          <property name="top_attach">2</property>
+                    <property name="top_attach">2</property>
                   </packing>
                 </child>
                 <child>
@@ -289,7 +289,7 @@
                   </packing>
                 </child>
                 <child>
-                  <object class="GtkLabel">
+                  <object class="GtkLabel" id="Trayicon_Hilite_Label">
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
                     <property name="label" translatable="yes">Nick Hilite:</property>


### PR DESCRIPTION
The tray icon functionality is completely broken on macOS at the moment. The tray icon popup does not appear, and minimizing Nicotine+ to tray doesn't hide the icon from the dock.

I've opted to disable the tray icon on macOS, as it's not worth dealing with GtkStatusIcon, which is a deprecated mess removed in GTK4. macOS has some kind of "Hide" button when right-clicking a dock icon, which seems good enough.