### PR TITLE
Clear tray and title notifications properly

### DIFF
--- a/pynicotine/gtkgui/chatrooms.py
+++ b/pynicotine/gtkgui/chatrooms.py
@@ -236,8 +236,11 @@ class RoomsControl:
         if self.frame.MainNotebook.get_current_page() != self.frame.MainNotebook.page_num(self.frame.chathbox) and not force:
             return
 
+        # page is None?
+        new_page = notebook.get_nth_page(page_num)
+
         for name, room in self.joinedrooms.items():
-            if room.Main == page:
+            if room.Main == new_page:
                 GLib.idle_add(room.ChatEntry.grab_focus)
 
                 # Remove hilite

--- a/pynicotine/gtkgui/privatechat.py
+++ b/pynicotine/gtkgui/privatechat.py
@@ -92,8 +92,11 @@ class PrivateChats(IconNotebook):
         if self.frame.MainNotebook.get_current_page() != self.frame.MainNotebook.page_num(self.frame.privatevbox) and not force:
             return
 
+        # page is None?
+        new_page = notebook.get_nth_page(page_num)
+
         for user, tab in list(self.users.items()):
-            if tab.Main == page:
+            if tab.Main == new_page:
                 GLib.idle_add(tab.ChatLine.grab_focus)
                 # Remove hilite if selected tab belongs to a user in the hilite list
                 if user in self.frame.hilites["private"]:

--- a/pynicotine/gtkgui/utils.py
+++ b/pynicotine/gtkgui/utils.py
@@ -883,9 +883,6 @@ class IconNotebook:
         if self.notebook.get_n_pages() == 0:
             self.notebook.set_show_tabs(False)
 
-    def on_focused(self, item):
-        self.frame.notifications.clear_page(self, item)
-
     def on_tab_click(self, widget, event, child):
         # Dummy implementation
         pass
@@ -939,8 +936,11 @@ class IconNotebook:
 
     def dismiss_icon(self, notebook, page, page_num):
 
-        self.set_image(page, 0)
-        self.set_text_color(page, 0)
+        # page is None?
+        new_page = self.get_nth_page(page_num)
+
+        self.set_image(new_page, 0)
+        self.set_text_color(new_page, 0)
 
     def request_hilite(self, page):
 


### PR DESCRIPTION
Reverts a minor change in https://github.com/Nicotine-Plus/nicotine-plus/pull/698. For some reason the "page" input variable is None...

Also removes on_focused leftover from detachable tabs.