### PR TITLE
Don't install unneeded dependencies for unit tests

### DIFF
--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -30,7 +30,8 @@ jobs:
       - name: Install build dependencies
         run: |
           export ARCH=${{ matrix.arch }}
-          files/windows/dependencies.sh
+          files/windows/dependencies-core.sh
+          files/windows/dependencies-packaging.sh
 
       - name: Build installer
         run: |
@@ -62,7 +63,8 @@ jobs:
 
       - name: Install build dependencies
         run: |
-          files/macos/dependencies.sh
+          files/macos/dependencies-core.sh
+          files/macos/dependencies-packaging.sh
 
       - name: Freeze application
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -58,7 +58,7 @@ jobs:
       - name: Install dependencies
         run: |
           export ARCH=x86_64
-          files/windows/dependencies.sh
+          files/windows/dependencies-core.sh
 
       - name: Lint with flake8
         run: |
@@ -78,7 +78,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          files/macos/dependencies.sh
+          files/macos/dependencies-core.sh
 
       - name: Lint with flake8
         run: |

--- a/doc/PACKAGING.md
+++ b/doc/PACKAGING.md
@@ -63,7 +63,8 @@ First, follow the instructions on installing MSYS2: [https://pygobject.readthedo
 Then, install dependencies:
 
 `export ARCH=x86_64`  
-`files/windows/dependencies.sh`
+`files/windows/dependencies-core.sh`
+`files/windows/dependencies-packaging.sh`
 
 Clone the Nicotine+ git repository:
 

--- a/files/macos/dependencies-core.sh
+++ b/files/macos/dependencies-core.sh
@@ -18,21 +18,17 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-""" This script is used to install dependencies in Homebrew """
+### This script is used to install core dependencies in Homebrew ###
+### These are enough to run unit tests and use non-UI code ###
 
-# Install most dependencies from the main Homebrew repos
+# Install dependencies from the main Homebrew repos
 brew install \
-  adwaita-icon-theme \
-  create-dmg \
   flake8 \
-  gdk-pixbuf \
-  gobject-introspection \
-  gspell \
-  gtk+3 \
-  librsvg \
-  pygobject3 \
-  taglib \
-  upx
+  taglib
 
-# Use pip for packages not available in Homebrew
-pip3 install miniupnpc pep8-naming pyinstaller==3.6 pytaglib pytest
+# Install dependencies with pip
+pip3 install \
+  miniupnpc \
+  pep8-naming \
+  pytaglib \
+  pytest

--- a/files/macos/dependencies-packaging.sh
+++ b/files/macos/dependencies-packaging.sh
@@ -1,0 +1,36 @@
+#!/bin/sh
+
+# COPYRIGHT (C) 2020 Nicotine+ Team
+#
+# GNU GENERAL PUBLIC LICENSE
+#    Version 3, 29 June 2007
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+### This script is used to install UI and packaging dependencies in Homebrew ###
+
+# Install dependencies from the main Homebrew repos
+brew install \
+  adwaita-icon-theme \
+  create-dmg \
+  gdk-pixbuf \
+  gobject-introspection \
+  gtk+3 \
+  librsvg \
+  pygobject3 \
+  upx
+
+# Install dependencies with pip
+pip3 install \
+  pyinstaller==3.6

--- a/files/windows/dependencies-core.sh
+++ b/files/windows/dependencies-core.sh
@@ -18,41 +18,30 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-""" This script is used to install dependencies in MinGW """
+### This script is used to install core dependencies in MinGW ###
+### These are enough to run unit tests and use non-UI code ###
 
-# Install most dependencies from the main MinGW repos
+# Install dependencies from the main MinGW repos
 pacman --noconfirm -S --needed \
-  git \
-  upx \
   mingw-w64-$ARCH-cython \
   mingw-w64-$ARCH-gcc \
-  mingw-w64-$ARCH-gspell \
-  mingw-w64-$ARCH-gtk3 \
   mingw-w64-$ARCH-miniupnpc \
-  mingw-w64-$ARCH-nsis \
-  mingw-w64-$ARCH-python3 \
-  mingw-w64-$ARCH-python3-gobject \
-  mingw-w64-$ARCH-python3-pip \
-  mingw-w64-$ARCH-python3-pytest \
-  mingw-w64-$ARCH-python3-flake8 \
+  mingw-w64-$ARCH-python \
+  mingw-w64-$ARCH-python-flake8 \
+  mingw-w64-$ARCH-python-pip \
+  mingw-w64-$ARCH-python-pytest \
   mingw-w64-$ARCH-taglib
 
-# Use pip for packages not available in MinGW repos
-pip install pep8-naming plyer semidbm
-
-# pyinstaller (we should switch back to pip once PyInstaller 4.1 is released)
-wget https://github.com/pyinstaller/pyinstaller/releases/download/v3.6/PyInstaller-3.6.tar.gz
-tar -zxvf PyInstaller-3.6.tar.gz
-cd PyInstaller-3.6/
-python setup.py install
-cd ..
-rm -rf PyInstaller-3.6/
+# Install dependencies with pip
+pip3 install \
+  pep8-naming \
+  semidbm
 
 # pytaglib
 wget https://github.com/supermihi/pytaglib/archive/v1.4.6.tar.gz
 tar -zxvf v1.4.6.tar.gz
 cd pytaglib-1.4.6/
 sed -i "/is_windows = / s/sys.platform.startswith('win')/False/" setup.py
-PYTAGLIB_CYTHONIZE=1 python setup.py install
+python setup.py install
 cd ..
 rm -rf pytaglib-1.4.6/

--- a/files/windows/dependencies-packaging.sh
+++ b/files/windows/dependencies-packaging.sh
@@ -1,0 +1,35 @@
+#!/bin/sh
+
+# COPYRIGHT (C) 2020 Nicotine+ Team
+#
+# GNU GENERAL PUBLIC LICENSE
+#    Version 3, 29 June 2007
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+### This script is used to install UI and packaing dependencies in MinGW ###
+
+# Install dependencies from the main MinGW repos
+pacman --noconfirm -S --needed \
+  upx \
+  mingw-w64-$ARCH-gspell \
+  mingw-w64-$ARCH-gtk3 \
+  mingw-w64-$ARCH-nsis \
+  mingw-w64-$ARCH-python-gobject \
+  mingw-w64-$ARCH-taglib
+
+# Install dependencies with pip
+pip3 install \
+  plyer \
+  pyinstaller==3.6


### PR DESCRIPTION
Since we don't include GTK-related functions in the core, and our unit tests currently only cover the core, there's no need to waste bandwidth installing unnecessary dependencies. Packaging software is also not needed for tests.