### PR TITLE
Remove option to stop responding to searches for a certain time

### DIFF
--- a/pynicotine/config.py
+++ b/pynicotine/config.py
@@ -257,8 +257,6 @@ class Config:
                 "filterout": [],
                 "filtersize": [],
                 "filterbr": [],
-                "distrib_timer": False,
-                "distrib_ignore": 60,
                 "search_results": True,
                 "max_displayed_results": 1000,
                 "max_stored_results": 1500,
@@ -578,6 +576,10 @@ class Config:
 
         # Remove old log folder option, superseded by individual log folders for transfers and debug messages
         self.remove_old_option("logging", "logsdir")
+
+        # Remove option to stop responding to searches for a certain time
+        self.remove_old_option("searches", "distrib_timer")
+        self.remove_old_option("searches", "distrib_ignore")
 
         # Checking for unknown section/options
         unknown1 = [

--- a/pynicotine/gtkgui/frame.py
+++ b/pynicotine/gtkgui/frame.py
@@ -2361,7 +2361,6 @@ class NicotineFrame:
 
         self.np.queue.put(slskmessages.SetUploadLimit(uselimit, uploadlimit, limitby))
         self.np.queue.put(slskmessages.SetDownloadLimit(config["transfers"]["downloadlimit"]))
-        self.np.toggle_respond_distributed(None, settings=True)
 
         if self.search_notebook:
             self.search_notebook.maxdisplayedresults = config["searches"]["max_displayed_results"]

--- a/pynicotine/gtkgui/settingswindow.py
+++ b/pynicotine/gtkgui/settingswindow.py
@@ -2267,8 +2267,6 @@ class SearchFrame(BuildFrame):
                 "enablefilters": self.EnableFilters,
                 "re_filter": self.RegexpFilters,
                 "defilter": None,
-                "distrib_timer": self.ToggleDistributed,
-                "distrib_ignore": self.ToggleDistributedInterval,
                 "reopen_tabs": self.ReopenTabs,
                 "search_results": self.ToggleResults,
                 "max_displayed_results": self.MaxDisplayedResults,
@@ -2312,8 +2310,6 @@ class SearchFrame(BuildFrame):
                     self.FilterFree.get_active(),
                     self.FilterCC.get_text()
                 ],
-                "distrib_timer": self.ToggleDistributed.get_active(),
-                "distrib_ignore": self.ToggleDistributedInterval.get_value_as_int(),
                 "reopen_tabs": self.ReopenTabs.get_active(),
                 "search_results": self.ToggleResults.get_active(),
                 "max_displayed_results": self.MaxDisplayedResults.get_value_as_int(),
@@ -2332,7 +2328,7 @@ class SearchFrame(BuildFrame):
         active = widget.get_active()
         for w in self.MinSearchCharsL1, self.MinSearchChars, self.MinSearchCharsL2, \
                 self.MaxResults, self.MaxResultsL1, self.MaxResultsL2, \
-                self.ToggleDistributed, self.ToggleDistributedInterval, self.secondsLabel:
+                self.secondsLabel:
             w.set_sensitive(active)
 
 


### PR DESCRIPTION
What exactly this option does was unclear for me when I started using Nicotine+, and apparently others have had a similar experience. I don't see what kind of purpose it serves anymore, there's always the manual toggle to disable sending of search results if you really need it.