### PR TITLE
Improve plugin loading and setting detection

### DIFF
--- a/files/windows/nicotine.spec
+++ b/files/windows/nicotine.spec
@@ -20,12 +20,19 @@
 
 block_cipher = None
 
-from PyInstaller.utils.hooks import get_gi_typelibs
-
 import glob
 import os
 import sys
 
+from pkgutil import walk_packages
+from PyInstaller.utils.hooks import get_gi_typelibs
+
+# Provide access to the pynicotine module
+sys.path.append('.')
+
+import pynicotine.plugins
+
+# Disable unnecessary modules
 sys.modules['FixTk'] = None
 sys.modules['lib2to3'] = None
 
@@ -40,9 +47,9 @@ if sys.platform == 'win32':
     # Notification support on Windows
     hiddenimports.append('plyer.platforms.win.notification')
 
-elif sys.platform == 'darwin':
-    # Notification support on macOS
-    hiddenimports.append('plyer.platforms.macosx.notification')
+# Include plugins
+hiddenimports += [name for importer, name, ispkg in walk_packages(path=pynicotine.plugins.__path__, prefix="pynicotine.plugins.") if ispkg]
+
 
 # Files to be added to the frozen app
 added_files = [

--- a/pynicotine/gtkgui/settingswindow.py
+++ b/pynicotine/gtkgui/settingswindow.py
@@ -3251,7 +3251,7 @@ class BuildDialog(Gtk.Dialog):
             if value is not None:
                 self.settings.frame.np.config.sections["plugins"][self.plugin][name] = value
         self.PluginProperties.hide()
-        self.settings.frame.np.pluginhandler.plugin_settings(self.settings.frame.np.pluginhandler.loaded_plugins[self.plugin].PLUGIN)
+        self.settings.frame.np.pluginhandler.plugin_settings(self.plugin, self.settings.frame.np.pluginhandler.loaded_plugins[self.plugin].PLUGIN)
 
     def show(self):
         self.PluginProperties.show()


### PR DESCRIPTION
- Attempt to load plugins by module name when possible, since the __init__.py files are not included in Windows and macOS builds. Include plugin modules in these builds. Fixes https://github.com/Nicotine-Plus/nicotine-plus/issues/761
- Ensure that the setting key for a plugin matches the plugin folder name (use the folder name directly instead of converting the plugin name to lowercase). Fixes https://github.com/Nicotine-Plus/nicotine-plus/issues/762, fixes https://github.com/Nicotine-Plus/nicotine-plus/issues/763
- Remove unnecessary macOS notification code from .spec file