### PR TITLE
Don't send number of shared files if not connected

### DIFF
--- a/pynicotine/pynicotine.py
+++ b/pynicotine/pynicotine.py
@@ -136,6 +136,7 @@ class NetworkEventProcessor:
         self.private_message_queue = {}
         self.users = {}
         self.user_addr_requested = set()
+
         self.queue = queue.Queue(0)
         self.shares = Shares(self, self.config, self.queue, self.ui_callback)
         self.pluginhandler = PluginHandler(self.ui_callback, plugins, self.config)
@@ -578,6 +579,7 @@ class NetworkEventProcessor:
 
             self.active_server_conn = None
             self.watchedusers = []
+            self.shares.set_connected(False)
 
             if self.transfers is not None:
                 self.transfers.abort_transfers()
@@ -617,6 +619,7 @@ class NetworkEventProcessor:
 
             self.transfers = transfers.Transfers(self.peerconns, self.queue, self, self.users,
                                                  self.network_callback, self.ui_callback.notifications, self.pluginhandler)
+            self.shares.set_connected(True)
 
             if msg.ip is not None:
                 self.ipaddress = msg.ip

--- a/pynicotine/shares.py
+++ b/pynicotine/shares.py
@@ -47,11 +47,12 @@ if sys.platform == "win32":
 
 class Shares:
 
-    def __init__(self, np, config, queue, ui_callback=None):
+    def __init__(self, np, config, queue, ui_callback=None, connected=False):
         self.np = np
         self.ui_callback = ui_callback
         self.config = config
         self.queue = queue
+        self.connected = connected
         self.translatepunctuation = str.maketrans(dict.fromkeys(string.punctuation, ' '))
 
         self.convert_shares()
@@ -79,6 +80,9 @@ class Shares:
             self.compress_shares("buddy")
 
         self.newbuddyshares = self.newnormalshares = False
+
+    def set_connected(self, connected):
+        self.connected = connected
 
     """ Shares-related actions """
 
@@ -296,7 +300,12 @@ class Shares:
                 self.ui_callback.rescan_finished(sharestype)
 
             self.compress_shares(sharestype)
-            self.send_num_shared_folders_files()
+
+            if self.connected:
+                """ Don't attempt to send file stats to the server before we're connected. If we skip the
+                step here, it will be done once we log in instead ("login" function in pynicotine.py). """
+
+                self.send_num_shared_folders_files()
 
         except Exception as ex:
             log.add(


### PR DESCRIPTION
We previously had a check for this that was lost after the shares refactor.

Fixes https://github.com/Nicotine-Plus/nicotine-plus/issues/768