### PR TITLE
Improvements to user browse and info

### DIFF
--- a/pynicotine/gtkgui/chatrooms.py
+++ b/pynicotine/gtkgui/chatrooms.py
@@ -1030,7 +1030,7 @@ class ChatRoom:
         # Double click starts a private message
         if event.button != 3:
             if event.type == Gdk.EventType._2BUTTON_PRESS:
-                self.frame.privatechats.send_message(user, None, 1)
+                self.frame.privatechats.send_message(user, show_user=True)
                 self.frame.change_main_page("private")
             return
 
@@ -1280,8 +1280,8 @@ class ChatRoom:
 
         elif cmd == "/pm":
             if byteargs:
-                self.frame.privatechats.send_message(byteargs, None, 1)
-                self.frame.on_private_chat(None)
+                self.frame.privatechats.send_message(byteargs, show_user=True)
+                self.frame.change_main_page("private")
 
         elif cmd in ["/m", "/msg"]:
             if byteargs:

--- a/pynicotine/gtkgui/frame.py
+++ b/pynicotine/gtkgui/frame.py
@@ -1136,12 +1136,12 @@ class NicotineFrame:
 
         # Deactivate if we only share with buddies
         if self.np.config.sections["transfers"]["friendsonly"]:
-            m = slskmessages.SharedFileList(None, {})
+            msg = slskmessages.SharedFileList(None, {})
         else:
-            m = slskmessages.SharedFileList(None, self.np.config.sections["transfers"]["sharedfilesstreams"])
+            msg = slskmessages.SharedFileList(None, self.np.config.sections["transfers"]["sharedfilesstreams"])
 
-        m.parse_network_message(m.make_network_message(nozlib=1), nozlib=1)
-        self.userbrowse.show_info(login, m)
+        msg.parse_network_message(msg.make_network_message(nozlib=1), nozlib=1)
+        self.userbrowse.show_user(login, msg)
 
     def on_browse_buddy_shares(self, *args):
         """ Browse your own buddy shares """
@@ -1150,12 +1150,12 @@ class NicotineFrame:
 
         # Show public shares if we don't have specific shares for buddies
         if not self.np.config.sections["transfers"]["enablebuddyshares"]:
-            m = slskmessages.SharedFileList(None, self.np.config.sections["transfers"]["sharedfilesstreams"])
+            msg = slskmessages.SharedFileList(None, self.np.config.sections["transfers"]["sharedfilesstreams"])
         else:
-            m = slskmessages.SharedFileList(None, self.np.config.sections["transfers"]["bsharedfilesstreams"])
+            msg = slskmessages.SharedFileList(None, self.np.config.sections["transfers"]["bsharedfilesstreams"])
 
-        m.parse_network_message(m.make_network_message(nozlib=1), nozlib=1)
-        self.userbrowse.show_info(login, m)
+        msg.parse_network_message(msg.make_network_message(nozlib=1), nozlib=1)
+        self.userbrowse.show_user(login, msg)
 
     # Modes
 
@@ -1826,6 +1826,7 @@ class NicotineFrame:
                 self.userinfo.show_local_info(user, descr, has_pic, pic, totalupl, queuesize, slotsavail, uploadallowed)
 
         else:
+            self.userinfo.show_user(user)
             self.np.process_request_to_peer(user, slskmessages.UserInfoRequest(None), self.userinfo)
 
     """ User Browse """
@@ -1839,6 +1840,7 @@ class NicotineFrame:
             if user == login:
                 self.on_browse_public_shares(None)
             else:
+                self.userbrowse.show_user(user)
                 self.np.process_request_to_peer(user, slskmessages.GetSharedFileList(None), self.userbrowse)
 
     def on_get_shares(self, widget):
@@ -1889,7 +1891,7 @@ class NicotineFrame:
         text = self.UserPrivateCombo.get_child().get_text()
         if not text:
             return
-        self.privatechats.send_message(text, None, 1)
+        self.privatechats.send_message(text, show_user=True)
         self.UserPrivateCombo.get_child().set_text("")
 
     """ Chat """

--- a/pynicotine/gtkgui/privatechat.py
+++ b/pynicotine/gtkgui/privatechat.py
@@ -140,7 +140,7 @@ class PrivateChats(IconNotebook):
             self.set_status_image(tab.Main, msg.status)
             tab.get_user_status(msg.status)
 
-    def send_message(self, user, text=None, direction=None, bytestring=False):
+    def send_message(self, user, text=None, show_user=False, bytestring=False):
 
         if user not in self.users:
             tab = PrivateChat(self, user)
@@ -148,7 +148,7 @@ class PrivateChats(IconNotebook):
             self.append_page(tab.Main, user, tab.on_close)
             self.frame.np.queue.put(slskmessages.AddUser(user))
 
-        if direction:
+        if show_user:
             if self.get_current_page() != self.page_num(self.users[user].Main):
                 self.set_current_page(self.page_num(self.users[user].Main))
 
@@ -297,7 +297,7 @@ class PrivateChats(IconNotebook):
             self.frame.np.config.sections["privatechat"]["users"].sort()
             for user in self.frame.np.config.sections["privatechat"]["users"]:
                 if user not in self.users:
-                    self.send_message(user, None, 1)
+                    self.send_message(user, show_user=True)
 
     def conn_close(self):
 
@@ -668,7 +668,7 @@ class PrivateChat:
 
         elif cmd == "/pm":
             if realargs:
-                self.frame.privatechats.send_message(realargs, None, 1)
+                self.frame.privatechats.send_message(realargs, show_user=True)
 
         elif cmd in ["/m", "/msg"]:
             if realargs:
@@ -731,7 +731,7 @@ class PrivateChat:
 
         elif cmd == "/ctcpversion":
             if args:
-                self.frame.privatechats.send_message(args, CTCP_VERSION, 1, bytestring=True)
+                self.frame.privatechats.send_message(args, CTCP_VERSION, show_user=True, bytestring=True)
 
         elif cmd in ["/clear", "/cl"]:
             self.ChatScroll.get_buffer().set_text("")

--- a/pynicotine/gtkgui/tray.py
+++ b/pynicotine/gtkgui/tray.py
@@ -112,7 +112,7 @@ class TrayApp:
         )
 
         if user is not None:
-            self.frame.privatechats.send_message(user, None, 1)
+            self.frame.privatechats.send_message(user, show_user=True)
             self.frame.change_main_page("private")
             self.show_window()
 

--- a/pynicotine/gtkgui/userbrowse.py
+++ b/pynicotine/gtkgui/userbrowse.py
@@ -206,7 +206,7 @@ class UserBrowse:
 
         self.change_colours()
 
-        for name, object in list(self.__dict__.items()):
+        for name, object in self.__dict__.items():
             if isinstance(object, PopupMenu):
                 object.set_user(self.user)
 
@@ -546,8 +546,9 @@ class UserBrowse:
         self.frame.np.config.sections["columns"]["userbrowse_widths"] = widths
 
     def show_user(self, msg):
-        self.conn = None
-        self.make_new_model(msg.list)
+        if msg is not None:
+            self.conn = None
+            self.make_new_model(msg.list)
 
     def load_shares(self, list):
         self.make_new_model(list)
@@ -884,7 +885,7 @@ class UserBrowse:
 
             # Get matching files in the current directory
             resultfiles = []
-            for file in list(self.files.keys()):
+            for file in self.files:
                 if query in file.lower():
                     resultfiles.append(file)
 

--- a/pynicotine/gtkgui/userbrowse.py
+++ b/pynicotine/gtkgui/userbrowse.py
@@ -47,7 +47,7 @@ from pynicotine.utils import get_result_bitrate_length
 
 class UserBrowse:
 
-    def __init__(self, userbrowses, user, conn):
+    def __init__(self, userbrowses, user):
 
         # Build the window
         load_ui_elements(self, os.path.join(os.path.dirname(os.path.realpath(__file__)), "ui", "userbrowse.ui"))
@@ -56,7 +56,7 @@ class UserBrowse:
 
         self.frame = userbrowses.frame
         self.user = user
-        self.conn = conn
+        self.conn = None
 
         # selected_folder is the current selected folder
         self.selected_folder = None
@@ -545,7 +545,7 @@ class UserBrowse:
         self.frame.np.config.sections["columns"]["userbrowse"] = columns
         self.frame.np.config.sections["columns"]["userbrowse_widths"] = widths
 
-    def show_info(self, msg):
+    def show_user(self, msg):
         self.conn = None
         self.make_new_model(msg.list)
 

--- a/pynicotine/gtkgui/userlist.py
+++ b/pynicotine/gtkgui/userlist.py
@@ -302,7 +302,7 @@ class UserList:
 
             if event.button != 3:
                 if event.type == Gdk.EventType._2BUTTON_PRESS:
-                    self.frame.privatechats.send_message(user, None, 1)
+                    self.frame.privatechats.send_message(user, show_user=True)
                     self.frame.change_main_page("private")
                 return
 

--- a/pynicotine/gtkgui/utils.py
+++ b/pynicotine/gtkgui/utils.py
@@ -1121,7 +1121,7 @@ class PopupMenu(Gtk.Menu):
         self.frame.change_main_page("search")
 
     def on_send_message(self, widget):
-        self.frame.privatechats.send_message(self.user, None, 1)
+        self.frame.privatechats.send_message(self.user, show_user=True)
         self.frame.change_main_page("private")
 
     def on_show_ip_address(self, widget):

--- a/pynicotine/pynicotine.py
+++ b/pynicotine/pynicotine.py
@@ -1298,7 +1298,7 @@ class NetworkEventProcessor:
             if i.conn is conn and self.userinfo is not None:
                 # probably impossible to do this
                 if i.username != self.config.sections["server"]["login"]:
-                    self.userinfo.show_info(i.username, msg)
+                    self.userinfo.show_user(i.username, msg)
                     break
 
     def user_info_request(self, msg):
@@ -1394,7 +1394,7 @@ class NetworkEventProcessor:
         for i in self.peerconns:
             if i.conn is conn and self.userbrowse is not None:
                 if i.username != self.config.sections["server"]["login"]:
-                    self.userbrowse.show_info(i.username, msg)
+                    self.userbrowse.show_user(i.username, msg)
                     break
 
     def file_search_result(self, msg):
@@ -1749,6 +1749,7 @@ class NetworkEventProcessor:
     def peer_transfer(self, msg):
         if self.userinfo is not None and msg.msg is slskmessages.UserInfoReply:
             self.userinfo.update_gauge(msg)
+
         if self.userbrowse is not None and msg.msg is slskmessages.SharedFileList:
             self.userbrowse.update_gauge(msg)
 

--- a/pynicotine/pynicotine.py
+++ b/pynicotine/pynicotine.py
@@ -320,7 +320,7 @@ class NetworkEventProcessor:
             self.queue.put(message)
 
             if window is not None:
-                window.init_window(conn.username, conn.conn)
+                window.show_user(conn.username, conn=conn.conn)
 
             if message.__class__ is slskmessages.TransferRequest and self.transfers is not None:
                 self.transfers.got_connect(message.req, conn.conn, message.direction)
@@ -1166,10 +1166,10 @@ class NetworkEventProcessor:
                 for j in i.msgs:
 
                     if j.__class__ is slskmessages.UserInfoRequest and self.userinfo is not None:
-                        self.userinfo.init_window(i.username, conn)
+                        self.userinfo.show_user(i.username, conn=conn)
 
                     if j.__class__ is slskmessages.GetSharedFileList and self.userbrowse is not None:
-                        self.userbrowse.init_window(i.username, conn)
+                        self.userbrowse.show_user(i.username, conn=conn)
 
                     if j.__class__ is slskmessages.FileRequest and self.transfers is not None:
                         self.transfers.got_file_connect(j.req, conn)
@@ -1298,7 +1298,7 @@ class NetworkEventProcessor:
             if i.conn is conn and self.userinfo is not None:
                 # probably impossible to do this
                 if i.username != self.config.sections["server"]["login"]:
-                    self.userinfo.show_user(i.username, msg)
+                    self.userinfo.show_user(i.username, msg.conn, msg)
                     break
 
     def user_info_request(self, msg):
@@ -1394,7 +1394,7 @@ class NetworkEventProcessor:
         for i in self.peerconns:
             if i.conn is conn and self.userbrowse is not None:
                 if i.username != self.config.sections["server"]["login"]:
-                    self.userbrowse.show_user(i.username, msg)
+                    self.userbrowse.show_user(i.username, msg.conn, msg)
                     break
 
     def file_search_result(self, msg):
@@ -1433,10 +1433,10 @@ class NetworkEventProcessor:
                 for j in i.msgs:
 
                     if j.__class__ is slskmessages.UserInfoRequest and self.userinfo is not None:
-                        self.userinfo.init_window(i.username, conn)
+                        self.userinfo.show_user(i.username, conn=conn)
 
                     if j.__class__ is slskmessages.GetSharedFileList and self.userbrowse is not None:
-                        self.userbrowse.init_window(i.username, conn)
+                        self.userbrowse.show_user(i.username, conn=conn)
 
                     if j.__class__ is slskmessages.FileRequest and self.transfers is not None:
                         self.transfers.got_file_connect(j.req, conn)


### PR DESCRIPTION
- If we aren't able to connect to a user for some reason, Nicotine+ would not open the user browse and info pages at all, giving the impression that buttons/items to open these pages didn't work. Always open these pages instead, and let them update if we receive any data from the user.
- If the user browse tab was hidden, and we requested to see a user browse, Nicotine+ would make the user info tab visible instead.
- Cleanups, reduce code duplication