### PR TITLE
Keep away mode checkbox in sync with away status

### DIFF
--- a/pynicotine/gtkgui/notifications.py
+++ b/pynicotine/gtkgui/notifications.py
@@ -45,7 +45,7 @@ class Notifications:
             if room not in self.frame.hilites["rooms"]:
                 self.frame.hilites["rooms"].append(room)
 
-                self.frame.tray_app.set_image()
+                self.frame.tray.set_image()
         elif location == "private":
             if user in self.frame.hilites[location]:
                 self.frame.hilites[location].remove(user)
@@ -53,7 +53,7 @@ class Notifications:
             elif user not in self.frame.hilites[location]:
                 self.frame.hilites[location].append(user)
 
-                self.frame.tray_app.set_image()
+                self.frame.tray.set_image()
 
         if tab and self.frame.np.config.sections["ui"]["urgencyhint"] and not self.frame.got_focus:
             self.frame.MainWindow.set_urgency_hint(True)
@@ -83,7 +83,7 @@ class Notifications:
                 self.frame.hilites["private"].remove(user)
             self.set_title(user)
 
-        self.frame.tray_app.set_image()
+        self.frame.tray.set_image()
 
     def set_title(self, user=None):
 

--- a/pynicotine/gtkgui/tray.py
+++ b/pynicotine/gtkgui/tray.py
@@ -27,7 +27,7 @@ from pynicotine.gtkgui.utils import PopupMenu
 from pynicotine.logfacility import log
 
 
-class TrayApp:
+class Tray:
 
     def __init__(self, frame):
         try:
@@ -75,7 +75,7 @@ class TrayApp:
                 ("#" + _("Lookup a User's IP"), self.on_get_a_users_ip),
                 ("#" + _("Lookup a User's Info"), self.on_get_a_users_info),
                 ("#" + _("Lookup a User's Shares"), self.on_get_a_users_shares),
-                ("$" + _("Toggle Away"), self.frame.on_away),
+                ("$" + _("Away"), self.frame.on_away),
                 ("#" + _("Settings"), self.frame.on_settings),
                 ("#" + _("Quit"), self.frame.on_quit)
             )
@@ -303,6 +303,30 @@ class TrayApp:
 
         except Exception as e:
             log.add_warning(_("ERROR: cannot set trayicon image: %(error)s"), {'error': e})
+
+    def set_away(self, enable):
+        if enable:
+            self.tray_status["status"] = "away"
+        else:
+            self.tray_status["status"] = "connect"
+
+        self.set_image()
+
+        # Toggle away checkbox in tray menu
+        away_item = self.tray_popup_menu.get_children()[8]
+        handler_id = self.tray_popup_menu.handlers[away_item]
+
+        with away_item.handler_block(handler_id):
+            # Temporarily disable handler, we only want to change the visual checkbox appearance
+            away_item.set_active(enable)
+
+    def set_connected(self, enable):
+        if enable:
+            self.tray_status["status"] = "connect"
+        else:
+            self.tray_status["status"] = "disconnect"
+
+        self.set_image()
 
     def set_server_actions_sensitive(self, status):
         items = self.tray_popup_menu.get_children()

--- a/pynicotine/gtkgui/ui/menus/menubar.ui
+++ b/pynicotine/gtkgui/ui/menus/menubar.ui
@@ -17,7 +17,7 @@
       </section>
       <section>
         <item>
-          <attribute name="label" translatable="yes">_Away/Return</attribute>
+          <attribute name="label" translatable="yes">_Away</attribute>
           <attribute name="action">app.away</attribute>
           <attribute name="accel">&lt;Alt&gt;a</attribute>
         </item>


### PR DESCRIPTION
- Mirror the appearance of the away item in the menu bar and tray
- Check/uncheck the checkbox if the away mode changes
- Code cleanup