### PR TITLE
Add documentation for 'can't create room' server message

### DIFF
--- a/doc/SLSKPROTOCOL.md
+++ b/doc/SLSKPROTOCOL.md
@@ -184,7 +184,8 @@ and callbacks for the messages are set in pynicotine.py.
 | 151  | [Stop Public Chat](#server-code-151)              |
 | 152  | [Public Chat Message](#server-code-152)           |
 | 153  | [Related Searches](#server-code-153)              |
-| 1001 | [Cannot Connect](#server-code-1001)               |
+| 1001 | [Can't Connect To Peer](#server-code-1001)        |
+| 1002 | [Can't Create Room](#server-code-1002)            |
 
 ### Server Code 1
 
@@ -2303,7 +2304,7 @@ Nicotine: RelatedSearch
 
 ### Server Code 1001
 
-**Cannot Connect**
+**Can't Connect To Peer**
 
 #### Function Names
 
@@ -2314,8 +2315,7 @@ Nicotine: CantConnectToPeer
 
 We send this to say we can't connect to peer after it has asked us to connect. We receive this if we asked peer to connect and it can't do this. This message means a connection can't be established either way.
 
-See also: [Peer Connection Message
-Order](#peer-connection-message-order)
+See also: [Peer Connection Message Order](#peer-connection-message-order)
 
 #### Data Order
 
@@ -2326,6 +2326,28 @@ Order](#peer-connection-message-order)
     unable to connect to each other.*
     1.  **int** <ins>token</ins>
     2.  **string** <ins>user</ins>
+
+### Server Code 1002
+
+**Can't Create Room**
+
+#### Function Names
+
+Museekd: Unimplemented  
+Nicotine: CantConnectToPeer
+
+#### Description
+
+**DEPRECATED (server sends a private message now)**
+
+Server tells us a new room cannot be created.
+
+#### Data Order
+
+  - Send
+      - *No Message*
+  - Receive
+    1.  **string** <ins>room</ins>
 
 # Peer Messages
 

--- a/pynicotine/pynicotine.py
+++ b/pynicotine/pynicotine.py
@@ -201,6 +201,7 @@ class NetworkEventProcessor:
             slskmessages.SayChatroom: self.say_chat_room,
             slskmessages.JoinRoom: self.join_room,
             slskmessages.UserLeftRoom: self.user_left_room,
+            slskmessages.CantCreateRoom: self.dummy_message,
             slskmessages.QueuedDownloads: self.dummy_message,
             slskmessages.GetPeerAddress: self.get_peer_address,
             slskmessages.OutConn: self.out_conn,

--- a/pynicotine/slskmessages.py
+++ b/pynicotine/slskmessages.py
@@ -551,7 +551,7 @@ class LeaveRoom(ServerMessage):
         return self.pack_object(self.room)
 
     def parse_network_message(self, message):
-        self.room = self.get_object(message, bytes)[1]
+        pos, self.room = self.get_object(message, bytes)
 
 
 class UserJoinedRoom(ServerMessage):
@@ -933,7 +933,7 @@ class RoomAdded(ServerMessage):
     """ The server tells us a new room has been added. """
 
     def parse_network_message(self, message):
-        self.room = self.get_object(message, bytes)[1]
+        pos, self.room = self.get_object(message, bytes)
 
 
 class RoomRemoved(ServerMessage):
@@ -941,7 +941,7 @@ class RoomRemoved(ServerMessage):
     """ The server tells us a room has been removed. """
 
     def parse_network_message(self, message):
-        self.room = self.get_object(message, bytes)[1]
+        pos, self.room = self.get_object(message, bytes)
 
 
 class RoomList(ServerMessage):
@@ -1006,7 +1006,7 @@ class AdminMessage(ServerMessage):
     """ A global message from the server admin has arrived. """
 
     def parse_network_message(self, message):
-        self.msg = self.get_object(message, bytes)[1]
+        pos, self.msg = self.get_object(message, bytes)
 
 
 class GlobalUserList(JoinRoom):
@@ -1587,7 +1587,7 @@ class PrivateRoomAdded(ServerMessage):
         self.room = room
 
     def parse_network_message(self, message):
-        self.room = self.get_object(message, bytes)[1]
+        pos, self.room = self.get_object(message, bytes)
 
 
 class PrivateRoomRemoved(PrivateRoomAdded):
@@ -1736,7 +1736,7 @@ class RelatedSearch(ServerMessage):
 
 
 class CantConnectToPeer(ServerMessage):
-    """ Message 1001 """
+    """ Server code: 1001 """
     """ We send this to say we can't connect to peer after it has asked us
     to connect. We receive this if we asked peer to connect and it can't do
     this. This message means a connection can't be established either way.
@@ -1756,13 +1756,14 @@ class CantConnectToPeer(ServerMessage):
     def parse_network_message(self, message):
         pos, self.token = self.get_object(message, int)
 
-# These are probably leftovers, not sure what to do with them
 
+class CantCreateRoom(ServerMessage):
+    """ Server code: 1002 """
+    """ Server tells us a new room cannot be created. """
+    """ DEPRECATED (server sends a private message now) """
 
-# class CantCreateRoom(ServerMessage):
-    # """ Server tells us a new room cannot be created"""
-    # def parseNetworkMessage(self, message):
-        # self.room = self.getObject(message, types.StringType)[1]
+    def parse_network_message(self, message):
+        pos, self.room = self.get_object(message, bytes)
 
 
 """

--- a/pynicotine/slskproto.py
+++ b/pynicotine/slskproto.py
@@ -45,6 +45,7 @@ from pynicotine.slskmessages import AdminMessage
 from pynicotine.slskmessages import BranchLevel
 from pynicotine.slskmessages import BranchRoot
 from pynicotine.slskmessages import CantConnectToPeer
+from pynicotine.slskmessages import CantCreateRoom
 from pynicotine.slskmessages import ChangePassword
 from pynicotine.slskmessages import CheckPrivileges
 from pynicotine.slskmessages import ChildDepth
@@ -362,7 +363,8 @@ class SlskProtoThread(threading.Thread):
         LeavePublicRoom: 151,
         PublicRoomMessage: 152,
         RelatedSearch: 153,           # Deprecated ?
-        CantConnectToPeer: 1001
+        CantConnectToPeer: 1001,
+        CantCreateRoom: 1002          # Deprecated
     }
 
     peercodes = {


### PR DESCRIPTION
The "Can't create room" server message code was added to PySoulSeek in 2003. It seems like it hasn't been used on the server in a very long time, as the server now sends a private message if a room can't be created, but it seems to belong to the special server error codes (1000-range).