### PR TITLE
UI refresh (part 2)

### DIFF
--- a/pynicotine/gtkgui/chatrooms.py
+++ b/pynicotine/gtkgui/chatrooms.py
@@ -1483,11 +1483,7 @@ class ChatRoom:
     def count_users(self):
 
         numusers = len(self.users)
-        if numusers > 0:
-            self.LabelPeople.show()
-            self.LabelPeople.set_text(_("User List (%i)") % numusers)
-        else:
-            self.LabelPeople.hide()
+        self.LabelPeople.set_markup("<b>%d</b>" % numusers)
 
         if self.room in self.roomsctrl.rooms:
             iterator = self.roomsctrl.roomsmodel.get_iter_first()

--- a/pynicotine/gtkgui/frame.py
+++ b/pynicotine/gtkgui/frame.py
@@ -2392,10 +2392,10 @@ class NicotineFrame:
             down = up = human_speed(0.0)
             filesup = filesdown = total_usersdown = total_usersup = 0
 
-        self.DownloadUsers.set_text(self.users_template % total_usersdown)
-        self.UploadUsers.set_text(self.users_template % total_usersup)
-        self.DownloadFiles.set_text(self.files_template % filesdown)
-        self.UploadFiles.set_text(self.files_template % filesup)
+        self.DownloadUsers.set_markup("<b>%d</b>" % total_usersdown)
+        self.UploadUsers.set_markup("<b>%d</b>" % total_usersup)
+        self.DownloadFiles.set_markup("<b>%d</b>" % filesdown)
+        self.UploadFiles.set_markup("<b>%d</b>" % filesup)
 
         self.DownStatus.pop(self.down_context_id)
         self.UpStatus.pop(self.up_context_id)

--- a/pynicotine/gtkgui/search.py
+++ b/pynicotine/gtkgui/search.py
@@ -358,6 +358,7 @@ class Searches(IconNotebook):
         popup.setup(
             ("#" + _("Copy search term"), self.searches[search_id][2].on_copy_search_term),
             ("", None),
+            ("#" + _("Clear all results"), self.searches[search_id][2].on_clear),
             ("#" + _("Close this tab"), self.searches[search_id][2].on_close)
         )
 

--- a/pynicotine/gtkgui/search.py
+++ b/pynicotine/gtkgui/search.py
@@ -723,7 +723,7 @@ class Search:
                 self.showtab = True
 
             # Update counter
-            self.Counter.set_text("Results: %d/%d" % (self.numvisibleresults, len(self.all_data)))
+            self.Counter.set_markup("<b>%d</b>" % self.numvisibleresults)
 
             # Update tab notification
             self.frame.searches.request_changed(self.Main)
@@ -928,7 +928,7 @@ class Search:
             if self.check_filter(row):
                 self.add_row_to_model(row)
 
-        self.Counter.set_text("Results: %d/%d" % (self.numvisibleresults, len(self.all_data)))
+        self.Counter.set_markup("<b>%d</b>" % self.numvisibleresults)
 
     def on_popup_menu_users(self, widget):
 

--- a/pynicotine/gtkgui/ui/buddylist.ui
+++ b/pynicotine/gtkgui/ui/buddylist.ui
@@ -10,7 +10,7 @@
         <property name="visible">True</property>
         <property name="can_focus">False</property>
         <property name="border_width">6</property>
-        <property name="spacing">5</property>
+        <property name="spacing">6</property>
         <child>
           <object class="GtkLabel" id="BuddiesLabel">
             <property name="visible">True</property>
@@ -29,7 +29,7 @@
           <object class="GtkLabel" id="UserLabel">
             <property name="visible">True</property>
             <property name="can_focus">False</property>
-            <property name="label" translatable="yes">User: </property>
+            <property name="label" translatable="yes">User:</property>
           </object>
           <packing>
             <property name="expand">False</property>
@@ -43,10 +43,6 @@
             <property name="visible">True</property>
             <property name="can_focus">True</property>
             <property name="invisible_char">•</property>
-            <property name="primary_icon_activatable">False</property>
-            <property name="secondary_icon_activatable">False</property>
-            <property name="primary_icon_sensitive">True</property>
-            <property name="secondary_icon_sensitive">True</property>
             <signal name="activate" handler="on_add_user" swapped="no"/>
           </object>
           <packing>
@@ -92,6 +88,9 @@
                 <property name="icon_name">applications-system-symbolic</property>
               </object>
             </child>
+            <style>
+              <class name="circular"/>
+            </style>
           </object>
           <packing>
             <property name="expand">False</property>

--- a/pynicotine/gtkgui/ui/chatrooms.ui
+++ b/pynicotine/gtkgui/ui/chatrooms.ui
@@ -281,19 +281,69 @@
               <object class="GtkBox">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
-                <property name="border_width">5</property>
-                <property name="spacing">15</property>
+                <property name="border_width">6</property>
+                <property name="spacing">10</property>
                 <child>
-                  <object class="GtkLabel" id="LabelPeople">
+                  <object class="GtkBox">
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
-                    <property name="halign">start</property>
-                    <property name="label" translatable="yes">User List</property>
-                    <property name="margin_start">5</property>
+                    <property name="spacing">6</property>
+                    <child>
+                      <object class="GtkLabel">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="label" translatable="yes">User List</property>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">True</property>
+                        <property name="position">0</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkButton">
+                        <property name="visible">True</property>
+                        <property name="sensitive">False</property>
+                        <property name="can-focus">False</property>
+                        <property name="receives-default">False</property>
+                        <child>
+                          <object class="GtkBox">
+                            <property name="width-request">24</property>
+                            <property name="visible">True</property>
+                            <property name="can-focus">False</property>
+                            <property name="spacing">5</property>
+                            <property name="homogeneous">True</property>
+                            <child>
+                              <object class="GtkLabel" id="LabelPeople">
+                                <property name="visible">True</property>
+                                <property name="can-focus">False</property>
+                                <property name="label">&lt;b&gt;0&lt;/b&gt;</property>
+                                <property name="use_markup">True</property>
+                              </object>
+                              <packing>
+                                <property name="expand">False</property>
+                                <property name="fill">True</property>
+                                <property name="padding">5</property>
+                                <property name="position">0</property>
+                              </packing>
+                            </child>
+                          </object>
+                        </child>
+                        <style>
+                          <class name="circular"/>
+                        </style>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">False</property>
+                        <property name="position">1</property>
+                      </packing>
+                    </child>
                   </object>
                   <packing>
                     <property name="expand">False</property>
                     <property name="fill">False</property>
+                    <property name="padding">5</property>
                     <property name="position">0</property>
                   </packing>
                 </child>
@@ -318,7 +368,6 @@
               <packing>
                 <property name="expand">False</property>
                 <property name="fill">False</property>
-                <property name="padding">5</property>
               </packing>
             </child>
             <child>

--- a/pynicotine/gtkgui/ui/mainwindow.ui
+++ b/pynicotine/gtkgui/ui/mainwindow.ui
@@ -87,7 +87,7 @@
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
                             <property name="border_width">6</property>
-                            <property name="spacing">5</property>
+                            <property name="spacing">6</property>
                             <child>
                               <object class="GtkLabel">
                                 <property name="visible">True</property>
@@ -162,6 +162,9 @@
                                     <property name="icon_name">applications-system-symbolic</property>
                                   </object>
                                 </child>
+                                <style>
+                                  <class name="circular"/>
+                                </style>
                               </object>
                               <packing>
                                 <property name="expand">False</property>
@@ -222,29 +225,129 @@
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
                             <property name="border_width">6</property>
-                            <property name="spacing">5</property>
+                            <property name="spacing">4</property>
                             <child>
-                              <object class="GtkLabel" id="DownloadUsers">
+                              <object class="GtkBox">
                                 <property name="visible">True</property>
                                 <property name="can_focus">False</property>
-                                <property name="label" translatable="yes">Users: 0</property>
+                                <property name="spacing">6</property>
+                                <child>
+                                  <object class="GtkLabel">
+                                    <property name="visible">True</property>
+                                    <property name="can_focus">False</property>
+                                    <property name="label" translatable="yes">Users</property>
+                                  </object>
+                                  <packing>
+                                    <property name="expand">False</property>
+                                    <property name="fill">True</property>
+                                    <property name="position">0</property>
+                                  </packing>
+                                </child>
+                                <child>
+                                  <object class="GtkButton">
+                                    <property name="visible">True</property>
+                                    <property name="sensitive">False</property>
+                                    <property name="can-focus">False</property>
+                                    <property name="receives-default">False</property>
+                                    <child>
+                                      <object class="GtkBox">
+                                        <property name="width-request">24</property>
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">False</property>
+                                        <property name="spacing">5</property>
+                                        <property name="homogeneous">True</property>
+                                        <child>
+                                          <object class="GtkLabel" id="DownloadUsers">
+                                            <property name="visible">True</property>
+                                            <property name="can-focus">False</property>
+                                            <property name="label">&lt;b&gt;0&lt;/b&gt;</property>
+                                            <property name="use_markup">True</property>
+                                          </object>
+                                          <packing>
+                                            <property name="expand">False</property>
+                                            <property name="fill">True</property>
+                                            <property name="position">0</property>
+                                          </packing>
+                                        </child>
+                                      </object>
+                                    </child>
+                                    <style>
+                                      <class name="circular"/>
+                                    </style>
+                                  </object>
+                                  <packing>
+                                    <property name="expand">False</property>
+                                    <property name="fill">False</property>
+                                    <property name="position">1</property>
+                                  </packing>
+                                </child>
                               </object>
                               <packing>
                                 <property name="expand">False</property>
-                                <property name="fill">True</property>
+                                <property name="fill">False</property>
                                 <property name="padding">5</property>
                                 <property name="position">0</property>
                               </packing>
                             </child>
                             <child>
-                              <object class="GtkLabel" id="DownloadFiles">
+                              <object class="GtkBox">
                                 <property name="visible">True</property>
                                 <property name="can_focus">False</property>
-                                <property name="label" translatable="yes">Files: 0</property>
+                                <property name="spacing">6</property>
+                                <child>
+                                  <object class="GtkLabel">
+                                    <property name="visible">True</property>
+                                    <property name="can_focus">False</property>
+                                    <property name="label" translatable="yes">Files</property>
+                                  </object>
+                                  <packing>
+                                    <property name="expand">False</property>
+                                    <property name="fill">True</property>
+                                    <property name="position">0</property>
+                                  </packing>
+                                </child>
+                                <child>
+                                  <object class="GtkButton">
+                                    <property name="visible">True</property>
+                                    <property name="sensitive">False</property>
+                                    <property name="can-focus">False</property>
+                                    <property name="receives-default">False</property>
+                                    <child>
+                                      <object class="GtkBox">
+                                        <property name="width-request">24</property>
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">False</property>
+                                        <property name="spacing">5</property>
+                                        <property name="homogeneous">True</property>
+                                        <child>
+                                          <object class="GtkLabel" id="DownloadFiles">
+                                            <property name="visible">True</property>
+                                            <property name="can-focus">False</property>
+                                            <property name="label">&lt;b&gt;0&lt;/b&gt;</property>
+                                            <property name="use_markup">True</property>
+                                          </object>
+                                          <packing>
+                                            <property name="expand">False</property>
+                                            <property name="fill">True</property>
+                                            <property name="position">0</property>
+                                          </packing>
+                                        </child>
+                                      </object>
+                                    </child>
+                                    <style>
+                                      <class name="circular"/>
+                                    </style>
+                                  </object>
+                                  <packing>
+                                    <property name="expand">False</property>
+                                    <property name="fill">False</property>
+                                    <property name="position">1</property>
+                                  </packing>
+                                </child>
                               </object>
                               <packing>
                                 <property name="expand">False</property>
-                                <property name="fill">True</property>
+                                <property name="fill">False</property>
                                 <property name="padding">5</property>
                                 <property name="position">1</property>
                               </packing>
@@ -322,6 +425,9 @@
                                     <property name="icon_name">applications-system-symbolic</property>
                                   </object>
                                 </child>
+                                <style>
+                                  <class name="circular"/>
+                                </style>
                               </object>
                               <packing>
                                 <property name="expand">False</property>
@@ -362,7 +468,7 @@
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
                             <property name="border_width">6</property>
-                            <property name="spacing">5</property>
+                            <property name="spacing">6</property>
                             <child>
                               <object class="GtkButton" id="clearFinishedAbortedButton">
                                 <property name="visible">True</property>
@@ -575,29 +681,129 @@
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
                             <property name="border_width">6</property>
-                            <property name="spacing">5</property>
+                            <property name="spacing">4</property>
                             <child>
-                              <object class="GtkLabel" id="UploadUsers">
+                              <object class="GtkBox">
                                 <property name="visible">True</property>
                                 <property name="can_focus">False</property>
-                                <property name="label" translatable="yes">Users: 0</property>
+                                <property name="spacing">6</property>
+                                <child>
+                                  <object class="GtkLabel">
+                                    <property name="visible">True</property>
+                                    <property name="can_focus">False</property>
+                                    <property name="label" translatable="yes">Users</property>
+                                  </object>
+                                  <packing>
+                                    <property name="expand">False</property>
+                                    <property name="fill">True</property>
+                                    <property name="position">0</property>
+                                  </packing>
+                                </child>
+                                <child>
+                                  <object class="GtkButton">
+                                    <property name="visible">True</property>
+                                    <property name="sensitive">False</property>
+                                    <property name="can-focus">False</property>
+                                    <property name="receives-default">False</property>
+                                    <child>
+                                      <object class="GtkBox">
+                                        <property name="width-request">24</property>
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">False</property>
+                                        <property name="spacing">5</property>
+                                        <property name="homogeneous">True</property>
+                                        <child>
+                                          <object class="GtkLabel" id="UploadUsers">
+                                            <property name="visible">True</property>
+                                            <property name="can-focus">False</property>
+                                            <property name="label">&lt;b&gt;0&lt;/b&gt;</property>
+                                            <property name="use_markup">True</property>
+                                          </object>
+                                          <packing>
+                                            <property name="expand">False</property>
+                                            <property name="fill">True</property>
+                                            <property name="position">0</property>
+                                          </packing>
+                                        </child>
+                                      </object>
+                                    </child>
+                                    <style>
+                                      <class name="circular"/>
+                                    </style>
+                                  </object>
+                                  <packing>
+                                    <property name="expand">False</property>
+                                    <property name="fill">False</property>
+                                    <property name="position">1</property>
+                                  </packing>
+                                </child>
                               </object>
                               <packing>
                                 <property name="expand">False</property>
-                                <property name="fill">True</property>
+                                <property name="fill">False</property>
                                 <property name="padding">5</property>
                                 <property name="position">0</property>
                               </packing>
                             </child>
                             <child>
-                              <object class="GtkLabel" id="UploadFiles">
+                              <object class="GtkBox">
                                 <property name="visible">True</property>
                                 <property name="can_focus">False</property>
-                                <property name="label" translatable="yes">Files: 0</property>
+                                <property name="spacing">6</property>
+                                <child>
+                                  <object class="GtkLabel">
+                                    <property name="visible">True</property>
+                                    <property name="can_focus">False</property>
+                                    <property name="label" translatable="yes">Files</property>
+                                  </object>
+                                  <packing>
+                                    <property name="expand">False</property>
+                                    <property name="fill">True</property>
+                                    <property name="position">0</property>
+                                  </packing>
+                                </child>
+                                <child>
+                                  <object class="GtkButton">
+                                    <property name="visible">True</property>
+                                    <property name="sensitive">False</property>
+                                    <property name="can-focus">False</property>
+                                    <property name="receives-default">False</property>
+                                    <child>
+                                      <object class="GtkBox">
+                                        <property name="width-request">24</property>
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">False</property>
+                                        <property name="spacing">5</property>
+                                        <property name="homogeneous">True</property>
+                                        <child>
+                                          <object class="GtkLabel" id="UploadFiles">
+                                            <property name="visible">True</property>
+                                            <property name="can-focus">False</property>
+                                            <property name="label">&lt;b&gt;0&lt;/b&gt;</property>
+                                            <property name="use_markup">True</property>
+                                          </object>
+                                          <packing>
+                                            <property name="expand">False</property>
+                                            <property name="fill">True</property>
+                                            <property name="position">0</property>
+                                          </packing>
+                                        </child>
+                                      </object>
+                                    </child>
+                                    <style>
+                                      <class name="circular"/>
+                                    </style>
+                                  </object>
+                                  <packing>
+                                    <property name="expand">False</property>
+                                    <property name="fill">False</property>
+                                    <property name="position">1</property>
+                                  </packing>
+                                </child>
                               </object>
                               <packing>
                                 <property name="expand">False</property>
-                                <property name="fill">True</property>
+                                <property name="fill">False</property>
                                 <property name="padding">5</property>
                                 <property name="position">1</property>
                               </packing>
@@ -676,6 +882,9 @@
                                     <property name="icon_name">applications-system-symbolic</property>
                                   </object>
                                 </child>
+                                <style>
+                                  <class name="circular"/>
+                                </style>
                               </object>
                               <packing>
                                 <property name="expand">False</property>
@@ -716,7 +925,7 @@
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
                             <property name="border_width">6</property>
-                            <property name="spacing">5</property>
+                            <property name="spacing">6</property>
                             <child>
                               <object class="GtkButton" id="clearUploadFinishedErredButton">
                                 <property name="visible">True</property>
@@ -929,7 +1138,7 @@
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
                             <property name="border_width">6</property>
-                            <property name="spacing">5</property>
+                            <property name="spacing">6</property>
                             <child>
                               <object class="GtkComboBox" id="SearchMethod">
                                 <property name="visible">True</property>
@@ -1085,6 +1294,9 @@
                                     <property name="icon_name">applications-system-symbolic</property>
                                   </object>
                                 </child>
+                                <style>
+                                  <class name="circular"/>
+                                </style>
                               </object>
                               <packing>
                                 <property name="expand">False</property>
@@ -1145,7 +1357,7 @@
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
                             <property name="border_width">6</property>
-                            <property name="spacing">5</property>
+                            <property name="spacing">6</property>
                             <child>
                               <object class="GtkLabel">
                                 <property name="visible">True</property>
@@ -1220,6 +1432,9 @@
                                     <property name="icon_name">applications-system-symbolic</property>
                                   </object>
                                 </child>
+                                <style>
+                                  <class name="circular"/>
+                                </style>
                               </object>
                               <packing>
                                 <property name="expand">False</property>
@@ -1280,7 +1495,7 @@
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
                             <property name="border_width">6</property>
-                            <property name="spacing">5</property>
+                            <property name="spacing">6</property>
                             <child>
                               <object class="GtkLabel">
                                 <property name="visible">True</property>
@@ -1390,6 +1605,9 @@
                                     <property name="icon_name">applications-system-symbolic</property>
                                   </object>
                                 </child>
+                                <style>
+                                  <class name="circular"/>
+                                </style>
                               </object>
                               <packing>
                                 <property name="expand">False</property>
@@ -1444,7 +1662,7 @@
                       <object class="GtkBox" id="interestsvbox">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
-                        <property name="spacing">5</property>
+                        <property name="spacing">6</property>
                         <property name="orientation">vertical</property>
                         <child>
                           <placeholder/>

--- a/pynicotine/gtkgui/ui/mainwindow.ui
+++ b/pynicotine/gtkgui/ui/mainwindow.ui
@@ -364,6 +364,20 @@
                               </packing>
                             </child>
                             <child>
+                              <object class="GtkCheckButton" id="ToggleAutoclearDownloads">
+                                <property name="label" translatable="yes">Autoclear finished / filtered</property>
+                                <property name="visible">True</property>
+                                <property name="can_focus">True</property>
+                                <property name="receives_default">False</property>
+                                <property name="draw_indicator">True</property>
+                              </object>
+                              <packing>
+                                <property name="expand">False</property>
+                                <property name="fill">False</property>
+                                <property name="position">3</property>
+                              </packing>
+                            </child>
+                            <child>
                               <object class="GtkToggleButton" id="ExpandDownloads">
                                 <property name="visible">True</property>
                                 <property name="can_focus">True</property>
@@ -381,20 +395,6 @@
                               <packing>
                                 <property name="expand">False</property>
                                 <property name="fill">True</property>
-                                <property name="position">3</property>
-                              </packing>
-                            </child>
-                            <child>
-                              <object class="GtkCheckButton" id="ToggleAutoclearDownloads">
-                                <property name="label" translatable="yes">Autoclear finished / filtered</property>
-                                <property name="visible">True</property>
-                                <property name="can_focus">True</property>
-                                <property name="receives_default">False</property>
-                                <property name="draw_indicator">True</property>
-                              </object>
-                              <packing>
-                                <property name="expand">False</property>
-                                <property name="fill">False</property>
                                 <property name="position">4</property>
                               </packing>
                             </child>
@@ -820,6 +820,20 @@
                               </packing>
                             </child>
                             <child>
+                              <object class="GtkCheckButton" id="ToggleAutoclearUploads">
+                                <property name="label" translatable="yes">Autoclear finished / aborted</property>
+                                <property name="visible">True</property>
+                                <property name="can_focus">True</property>
+                                <property name="receives_default">False</property>
+                                <property name="draw_indicator">True</property>
+                              </object>
+                              <packing>
+                                <property name="expand">False</property>
+                                <property name="fill">False</property>
+                                <property name="position">3</property>
+                              </packing>
+                            </child>
+                            <child>
                               <object class="GtkToggleButton" id="ExpandUploads">
                                 <property name="visible">True</property>
                                 <property name="can_focus">True</property>
@@ -838,20 +852,6 @@
                               <packing>
                                 <property name="expand">False</property>
                                 <property name="fill">True</property>
-                                <property name="position">3</property>
-                              </packing>
-                            </child>
-                            <child>
-                              <object class="GtkCheckButton" id="ToggleAutoclearUploads">
-                                <property name="label" translatable="yes">Autoclear finished / aborted</property>
-                                <property name="visible">True</property>
-                                <property name="can_focus">True</property>
-                                <property name="receives_default">False</property>
-                                <property name="draw_indicator">True</property>
-                              </object>
-                              <packing>
-                                <property name="expand">False</property>
-                                <property name="fill">False</property>
                                 <property name="position">4</property>
                               </packing>
                             </child>

--- a/pynicotine/gtkgui/ui/search.ui
+++ b/pynicotine/gtkgui/ui/search.ui
@@ -76,6 +76,39 @@
           </packing>
         </child>
         <child>
+          <object class="GtkCheckButton" id="filtersCheck">
+            <property name="label" translatable="yes">Enable filters</property>
+            <property name="visible">True</property>
+            <property name="can_focus">True</property>
+            <property name="receives_default">False</property>
+            <property name="use_underline">True</property>
+            <property name="draw_indicator">True</property>
+            <signal name="toggled" handler="on_toggle_filters" swapped="no"/>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">1</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkCheckButton" id="RememberCheckButton">
+            <property name="label" translatable="yes">Wish</property>
+            <property name="visible">True</property>
+            <property name="can_focus">True</property>
+            <property name="receives_default">False</property>
+            <property name="tooltip_text" translatable="yes">This search will be opened the next time you start Nicotine+ and will send out new search requests after a server-set intervals (usually around one hour)</property>
+            <property name="use_underline">True</property>
+            <property name="draw_indicator">True</property>
+            <signal name="toggled" handler="on_toggle_remember" swapped="no"/>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">False</property>
+            <property name="position">2</property>
+          </packing>
+        </child>
+        <child>
           <object class="GtkToggleButton" id="ExpandButton">
             <property name="can_focus">True</property>
             <property name="receives_default">True</property>
@@ -93,74 +126,7 @@
           <packing>
             <property name="expand">False</property>
             <property name="fill">True</property>
-            <property name="position">1</property>
-          </packing>
-        </child>
-        <child>
-          <object class="GtkCheckButton" id="filtersCheck">
-            <property name="label" translatable="yes">Enable filters</property>
-            <property name="visible">True</property>
-            <property name="can_focus">True</property>
-            <property name="receives_default">False</property>
-            <property name="use_underline">True</property>
-            <property name="draw_indicator">True</property>
-            <signal name="toggled" handler="on_toggle_filters" swapped="no"/>
-          </object>
-          <packing>
-            <property name="expand">False</property>
-            <property name="fill">True</property>
-            <property name="position">2</property>
-          </packing>
-        </child>
-        <child>
-          <object class="GtkCheckButton" id="RememberCheckButton">
-            <property name="label" translatable="yes">Wish</property>
-            <property name="visible">True</property>
-            <property name="can_focus">True</property>
-            <property name="receives_default">False</property>
-            <property name="tooltip_text" translatable="yes">This search will be opened the next time you start Nicotine+ and will send out new search requests after a server-set intervals (usually around one hour)</property>
-            <property name="use_underline">True</property>
-            <property name="draw_indicator">True</property>
-            <signal name="toggled" handler="on_toggle_remember" swapped="no"/>
-          </object>
-          <packing>
-            <property name="expand">False</property>
-            <property name="fill">False</property>
             <property name="position">3</property>
-          </packing>
-        </child>
-        <child>
-          <object class="GtkComboBox" id="ResultGrouping">
-            <property name="visible">True</property>
-            <property name="can_focus">False</property>
-            <property name="tooltip_text" translatable="yes">Result grouping mode</property>
-          </object>
-          <packing>
-            <property name="expand">False</property>
-            <property name="fill">False</property>
-            <property name="position">4</property>
-          </packing>
-        </child>
-        <child>
-          <object class="GtkButton" id="ClearButton">
-            <property name="visible">True</property>
-            <property name="can_focus">True</property>
-            <property name="receives_default">False</property>
-            <property name="tooltip_text" translatable="yes">Clear all results</property>
-            <property name="image">clear</property>
-            <property name="always_show_image">True</property>
-            <signal name="clicked" handler="on_clear" swapped="no"/>
-            <child>
-              <object class="GtkImage" id="clear">
-                <property name="can_focus">False</property>
-                <property name="icon_name">edit-clear-symbolic</property>
-              </object>
-            </child>
-          </object>
-          <packing>
-            <property name="expand">False</property>
-            <property name="fill">False</property>
-            <property name="position">5</property>
           </packing>
         </child>
         <child>
@@ -196,7 +162,19 @@
           <packing>
             <property name="expand">False</property>
             <property name="fill">False</property>
-            <property name="position">6</property>
+            <property name="position">4</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkComboBox" id="ResultGrouping">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <property name="tooltip_text" translatable="yes">Result grouping mode</property>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">False</property>
+            <property name="position">5</property>
           </packing>
         </child>
       </object>

--- a/pynicotine/gtkgui/ui/search.ui
+++ b/pynicotine/gtkgui/ui/search.ui
@@ -9,14 +9,64 @@
       <object class="GtkBox">
         <property name="visible">True</property>
         <property name="can_focus">False</property>
-        <property name="spacing">5</property>
+        <property name="spacing">6</property>
         <property name="border_width">7</property>
         <child>
-          <object class="GtkLabel" id="Counter">
+          <object class="GtkBox">
             <property name="visible">True</property>
             <property name="can_focus">False</property>
-            <property name="xalign">0</property>
-            <property name="label" translatable="yes">Results: 0/0</property>
+            <property name="spacing">6</property>
+            <child>
+              <object class="GtkLabel">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="label" translatable="yes">Results</property>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">0</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkButton">
+                <property name="visible">True</property>
+                <property name="sensitive">False</property>
+                <property name="can-focus">False</property>
+                <property name="receives-default">False</property>
+                <child>
+                  <object class="GtkBox">
+                    <property name="width-request">24</property>
+                    <property name="visible">True</property>
+                    <property name="can-focus">False</property>
+                    <property name="spacing">5</property>
+                    <property name="homogeneous">True</property>
+                    <child>
+                      <object class="GtkLabel" id="Counter">
+                        <property name="visible">True</property>
+                        <property name="can-focus">False</property>
+                        <property name="label">&lt;b&gt;0&lt;/b&gt;</property>
+                        <property name="use_markup">True</property>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">True</property>
+                        <property name="padding">5</property>
+                        <property name="position">0</property>
+                      </packing>
+                    </child>
+                  </object>
+                </child>
+                <style>
+                  <class name="circular"/>
+                </style>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">False</property>
+                <property name="position">1</property>
+              </packing>
+            </child>
           </object>
           <packing>
             <property name="expand">True</property>
@@ -406,6 +456,9 @@
                         <property name="icon_name">dialog-question-symbolic</property>
                       </object>
                     </child>
+                    <style>
+                      <class name="circular"/>
+                    </style>
                   </object>
                   <packing>
                     <property name="expand">False</property>

--- a/pynicotine/gtkgui/ui/userbrowse.ui
+++ b/pynicotine/gtkgui/ui/userbrowse.ui
@@ -18,32 +18,133 @@
               <object class="GtkBox">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
-                <property name="spacing">10</property>
-                <property name="border_width">10</property>
+                <property name="spacing">3</property>
+                <property name="border_width">2</property>
                 <child>
-                  <object class="GtkLabel" id="NumDirectories">
+                  <object class="GtkBox">
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
-                    <property name="xalign">0</property>
-                    <property name="label" translatable="yes">Dirs: Unknown</property>
+                    <property name="spacing">6</property>
+                    <child>
+                      <object class="GtkLabel">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="label" translatable="yes">Folders</property>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">True</property>
+                        <property name="position">0</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkButton">
+                        <property name="visible">True</property>
+                        <property name="sensitive">False</property>
+                        <property name="can-focus">False</property>
+                        <property name="receives-default">False</property>
+                        <child>
+                          <object class="GtkBox">
+                            <property name="width-request">24</property>
+                            <property name="visible">True</property>
+                            <property name="can-focus">False</property>
+                            <property name="spacing">5</property>
+                            <property name="homogeneous">True</property>
+                            <child>
+                              <object class="GtkLabel" id="NumDirectories">
+                                <property name="visible">True</property>
+                                <property name="can-focus">False</property>
+                                <property name="label">&lt;b&gt;0&lt;/b&gt;</property>
+                                <property name="use_markup">True</property>
+                              </object>
+                              <packing>
+                                <property name="expand">False</property>
+                                <property name="fill">True</property>
+                                <property name="padding">5</property>
+                                <property name="position">0</property>
+                              </packing>
+                            </child>
+                          </object>
+                        </child>
+                        <style>
+                          <class name="circular"/>
+                        </style>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">False</property>
+                        <property name="position">1</property>
+                      </packing>
+                    </child>
                   </object>
                   <packing>
                     <property name="expand">False</property>
-                    <property name="fill">True</property>
-                    <property name="position">1</property>
+                    <property name="fill">False</property>
+                    <property name="padding">10</property>
+                    <property name="position">0</property>
                   </packing>
                 </child>
                 <child>
-                  <object class="GtkLabel" id="AmountShared">
+                  <object class="GtkBox">
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
-                    <property name="xalign">0</property>
-                    <property name="label" translatable="yes">Shared: Unknown</property>
+                    <property name="spacing">6</property>
+                    <child>
+                      <object class="GtkLabel">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="label" translatable="yes">Shared</property>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">True</property>
+                        <property name="position">0</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkButton">
+                        <property name="visible">True</property>
+                        <property name="sensitive">False</property>
+                        <property name="can-focus">False</property>
+                        <property name="receives-default">False</property>
+                        <child>
+                          <object class="GtkBox">
+                            <property name="width-request">24</property>
+                            <property name="visible">True</property>
+                            <property name="can-focus">False</property>
+                            <property name="spacing">5</property>
+                            <property name="homogeneous">True</property>
+                            <child>
+                              <object class="GtkLabel" id="AmountShared">
+                                <property name="visible">True</property>
+                                <property name="can-focus">False</property>
+                                <property name="label">&lt;b&gt;0 B&lt;/b&gt;</property>
+                                <property name="use_markup">True</property>
+                              </object>
+                              <packing>
+                                <property name="expand">False</property>
+                                <property name="fill">True</property>
+                                <property name="padding">5</property>
+                                <property name="position">0</property>
+                              </packing>
+                            </child>
+                          </object>
+                        </child>
+                        <style>
+                          <class name="circular"/>
+                        </style>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">False</property>
+                        <property name="position">1</property>
+                      </packing>
+                    </child>
                   </object>
                   <packing>
                     <property name="expand">True</property>
                     <property name="fill">True</property>
-                    <property name="position">2</property>
+                    <property name="position">1</property>
                   </packing>
                 </child>
               </object>
@@ -58,9 +159,9 @@
               <object class="GtkBox">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
-                <property name="spacing">5</property>
-                <property name="margin_start">8</property>
-                <property name="margin_end">8</property>
+                <property name="spacing">6</property>
+                <property name="margin_start">11</property>
+                <property name="margin_end">11</property>
                 <property name="margin_bottom">5</property>
                 <child>
                   <object class="GtkSearchEntry" id="SearchEntry">
@@ -98,28 +199,6 @@
                   </packing>
                 </child>
                 <child>
-                  <object class="GtkButton" id="SaveButton">
-                    <property name="visible">True</property>
-                    <property name="can_focus">True</property>
-                    <property name="receives_default">False</property>
-                    <property name="tooltip_text" translatable="yes">Save file list to disk</property>
-                    <property name="image">save</property>
-                    <property name="always_show_image">True</property>
-                    <signal name="clicked" handler="on_save" swapped="no"/>
-                    <child>
-                      <object class="GtkImage" id="save">
-                        <property name="can_focus">False</property>
-                        <property name="icon_name">document-save-symbolic</property>
-                      </object>
-                    </child>
-                  </object>
-                  <packing>
-                    <property name="expand">False</property>
-                    <property name="fill">False</property>
-                    <property name="position">2</property>
-                  </packing>
-                </child>
-                <child>
                   <object class="GtkToggleButton" id="ExpandButton">
                     <property name="visible">True</property>
                     <property name="can_focus">True</property>
@@ -138,7 +217,7 @@
                   <packing>
                     <property name="expand">False</property>
                     <property name="fill">False</property>
-                    <property name="position">3</property>
+                    <property name="position">2</property>
                   </packing>
                 </child>
               </object>

--- a/pynicotine/gtkgui/ui/userinfo.ui
+++ b/pynicotine/gtkgui/ui/userinfo.ui
@@ -424,7 +424,7 @@
         <property name="visible">True</property>
         <property name="can_focus">False</property>
         <property name="border_width">10</property>
-        <property name="spacing">5</property>
+        <property name="spacing">6</property>
         <property name="orientation">vertical</property>
         <child>
           <object class="GtkButton">

--- a/pynicotine/gtkgui/userbrowse.py
+++ b/pynicotine/gtkgui/userbrowse.py
@@ -94,6 +94,8 @@ class UserBrowse:
                 ("#" + _("Get user i_nfo"), menu.on_get_user_info),
                 ("#" + _("Gi_ve privileges"), menu.on_give_privileges),
                 ("", None),
+                ("#" + _("_Save shares list to disk"), self.on_save),
+                ("", None),
                 ("$" + _("_Add user to list"), menu.on_add_to_list),
                 ("$" + _("_Ban this user"), menu.on_ban_user),
                 ("$" + _("_Ignore this user"), menu.on_ignore_user)
@@ -225,11 +227,11 @@ class UserBrowse:
         items[1].set_sensitive(act)
         items[2].set_sensitive(act)
 
-        items[5].set_active(self.user in [i[0] for i in self.frame.np.config.sections["server"]["userlist"]])
-        items[6].set_active(self.user in self.frame.np.config.sections["server"]["banlist"])
-        items[7].set_active(self.user in self.frame.np.config.sections["server"]["ignorelist"])
+        items[7].set_active(self.user in [i[0] for i in self.frame.np.config.sections["server"]["userlist"]])
+        items[8].set_active(self.user in self.frame.np.config.sections["server"]["banlist"])
+        items[9].set_active(self.user in self.frame.np.config.sections["server"]["ignorelist"])
 
-        for i in range(3, 8):
+        for i in range(3, 10):
             items[i].set_sensitive(act)
 
         return True
@@ -363,8 +365,8 @@ class UserBrowse:
                 if filedata[2] < maxsize:
                     self.totalsize += filedata[2]
 
-        self.AmountShared.set_text(_("Shared: %s") % human_size(self.totalsize))
-        self.NumDirectories.set_text(_("Dirs: %s") % len(self.shares))
+        self.AmountShared.set_markup("<b>%s</b>" % human_size(self.totalsize))
+        self.NumDirectories.set_markup("<b>%d</b>" % len(self.shares))
 
         # Generate the directory tree and select first directory
         currentdir = self.browse_get_dirs()
@@ -378,7 +380,6 @@ class UserBrowse:
 
         self.FolderTreeView.set_sensitive(True)
         self.FileTreeView.set_sensitive(True)
-        self.SaveButton.set_sensitive(True)
 
         if self.ExpandButton.get_active():
             self.FolderTreeView.expand_all()
@@ -918,7 +919,6 @@ class UserBrowse:
     def on_refresh(self, widget):
         self.FolderTreeView.set_sensitive(False)
         self.FileTreeView.set_sensitive(False)
-        self.SaveButton.set_sensitive(False)
         self.frame.browse_user(self.user)
 
     def on_copy_url(self, widget):


### PR DESCRIPTION
- Add badges behind numbers (number of chatroom users, downloads/uploads, shared files, search results)
- Make quick settings buttons rounded
- Move "save shares list to disk" option to popup menu
- Minor spacing tweak

![refresh2](https://user-images.githubusercontent.com/8754153/97619672-2dd75480-1a29-11eb-932e-070487cb219a.png)
![refresh3](https://user-images.githubusercontent.com/8754153/97619677-2e6feb00-1a29-11eb-9dbc-88fcd3e8da03.png)
