### PR TITLE
Hide hilite image if empty

### DIFF
--- a/pynicotine/gtkgui/search.py
+++ b/pynicotine/gtkgui/search.py
@@ -723,8 +723,8 @@ class Search:
                 self.searches.show_tab(self, self.id, self.text, self.mode)
                 self.showtab = True
 
-            # Update counter
-            self.Counter.set_markup("<b>%d</b>" % self.numvisibleresults)
+            # Update number of results
+            self.update_counter()
 
             # Update tab notification
             self.frame.searches.request_changed(self.Main)
@@ -929,7 +929,8 @@ class Search:
             if self.check_filter(row):
                 self.add_row_to_model(row)
 
-        self.Counter.set_markup("<b>%d</b>" % self.numvisibleresults)
+        # Update number of visible results
+        self.update_counter()
 
     def on_popup_menu_users(self, widget):
 
@@ -1013,6 +1014,9 @@ class Search:
         self.selected_users = set()
 
         self.ResultsList.get_selection().selected_foreach(self.selected_results_callback)
+
+    def update_counter(self):
+        self.Counter.set_markup("<b>%d</b>" % self.numvisibleresults)
 
     def change_colours(self):
 
@@ -1308,6 +1312,10 @@ class Search:
         self.usersiters.clear()
         self.directoryiters.clear()
         self.resultsmodel.clear()
+        self.numvisibleresults = 0
+
+        # Update number of visible results
+        self.update_counter()
 
     def on_close(self, widget):
 

--- a/pynicotine/gtkgui/utils.py
+++ b/pynicotine/gtkgui/utils.py
@@ -615,7 +615,6 @@ class ImageLabel(Gtk.Box):
 
         if show_hilite_image:
             self.set_hilite_image(hilite_image)
-            self.hilite_image.show()
 
         self._pack_children()
         self._order_children()
@@ -746,14 +745,19 @@ class ImageLabel(Gtk.Box):
             self.label.set_markup("<span foreground=\"%s\">%s</span>" % (color, self.text.replace("<", "&lt;").replace(">", "&gt;").replace("&", "&amp;")))
 
     def set_hilite_image(self, pixbuf):
+        if pixbuf is None:
+            self.show_hilite_image(False)
+        else:
+            self.show_hilite_image(True)
+
         self.hilite_pixbuf = pixbuf
         self.hilite_image.set_from_pixbuf(pixbuf)
 
     def get_hilite_image(self):
         return self.hilite_pixbuf
 
-    def set_status_image(self, img):
-        if img is self.status_pixbuf:
+    def set_status_image(self, pixbuf):
+        if pixbuf is self.status_pixbuf:
             return
 
         if NICOTINE.np.config.sections["ui"]["tab_status_icons"]:
@@ -761,8 +765,8 @@ class ImageLabel(Gtk.Box):
         else:
             self.status_image.hide()
 
-        self.status_pixbuf = img
-        self.status_image.set_from_pixbuf(img)
+        self.status_pixbuf = pixbuf
+        self.status_image.set_from_pixbuf(pixbuf)
 
     def get_status_image(self):
         return self.status_pixbuf


### PR DESCRIPTION
There hilite icon still takes up some space in the tab when no image is set, so hide it.