### PR TITLE
Recursive download fix

### DIFF
--- a/pynicotine/gtkgui/downloads.py
+++ b/pynicotine/gtkgui/downloads.py
@@ -124,8 +124,6 @@ class Downloads(TransferList):
     def expand(self, path):
         if self.frame.ExpandDownloads.get_active():
             self.frame.DownloadList.expand_to_path(path)
-        else:
-            collapse_treeview(self.frame.DownloadList, self.tree_users)
 
     def on_expand_downloads(self, widget):
 

--- a/pynicotine/gtkgui/uploads.py
+++ b/pynicotine/gtkgui/uploads.py
@@ -123,8 +123,6 @@ class Uploads(TransferList):
     def expand(self, path):
         if self.frame.ExpandUploads.get_active():
             self.frame.UploadList.expand_to_path(path)
-        else:
-            collapse_treeview(self.frame.UploadList, self.tree_users)
 
     def on_expand_uploads(self, widget):
 
@@ -164,7 +162,7 @@ class Uploads(TransferList):
                 if i.user == user:
                     self.selected_transfers.add(i)
 
-        TransferList.on_abort_transfer(self, widget, False, False)
+        self.on_abort_transfer(widget, False, False)
         self.frame.np.transfers.calc_upload_queue_sizes()
         self.frame.np.transfers.check_upload_queue()
 
@@ -303,18 +301,18 @@ class Uploads(TransferList):
 
         self.select_transfers()
 
-        TransferList.on_abort_transfer(self, widget, remove, clear)
+        self.on_abort_transfer(widget, remove, clear)
         self.frame.np.transfers.calc_upload_queue_sizes()
         self.frame.np.transfers.check_upload_queue()
 
     def on_clear_queued(self, widget):
 
-        TransferList.on_clear_queued(self, widget)
+        self.on_clear_queued(widget)
         self.frame.np.transfers.calc_upload_queue_sizes()
         self.frame.np.transfers.check_upload_queue()
 
     def on_clear_failed(self, widget):
 
-        TransferList.on_clear_failed(self, widget)
+        self.on_clear_failed(widget)
         self.frame.np.transfers.calc_upload_queue_sizes()
         self.frame.np.transfers.check_upload_queue()

--- a/pynicotine/gtkgui/userbrowse.py
+++ b/pynicotine/gtkgui/userbrowse.py
@@ -695,7 +695,7 @@ class UserBrowse:
             return
 
         for subdir, subf in self.shares:
-            if dir in subdir and dir != subdir:
+            if folder in subdir and folder != subdir:
                 self.download_directory(subdir, os.path.join(ldir, ""))
 
     def on_download_files(self, widget, prefix=""):


### PR DESCRIPTION
- Fixes https://github.com/Nicotine-Plus/nicotine-plus/issues/790 (regression from the last major refactoring)
- Don't collapse the download/upload treeview whenever a transfer is updated