### PR TITLE
Notification and window improvements

### DIFF
--- a/pynicotine/gtkgui/chatrooms.py
+++ b/pynicotine/gtkgui/chatrooms.py
@@ -1120,7 +1120,7 @@ class ChatRoom:
             if tag == self.tag_hilite:
 
                 self.roomsctrl.chat_notebook.request_hilite(self.Main)
-                self.frame.chat_request_icon(1, self.Main)
+                self.frame.request_tab_icon(self.frame.ChatTabLabel, status=1)
 
                 if self.frame.np.config.sections["notifications"]["notification_popup_chatroom_mention"]:
                     self.frame.notifications.new_notification(
@@ -1131,7 +1131,7 @@ class ChatRoom:
 
             else:
                 self.roomsctrl.chat_notebook.request_changed(self.Main)
-                self.frame.chat_request_icon(0)
+                self.frame.request_tab_icon(self.frame.ChatTabLabel, status=0)
 
             if self.roomsctrl.chat_notebook.get_current_page() != self.roomsctrl.chat_notebook.page_num(self.roomsctrl.joinedrooms[self.room].Main) or \
                 self.frame.MainNotebook.get_current_page() != self.frame.MainNotebook.page_num(self.frame.chathbox) or \
@@ -1271,8 +1271,7 @@ class ChatRoom:
         elif cmd == "/ip":
             if byteargs:
                 user = byteargs
-                if user not in self.frame.np.ip_requested:
-                    self.frame.np.ip_requested.append(user)
+                self.frame.np.ip_requested.add(user)
                 self.frame.np.queue.put(slskmessages.GetPeerAddress(user))
 
         elif cmd == "/pm":

--- a/pynicotine/gtkgui/downloads.py
+++ b/pynicotine/gtkgui/downloads.py
@@ -43,10 +43,10 @@ from pynicotine.gtkgui.utils import set_treeview_selected_row
 
 class Downloads(TransferList):
 
-    def __init__(self, frame):
+    def __init__(self, frame, tab):
 
         TransferList.__init__(self, frame, frame.DownloadList, type='download')
-        self.myvbox = self.frame.downloadsvbox
+        self.tab = tab
 
         self.popup_menu_users = PopupMenu(self.frame, False)
         self.popup_menu_clear = popup2 = PopupMenu(self.frame, False)

--- a/pynicotine/gtkgui/notifications.py
+++ b/pynicotine/gtkgui/notifications.py
@@ -26,7 +26,6 @@ from gi.repository import Gio
 
 from pynicotine.logfacility import log
 from pynicotine.utils import execute_command
-from pynicotine.utils import version
 
 
 class Notifications:
@@ -46,16 +45,19 @@ class Notifications:
                 self.frame.hilites["rooms"].append(room)
 
                 self.frame.tray.set_image()
+
         elif location == "private":
             if user in self.frame.hilites[location]:
                 self.frame.hilites[location].remove(user)
                 self.frame.hilites[location].append(user)
+
             elif user not in self.frame.hilites[location]:
                 self.frame.hilites[location].append(user)
 
                 self.frame.tray.set_image()
 
-        if tab and self.frame.np.config.sections["ui"]["urgencyhint"] and not self.frame.got_focus:
+        if tab and self.frame.np.config.sections["ui"]["urgencyhint"] and \
+                not self.frame.MainWindow.is_focus():
             self.frame.MainWindow.set_urgency_hint(True)
 
         self.set_title(user)
@@ -89,25 +91,25 @@ class Notifications:
 
         if self.frame.hilites["rooms"] == [] and self.frame.hilites["private"] == []:
             # Reset Title
-            if self.frame.MainWindow.get_title() != "Nicotine+" + " " + version:
-                self.frame.MainWindow.set_title("Nicotine+" + " " + version)
+            self.frame.MainWindow.set_title("Nicotine+")
+
         elif self.frame.np.config.sections["notifications"]["notification_window_title"]:
             # Private Chats have a higher priority
             if len(self.frame.hilites["private"]) > 0:
                 user = self.frame.hilites["private"][-1]
                 self.frame.MainWindow.set_title(
-                    "Nicotine+" + " " + version + " :: " + _("Private Message from %(user)s") % {'user': user}
+                    "Nicotine+ - " + _("Private Message from %(user)s") % {'user': user}
                 )
             # Allow for the possibility the username is not available
             elif len(self.frame.hilites["rooms"]) > 0:
                 room = self.frame.hilites["rooms"][-1]
                 if user is None:
                     self.frame.MainWindow.set_title(
-                        "Nicotine+" + " " + version + " :: " + _("You've been mentioned in the %(room)s room") % {'room': room}
+                        "Nicotine+ - " + _("You've been mentioned in the %(room)s room") % {'room': room}
                     )
                 else:
                     self.frame.MainWindow.set_title(
-                        "Nicotine+" + " " + version + " :: " + _("%(user)s mentioned you in the %(room)s room") % {'user': user, 'room': room}
+                        "Nicotine+ - " + _("%(user)s mentioned you in the %(room)s room") % {'user': user, 'room': room}
                     )
 
     def new_tts(self, message):

--- a/pynicotine/gtkgui/privatechat.py
+++ b/pynicotine/gtkgui/privatechat.py
@@ -235,7 +235,7 @@ class PrivateChats(IconNotebook):
         self.request_changed(chat.Main)
 
         # Hilight main private chats Label
-        self.frame.request_icon(self.frame.PrivateChatTabLabel, chat.Main)
+        self.frame.request_tab_icon(self.frame.PrivateChatTabLabel)
 
         # Show notifications if the private chats notebook isn't selected,
         # the tab is not selected, or the main window isn't mapped
@@ -659,8 +659,7 @@ class PrivateChat:
         elif cmd == "/ip":
             if args:
                 user = args
-                if user not in self.frame.np.ip_requested:
-                    self.frame.np.ip_requested.append(user)
+                self.frame.np.ip_requested.add(user)
                 self.frame.np.queue.put(slskmessages.GetPeerAddress(user))
 
         elif cmd == "/pm":

--- a/pynicotine/gtkgui/search.py
+++ b/pynicotine/gtkgui/search.py
@@ -80,6 +80,7 @@ class Searches(IconNotebook):
         )
 
         self.popup_enable()
+        self.load_config()
 
         self.wish_list = WishList(frame, self)
 
@@ -728,8 +729,7 @@ class Search:
 
             # Update tab notification
             self.frame.searches.request_changed(self.Main)
-            if self.frame.MainNotebook.get_current_page() != self.frame.MainNotebook.page_num(self.frame.searchvbox):
-                self.frame.SearchTabLabel.get_child().set_hilite_image(self.frame.images["hilite"])
+            self.frame.request_tab_icon(self.frame.SearchTabLabel)
 
     def get_flag(self, user, flag=None):
 

--- a/pynicotine/gtkgui/transferlist.py
+++ b/pynicotine/gtkgui/transferlist.py
@@ -172,17 +172,7 @@ class TransferList:
         self.widget.get_selection().selected_foreach(self.selected_transfers_callback)
 
     def new_transfer_notification(self):
-        current_page = self.frame.MainNotebook.get_current_page()
-        my_page = self.frame.MainNotebook.page_num(self.myvbox)
-
-        if (current_page == my_page):
-            return
-
-        tablabel = self.frame.get_tab_label(self.frame.MainNotebook.get_tab_label(self.myvbox))
-        if not tablabel:
-            return
-
-        tablabel.set_hilite_image(self.frame.images["hilite"])
+        self.frame.request_tab_icon(self.tab)
 
     def on_ban(self, widget):
         self.select_transfers()
@@ -254,10 +244,7 @@ class TransferList:
             self.last_save = curtime
 
         if not forceupdate:
-            current_page = self.frame.MainNotebook.get_current_page()
-            my_page = self.frame.MainNotebook.page_num(self.myvbox)
-
-            if (current_page != my_page):
+            if self.frame.current_tab != self.tab:
                 """ No need to do unnecessary work if transfers are not visible """
                 return
 

--- a/pynicotine/gtkgui/tray.py
+++ b/pynicotine/gtkgui/tray.py
@@ -146,9 +146,7 @@ class Tray:
             droplist=users
         )
         if user is not None:
-            if user not in self.frame.np.ip_requested:
-                self.frame.np.ip_requested.append(user)
-
+            self.frame.np.ip_requested.add(user)
             self.frame.np.queue.put(slskmessages.GetPeerAddress(user))
 
     def on_get_a_users_shares(self, widget, prefix=""):

--- a/pynicotine/gtkgui/uploads.py
+++ b/pynicotine/gtkgui/uploads.py
@@ -41,10 +41,10 @@ from pynicotine.gtkgui.utils import set_treeview_selected_row
 
 class Uploads(TransferList):
 
-    def __init__(self, frame):
+    def __init__(self, frame, tab):
 
         TransferList.__init__(self, frame, frame.UploadList, type='upload')
-        self.myvbox = self.frame.uploadsvbox
+        self.tab = tab
 
         self.popup_menu_users = PopupMenu(self.frame, False)
         self.popup_menu_clear = popup2 = PopupMenu(self.frame, False)

--- a/pynicotine/gtkgui/userinfo.py
+++ b/pynicotine/gtkgui/userinfo.py
@@ -45,7 +45,7 @@ from pynicotine.logfacility import log
 # User Info and User Browse Notebooks
 class UserTabs(IconNotebook):
 
-    def __init__(self, frame, subwindow, notebookraw):
+    def __init__(self, frame, subwindow, notebookraw, tab):
 
         self.frame = frame
 
@@ -67,10 +67,7 @@ class UserTabs(IconNotebook):
         self.subwindow = subwindow
 
         self.users = {}
-        self.mytab = None
-
-    def set_tab_label(self, mytab):
-        self.mytab = mytab
+        self.tab = tab
 
     def init_window(self, user):
 
@@ -88,10 +85,10 @@ class UserTabs(IconNotebook):
         self.users[user].show_user(msg)
         self.request_changed(self.users[user].Main)
 
-        if self.mytab is not None:
-            self.frame.request_icon(self.mytab)
+        if self.tab is not None:
+            self.frame.request_tab_icon(self.tab)
 
-        tab_name = self.frame.match_main_notebox(self.mytab)
+        tab_name = self.frame.match_main_notebox(self.tab)
         self.frame.change_main_page(tab_name)
 
     def save_columns(self):
@@ -430,9 +427,7 @@ class UserInfo:
 
     def on_show_ip_address(self, widget):
 
-        if self.user not in self.frame.np.ip_requested:
-            self.frame.np.ip_requested.append(self.user)
-
+        self.frame.np.ip_requested.add(self.user)
         self.frame.np.queue.put(slskmessages.GetPeerAddress(self.user))
 
     def on_refresh(self, widget):

--- a/pynicotine/gtkgui/utils.py
+++ b/pynicotine/gtkgui/utils.py
@@ -1109,9 +1109,7 @@ class PopupMenu(Gtk.Menu):
 
     def on_show_ip_address(self, widget):
 
-        if self.user not in self.frame.np.ip_requested:
-            self.frame.np.ip_requested.append(self.user)
-
+        self.frame.np.ip_requested.add(self.user)
         self.frame.np.queue.put(slskmessages.GetPeerAddress(self.user))
 
     def on_get_user_info(self, widget):

--- a/pynicotine/pynicotine.py
+++ b/pynicotine/pynicotine.py
@@ -129,10 +129,10 @@ class NetworkEventProcessor:
         log.set_log_levels(self.config.sections["logging"]["debugmodes"])
 
         self.peerconns = []
-        self.watchedusers = []
+        self.watchedusers = set()
         self.ipblock_requested = {}
         self.ipignore_requested = {}
-        self.ip_requested = []
+        self.ip_requested = set()
         self.private_message_queue = {}
         self.users = {}
         self.user_addr_requested = set()
@@ -576,7 +576,7 @@ class NetworkEventProcessor:
                 self.manualdisconnect = False
 
             self.active_server_conn = None
-            self.watchedusers = []
+            self.watchedusers.clear()
             self.shares.set_connected(False)
 
             if self.transfers is not None:
@@ -870,8 +870,7 @@ class NetworkEventProcessor:
 
     def add_user(self, msg):
 
-        if msg.user not in self.watchedusers:
-            self.watchedusers.append(msg.user)
+        self.watchedusers.add(msg.user)
 
         if not msg.userexists:
             if msg.user not in self.users:


### PR DESCRIPTION
- Consolidate duplicate efforts for changing tab hilite icons into one function, "request_tab_icon"
- Remove Nicotine+ version number from window title. It takes up space and is not relevant information for everyday use.
- Don't modify window icon when new messages arrive, as this change is not guaranteed to work across desktop environments. Rely on other notification methods instead, such as window urgency, tray icon, notification bubbles and window title notifications.
- Code cleanups