### PR TITLE
Refactor code related to widget colors and fonts

### DIFF
--- a/pynicotine/gtkgui/chatrooms.py
+++ b/pynicotine/gtkgui/chatrooms.py
@@ -40,7 +40,6 @@ from pynicotine.gtkgui.dialogs import entry_dialog
 from pynicotine.gtkgui.roomwall import RoomWall
 from pynicotine.gtkgui.roomwall import Tickers
 from pynicotine.gtkgui.utils import append_line
-from pynicotine.gtkgui.utils import change_list_font
 from pynicotine.gtkgui.utils import hide_columns
 from pynicotine.gtkgui.utils import humanize
 from pynicotine.gtkgui.utils import human_speed
@@ -54,10 +53,10 @@ from pynicotine.gtkgui.utils import TextSearchBar
 from pynicotine.gtkgui.utils import expand_alias
 from pynicotine.gtkgui.utils import is_alias
 from pynicotine.gtkgui.utils import show_country_tooltip
-from pynicotine.gtkgui.utils import set_text_bg
-from pynicotine.gtkgui.utils import update_cell_colors
-from pynicotine.gtkgui.utils import update_color
-from pynicotine.gtkgui.utils import update_font
+from pynicotine.gtkgui.utils import set_widget_fg_bg_css
+from pynicotine.gtkgui.utils import set_widget_color
+from pynicotine.gtkgui.utils import set_widget_font
+from pynicotine.gtkgui.utils import update_widget_visuals
 from pynicotine.logfacility import log
 from pynicotine.utils import clean_file
 from pynicotine.utils import cmp
@@ -150,7 +149,7 @@ class RoomsControl:
         self.chat_notebook.notebook.connect("switch-page", self.on_switch_page)
         self.chat_notebook.notebook.connect("page-reordered", self.on_reordered_page)
 
-        set_text_bg(self.frame.roomlist.SearchRooms)
+        self.update_visuals()
 
     def is_private_room_owned(self, room):
 
@@ -204,8 +203,6 @@ class RoomsControl:
         else:
             cellrenderer.set_property("weight", Pango.Weight.NORMAL)
             cellrenderer.set_property("underline", Pango.Underline.NONE)
-
-        update_cell_colors(column, cellrenderer, model, iterator)
 
     def on_reordered_page(self, notebook, page, page_num, force=0):
 
@@ -680,8 +677,6 @@ class RoomsControl:
 
     def update_visuals(self):
 
-        set_text_bg(self.frame.roomlist.SearchRooms)
-
         for room in self.joinedrooms.values():
             room.update_visuals()
             room.update_tags()
@@ -811,8 +806,8 @@ class ChatRoom:
             [_("Status"), widths[0], "pixbuf"],
             [_("Country"), widths[1], "pixbuf"],
             [_("User"), widths[2], "text", self.user_column_draw],
-            [_("Speed"), widths[3], "number", update_cell_colors],
-            [_("Files"), widths[4], "number", update_cell_colors]
+            [_("Speed"), widths[3], "number"],
+            [_("Files"), widths[4], "number"]
         )
 
         cols[0].set_sort_column_id(5)
@@ -1519,8 +1514,6 @@ class ChatRoom:
                 cellrenderer.set_property("weight", Pango.Weight.NORMAL)
                 cellrenderer.set_property("underline", Pango.Underline.NONE)
 
-        update_cell_colors(column, cellrenderer, model, iterator)
-
     def get_user_stats(self, user, avgspeed, files):
 
         if user not in self.users:
@@ -1562,8 +1555,8 @@ class ChatRoom:
 
         tag = buffer.create_tag()
 
-        update_color(tag, self.frame.np.config.sections["ui"][color])
-        update_font(tag, self.frame.np.config.sections["ui"]["chatfont"])
+        set_widget_color(tag, self.frame.np.config.sections["ui"][color])
+        set_widget_font(tag, self.frame.np.config.sections["ui"]["chatfont"])
 
         if username is not None:
 
@@ -1618,10 +1611,10 @@ class ChatRoom:
 
     def update_visuals(self):
 
-        change_list_font(self.UserList, self.frame.np.config.sections["ui"]["listfont"])
+        for widget in self.__dict__.values():
+            update_widget_visuals(widget, update_text_tags=False)
 
-        set_text_bg(self.ChatEntry)
-        set_text_bg(self.room_wall.RoomWallEntry)
+        self.room_wall.update_visuals()
 
     def create_tags(self):
 
@@ -1655,8 +1648,8 @@ class ChatRoom:
 
     def update_tag_visuals(self, tag, color):
 
-        update_color(tag, self.frame.np.config.sections["ui"][color])
-        update_font(tag, self.frame.np.config.sections["ui"]["chatfont"])
+        set_widget_color(tag, self.frame.np.config.sections["ui"][color])
+        set_widget_font(tag, self.frame.np.config.sections["ui"]["chatfont"])
 
         # Hotspots
         if color in ("useraway", "useronline", "useroffline"):

--- a/pynicotine/gtkgui/chatrooms.py
+++ b/pynicotine/gtkgui/chatrooms.py
@@ -40,6 +40,7 @@ from pynicotine.gtkgui.dialogs import entry_dialog
 from pynicotine.gtkgui.roomwall import RoomWall
 from pynicotine.gtkgui.roomwall import Tickers
 from pynicotine.gtkgui.utils import append_line
+from pynicotine.gtkgui.utils import change_list_font
 from pynicotine.gtkgui.utils import hide_columns
 from pynicotine.gtkgui.utils import humanize
 from pynicotine.gtkgui.utils import human_speed
@@ -53,6 +54,10 @@ from pynicotine.gtkgui.utils import TextSearchBar
 from pynicotine.gtkgui.utils import expand_alias
 from pynicotine.gtkgui.utils import is_alias
 from pynicotine.gtkgui.utils import show_country_tooltip
+from pynicotine.gtkgui.utils import set_text_bg
+from pynicotine.gtkgui.utils import update_cell_colors
+from pynicotine.gtkgui.utils import update_color
+from pynicotine.gtkgui.utils import update_font
 from pynicotine.logfacility import log
 from pynicotine.utils import clean_file
 from pynicotine.utils import cmp
@@ -145,7 +150,7 @@ class RoomsControl:
         self.chat_notebook.notebook.connect("switch-page", self.on_switch_page)
         self.chat_notebook.notebook.connect("page-reordered", self.on_reordered_page)
 
-        self.frame.set_text_bg(self.frame.roomlist.SearchRooms)
+        set_text_bg(self.frame.roomlist.SearchRooms)
 
     def is_private_room_owned(self, room):
 
@@ -200,7 +205,7 @@ class RoomsControl:
             cellrenderer.set_property("weight", Pango.Weight.NORMAL)
             cellrenderer.set_property("underline", Pango.Underline.NONE)
 
-        self.frame.cell_data_func(column, cellrenderer, model, iterator)
+        update_cell_colors(column, cellrenderer, model, iterator)
 
     def on_reordered_page(self, notebook, page, page_num, force=0):
 
@@ -673,12 +678,13 @@ class RoomsControl:
 
         room.say_chat_room(msg, text, public=True)
 
-    def update_colours(self):
+    def update_visuals(self):
 
-        self.frame.set_text_bg(self.frame.roomlist.SearchRooms)
+        set_text_bg(self.frame.roomlist.SearchRooms)
 
         for room in self.joinedrooms.values():
-            room.change_colours()
+            room.update_visuals()
+            room.update_tags()
 
     def save_columns(self):
 
@@ -805,8 +811,8 @@ class ChatRoom:
             [_("Status"), widths[0], "pixbuf"],
             [_("Country"), widths[1], "pixbuf"],
             [_("User"), widths[2], "text", self.user_column_draw],
-            [_("Speed"), widths[3], "number", self.frame.cell_data_func],
-            [_("Files"), widths[4], "number", self.frame.cell_data_func]
+            [_("Speed"), widths[3], "number", update_cell_colors],
+            [_("Files"), widths[4], "number", update_cell_colors]
         )
 
         cols[0].set_sort_column_id(5)
@@ -864,7 +870,8 @@ class ChatRoom:
 
         self.usersmodel.set_sort_column_id(2, Gtk.SortType.ASCENDING)
 
-        self.update_colours()
+        self.create_tags()
+        self.update_visuals()
 
         self.UserList.set_model(self.usersmodel)
 
@@ -1206,9 +1213,9 @@ class ChatRoom:
             color = self.get_user_status_color(self.usersmodel.get_value(self.users[user], 5))
 
         if user not in self.tag_users:
-            self.tag_users[user] = self.makecolour(self.ChatScroll.get_buffer(), color, user)
+            self.tag_users[user] = self.create_tag(self.ChatScroll.get_buffer(), color, user)
         else:
-            self.changecolour(self.tag_users[user], color)
+            self.update_tag_visuals(self.tag_users[user], color)
 
     def thread_alias(self, alias):
 
@@ -1512,7 +1519,7 @@ class ChatRoom:
                 cellrenderer.set_property("weight", Pango.Weight.NORMAL)
                 cellrenderer.set_property("underline", Pango.Underline.NONE)
 
-        self.frame.cell_data_func(column, cellrenderer, model, iterator)
+        update_cell_colors(column, cellrenderer, model, iterator)
 
     def get_user_stats(self, user, avgspeed, files):
 
@@ -1540,7 +1547,7 @@ class ChatRoom:
 
         if user in self.tag_users:
             color = self.get_user_status_color(status)
-            self.changecolour(self.tag_users[user], color)
+            self.update_tag_visuals(self.tag_users[user], color)
 
         self.usersmodel.set(self.users[user], 0, img, 5, status)
 
@@ -1551,15 +1558,12 @@ class ChatRoom:
 
         self.usersmodel.set(self.users[user], 1, self.frame.get_flag_image(flag), 8, flag)
 
-    def makecolour(self, buffer, colour, username=None):
+    def create_tag(self, buffer, color, username=None):
 
-        colour = self.frame.np.config.sections["ui"][colour]
-        font = self.frame.np.config.sections["ui"]["chatfont"]
+        tag = buffer.create_tag()
 
-        tag = buffer.create_tag(font=font)
-
-        if colour:
-            tag.set_property("foreground", colour)
+        update_color(tag, self.frame.np.config.sections["ui"][color])
+        update_font(tag, self.frame.np.config.sections["ui"]["chatfont"])
 
         if username is not None:
 
@@ -1612,26 +1616,28 @@ class ChatRoom:
 
         return True
 
-    def update_colours(self):
+    def update_visuals(self):
 
-        self.frame.change_list_font(self.UserList, self.frame.np.config.sections["ui"]["listfont"])
+        change_list_font(self.UserList, self.frame.np.config.sections["ui"]["listfont"])
+
+        set_text_bg(self.ChatEntry)
+        set_text_bg(self.room_wall.RoomWallEntry)
+
+    def create_tags(self):
 
         buffer = self.ChatScroll.get_buffer()
 
-        self.tag_remote = self.makecolour(buffer, "chatremote")
-        self.tag_local = self.makecolour(buffer, "chatlocal")
-        self.tag_me = self.makecolour(buffer, "chatme")
-        self.tag_hilite = self.makecolour(buffer, "chathilite")
+        self.tag_remote = self.create_tag(buffer, "chatremote")
+        self.tag_local = self.create_tag(buffer, "chatlocal")
+        self.tag_me = self.create_tag(buffer, "chatme")
+        self.tag_hilite = self.create_tag(buffer, "chathilite")
 
         self.tag_users = {}
         for user in self.tag_users:
             self.get_user_tag(user)
 
         logbuffer = self.RoomLog.get_buffer()
-        self.tag_log = self.makecolour(logbuffer, "chatremote")
-
-        self.frame.set_text_bg(self.ChatEntry)
-        self.frame.set_text_bg(self.room_wall.RoomWallEntry)
+        self.tag_log = self.create_tag(logbuffer, "chatremote")
 
     def get_user_status_color(self, status):
 
@@ -1647,20 +1653,13 @@ class ChatRoom:
 
         return color
 
-    def changecolour(self, tag, colour):
+    def update_tag_visuals(self, tag, color):
 
-        color = self.frame.np.config.sections["ui"][colour]
-
-        if color == "":
-            color = None
-
-        tag.set_property("foreground", color)
-
-        font = self.frame.np.config.sections["ui"]["chatfont"]
-        tag.set_property("font", font)
+        update_color(tag, self.frame.np.config.sections["ui"][color])
+        update_font(tag, self.frame.np.config.sections["ui"]["chatfont"])
 
         # Hotspots
-        if colour in ["useraway", "useronline", "useroffline"]:
+        if color in ("useraway", "useronline", "useroffline"):
 
             usernamestyle = self.frame.np.config.sections["ui"]["usernamestyle"]
 
@@ -1679,20 +1678,16 @@ class ChatRoom:
             else:
                 tag.set_property("underline", Pango.Underline.NONE)
 
-    def change_colours(self):
+    def update_tags(self):
 
-        self.changecolour(self.tag_remote, "chatremote")
-        self.changecolour(self.tag_local, "chatlocal")
-        self.changecolour(self.tag_me, "chatme")
-        self.changecolour(self.tag_hilite, "chathilite")
-        self.changecolour(self.tag_log, "chatremote")
+        self.update_tag_visuals(self.tag_remote, "chatremote")
+        self.update_tag_visuals(self.tag_local, "chatlocal")
+        self.update_tag_visuals(self.tag_me, "chatme")
+        self.update_tag_visuals(self.tag_hilite, "chathilite")
+        self.update_tag_visuals(self.tag_log, "chatremote")
 
         for user in self.tag_users:
             self.get_user_tag(user)
-
-        self.frame.set_text_bg(self.ChatEntry)
-        self.frame.set_text_bg(self.room_wall.RoomWallEntry)
-        self.frame.change_list_font(self.UserList, self.frame.np.config.sections["ui"]["listfont"])
 
     def on_leave(self, widget=None):
 
@@ -1747,7 +1742,7 @@ class ChatRoom:
             del config["columns"]["chatrooms_widths"][self.room]
 
         for tag in self.tag_users.values():
-            self.changecolour(tag, "useroffline")
+            self.update_tag_visuals(tag, "useroffline")
 
         self.tickers.set_ticker([])
 

--- a/pynicotine/gtkgui/chatrooms.py
+++ b/pynicotine/gtkgui/chatrooms.py
@@ -53,7 +53,6 @@ from pynicotine.gtkgui.utils import TextSearchBar
 from pynicotine.gtkgui.utils import expand_alias
 from pynicotine.gtkgui.utils import is_alias
 from pynicotine.gtkgui.utils import show_country_tooltip
-from pynicotine.gtkgui.utils import set_widget_fg_bg_css
 from pynicotine.gtkgui.utils import set_widget_color
 from pynicotine.gtkgui.utils import set_widget_font
 from pynicotine.gtkgui.utils import update_widget_visuals

--- a/pynicotine/gtkgui/frame.py
+++ b/pynicotine/gtkgui/frame.py
@@ -1241,11 +1241,19 @@ class NicotineFrame:
         if not icon_tab_label:
             return
 
-        if status == 0 and icon_tab_label.get_hilite_image() == self.images["hilite"]:
-            # Chat mentions have priority over normal notifications
+        if status == 1:
+            hilite_icon = self.images["hilite"]
+        else:
+            hilite_icon = self.images["hilite3"]
+
+            if icon_tab_label.get_hilite_image() == self.images["hilite"]:
+                # Chat mentions have priority over normal notifications
+                return
+
+        if hilite_icon == icon_tab_label.get_hilite_image():
             return
 
-        icon_tab_label.set_hilite_image(status == 1 and self.images["hilite"] or self.images["hilite3"])
+        icon_tab_label.set_hilite_image(hilite_icon)
         icon_tab_label.set_text_color(status + 1)
 
     def on_switch_page(self, notebook, page, page_num):

--- a/pynicotine/gtkgui/frame.py
+++ b/pynicotine/gtkgui/frame.py
@@ -62,13 +62,17 @@ from pynicotine.gtkgui.userinfo import UserTabs
 from pynicotine.gtkgui.userlist import UserList
 from pynicotine.gtkgui.utils import append_line
 from pynicotine.gtkgui.utils import BuddiesComboBox
+from pynicotine.gtkgui.utils import change_list_font
 from pynicotine.gtkgui.utils import human_speed
 from pynicotine.gtkgui.utils import ImageLabel
 from pynicotine.gtkgui.utils import load_ui_elements
 from pynicotine.gtkgui.utils import open_uri
 from pynicotine.gtkgui.utils import PopupMenu
 from pynicotine.gtkgui.utils import scroll_bottom
+from pynicotine.gtkgui.utils import set_text_bg
 from pynicotine.gtkgui.utils import TextSearchBar
+from pynicotine.gtkgui.utils import update_color
+from pynicotine.gtkgui.utils import update_font
 from pynicotine.logfacility import log
 from pynicotine.nowplaying import NowPlaying
 from pynicotine.pynicotine import NetworkEventProcessor
@@ -353,7 +357,8 @@ class NicotineFrame:
         self.sSharesButton.connect("clicked", self.on_get_shares)
         self.UserBrowseCombo.get_child().connect("activate", self.on_get_shares)
 
-        self.update_colours(first=True)
+        self.tag_log = self.LogWindow.get_buffer().create_tag()
+        self.update_visuals()
 
         """ Now Playing """
 
@@ -570,6 +575,29 @@ class NicotineFrame:
         else:
             for name in names:
                 self.images[name] = load_static(name)
+
+    def update_visuals(self):
+
+        update_color(self.tag_log, self.np.config.sections["ui"]["chatremote"])
+        update_font(self.tag_log, self.np.config.sections["ui"]["chatfont"])
+
+        for listview in [
+            self.userlist.UserListTree,
+            self.interests.RecommendationsList,
+            self.interests.UnrecommendationsList,
+            self.interests.RecommendationUsersList,
+            self.interests.LikesList,
+            self.interests.DislikesList,
+            self.roomlist.RoomsList
+        ]:
+            change_list_font(listview, self.np.config.sections["ui"]["listfont"])
+
+        set_text_bg(self.UserPrivateCombo.get_child())
+        set_text_bg(self.UserInfoCombo.get_child())
+        set_text_bg(self.UserBrowseCombo.get_child())
+        set_text_bg(self.search_entry)
+        set_text_bg(self.interests.AddLikeEntry)
+        set_text_bg(self.interests.AddDislikeEntry)
 
     """ Connection """
 
@@ -859,7 +887,8 @@ class NicotineFrame:
 
         self.np.queue.put(slskmessages.SetStatus(self.away and 1 or 2))
         self.away_action.set_state(GLib.Variant.new_boolean(self.away))
-        self.privatechats.update_colours()
+
+        self.privatechats.update_visuals()
 
     def on_check_privileges(self, *args):
         self.np.queue.put(slskmessages.CheckPrivileges())
@@ -883,15 +912,16 @@ class NicotineFrame:
     def on_settings(self, *args, page=None):
         if self.settingswindow is None:
             self.settingswindow = Settings(self)
-            self.settingswindow.SettingsWindow.connect("settings-closed", self.on_settings_closed)
+            self.settingswindow.SettingsWindow.connect("settings-updated", self.on_settings_updated)
 
-        if self.fastconfigure is not None and self.fastconfigure.FastConfigureAssistant.get_property("visible"):
+        if self.fastconfigure is not None and \
+                self.fastconfigure.FastConfigureAssistant.get_property("visible"):
             return
 
         self.settingswindow.set_settings(self.np.config.sections)
 
         if page:
-            self.settingswindow.switch_to_page(page)
+            self.settingswindow.set_active_page(page)
 
         self.settingswindow.SettingsWindow.show()
         self.settingswindow.SettingsWindow.deiconify()
@@ -1518,87 +1548,6 @@ class NicotineFrame:
             self.MainNotebook.set_current_page(page_num(tab_box))
         else:
             self.show_tab(tab_box)
-
-    """ Fonts and Colors """
-
-    def cell_data_func(self, column, cellrenderer, model, iterator, dummy="dummy"):
-        colour = self.np.config.sections["ui"]["search"]
-
-        if colour == "":
-            colour = None
-
-        cellrenderer.set_property("foreground", colour)
-
-    def change_list_font(self, listview, font):
-        for c in listview.get_columns():
-            for r in c.get_cells():
-                if isinstance(r, (Gtk.CellRendererText, Gtk.CellRendererCombo)):
-                    r.set_property("font", font)
-
-    def update_colours(self, first=False):
-        if first:
-            self.tag_log = self.LogWindow.get_buffer().create_tag()
-
-        color = self.np.config.sections["ui"]["chatremote"]
-
-        if color == "":
-            color = None
-
-        self.tag_log.set_property("foreground", color)
-
-        font = self.np.config.sections["ui"]["chatfont"]
-        self.tag_log.set_property("font", font)
-
-        for listview in [
-            self.userlist.UserListTree,
-            self.interests.RecommendationsList,
-            self.interests.UnrecommendationsList,
-            self.interests.RecommendationUsersList,
-            self.interests.LikesList,
-            self.interests.DislikesList,
-            self.roomlist.RoomsList
-        ]:
-            self.change_list_font(listview, self.np.config.sections["ui"]["listfont"])
-
-        self.set_text_bg(self.UserPrivateCombo.get_child())
-        self.set_text_bg(self.UserInfoCombo.get_child())
-        self.set_text_bg(self.UserBrowseCombo.get_child())
-        self.set_text_bg(self.search_entry)
-        self.set_text_bg(self.interests.AddLikeEntry)
-        self.set_text_bg(self.interests.AddDislikeEntry)
-
-    def set_text_bg(self, widget, bgcolor="", fgcolor=""):
-        if bgcolor == "" and self.np.config.sections["ui"]["textbg"] == "":
-            rgba = None
-        else:
-            if bgcolor == "":
-                bgcolor = self.np.config.sections["ui"]["textbg"]
-            rgba = Gdk.RGBA()
-            rgba.parse(bgcolor)
-
-        widget.override_background_color(Gtk.StateFlags.NORMAL, rgba)
-
-        if isinstance(widget, Gtk.Entry):
-            if fgcolor != "":
-                rgba = Gdk.RGBA()
-                rgba.parse(fgcolor)
-            elif fgcolor == "" and self.np.config.sections["ui"]["inputcolor"] == "":
-                rgba = None
-            elif fgcolor == "" and self.np.config.sections["ui"]["inputcolor"] != "":
-                fgcolor = self.np.config.sections["ui"]["inputcolor"]
-                rgba = Gdk.RGBA()
-                rgba.parse(fgcolor)
-
-            widget.override_color(Gtk.StateFlags.NORMAL, rgba)
-
-        if isinstance(widget, Gtk.TreeView):
-            colour = self.np.config.sections["ui"]["search"]
-            if colour == "":
-                colour = None
-            for c in widget.get_columns():
-                for r in c.get_cells():
-                    if isinstance(r, (Gtk.CellRendererText, Gtk.CellRendererCombo)):
-                        r.set_property("foreground", colour)
 
     """ Dialogs
     TODO: move to dialogs.py what's possible """
@@ -2371,21 +2320,14 @@ class NicotineFrame:
 
         self.tray.set_transfer_status(self.tray_download_template % {'speed': down}, self.tray_upload_template % {'speed': up})
 
-    """ Exit """
+    """ Settings """
 
-    def on_settings_closed(self, widget, msg):
-
-        if msg == "cancel":
-            self.settingswindow.SettingsWindow.hide()
-            return
+    def on_settings_updated(self, widget, msg):
 
         output = self.settingswindow.get_settings()
 
         if not isinstance(output, tuple):
             return
-
-        if msg == "ok":
-            self.settingswindow.SettingsWindow.hide()
 
         needrescan, needcolors, needcompletion, config = output
 
@@ -2420,6 +2362,7 @@ class NicotineFrame:
 
         if not config["ui"]["trayicon"] and self.tray.is_tray_icon_visible():
             self.tray.hide()
+
         elif config["ui"]["trayicon"] and not self.tray.is_tray_icon_visible():
             self.tray.create()
 
@@ -2431,16 +2374,17 @@ class NicotineFrame:
         Gtk.Settings.get_default().set_property("gtk-application-prefer-dark-theme", dark_mode_state)
 
         if needcolors:
-            self.chatrooms.roomsctrl.update_colours()
-            self.privatechats.update_colours()
-            self.searches.update_colours()
-            self.downloads.update_colours()
-            self.uploads.update_colours()
-            self.userinfo.update_colours()
-            self.userbrowse.update_colours()
-            self.settingswindow.update_colours()
-            self.userlist.update_colours()
-            self.update_colours()
+            self.chatrooms.roomsctrl.update_visuals()
+            self.privatechats.update_visuals()
+            self.searches.update_visuals()
+            self.downloads.update_visuals()
+            self.uploads.update_visuals()
+            self.userinfo.update_visuals()
+            self.userbrowse.update_visuals()
+            self.userlist.update_visuals()
+
+            self.settingswindow.update_visuals()
+            self.update_visuals()
 
         self.on_show_chat_buttons()
 
@@ -2490,6 +2434,8 @@ class NicotineFrame:
         else:
             if self.np.transfers is None:
                 self.connect_action.set_enabled(True)
+
+    """ Exit """
 
     def on_delete_event(self, widget, event):
 

--- a/pynicotine/gtkgui/frame.py
+++ b/pynicotine/gtkgui/frame.py
@@ -62,17 +62,14 @@ from pynicotine.gtkgui.userinfo import UserTabs
 from pynicotine.gtkgui.userlist import UserList
 from pynicotine.gtkgui.utils import append_line
 from pynicotine.gtkgui.utils import BuddiesComboBox
-from pynicotine.gtkgui.utils import change_list_font
 from pynicotine.gtkgui.utils import human_speed
 from pynicotine.gtkgui.utils import ImageLabel
 from pynicotine.gtkgui.utils import load_ui_elements
 from pynicotine.gtkgui.utils import open_uri
 from pynicotine.gtkgui.utils import PopupMenu
 from pynicotine.gtkgui.utils import scroll_bottom
-from pynicotine.gtkgui.utils import set_text_bg
 from pynicotine.gtkgui.utils import TextSearchBar
-from pynicotine.gtkgui.utils import update_color
-from pynicotine.gtkgui.utils import update_font
+from pynicotine.gtkgui.utils import update_widget_visuals
 from pynicotine.logfacility import log
 from pynicotine.nowplaying import NowPlaying
 from pynicotine.pynicotine import NetworkEventProcessor
@@ -578,26 +575,8 @@ class NicotineFrame:
 
     def update_visuals(self):
 
-        update_color(self.tag_log, self.np.config.sections["ui"]["chatremote"])
-        update_font(self.tag_log, self.np.config.sections["ui"]["chatfont"])
-
-        for listview in [
-            self.userlist.UserListTree,
-            self.interests.RecommendationsList,
-            self.interests.UnrecommendationsList,
-            self.interests.RecommendationUsersList,
-            self.interests.LikesList,
-            self.interests.DislikesList,
-            self.roomlist.RoomsList
-        ]:
-            change_list_font(listview, self.np.config.sections["ui"]["listfont"])
-
-        set_text_bg(self.UserPrivateCombo.get_child())
-        set_text_bg(self.UserInfoCombo.get_child())
-        set_text_bg(self.UserBrowseCombo.get_child())
-        set_text_bg(self.search_entry)
-        set_text_bg(self.interests.AddLikeEntry)
-        set_text_bg(self.interests.AddDislikeEntry)
+        for widget in self.__dict__.values():
+            update_widget_visuals(widget)
 
     """ Connection """
 
@@ -2382,6 +2361,9 @@ class NicotineFrame:
             self.userinfo.update_visuals()
             self.userbrowse.update_visuals()
             self.userlist.update_visuals()
+
+            self.roomlist.update_visuals()
+            self.interests.update_visuals()
 
             self.settingswindow.update_visuals()
             self.update_visuals()

--- a/pynicotine/gtkgui/interests.py
+++ b/pynicotine/gtkgui/interests.py
@@ -31,7 +31,7 @@ from pynicotine.gtkgui.utils import humanize
 from pynicotine.gtkgui.utils import human_speed
 from pynicotine.gtkgui.utils import initialise_columns
 from pynicotine.gtkgui.utils import PopupMenu
-from pynicotine.gtkgui.utils import update_cell_colors
+from pynicotine.gtkgui.utils import update_widget_visuals
 
 
 class Interests:
@@ -59,7 +59,7 @@ class Interests:
 
         cols = initialise_columns(
             self.LikesList,
-            [_("I like") + ":", 0, "text", update_cell_colors]
+            [_("I like") + ":", 0, "text"]
         )
 
         cols[0].set_sort_column_id(0)
@@ -82,7 +82,7 @@ class Interests:
 
         cols = initialise_columns(
             self.DislikesList,
-            [_("I dislike") + ":", 0, "text", update_cell_colors]
+            [_("I dislike") + ":", 0, "text"]
         )
 
         cols[0].set_sort_column_id(0)
@@ -100,8 +100,8 @@ class Interests:
 
         cols = initialise_columns(
             self.RecommendationsList,
-            [_("Rating"), 0, "text", update_cell_colors],
-            [_("Item"), -1, "text", update_cell_colors]
+            [_("Rating"), 0, "text"],
+            [_("Item"), -1, "text"]
         )
 
         cols[0].set_sort_column_id(2)
@@ -128,8 +128,8 @@ class Interests:
 
         cols = initialise_columns(
             self.UnrecommendationsList,
-            [_("Rating"), 0, "text", update_cell_colors],
-            [_("Item"), -1, "text", update_cell_colors]
+            [_("Rating"), 0, "text"],
+            [_("Item"), -1, "text"]
         )
 
         cols[0].set_sort_column_id(2)
@@ -159,9 +159,9 @@ class Interests:
         cols = initialise_columns(
             self.RecommendationUsersList,
             ["", statusiconwidth, "pixbuf"],
-            [_("User"), 100, "text", update_cell_colors],
-            [_("Speed"), 0, "text", update_cell_colors],
-            [_("Files"), 0, "text", update_cell_colors],
+            [_("User"), 100, "text"],
+            [_("Speed"), 0, "text"],
+            [_("Files"), 0, "text"],
         )
 
         cols[0].set_sort_column_id(4)
@@ -203,6 +203,8 @@ class Interests:
 
         for thing in self.np.config.sections["interests"]["dislikes"]:
             self.dislikes[thing] = self.dislikes_model.append([thing])
+
+        self.update_visuals()
 
     def on_add_thing_i_like(self, widget):
         thing = self.AddLikeEntry.get_text()
@@ -456,3 +458,8 @@ class Interests:
         items[1].set_active(thing in self.np.config.sections["interests"]["dislikes"])
 
         self.ur_popup_menu.popup(None, None, None, None, event.button, event.time)
+
+    def update_visuals(self):
+
+        for widget in self.__dict__.values():
+            update_widget_visuals(widget)

--- a/pynicotine/gtkgui/interests.py
+++ b/pynicotine/gtkgui/interests.py
@@ -31,6 +31,7 @@ from pynicotine.gtkgui.utils import humanize
 from pynicotine.gtkgui.utils import human_speed
 from pynicotine.gtkgui.utils import initialise_columns
 from pynicotine.gtkgui.utils import PopupMenu
+from pynicotine.gtkgui.utils import update_cell_colors
 
 
 class Interests:
@@ -58,7 +59,7 @@ class Interests:
 
         cols = initialise_columns(
             self.LikesList,
-            [_("I like") + ":", 0, "text", self.frame.cell_data_func]
+            [_("I like") + ":", 0, "text", update_cell_colors]
         )
 
         cols[0].set_sort_column_id(0)
@@ -81,7 +82,7 @@ class Interests:
 
         cols = initialise_columns(
             self.DislikesList,
-            [_("I dislike") + ":", 0, "text", self.frame.cell_data_func]
+            [_("I dislike") + ":", 0, "text", update_cell_colors]
         )
 
         cols[0].set_sort_column_id(0)
@@ -99,8 +100,8 @@ class Interests:
 
         cols = initialise_columns(
             self.RecommendationsList,
-            [_("Rating"), 0, "text", self.frame.cell_data_func],
-            [_("Item"), -1, "text", self.frame.cell_data_func]
+            [_("Rating"), 0, "text", update_cell_colors],
+            [_("Item"), -1, "text", update_cell_colors]
         )
 
         cols[0].set_sort_column_id(2)
@@ -127,8 +128,8 @@ class Interests:
 
         cols = initialise_columns(
             self.UnrecommendationsList,
-            [_("Rating"), 0, "text", self.frame.cell_data_func],
-            [_("Item"), -1, "text", self.frame.cell_data_func]
+            [_("Rating"), 0, "text", update_cell_colors],
+            [_("Item"), -1, "text", update_cell_colors]
         )
 
         cols[0].set_sort_column_id(2)
@@ -158,9 +159,9 @@ class Interests:
         cols = initialise_columns(
             self.RecommendationUsersList,
             ["", statusiconwidth, "pixbuf"],
-            [_("User"), 100, "text", self.frame.cell_data_func],
-            [_("Speed"), 0, "text", self.frame.cell_data_func],
-            [_("Files"), 0, "text", self.frame.cell_data_func],
+            [_("User"), 100, "text", update_cell_colors],
+            [_("Speed"), 0, "text", update_cell_colors],
+            [_("Files"), 0, "text", update_cell_colors],
         )
 
         cols[0].set_sort_column_id(4)

--- a/pynicotine/gtkgui/privatechat.py
+++ b/pynicotine/gtkgui/privatechat.py
@@ -42,10 +42,10 @@ from pynicotine.gtkgui.utils import is_alias
 from pynicotine.gtkgui.utils import load_ui_elements
 from pynicotine.gtkgui.utils import PopupMenu
 from pynicotine.gtkgui.utils import scroll_bottom
-from pynicotine.gtkgui.utils import set_text_bg
 from pynicotine.gtkgui.utils import TextSearchBar
-from pynicotine.gtkgui.utils import update_color
-from pynicotine.gtkgui.utils import update_font
+from pynicotine.gtkgui.utils import set_widget_color
+from pynicotine.gtkgui.utils import set_widget_font
+from pynicotine.gtkgui.utils import update_widget_visuals
 from pynicotine.logfacility import log
 from pynicotine.utils import clean_file
 from pynicotine.utils import version
@@ -777,13 +777,15 @@ class PrivateChat:
         self.frame.now_playing.display_now_playing(callback=self.send_message)
 
     def update_visuals(self):
-        set_text_bg(self.ChatLine)
+
+        for widget in self.__dict__.values():
+            update_widget_visuals(widget, update_text_tags=False)
 
     def create_tag(self, buffer, color):
 
         tag = buffer.create_tag()
-        update_color(tag, self.frame.np.config.sections["ui"][color])
-        update_font(tag, self.frame.np.config.sections["ui"]["chatfont"])
+        set_widget_color(tag, self.frame.np.config.sections["ui"][color])
+        set_widget_font(tag, self.frame.np.config.sections["ui"]["chatfont"])
 
         return tag
 
@@ -837,8 +839,8 @@ class PrivateChat:
 
     def update_tag_visuals(self, tag, color):
 
-        update_color(tag, self.frame.np.config.sections["ui"][color])
-        update_font(tag, self.frame.np.config.sections["ui"]["chatfont"])
+        set_widget_color(tag, self.frame.np.config.sections["ui"][color])
+        set_widget_font(tag, self.frame.np.config.sections["ui"]["chatfont"])
 
         if color in ("useraway", "useronline", "useroffline"):
 

--- a/pynicotine/gtkgui/roomlist.py
+++ b/pynicotine/gtkgui/roomlist.py
@@ -25,6 +25,7 @@ import os
 
 from pynicotine import slskmessages
 from pynicotine.gtkgui.utils import load_ui_elements
+from pynicotine.gtkgui.utils import update_widget_visuals
 
 
 class RoomList:
@@ -42,6 +43,8 @@ class RoomList:
 
         self.AcceptPrivateRoom.set_active(self.frame.np.config.sections["server"]["private_chatrooms"])
         self.AcceptPrivateRoom.connect("toggled", self.on_toggle_accept_private_room)
+
+        self.update_visuals()
 
     def on_search_room(self, widget):
 
@@ -77,5 +80,11 @@ class RoomList:
         self.frame.np.queue.put(slskmessages.RoomList())
 
     def on_toggle_accept_private_room(self, widget):
+
         value = self.AcceptPrivateRoom.get_active()
         self.frame.np.queue.put(slskmessages.PrivateRoomToggle(value))
+
+    def update_visuals(self):
+
+        for widget in self.__dict__.values():
+            update_widget_visuals(widget)

--- a/pynicotine/gtkgui/roomwall.py
+++ b/pynicotine/gtkgui/roomwall.py
@@ -21,6 +21,7 @@ import os
 from pynicotine import slskmessages
 from pynicotine.gtkgui.utils import append_line
 from pynicotine.gtkgui.utils import load_ui_elements
+from pynicotine.gtkgui.utils import update_widget_visuals
 
 
 class RoomWall:
@@ -40,6 +41,7 @@ class RoomWall:
         self.RoomWallDialog.connect("delete_event", self.hide)
 
     def on_set_room_wall_message(self, widget):
+
         result = self.RoomWallEntry.get_text()
         self.RoomWallEntry.set_text("")
 
@@ -58,12 +60,19 @@ class RoomWall:
         tickers = self.room.tickers.get_tickers()
         append_line(self.RoomWallList, "%s" % ("\n".join(["[%s] %s" % (user, msg) for (user, msg) in tickers if not user == login])), showstamp=False, scroll=False)
 
+    def update_visuals(self):
+
+        for widget in self.__dict__.values():
+            update_widget_visuals(widget)
+
     def hide(self, w=None, event=None):
+
         self.RoomWallList.get_buffer().set_text("")
         self.RoomWallDialog.hide()
         return True
 
     def show(self):
+
         tickers = self.room.tickers.get_tickers()
         append_line(self.RoomWallList, "%s" % ("\n".join(["[%s] %s" % (user, msg) for (user, msg) in tickers])), showstamp=False, scroll=False)
         self.RoomWallDialog.show()

--- a/pynicotine/gtkgui/search.py
+++ b/pynicotine/gtkgui/search.py
@@ -36,7 +36,6 @@ from pynicotine import slskmessages
 from pynicotine.geoip.countrycodes import code2name
 from pynicotine.gtkgui.dirchooser import choose_dir
 from pynicotine.gtkgui.fileproperties import FileProperties
-from pynicotine.gtkgui.utils import change_list_font
 from pynicotine.gtkgui.utils import collapse_treeview
 from pynicotine.gtkgui.utils import fill_file_grouping_combobox
 from pynicotine.gtkgui.utils import hide_columns
@@ -48,9 +47,10 @@ from pynicotine.gtkgui.utils import initialise_columns
 from pynicotine.gtkgui.utils import load_ui_elements
 from pynicotine.gtkgui.utils import PopupMenu
 from pynicotine.gtkgui.utils import select_user_row_iter
-from pynicotine.gtkgui.utils import set_text_bg
+from pynicotine.gtkgui.utils import set_widget_fg_bg_css
 from pynicotine.gtkgui.utils import set_treeview_selected_row
 from pynicotine.gtkgui.utils import show_country_tooltip
+from pynicotine.gtkgui.utils import update_widget_visuals
 from pynicotine.gtkgui.wishlist import WishList
 from pynicotine.logfacility import log
 from pynicotine.utils import get_result_bitrate_length
@@ -338,7 +338,7 @@ class Searches(IconNotebook):
                 continue
             id[2].update_visuals()
 
-        set_text_bg(self.wish_list.AddWishEntry)
+        self.wish_list.update_visuals()
 
     def save_columns(self):
 
@@ -898,18 +898,18 @@ class Search:
                 f_in = re.compile(f_in.lower())
                 self.filters[0] = f_in
             except sre_constants.error:
-                set_text_bg(self.FilterIn.get_child(), "red", "white")
+                set_widget_fg_bg_css(self.FilterIn.get_child(), "red", "white")
             else:
-                set_text_bg(self.FilterIn.get_child())
+                set_widget_fg_bg_css(self.FilterIn.get_child())
 
         if f_out:
             try:
                 f_out = re.compile(f_out.lower())
                 self.filters[1] = f_out
             except sre_constants.error:
-                set_text_bg(self.FilterOut.get_child(), "red", "white")
+                set_widget_fg_bg_css(self.FilterOut.get_child(), "red", "white")
             else:
-                set_text_bg(self.FilterOut.get_child())
+                set_widget_fg_bg_css(self.FilterOut.get_child())
 
         if size:
             self.filters[2] = size
@@ -1023,13 +1023,8 @@ class Search:
 
     def update_visuals(self):
 
-        set_text_bg(self.FilterIn.get_child())
-        set_text_bg(self.FilterOut.get_child())
-        set_text_bg(self.FilterSize.get_child())
-        set_text_bg(self.FilterBitrate.get_child())
-        set_text_bg(self.FilterCountry.get_child())
-
-        change_list_font(self.ResultsList, self.frame.np.config.sections["ui"]["searchfont"])
+        for widget in self.__dict__.values():
+            update_widget_visuals(widget, list_font_target="searchfont")
 
     def save_columns(self):
 

--- a/pynicotine/gtkgui/search.py
+++ b/pynicotine/gtkgui/search.py
@@ -36,6 +36,7 @@ from pynicotine import slskmessages
 from pynicotine.geoip.countrycodes import code2name
 from pynicotine.gtkgui.dirchooser import choose_dir
 from pynicotine.gtkgui.fileproperties import FileProperties
+from pynicotine.gtkgui.utils import change_list_font
 from pynicotine.gtkgui.utils import collapse_treeview
 from pynicotine.gtkgui.utils import fill_file_grouping_combobox
 from pynicotine.gtkgui.utils import hide_columns
@@ -47,6 +48,7 @@ from pynicotine.gtkgui.utils import initialise_columns
 from pynicotine.gtkgui.utils import load_ui_elements
 from pynicotine.gtkgui.utils import PopupMenu
 from pynicotine.gtkgui.utils import select_user_row_iter
+from pynicotine.gtkgui.utils import set_text_bg
 from pynicotine.gtkgui.utils import set_treeview_selected_row
 from pynicotine.gtkgui.utils import show_country_tooltip
 from pynicotine.gtkgui.wishlist import WishList
@@ -84,7 +86,7 @@ class Searches(IconNotebook):
 
         self.wish_list = WishList(frame, self)
 
-        self.update_colours()
+        self.update_visuals()
 
     def load_config(self):
         """
@@ -329,14 +331,14 @@ class Searches(IconNotebook):
         self.remove_page(tab.Main)
         tab.Main.destroy()
 
-    def update_colours(self):
+    def update_visuals(self):
 
         for id in self.searches.values():
             if id[2] is None:
                 continue
-            id[2].change_colours()
+            id[2].update_visuals()
 
-        self.frame.set_text_bg(self.wish_list.AddWishEntry)
+        set_text_bg(self.wish_list.AddWishEntry)
 
     def save_columns(self):
 
@@ -523,7 +525,7 @@ class Search:
 
         self.ResultsList.connect("button_press_event", self.on_list_clicked)
 
-        self.change_colours()
+        self.update_visuals()
 
         """ Filters """
 
@@ -896,18 +898,18 @@ class Search:
                 f_in = re.compile(f_in.lower())
                 self.filters[0] = f_in
             except sre_constants.error:
-                self.frame.set_text_bg(self.FilterIn.get_child(), "red", "white")
+                set_text_bg(self.FilterIn.get_child(), "red", "white")
             else:
-                self.frame.set_text_bg(self.FilterIn.get_child())
+                set_text_bg(self.FilterIn.get_child())
 
         if f_out:
             try:
                 f_out = re.compile(f_out.lower())
                 self.filters[1] = f_out
             except sre_constants.error:
-                self.frame.set_text_bg(self.FilterOut.get_child(), "red", "white")
+                set_text_bg(self.FilterOut.get_child(), "red", "white")
             else:
-                self.frame.set_text_bg(self.FilterOut.get_child())
+                set_text_bg(self.FilterOut.get_child())
 
         if size:
             self.filters[2] = size
@@ -1019,17 +1021,15 @@ class Search:
     def update_counter(self):
         self.Counter.set_markup("<b>%d</b>" % self.numvisibleresults)
 
-    def change_colours(self):
+    def update_visuals(self):
 
-        self.frame.set_text_bg(self.FilterIn.get_child())
-        self.frame.set_text_bg(self.FilterOut.get_child())
-        self.frame.set_text_bg(self.FilterSize.get_child())
-        self.frame.set_text_bg(self.FilterBitrate.get_child())
-        self.frame.set_text_bg(self.FilterCountry.get_child())
+        set_text_bg(self.FilterIn.get_child())
+        set_text_bg(self.FilterOut.get_child())
+        set_text_bg(self.FilterSize.get_child())
+        set_text_bg(self.FilterBitrate.get_child())
+        set_text_bg(self.FilterCountry.get_child())
 
-        font = self.frame.np.config.sections["ui"]["searchfont"]
-
-        self.frame.change_list_font(self.ResultsList, font)
+        change_list_font(self.ResultsList, self.frame.np.config.sections["ui"]["searchfont"])
 
     def save_columns(self):
 

--- a/pynicotine/gtkgui/settingswindow.py
+++ b/pynicotine/gtkgui/settingswindow.py
@@ -43,6 +43,8 @@ from pynicotine.gtkgui.utils import human_size
 from pynicotine.gtkgui.utils import initialise_columns
 from pynicotine.gtkgui.utils import load_ui_elements
 from pynicotine.gtkgui.utils import open_uri
+from pynicotine.gtkgui.utils import update_cell_colors
+from pynicotine.gtkgui.utils import update_widget_visuals
 from pynicotine.logfacility import log
 from pynicotine.upnp import UPnPPortMapping
 from pynicotine.utils import unescape
@@ -1214,8 +1216,8 @@ class IgnoreFrame(BuildFrame):
         self.ignored_ips_list = Gtk.ListStore(str, str)
         cols = initialise_columns(
             self.IgnoredIPs,
-            [_("Addresses"), -1, "text", self.frame.cell_data_func],
-            [_("Users"), -1, "text", self.frame.cell_data_func]
+            [_("Addresses"), -1, "text", update_cell_colors],
+            [_("Users"), -1, "text", update_cell_colors]
         )
         cols[0].set_sort_column_id(0)
         cols[1].set_sort_column_id(1)
@@ -1344,8 +1346,8 @@ class BanFrame(BuildFrame):
         self.blocked_list_model = Gtk.ListStore(str, str)
         cols = initialise_columns(
             self.BlockedList,
-            [_("Addresses"), -1, "text", self.frame.cell_data_func],
-            [_("Users"), -1, "text", self.frame.cell_data_func]
+            [_("Addresses"), -1, "text", update_cell_colors],
+            [_("Users"), -1, "text", update_cell_colors]
         )
         cols[0].set_sort_column_id(0)
         cols[1].set_sort_column_id(1)
@@ -2636,7 +2638,7 @@ class CensorFrame(BuildFrame):
 
         cols = initialise_columns(
             self.CensorList,
-            [_("Pattern"), -1, "edit", self.frame.cell_data_func]
+            [_("Pattern"), -1, "edit", update_cell_colors]
         )
 
         cols[0].set_sort_column_id(0)
@@ -2750,8 +2752,8 @@ class AutoReplaceFrame(BuildFrame):
 
         cols = initialise_columns(
             self.ReplacementList,
-            [_("Pattern"), 150, "edit", self.frame.cell_data_func],
-            [_("Replacement"), -1, "edit", self.frame.cell_data_func]
+            [_("Pattern"), 150, "edit", update_cell_colors],
+            [_("Replacement"), -1, "edit", update_cell_colors]
         )
         cols[0].set_sort_column_id(0)
         cols[1].set_sort_column_id(1)
@@ -3451,8 +3453,8 @@ class Settings:
         # Build the window
         load_ui_elements(self, os.path.join(os.path.dirname(os.path.realpath(__file__)), "ui", "settings", "settingswindow.ui"))
 
-        # Signal sent and catch by frame.py on close
-        GObject.signal_new("settings-closed", Gtk.Window, GObject.SignalFlags.RUN_LAST, GObject.TYPE_NONE, (GObject.TYPE_STRING,))
+        # Signal sent and catch by frame.py on update
+        GObject.signal_new("settings-updated", Gtk.Window, GObject.SignalFlags.RUN_LAST, GObject.TYPE_NONE, (GObject.TYPE_STRING,))
 
         # Connect the custom handlers
         self.SettingsWindow.set_transient_for(frame.MainWindow)
@@ -3551,105 +3553,86 @@ class Settings:
         # Set the cursor to the second element of the TreeViewColumn.
         self.SettingsTreeview.set_cursor((0, 0))
 
-        self.update_colours()
+        self.update_visuals()
 
-    def colour_widgets(self, widget):
-
-        if isinstance(widget, Gtk.Entry):
-            self.set_text_bg(widget)
-        if isinstance(widget, Gtk.TreeView):
-            self.frame.change_list_font(widget, self.frame.np.config.sections["ui"]["listfont"])
-
-    def update_colours(self):
+    def update_visuals(self):
 
         for widget in self.__dict__.values():
-            self.colour_widgets(widget)
+            update_widget_visuals(widget)
 
         for name, page in self.pages.items():
             for widget in page.__dict__.values():
-                self.colour_widgets(widget)
-
-    def set_text_bg(self, widget, bgcolor="", fgcolor=""):
-        self.frame.set_text_bg(widget, bgcolor, fgcolor)
+                update_widget_visuals(widget)
 
     def switch_page(self, widget):
+
         child = self.viewport1.get_child()
+
         if child:
             self.viewport1.remove(child)
+
         model, iterator = widget.get_selected()
+
         if iterator is None:
             self.viewport1.add(self.empty_label)
             return
+
         page = model.get_value(iterator, 1)
+
         if page in self.pages:
             self.viewport1.add(self.pages[page].Main)
         else:
             self.viewport1.add(self.empty_label)
 
-    def switch_to_page(self, page):
+    def set_active_page(self, page):
 
+        # Unminimize window
         self.SettingsWindow.deiconify()
+
         child = self.viewport1.get_child()
+
         if child:
             self.viewport1.remove(child)
 
         if self.tree[page] is None:
             self.viewport1.add(self.empty_label)
             return
+
         model = self.SettingsTreeview.get_model()
         sel = self.SettingsTreeview.get_selection()
         sel.unselect_all()
         path = model.get_path(self.tree[page])
+
         self.SettingsTreeview.expand_to_path(path)
+
         if path is not None:
             sel.select_path(path)
 
-    def on_backup_config(self, *args):
-        response = save_file(
-            self.SettingsWindow.get_toplevel(),
-            os.path.dirname(self.frame.np.config.filename),
-            title="Pick a filename for config backup, or cancel to use a timestamp"
-        )
-        if response:
-            error, message = self.frame.np.config.write_config_backup(response[0])
-        else:
-            error, message = self.frame.np.config.write_config_backup()
-        if error:
-            log.add("Error backing up config: %s", message)
-        else:
-            log.add("Config backed up to: %s", message)
-
-    def on_apply(self, widget):
-        self.SettingsWindow.emit("settings-closed", "apply")
-
-    def on_ok(self, widget):
-        self.SettingsWindow.emit("settings-closed", "ok")
-
-    def on_cancel(self, widget):
-        self.SettingsWindow.emit("settings-closed", "cancel")
-
-    def on_delete(self, widget, event):
-        self.on_cancel(widget)
-        widget.stop_emission_by_name("delete-event")
-        return True
-
     def get_position(self, combobox, option):
+
         iterator = combobox.get_model().get_iter_first()
+
         while iterator is not None:
             word = combobox.get_model().get_value(iterator, 0)
+
             if word.lower() == option or word == option:
                 combobox.set_active_iter(iterator)
                 break
+
             iterator = combobox.get_model().iter_next(iterator)
 
     def set_widgets_data(self, config, options):
+
         for section, keys in options.items():
             if section not in config:
                 continue
+
             for key in keys:
                 widget = options[section][key]
+
                 if widget is None:
                     continue
+
                 if config[section][key] is None:
                     self.clear_widget(widget)
                 else:
@@ -3659,39 +3642,55 @@ class Settings:
 
         if isinstance(widget, Gtk.SpinButton):
             return int(widget.get_value())
+
         elif isinstance(widget, Gtk.Entry):
             return widget.get_text()
+
         elif isinstance(widget, Gtk.TextView):
             buffer = widget.get_buffer()
             start, end = buffer.get_bounds()
+
             return widget.get_buffer().get_text(start, end, True)
+
         elif isinstance(widget, Gtk.CheckButton):
             return widget.get_active()
+
         elif isinstance(widget, Gtk.ComboBox):
             return widget.get_model().get(widget.get_active_iter(), 0)[0]
+
         elif isinstance(widget, Gtk.FontButton):
             widget.get_font()
+
         elif isinstance(widget, Gtk.TreeView) and widget.get_model().get_n_columns() == 1:
             wlist = []
             iterator = widget.get_model().get_iter_first()
+
             while iterator:
                 word = widget.get_model().get_value(iterator, 0)
+
                 if word is not None:
                     wlist.append(word)
+
                 iterator = widget.get_model().iter_next(iterator)
+
             return wlist
 
     def clear_widget(self, widget):
         if isinstance(widget, Gtk.SpinButton):
             widget.set_value(0)
+
         elif isinstance(widget, Gtk.Entry):
             widget.set_text("")
+
         elif isinstance(widget, Gtk.TextView):
             widget.get_buffer().set_text("")
+
         elif isinstance(widget, Gtk.CheckButton):
             widget.set_active(0)
+
         elif isinstance(widget, Gtk.ComboBox):
             self.get_position(widget, "")
+
         elif isinstance(widget, Gtk.FontButton):
             widget.set_font("")
 
@@ -3699,33 +3698,42 @@ class Settings:
 
         if isinstance(widget, Gtk.SpinButton):
             widget.set_value(int(value))
+
         elif isinstance(widget, Gtk.Entry):
             if isinstance(value, (str, int)):
                 widget.set_text(value)
+
         elif isinstance(widget, Gtk.TextView):
             if isinstance(value, (str, int)):
                 widget.get_buffer().set_text(value)
+
         elif isinstance(widget, Gtk.CheckButton):
             widget.set_active(value)
+
         elif isinstance(widget, Gtk.ComboBox):
             if isinstance(value, str):
                 self.get_position(widget, value)
+
             elif isinstance(value, int):
                 widget.set_active(value)
+
         elif isinstance(widget, Gtk.FontButton):
             widget.set_font(value)
+
         elif isinstance(widget, Gtk.TreeView) and isinstance(value, list) and widget.get_model().get_n_columns() == 1:
             for item in value:
                 widget.get_model().append([item])
 
     def invalid_settings(self, domain, key):
+
         for name, page in self.pages.items():
             if domain in page.options:
                 if key in page.options[domain]:
-                    self.switch_to_page(name)
+                    self.set_active_page(name)
                     break
 
     def set_settings(self, config):
+
         for page in self.pages.values():
             page.set_settings(config)
 
@@ -3755,3 +3763,36 @@ class Settings:
             return self.pages["Shares"].get_need_rescan(), (self.pages["Colours"].needcolors or self.pages["Fonts"].needcolors), self.pages["Completion"].needcompletion, config
         except UserWarning:
             return None
+
+    def on_backup_config(self, *args):
+
+        response = save_file(
+            self.SettingsWindow.get_toplevel(),
+            os.path.dirname(self.frame.np.config.filename),
+            title="Pick a filename for config backup, or cancel to use a timestamp"
+        )
+
+        if response:
+            error, message = self.frame.np.config.write_config_backup(response[0])
+        else:
+            error, message = self.frame.np.config.write_config_backup()
+
+        if error:
+            log.add("Error backing up config: %s", message)
+        else:
+            log.add("Config backed up to: %s", message)
+
+    def on_apply(self, widget):
+        self.SettingsWindow.emit("settings-updated", "apply")
+
+    def on_ok(self, widget):
+        self.SettingsWindow.hide()
+        self.SettingsWindow.emit("settings-updated", "ok")
+
+    def on_cancel(self, widget):
+        self.SettingsWindow.hide()
+
+    def on_delete(self, widget, event):
+        self.on_cancel(widget)
+        widget.stop_emission_by_name("delete-event")
+        return True

--- a/pynicotine/gtkgui/settingswindow.py
+++ b/pynicotine/gtkgui/settingswindow.py
@@ -43,7 +43,7 @@ from pynicotine.gtkgui.utils import human_size
 from pynicotine.gtkgui.utils import initialise_columns
 from pynicotine.gtkgui.utils import load_ui_elements
 from pynicotine.gtkgui.utils import open_uri
-from pynicotine.gtkgui.utils import update_cell_colors
+from pynicotine.gtkgui.utils import set_widget_fg_bg_css
 from pynicotine.gtkgui.utils import update_widget_visuals
 from pynicotine.logfacility import log
 from pynicotine.upnp import UPnPPortMapping
@@ -1216,8 +1216,8 @@ class IgnoreFrame(BuildFrame):
         self.ignored_ips_list = Gtk.ListStore(str, str)
         cols = initialise_columns(
             self.IgnoredIPs,
-            [_("Addresses"), -1, "text", update_cell_colors],
-            [_("Users"), -1, "text", update_cell_colors]
+            [_("Addresses"), -1, "text"],
+            [_("Users"), -1, "text"]
         )
         cols[0].set_sort_column_id(0)
         cols[1].set_sort_column_id(1)
@@ -1346,8 +1346,8 @@ class BanFrame(BuildFrame):
         self.blocked_list_model = Gtk.ListStore(str, str)
         cols = initialise_columns(
             self.BlockedList,
-            [_("Addresses"), -1, "text", update_cell_colors],
-            [_("Users"), -1, "text", update_cell_colors]
+            [_("Addresses"), -1, "text"],
+            [_("Users"), -1, "text"]
         )
         cols[0].set_sort_column_id(0)
         cols[1].set_sort_column_id(1)
@@ -1645,7 +1645,7 @@ class ColoursFrame(BuildFrame):
 
         # Combobox for user names style
         self.username_style_store = Gtk.ListStore(GObject.TYPE_STRING)
-        for item in ["bold", "italic", "underline", "normal"]:
+        for item in ("bold", "italic", "underline", "normal"):
             self.username_style_store.append([item])
 
         self.UsernameStyle.set_model(self.username_style_store)
@@ -1786,13 +1786,7 @@ class ColoursFrame(BuildFrame):
                 if option in value:
 
                     drawingarea = self.colorsd[key][option]
-
-                    try:
-                        colour = Gdk.color_parse(config[key][option])
-                    except Exception:
-                        colour = None
-
-                    drawingarea.modify_bg(Gtk.StateType.NORMAL, colour)
+                    set_widget_fg_bg_css(drawingarea, config[key][option])
                     break
 
         self.toggled_away_colours(self.DisplayAwayColours)
@@ -1844,12 +1838,16 @@ class ColoursFrame(BuildFrame):
         for key, value in self.options.items():
             if option in value:
                 widget = self.options[key][option]
+
                 if isinstance(widget, Gtk.SpinButton):
                     widget.set_value_as_int(defaults[key][option])
+
                 elif isinstance(widget, Gtk.Entry):
                     widget.set_text(defaults[key][option])
+
                 elif isinstance(widget, Gtk.CheckButton):
                     widget.set_active(defaults[key][option])
+
                 elif isinstance(widget, Gtk.ComboBox):
                     widget.get_child().set_text(defaults[key][option])
 
@@ -1858,36 +1856,32 @@ class ColoursFrame(BuildFrame):
             if option in value:
 
                 drawingarea = self.colorsd[key][option]
-
-                try:
-                    colour = Gdk.color_parse(defaults[key][option])
-                except Exception:
-                    colour = None
-
-                drawingarea.modify_bg(Gtk.StateFlags.NORMAL, colour)
+                set_widget_fg_bg_css(drawingarea, defaults[key][option])
                 break
 
     def on_clear_all_colours(self, button):
 
         for option in self.colors:
             for section, value in self.options.items():
-
                 if option in value:
-
                     widget = self.options[section][option]
+
                     if isinstance(widget, Gtk.SpinButton):
                         widget.set_value_as_int(0)
+
                     elif isinstance(widget, Gtk.Entry):
                         widget.set_text("")
+
                     elif isinstance(widget, Gtk.CheckButton):
                         widget.set_active(0)
+
                     elif isinstance(widget, Gtk.ComboBox):
                         widget.get_child().set_text("")
 
             for section, value in self.colorsd.items():
                 if option in value:
                     drawingarea = self.colorsd[section][option]
-                    drawingarea.modify_bg(Gtk.StateFlags.NORMAL, None)
+                    set_widget_fg_bg_css(drawingarea)
 
     def fonts_colors_changed(self, widget):
         self.needcolors = 1
@@ -1911,12 +1905,12 @@ class ColoursFrame(BuildFrame):
     def pick_colour(self, widget, entry, area):
 
         dlg = Gtk.ColorChooserDialog(_("Pick a color, any color"))
-        colourtext = entry.get_text()
+        color = entry.get_text()
 
-        if colourtext is not None and colourtext != '':
+        if color:
             try:
                 rgba = Gdk.RGBA()
-                rgba.parse(colourtext)
+                rgba.parse(color)
             except Exception:
                 dlg.destroy()
                 return
@@ -1926,8 +1920,8 @@ class ColoursFrame(BuildFrame):
         if dlg.run() == Gtk.ResponseType.OK:
 
             rgba = dlg.get_rgba()
-            colourtext = "#%02X%02X%02X" % (round(rgba.red * 255), round(rgba.green * 255), round(rgba.blue * 255))
-            entry.set_text(colourtext)
+            color = "#%02X%02X%02X" % (round(rgba.red * 255), round(rgba.green * 255), round(rgba.blue * 255))
+            entry.set_text(color)
 
             for section in self.options.keys():
 
@@ -1941,7 +1935,7 @@ class ColoursFrame(BuildFrame):
 
                     if entry is value:
                         drawingarea = self.colorsd[section][key]
-                        drawingarea.modify_bg(Gtk.StateFlags.NORMAL, rgba.to_color())
+                        set_widget_fg_bg_css(drawingarea, bg_color=color)
                         break
 
         dlg.destroy()
@@ -2638,7 +2632,7 @@ class CensorFrame(BuildFrame):
 
         cols = initialise_columns(
             self.CensorList,
-            [_("Pattern"), -1, "edit", update_cell_colors]
+            [_("Pattern"), -1, "edit"]
         )
 
         cols[0].set_sort_column_id(0)
@@ -2752,8 +2746,8 @@ class AutoReplaceFrame(BuildFrame):
 
         cols = initialise_columns(
             self.ReplacementList,
-            [_("Pattern"), 150, "edit", update_cell_colors],
-            [_("Replacement"), -1, "edit", update_cell_colors]
+            [_("Pattern"), 150, "edit"],
+            [_("Replacement"), -1, "edit"]
         )
         cols[0].set_sort_column_id(0)
         cols[1].set_sort_column_id(1)

--- a/pynicotine/gtkgui/transferlist.py
+++ b/pynicotine/gtkgui/transferlist.py
@@ -29,13 +29,13 @@ from time import time
 from gi.repository import GObject
 from gi.repository import Gtk
 
-from pynicotine.gtkgui.utils import change_list_font
 from pynicotine.gtkgui.utils import hide_columns
 from pynicotine.gtkgui.utils import human_size
 from pynicotine.gtkgui.utils import human_speed
 from pynicotine.gtkgui.utils import initialise_columns
 from pynicotine.gtkgui.utils import PopupMenu
 from pynicotine.gtkgui.utils import select_user_row_iter
+from pynicotine.gtkgui.utils import update_widget_visuals
 
 
 class TransferList:
@@ -154,7 +154,9 @@ class TransferList:
         self.frame.np.config.sections["columns"][self.type + "_widths"] = widths
 
     def update_visuals(self):
-        change_list_font(self.widget, self.frame.np.config.sections["ui"]["transfersfont"])
+
+        for widget in self.__dict__.values():
+            update_widget_visuals(widget, list_font_target="transfersfont")
 
     def init_interface(self, list):
         self.list = list

--- a/pynicotine/gtkgui/transferlist.py
+++ b/pynicotine/gtkgui/transferlist.py
@@ -29,6 +29,7 @@ from time import time
 from gi.repository import GObject
 from gi.repository import Gtk
 
+from pynicotine.gtkgui.utils import change_list_font
 from pynicotine.gtkgui.utils import hide_columns
 from pynicotine.gtkgui.utils import human_size
 from pynicotine.gtkgui.utils import human_speed
@@ -139,7 +140,7 @@ class TransferList:
         widget.connect("button_press_event", self.on_popup_menu, "mouse")
         widget.connect("key-press-event", self.on_key_press_event)
 
-        self.update_colours()
+        self.update_visuals()
 
     def save_columns(self):
         columns = []
@@ -152,8 +153,8 @@ class TransferList:
         self.frame.np.config.sections["columns"][self.type + "_columns"] = columns
         self.frame.np.config.sections["columns"][self.type + "_widths"] = widths
 
-    def update_colours(self):
-        self.frame.change_list_font(self.widget, self.frame.np.config.sections["ui"]["transfersfont"])
+    def update_visuals(self):
+        change_list_font(self.widget, self.frame.np.config.sections["ui"]["transfersfont"])
 
     def init_interface(self, list):
         self.list = list

--- a/pynicotine/gtkgui/userbrowse.py
+++ b/pynicotine/gtkgui/userbrowse.py
@@ -33,13 +33,16 @@ from _thread import start_new_thread
 from pynicotine import slskmessages
 from pynicotine.gtkgui.dirchooser import choose_dir
 from pynicotine.gtkgui.dialogs import combo_box_dialog
+from pynicotine.gtkgui.utils import change_list_font
 from pynicotine.gtkgui.utils import hide_columns
 from pynicotine.gtkgui.utils import human_size
 from pynicotine.gtkgui.utils import initialise_columns
 from pynicotine.gtkgui.utils import load_ui_elements
 from pynicotine.gtkgui.utils import open_file_path
 from pynicotine.gtkgui.utils import PopupMenu
+from pynicotine.gtkgui.utils import set_text_bg
 from pynicotine.gtkgui.utils import set_treeview_selected_row
+from pynicotine.gtkgui.utils import update_cell_colors
 from pynicotine.logfacility import log
 from pynicotine.utils import clean_file
 from pynicotine.utils import get_result_bitrate_length
@@ -81,7 +84,7 @@ class UserBrowse:
 
         cols = initialise_columns(
             self.FolderTreeView,
-            [_("Directories"), -1, "text", self.cell_data_func]  # 0
+            [_("Directories"), -1, "text", update_cell_colors]  # 0
         )
         cols[0].set_sort_column_id(0)
 
@@ -165,10 +168,10 @@ class UserBrowse:
         widths = self.frame.np.config.sections["columns"]["userbrowse_widths"]
         cols = initialise_columns(
             self.FileTreeView,
-            [_("Filename"), widths[0], "text", self.cell_data_func],
-            [_("Size"), widths[1], "number", self.cell_data_func],
-            [_("Bitrate"), widths[2], "number", self.cell_data_func],
-            [_("Length"), widths[3], "number", self.cell_data_func]
+            [_("Filename"), widths[0], "text", update_cell_colors],
+            [_("Size"), widths[1], "number", update_cell_colors],
+            [_("Bitrate"), widths[2], "number", update_cell_colors],
+            [_("Length"), widths[3], "number", update_cell_colors]
         )
         cols[0].set_sort_column_id(0)
         cols[1].set_sort_column_id(4)
@@ -206,7 +209,7 @@ class UserBrowse:
 
         self.FileTreeView.connect("button_press_event", self.on_file_clicked)
 
-        self.change_colours()
+        self.update_visuals()
 
         for name, object in self.__dict__.items():
             if isinstance(object, PopupMenu):
@@ -236,17 +239,12 @@ class UserBrowse:
 
         return True
 
-    def change_colours(self):
-        self.frame.set_text_bg(self.SearchEntry)
+    def update_visuals(self):
 
-        self.frame.change_list_font(self.FolderTreeView, self.frame.np.config.sections["ui"]["browserfont"])
-        self.frame.change_list_font(self.FileTreeView, self.frame.np.config.sections["ui"]["browserfont"])
+        set_text_bg(self.SearchEntry)
 
-    def cell_data_func(self, column, cellrenderer, model, iterator, dummy="dummy"):
-        colour = self.frame.np.config.sections["ui"]["search"]
-        if colour == "":
-            colour = None
-        cellrenderer.set_property("foreground", colour)
+        change_list_font(self.FolderTreeView, self.frame.np.config.sections["ui"]["browserfont"])
+        change_list_font(self.FileTreeView, self.frame.np.config.sections["ui"]["browserfont"])
 
     def on_expand(self, widget):
 

--- a/pynicotine/gtkgui/userbrowse.py
+++ b/pynicotine/gtkgui/userbrowse.py
@@ -33,16 +33,14 @@ from _thread import start_new_thread
 from pynicotine import slskmessages
 from pynicotine.gtkgui.dirchooser import choose_dir
 from pynicotine.gtkgui.dialogs import combo_box_dialog
-from pynicotine.gtkgui.utils import change_list_font
 from pynicotine.gtkgui.utils import hide_columns
 from pynicotine.gtkgui.utils import human_size
 from pynicotine.gtkgui.utils import initialise_columns
 from pynicotine.gtkgui.utils import load_ui_elements
 from pynicotine.gtkgui.utils import open_file_path
 from pynicotine.gtkgui.utils import PopupMenu
-from pynicotine.gtkgui.utils import set_text_bg
 from pynicotine.gtkgui.utils import set_treeview_selected_row
-from pynicotine.gtkgui.utils import update_cell_colors
+from pynicotine.gtkgui.utils import update_widget_visuals
 from pynicotine.logfacility import log
 from pynicotine.utils import clean_file
 from pynicotine.utils import get_result_bitrate_length
@@ -84,7 +82,7 @@ class UserBrowse:
 
         cols = initialise_columns(
             self.FolderTreeView,
-            [_("Directories"), -1, "text", update_cell_colors]  # 0
+            [_("Directories"), -1, "text"]  # 0
         )
         cols[0].set_sort_column_id(0)
 
@@ -168,10 +166,10 @@ class UserBrowse:
         widths = self.frame.np.config.sections["columns"]["userbrowse_widths"]
         cols = initialise_columns(
             self.FileTreeView,
-            [_("Filename"), widths[0], "text", update_cell_colors],
-            [_("Size"), widths[1], "number", update_cell_colors],
-            [_("Bitrate"), widths[2], "number", update_cell_colors],
-            [_("Length"), widths[3], "number", update_cell_colors]
+            [_("Filename"), widths[0], "text"],
+            [_("Size"), widths[1], "number"],
+            [_("Bitrate"), widths[2], "number"],
+            [_("Length"), widths[3], "number"]
         )
         cols[0].set_sort_column_id(0)
         cols[1].set_sort_column_id(4)
@@ -241,10 +239,8 @@ class UserBrowse:
 
     def update_visuals(self):
 
-        set_text_bg(self.SearchEntry)
-
-        change_list_font(self.FolderTreeView, self.frame.np.config.sections["ui"]["browserfont"])
-        change_list_font(self.FileTreeView, self.frame.np.config.sections["ui"]["browserfont"])
+        for widget in self.__dict__.values():
+            update_widget_visuals(widget, list_font_target="browserfont")
 
     def on_expand(self, widget):
 

--- a/pynicotine/gtkgui/userinfo.py
+++ b/pynicotine/gtkgui/userinfo.py
@@ -32,16 +32,13 @@ from gi.repository import Gtk
 from pynicotine import slskmessages
 from pynicotine.gtkgui.dirchooser import save_file
 from pynicotine.gtkgui.utils import append_line
-from pynicotine.gtkgui.utils import change_list_font
 from pynicotine.gtkgui.utils import humanize
 from pynicotine.gtkgui.utils import human_speed
 from pynicotine.gtkgui.utils import IconNotebook
 from pynicotine.gtkgui.utils import initialise_columns
 from pynicotine.gtkgui.utils import load_ui_elements
 from pynicotine.gtkgui.utils import PopupMenu
-from pynicotine.gtkgui.utils import update_cell_colors
-from pynicotine.gtkgui.utils import update_color
-from pynicotine.gtkgui.utils import update_font
+from pynicotine.gtkgui.utils import update_widget_visuals
 from pynicotine.logfacility import log
 
 
@@ -220,7 +217,7 @@ class UserInfo:
         self.hates_store = Gtk.ListStore(str)
         self.Hates.set_model(self.hates_store)
 
-        cols = initialise_columns(self.Hates, [_("Hates"), 0, "text", update_cell_colors])
+        cols = initialise_columns(self.Hates, [_("Hates"), 0, "text"])
         cols[0].set_sort_column_id(0)
 
         self.hates_store.set_sort_column_id(0, Gtk.SortType.ASCENDING)
@@ -228,14 +225,12 @@ class UserInfo:
         self.likes_store = Gtk.ListStore(str)
         self.Likes.set_model(self.likes_store)
 
-        cols = initialise_columns(self.Likes, [_("Likes"), 0, "text", update_cell_colors])
+        cols = initialise_columns(self.Likes, [_("Likes"), 0, "text"])
         cols[0].set_sort_column_id(0)
 
         self.likes_store.set_sort_column_id(0, Gtk.SortType.ASCENDING)
 
         self.tag_local = self.descr.get_buffer().create_tag()
-        update_color(self.tag_local, self.frame.np.config.sections["ui"]["chatremote"])
-        update_font(self.tag_local, self.frame.np.config.sections["ui"]["chatfont"])
 
         self.update_visuals()
 
@@ -314,11 +309,8 @@ class UserInfo:
 
     def update_visuals(self):
 
-        update_color(self.tag_local, self.frame.np.config.sections["ui"]["chatremote"])
-        update_font(self.tag_local, self.frame.np.config.sections["ui"]["chatfont"])
-
-        change_list_font(self.Likes, self.frame.np.config.sections["ui"]["listfont"])
-        change_list_font(self.Hates, self.frame.np.config.sections["ui"]["listfont"])
+        for widget in self.__dict__.values():
+            update_widget_visuals(widget)
 
     def show_interests(self, likes, hates):
 

--- a/pynicotine/gtkgui/userinfo.py
+++ b/pynicotine/gtkgui/userinfo.py
@@ -27,18 +27,21 @@ from gettext import gettext as _
 
 from gi.repository import Gdk
 from gi.repository import GdkPixbuf
-from gi.repository import GObject
 from gi.repository import Gtk
 
 from pynicotine import slskmessages
 from pynicotine.gtkgui.dirchooser import save_file
 from pynicotine.gtkgui.utils import append_line
+from pynicotine.gtkgui.utils import change_list_font
 from pynicotine.gtkgui.utils import humanize
 from pynicotine.gtkgui.utils import human_speed
 from pynicotine.gtkgui.utils import IconNotebook
 from pynicotine.gtkgui.utils import initialise_columns
 from pynicotine.gtkgui.utils import load_ui_elements
 from pynicotine.gtkgui.utils import PopupMenu
+from pynicotine.gtkgui.utils import update_cell_colors
+from pynicotine.gtkgui.utils import update_color
+from pynicotine.gtkgui.utils import update_font
 from pynicotine.logfacility import log
 
 
@@ -130,10 +133,10 @@ class UserTabs(IconNotebook):
             if i.conn == msg.conn.conn:
                 i.update_gauge(msg)
 
-    def update_colours(self):
+    def update_visuals(self):
 
         for i in self.users.values():
-            i.change_colours()
+            i.update_visuals()
 
     def tab_popup(self, user):
 
@@ -214,20 +217,27 @@ class UserInfo:
         self.actual_zoom = 0
         self.status = 0
 
-        self.hates_store = Gtk.ListStore(GObject.TYPE_STRING)
+        self.hates_store = Gtk.ListStore(str)
         self.Hates.set_model(self.hates_store)
-        cols = initialise_columns(self.Hates, [_("Hates"), 0, "text", self.cell_data_func])
+
+        cols = initialise_columns(self.Hates, [_("Hates"), 0, "text", update_cell_colors])
         cols[0].set_sort_column_id(0)
+
         self.hates_store.set_sort_column_id(0, Gtk.SortType.ASCENDING)
 
-        self.likes_store = Gtk.ListStore(GObject.TYPE_STRING)
+        self.likes_store = Gtk.ListStore(str)
         self.Likes.set_model(self.likes_store)
-        cols = initialise_columns(self.Likes, [_("Likes"), 0, "text", self.cell_data_func])
+
+        cols = initialise_columns(self.Likes, [_("Likes"), 0, "text", update_cell_colors])
         cols[0].set_sort_column_id(0)
+
         self.likes_store.set_sort_column_id(0, Gtk.SortType.ASCENDING)
 
-        self.tag_local = self.makecolour("chatremote")
-        self.change_colours()
+        self.tag_local = self.descr.get_buffer().create_tag()
+        update_color(self.tag_local, self.frame.np.config.sections["ui"]["chatremote"])
+        update_font(self.tag_local, self.frame.np.config.sections["ui"]["chatfont"])
+
+        self.update_visuals()
 
         self.likes_popup_menu = popup = PopupMenu(self.frame)
         popup.setup(
@@ -302,45 +312,13 @@ class UserInfo:
 
         self.hates_popup_menu.popup(None, None, None, None, event.button, event.time)
 
-    def cell_data_func(self, column, cellrenderer, model, iterator, dummy="dummy"):
+    def update_visuals(self):
 
-        colour = self.frame.np.config.sections["ui"]["search"]
-        if colour == "":
-            colour = None
+        update_color(self.tag_local, self.frame.np.config.sections["ui"]["chatremote"])
+        update_font(self.tag_local, self.frame.np.config.sections["ui"]["chatfont"])
 
-        cellrenderer.set_property("foreground", colour)
-
-    def makecolour(self, colour):
-
-        buffer = self.descr.get_buffer()
-        colour = self.frame.np.config.sections["ui"][colour]
-        font = self.frame.np.config.sections["ui"]["chatfont"]
-
-        tag = buffer.create_tag(font=font)
-
-        if colour:
-            tag.set_property("foreground", colour)
-
-        return tag
-
-    def changecolour(self, tag, colour):
-
-        color = self.frame.np.config.sections["ui"][colour]
-
-        if color == "":
-            color = None
-
-        tag.set_property("foreground", color)
-
-        font = self.frame.np.config.sections["ui"]["chatfont"]
-        tag.set_property("font", font)
-
-    def change_colours(self):
-
-        self.changecolour(self.tag_local, "chatremote")
-
-        self.frame.change_list_font(self.Likes, self.frame.np.config.sections["ui"]["listfont"])
-        self.frame.change_list_font(self.Hates, self.frame.np.config.sections["ui"]["listfont"])
+        change_list_font(self.Likes, self.frame.np.config.sections["ui"]["listfont"])
+        change_list_font(self.Hates, self.frame.np.config.sections["ui"]["listfont"])
 
     def show_interests(self, likes, hates):
 

--- a/pynicotine/gtkgui/userlist.py
+++ b/pynicotine/gtkgui/userlist.py
@@ -38,9 +38,8 @@ from pynicotine.gtkgui.utils import human_speed
 from pynicotine.gtkgui.utils import initialise_columns
 from pynicotine.gtkgui.utils import load_ui_elements
 from pynicotine.gtkgui.utils import PopupMenu
-from pynicotine.gtkgui.utils import set_text_bg
 from pynicotine.gtkgui.utils import show_country_tooltip
-from pynicotine.gtkgui.utils import update_cell_colors
+from pynicotine.gtkgui.utils import update_widget_visuals
 from pynicotine.logfacility import log
 
 
@@ -79,14 +78,14 @@ class UserList:
             self.UserListTree,
             [_("Status"), widths[0], "pixbuf"],
             [_("Country"), widths[1], "pixbuf"],
-            [_("User"), widths[2], "text", update_cell_colors],
-            [_("Speed"), widths[3], "number", update_cell_colors],
-            [_("Files"), widths[4], "number", update_cell_colors],
+            [_("User"), widths[2], "text"],
+            [_("Speed"), widths[3], "number"],
+            [_("Files"), widths[4], "number"],
             [_("Trusted"), widths[5], "toggle"],
             [_("Notify"), widths[6], "toggle"],
             [_("Privileged"), widths[7], "toggle"],
-            [_("Last seen"), widths[8], "text", update_cell_colors],
-            [_("Comments"), widths[9], "edit", update_cell_colors]
+            [_("Last seen"), widths[8], "text"],
+            [_("Comments"), widths[9], "edit"]
         )
 
         self.col_status, self.col_country, self.col_user, self.col_speed, self.col_files, self.col_trusted, self.col_notify, self.col_privileged, self.col_last_seen, self.col_comments = cols
@@ -199,6 +198,8 @@ class UserList:
 
         self.UserListTree.connect("button_press_event", self.on_popup_menu)
 
+        self.update_visuals()
+
     def on_tooltip(self, widget, x, y, keyboard_mode, tooltip):
         return show_country_tooltip(widget, x, y, tooltip, 14, 'flag_')
 
@@ -212,7 +213,9 @@ class UserList:
         self.add_to_list(text)
 
     def update_visuals(self):
-        set_text_bg(self.AddUserEntry)
+
+        for widget in self.__dict__.values():
+            update_widget_visuals(widget)
 
     def on_settings_ban_ignore(self, widget):
         self.frame.on_settings_ban_ignore(widget)

--- a/pynicotine/gtkgui/userlist.py
+++ b/pynicotine/gtkgui/userlist.py
@@ -38,7 +38,9 @@ from pynicotine.gtkgui.utils import human_speed
 from pynicotine.gtkgui.utils import initialise_columns
 from pynicotine.gtkgui.utils import load_ui_elements
 from pynicotine.gtkgui.utils import PopupMenu
+from pynicotine.gtkgui.utils import set_text_bg
 from pynicotine.gtkgui.utils import show_country_tooltip
+from pynicotine.gtkgui.utils import update_cell_colors
 from pynicotine.logfacility import log
 
 
@@ -77,14 +79,14 @@ class UserList:
             self.UserListTree,
             [_("Status"), widths[0], "pixbuf"],
             [_("Country"), widths[1], "pixbuf"],
-            [_("User"), widths[2], "text", self.cell_data_func],
-            [_("Speed"), widths[3], "number", self.cell_data_func],
-            [_("Files"), widths[4], "number", self.cell_data_func],
+            [_("User"), widths[2], "text", update_cell_colors],
+            [_("Speed"), widths[3], "number", update_cell_colors],
+            [_("Files"), widths[4], "number", update_cell_colors],
             [_("Trusted"), widths[5], "toggle"],
             [_("Notify"), widths[6], "toggle"],
             [_("Privileged"), widths[7], "toggle"],
-            [_("Last seen"), widths[8], "text", self.cell_data_func],
-            [_("Comments"), widths[9], "edit", self.cell_data_func]
+            [_("Last seen"), widths[8], "text", update_cell_colors],
+            [_("Comments"), widths[9], "edit", update_cell_colors]
         )
 
         self.col_status, self.col_country, self.col_user, self.col_speed, self.col_files, self.col_trusted, self.col_notify, self.col_privileged, self.col_last_seen, self.col_comments = cols
@@ -209,20 +211,11 @@ class UserList:
         self.AddUserEntry.set_text("")
         self.add_to_list(text)
 
-    def update_colours(self):
-        self.frame.set_text_bg(self.AddUserEntry)
+    def update_visuals(self):
+        set_text_bg(self.AddUserEntry)
 
     def on_settings_ban_ignore(self, widget):
         self.frame.on_settings_ban_ignore(widget)
-
-    def cell_data_func(self, column, cellrenderer, model, iterator, dummy="dummy"):
-
-        colour = self.frame.np.config.sections["ui"]["search"]
-
-        if colour == "":
-            colour = None
-
-        cellrenderer.set_property("foreground", colour)
 
     def cell_toggle_callback(self, widget, index, treeview, pos):
 

--- a/pynicotine/gtkgui/utils.py
+++ b/pynicotine/gtkgui/utils.py
@@ -681,7 +681,7 @@ class ImageLabel(Gtk.Box):
         self._order_children()
 
     def show_hilite_image(self, show=True):
-        if show:
+        if show and self.get_hilite_image() is not None:
             self.hilite_image.show()
         else:
             self.hilite_image.hide()
@@ -1458,3 +1458,76 @@ def _expand_alias(aliases, cmd):
         log.add_warning("%s", error)
 
     return ""
+
+
+""" Fonts and Colors """
+
+
+def change_list_color(listview, color):
+
+    for c in listview.get_columns():
+        for r in c.get_cells():
+            if isinstance(r, (Gtk.CellRendererText, Gtk.CellRendererCombo)):
+                update_color(r, color)
+
+
+def change_list_font(listview, font):
+
+    for c in listview.get_columns():
+        for r in c.get_cells():
+            if isinstance(r, (Gtk.CellRendererText, Gtk.CellRendererCombo)):
+                update_font(r, font)
+
+
+def set_text_bg(widget, bgcolor="", fgcolor=""):
+    if bgcolor == "" and NICOTINE.np.config.sections["ui"]["textbg"] == "":
+        rgba = None
+    else:
+        if bgcolor == "":
+            bgcolor = NICOTINE.np.config.sections["ui"]["textbg"]
+        rgba = Gdk.RGBA()
+        rgba.parse(bgcolor)
+
+    widget.override_background_color(Gtk.StateFlags.NORMAL, rgba)
+
+    if isinstance(widget, Gtk.Entry):
+        if fgcolor != "":
+            rgba = Gdk.RGBA()
+            rgba.parse(fgcolor)
+        elif fgcolor == "" and NICOTINE.np.config.sections["ui"]["inputcolor"] == "":
+            rgba = None
+        elif fgcolor == "" and NICOTINE.np.config.sections["ui"]["inputcolor"] != "":
+            fgcolor = NICOTINE.np.config.sections["ui"]["inputcolor"]
+            rgba = Gdk.RGBA()
+            rgba.parse(fgcolor)
+
+        widget.override_color(Gtk.StateFlags.NORMAL, rgba)
+
+    if isinstance(widget, Gtk.TreeView):
+        change_list_color(widget, NICOTINE.np.config.sections["ui"]["search"])
+
+
+def update_cell_colors(column, cellrenderer, model, iterator, dummy="dummy"):
+    update_color(cellrenderer, NICOTINE.np.config.sections["ui"]["search"])
+
+
+def update_color(widget, color):
+
+    if color:
+        widget.set_property("foreground", color)
+    else:
+        widget.set_property("foreground-set", False)
+
+
+def update_font(widget, font):
+
+    widget.set_property("font", font)
+
+
+def update_widget_visuals(widget):
+
+    if isinstance(widget, Gtk.Entry):
+        set_text_bg(widget)
+
+    if isinstance(widget, Gtk.TreeView):
+        change_list_font(widget, NICOTINE.np.config.sections["ui"]["listfont"])

--- a/pynicotine/gtkgui/utils.py
+++ b/pynicotine/gtkgui/utils.py
@@ -754,13 +754,10 @@ class ImageLabel(Gtk.Box):
             self.label.set_markup("<span foreground=\"%s\">%s</span>" % (color, self.text.replace("<", "&lt;").replace(">", "&gt;").replace("&", "&amp;")))
 
     def set_hilite_image(self, pixbuf):
-        if pixbuf is None:
-            self.show_hilite_image(False)
-        else:
-            self.show_hilite_image(True)
-
         self.hilite_pixbuf = pixbuf
         self.hilite_image.set_from_pixbuf(pixbuf)
+
+        self.show_hilite_image()
 
     def get_hilite_image(self):
         return self.hilite_pixbuf

--- a/pynicotine/gtkgui/wishlist.py
+++ b/pynicotine/gtkgui/wishlist.py
@@ -32,6 +32,7 @@ from gi.repository import Gtk
 from pynicotine import slskmessages
 from pynicotine.gtkgui.utils import initialise_columns
 from pynicotine.gtkgui.utils import load_ui_elements
+from pynicotine.gtkgui.utils import update_widget_visuals
 from pynicotine.logfacility import log
 
 
@@ -78,6 +79,7 @@ class WishList:
         self.frame.WishList.connect("clicked", self.show)
 
     def cell_edited_callback(self, widget, index, value, treeview, pos):
+
         store = treeview.get_model()
         iterator = store.get_iter(index)
         old_value = store.get_value(iterator, 0)
@@ -87,6 +89,7 @@ class WishList:
             self.add_wish(value)
 
     def on_add_wish(self, widget):
+
         wish = self.AddWishEntry.get_text()
         self.AddWishEntry.set_text("")
 
@@ -94,6 +97,7 @@ class WishList:
             self.do_wishlist_search(self.searches.searchid, wish)
 
     def on_remove_wish(self, widget):
+
         iters = []
         self.WishlistView.get_selection().selected_foreach(self._remove_wish, iters)
 
@@ -108,6 +112,7 @@ class WishList:
         self.WishlistView.get_selection().select_all()
 
     def add_wish(self, wish):
+
         if not wish:
             return False
 
@@ -123,6 +128,7 @@ class WishList:
         return True
 
     def remove_wish(self, wish):
+
         if wish in self.wishes:
             self.store.remove(self.wishes[wish])
             del self.wishes[wish]
@@ -146,6 +152,7 @@ class WishList:
                     break
 
     def set_interval(self, msg):
+
         self.interval = msg.seconds
 
         if not self.disconnected:
@@ -189,6 +196,11 @@ class WishList:
         if self.timer is not None:
             GLib.source_remove(self.timer)
             self.timer = None
+
+    def update_visuals(self):
+
+        for widget in self.__dict__.values():
+            update_widget_visuals(widget)
 
     def show(self, widget):
         self.WishListDialog.show()


### PR DESCRIPTION
- Automatically detect widgets that need to be modified instead of hard-coding them. This will make it much easier to expand the theming system in the future if we want to.
- Remove duplicate functions
- Rename incorrect and confusing function names
- Get rid of cell data functions for modifying treeview colors. These were somewhat resource-intensive and completely redundant, as the colors were already modified by other means.
- Move away from deprecated GTK apis, use CSS instead
- Fix minor issue where hilite icons weren't always visible