### PR TITLE
Show folders when transfer is added in collapsed group by folder-mode

### DIFF
--- a/pynicotine/gtkgui/downloads.py
+++ b/pynicotine/gtkgui/downloads.py
@@ -121,9 +121,14 @@ class Downloads(TransferList):
 
         dialog.destroy()
 
-    def expand(self, path):
+    def expand(self, transfer_path, user_path):
         if self.frame.ExpandDownloads.get_active():
-            self.frame.DownloadList.expand_to_path(path)
+            self.frame.DownloadList.expand_to_path(transfer_path)
+
+        elif user_path and self.tree_users == 1:
+            # Group by folder, show user folders in collapsed mode
+
+            self.frame.DownloadList.expand_to_path(user_path)
 
     def on_expand_downloads(self, widget):
 

--- a/pynicotine/gtkgui/transferlist.py
+++ b/pynicotine/gtkgui/transferlist.py
@@ -507,8 +507,16 @@ class TransferList:
 
             # Expand path
             if parent is not None:
-                path = self.transfersmodel.get_path(iterator)
-                self.expand(path)
+                transfer_path = self.transfersmodel.get_path(iterator)
+
+                if self.tree_users == 1:
+                    # Group by folder, we need the user path to expand it
+
+                    user_path = self.transfersmodel.get_path(self.users[user])
+                else:
+                    user_path = None
+
+                self.expand(transfer_path, user_path)
 
     def remove_specific(self, transfer, cleartreeviewonly=False):
         if not cleartreeviewonly:

--- a/pynicotine/gtkgui/uploads.py
+++ b/pynicotine/gtkgui/uploads.py
@@ -120,9 +120,14 @@ class Uploads(TransferList):
         command = self.frame.np.config.sections["ui"]["filemanager"]
         open_file_path(final_path, command)
 
-    def expand(self, path):
+    def expand(self, transfer_path, user_path):
         if self.frame.ExpandUploads.get_active():
-            self.frame.UploadList.expand_to_path(path)
+            self.frame.UploadList.expand_to_path(transfer_path)
+
+        elif user_path and self.tree_users == 1:
+            # Group by folder, show user folders in collapsed mode
+
+            self.frame.UploadList.expand_to_path(user_path)
 
     def on_expand_uploads(self, widget):
 


### PR DESCRIPTION
This is what the code removed in https://github.com/Nicotine-Plus/nicotine-plus/pull/793 was intended to do, to expand only the user of a newly added transfer instead of all users.