### PR TITLE
Add slight cooldown before rescanning/compressing shares on startup

### DIFF
--- a/pynicotine/shares.py
+++ b/pynicotine/shares.py
@@ -71,13 +71,6 @@ class Shares:
         )
 
         self.compressed_shares_buddy = self.compressed_shares_normal = None
-
-        if not self.config.sections["transfers"]["friendsonly"]:
-            self.compress_shares("normal")
-
-        if self.config.sections["transfers"]["enablebuddyshares"]:
-            self.compress_shares("buddy")
-
         self.newbuddyshares = self.newnormalshares = False
 
     def set_connected(self, connected):


### PR DESCRIPTION
Although using a thread to compress shares reduces startup times a lot, it's still blocking program startup slightly if you are sharing a lot of files. Add a two second cooldown before rescanning/compressing shares to let the rest of the program start without delay.

Also stop compressing shares if rescan on startup is enabled, otherwise we do it twice.