### PR TITLE
Corrections to peer connection logic

### DIFF
--- a/pynicotine/config.py
+++ b/pynicotine/config.py
@@ -87,7 +87,6 @@ class Config:
                 "server": ('server.slsknet.org', 2242),
                 "login": '',
                 "passw": '',
-                "firewalled": False,
                 "ctcpmsgs": False,
                 "autosearch": [],
                 "autoreply": "",
@@ -580,6 +579,9 @@ class Config:
         # Remove option to stop responding to searches for a certain time
         self.remove_old_option("searches", "distrib_timer")
         self.remove_old_option("searches", "distrib_ignore")
+
+        # Remove "I can receive direct connections"-option, it's redundant now
+        self.remove_old_option("server", "firewalled")
 
         # Checking for unknown section/options
         unknown1 = [

--- a/pynicotine/gtkgui/fastconfigure.py
+++ b/pynicotine/gtkgui/fastconfigure.py
@@ -20,7 +20,6 @@
 
 import os
 from gettext import gettext as _
-from os.path import exists
 from os.path import getsize
 from os.path import join
 
@@ -125,11 +124,6 @@ class FastConfigureAssistant(object):
         self.password.set_text(
             self.config.sections["server"]["passw"]
         )
-
-        if self.config.sections["server"]["firewalled"]:
-            self.portclosed.set_active(True)
-        else:
-            self.portopen.set_active(True)
 
         self.lowerport.set_value(
             self.config.sections["server"]["portrange"][0]
@@ -239,12 +233,10 @@ class FastConfigureAssistant(object):
                 complete = True
 
         elif name == 'portpage':
-            if self.portopen.get_active() or \
-               self.portclosed.get_active():
-                complete = True
+            complete = True
 
         elif name == 'sharepage':
-            if exists(self.downloaddir.get_filename()):
+            if self.downloaddir.get_file():
                 complete = True
 
         elif name == 'summarypage':

--- a/pynicotine/gtkgui/fastconfigure.py
+++ b/pynicotine/gtkgui/fastconfigure.py
@@ -242,14 +242,6 @@ class FastConfigureAssistant(object):
         elif name == 'summarypage':
 
             complete = True
-            showcpwarning = (
-                self.portclosed.get_active()
-            )
-
-            if showcpwarning:
-                self.labelclosedport.show()
-            else:
-                self.labelclosedport.hide()
 
             shownfwarning = (
                 self.onlysharewithfriends.get_active() or

--- a/pynicotine/gtkgui/frame.py
+++ b/pynicotine/gtkgui/frame.py
@@ -1745,7 +1745,7 @@ class NicotineFrame:
 
         else:
             self.userinfo.show_user(user)
-            self.np.process_request_to_peer(user, msg, self.userinfo)
+            self.np.send_message_to_peer(user, msg)
 
     """ User Browse """
 
@@ -1759,7 +1759,7 @@ class NicotineFrame:
                 self.on_browse_public_shares(None)
             else:
                 self.userbrowse.show_user(user)
-                self.np.process_request_to_peer(user, slskmessages.GetSharedFileList(None), self.userbrowse)
+                self.np.send_message_to_peer(user, slskmessages.GetSharedFileList(None))
 
     def on_get_shares(self, widget):
         text = self.UserBrowseCombo.get_child().get_text()

--- a/pynicotine/gtkgui/privatechat.py
+++ b/pynicotine/gtkgui/privatechat.py
@@ -222,6 +222,7 @@ class PrivateChats(IconNotebook):
             ip, port = self.frame.np.users[msg.user].addr
             if self.frame.np.ip_ignored(ip):
                 return
+
         elif newmessage:
             self.frame.np.queue.put(slskmessages.GetPeerAddress(msg.user))
             self.frame.np.private_message_queue_add(msg, text)

--- a/pynicotine/gtkgui/privatechat.py
+++ b/pynicotine/gtkgui/privatechat.py
@@ -599,7 +599,7 @@ class PrivateChat:
 
         if self.PeerPrivateMessages.get_active():
             # not in the soulseek protocol
-            self.frame.np.process_request_to_peer(self.user, slskmessages.PMessageUser(None, my_username, payload))
+            self.frame.np.send_message_to_peer(self.user, slskmessages.PMessageUser(None, my_username, payload))
         else:
             self.frame.np.queue.put(slskmessages.MessageUser(self.user, payload))
 

--- a/pynicotine/gtkgui/search.py
+++ b/pynicotine/gtkgui/search.py
@@ -256,7 +256,7 @@ class Searches(IconNotebook):
 
     def do_peer_search(self, id, text, users):
         for user in users:
-            self.frame.np.process_request_to_peer(user, slskmessages.FileSearchRequest(None, id, text))
+            self.frame.np.send_message_to_peer(user, slskmessages.FileSearchRequest(None, id, text))
 
     def get_user_search_name(self, id):
 
@@ -1208,7 +1208,7 @@ class Search:
                 """ Ensure we don't send folder content requests for a folder more than once,
                 e.g. when several selected resuls belong to the same folder. """
 
-                self.frame.np.process_request_to_peer(user, slskmessages.FolderContentsRequest(None, folder))
+                self.frame.np.send_message_to_peer(user, slskmessages.FolderContentsRequest(None, folder))
                 requested_folders[user].append(folder)
 
     def on_download_folders_to(self, widget):
@@ -1233,7 +1233,7 @@ class Search:
                 e.g. when several selected resuls belong to the same folder. """
 
                 self.frame.np.requested_folders[user][folder] = destination
-                self.frame.np.process_request_to_peer(user, slskmessages.FolderContentsRequest(None, folder))
+                self.frame.np.send_message_to_peer(user, slskmessages.FolderContentsRequest(None, folder))
 
     def on_copy_url(self, widget):
         user, path = next(iter(self.selected_results))[:2]

--- a/pynicotine/gtkgui/settingswindow.py
+++ b/pynicotine/gtkgui/settingswindow.py
@@ -75,7 +75,6 @@ class ServerFrame(BuildFrame):
                 "login": self.Login,
                 "passw": self.Password,
                 "portrange": None,
-                "firewalled": self.DirectConnection,
                 "upnp": self.UseUPnP,
                 "ctcpmsgs": self.ctcptogglebutton
             }
@@ -111,9 +110,6 @@ class ServerFrame(BuildFrame):
         if server["portrange"] is not None:
             self.FirstPort.set_value(server["portrange"][0])
             self.LastPort.set_value(server["portrange"][1])
-
-        if server["firewalled"] is not None:
-            self.DirectConnection.set_active(not server["firewalled"])
 
         if server["ctcpmsgs"] is not None:
             self.ctcptogglebutton.set_active(not server["ctcpmsgs"])
@@ -185,15 +181,12 @@ class ServerFrame(BuildFrame):
             dlg.destroy()
             raise UserWarning
 
-        firewalled = not self.DirectConnection.get_active()
-
         return {
             "server": {
                 "server": server,
                 "login": self.Login.get_text(),
                 "passw": self.Password.get_text(),
                 "portrange": portrange,
-                "firewalled": firewalled,
                 "upnp": self.UseUPnP.get_active(),
                 "ctcpmsgs": not self.ctcptogglebutton.get_active(),
             }

--- a/pynicotine/gtkgui/ui/fastconfigure.ui
+++ b/pynicotine/gtkgui/ui/fastconfigure.ui
@@ -269,66 +269,6 @@ Please keep in mind that more common usernames may be taken. If you're unable to
                 <property name="position">1</property>
               </packing>
             </child>
-            <child>
-              <object class="GtkBox" id="portselection1">
-                <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="halign">center</property>
-                <property name="spacing">10</property>
-                <child>
-                  <object class="GtkRadioButton" id="portopen">
-                    <property name="label" translatable="yes">The page says my port is open</property>
-                    <property name="visible">True</property>
-                    <property name="can_focus">True</property>
-                    <property name="receives_default">False</property>
-                    <property name="draw_indicator">True</property>
-                    <signal name="toggled" handler="on_button_pressed" swapped="no"/>
-                  </object>
-                  <packing>
-                    <property name="expand">True</property>
-                    <property name="fill">True</property>
-                    <property name="position">0</property>
-                  </packing>
-                </child>
-                <child>
-                  <object class="GtkRadioButton" id="portclosed">
-                    <property name="label" translatable="yes">The page says my port is closed</property>
-                    <property name="visible">True</property>
-                    <property name="can_focus">True</property>
-                    <property name="receives_default">False</property>
-                    <property name="draw_indicator">True</property>
-                    <property name="group">portopen</property>
-                    <signal name="toggled" handler="on_button_pressed" swapped="no"/>
-                  </object>
-                  <packing>
-                    <property name="expand">True</property>
-                    <property name="fill">True</property>
-                    <property name="position">1</property>
-                  </packing>
-                </child>
-              </object>
-              <packing>
-                <property name="expand">True</property>
-                <property name="fill">True</property>
-                <property name="position">2</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkLabel">
-                <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="label" translatable="yes">Only select "The page says my port is closed" if all attempts at opening the port were unsuccessful. This can happen if your ISP blocks ports.</property>
-                <property name="justify">center</property>
-                <property name="wrap">True</property>
-                <property name="width_chars">60</property>
-                <property name="max_width_chars">60</property>
-              </object>
-              <packing>
-                <property name="expand">True</property>
-                <property name="fill">True</property>
-                <property name="position">3</property>
-              </packing>
-            </child>
           </object>
           <packing>
             <property name="expand">True</property>

--- a/pynicotine/gtkgui/ui/fastconfigure.ui
+++ b/pynicotine/gtkgui/ui/fastconfigure.ui
@@ -59,7 +59,7 @@
             <property name="margin_end">5</property>
             <property name="margin_top">5</property>
             <property name="margin_bottom">5</property>
-            <property name="label" translatable="yes">In order to start you need to fill in a few details. Press "Next" to start configuring Nicotine+.</property>
+            <property name="label" translatable="yes">In order to start, you need to fill in a few details. Press "Next" to start configuring Nicotine+.</property>
             <property name="justify">center</property>
             <property name="wrap">True</property>
             <property name="width_chars">60</property>
@@ -568,7 +568,7 @@ Please keep in mind that more common usernames may be taken. If you're unable to
             <property name="visible">True</property>
             <property name="can_focus">False</property>
             <property name="halign">start</property>
-            <property name="label" translatable="yes">Since your port is closed you will be unable to connect to roughly 50% of the people. This is inherent to Peer-2-Peer and not specifically a problem of Nicotine+.</property>
+            <property name="label" translatable="yes">If your port is closed, you will be unable to connect to roughly 50% of the people. This is inherent to Peer-2-Peer and not specifically a problem of Nicotine+.</property>
             <property name="justify">fill</property>
             <property name="wrap">True</property>
             <property name="width_chars">60</property>
@@ -585,7 +585,7 @@ Please keep in mind that more common usernames may be taken. If you're unable to
             <property name="visible">True</property>
             <property name="can_focus">False</property>
             <property name="halign">start</property>
-            <property name="label" translatable="yes">You do not publicly share any files. In itself this is not a problem but many people will ban you if you're downloading from them for this reason.</property>
+            <property name="label" translatable="yes">You do not publicly share any files. This in itself is not a problem, but many people will ban you if you're downloading from them for this reason.</property>
             <property name="use_markup">True</property>
             <property name="justify">fill</property>
             <property name="wrap">True</property>

--- a/pynicotine/gtkgui/ui/settings/server.ui
+++ b/pynicotine/gtkgui/ui/settings/server.ui
@@ -306,21 +306,6 @@
       </packing>
     </child>
     <child>
-      <object class="GtkCheckButton" id="DirectConnection">
-        <property name="label" translatable="yes">I can receive direct connections</property>
-        <property name="visible">True</property>
-        <property name="can_focus">True</property>
-        <property name="receives_default">False</property>
-        <property name="use_underline">True</property>
-        <property name="draw_indicator">True</property>
-      </object>
-      <packing>
-        <property name="expand">False</property>
-        <property name="fill">False</property>
-        <property name="position">9</property>
-      </packing>
-    </child>
-    <child>
       <object class="GtkLabel" id="Requirement">
         <property name="visible">True</property>
         <property name="can_focus">False</property>

--- a/pynicotine/gtkgui/uploads.py
+++ b/pynicotine/gtkgui/uploads.py
@@ -29,6 +29,7 @@ from gi.repository import Gdk
 from gi.repository import Gtk
 
 from _thread import start_new_thread
+from pynicotine import slskmessages
 from pynicotine.gtkgui.dialogs import option_dialog
 from pynicotine.gtkgui.transferlist import TransferList
 from pynicotine.gtkgui.utils import collapse_treeview
@@ -319,6 +320,7 @@ class Uploads(TransferList):
             if user in self.frame.np.transfers.get_transferring_users():
                 continue
 
+            self.frame.np.send_message_to_peer(user, slskmessages.UploadQueueNotification(None))
             self.frame.np.transfers.push_file(user, filename, path, transfer=transfer)
 
         self.frame.np.transfers.check_upload_queue()

--- a/pynicotine/gtkgui/uploads.py
+++ b/pynicotine/gtkgui/uploads.py
@@ -29,7 +29,6 @@ from gi.repository import Gdk
 from gi.repository import Gtk
 
 from _thread import start_new_thread
-from pynicotine import slskmessages
 from pynicotine.gtkgui.dialogs import option_dialog
 from pynicotine.gtkgui.transferlist import TransferList
 from pynicotine.gtkgui.utils import collapse_treeview
@@ -320,7 +319,6 @@ class Uploads(TransferList):
             if user in self.frame.np.transfers.get_transferring_users():
                 continue
 
-            self.frame.np.process_request_to_peer(user, slskmessages.UploadQueueNotification(None))
             self.frame.np.transfers.push_file(user, filename, path, transfer=transfer)
 
         self.frame.np.transfers.check_upload_queue()

--- a/pynicotine/gtkgui/userbrowse.py
+++ b/pynicotine/gtkgui/userbrowse.py
@@ -30,6 +30,7 @@ from gi.repository import GObject
 from gi.repository import Gtk
 
 from _thread import start_new_thread
+from pynicotine import slskmessages
 from pynicotine.gtkgui.dirchooser import choose_dir
 from pynicotine.gtkgui.dialogs import combo_box_dialog
 from pynicotine.gtkgui.utils import hide_columns
@@ -761,6 +762,8 @@ class UserBrowse:
         if user is None or user == "":
             return
 
+        self.frame.np.send_message_to_peer(user, slskmessages.UploadQueueNotification(None))
+
         self.upload_directory_to(user, folder, recurse)
 
     def on_upload_directory_recursive_to(self, widget):
@@ -814,6 +817,8 @@ class UserBrowse:
 
         if user is None or user == "":
             return
+
+        self.frame.np.send_message_to_peer(user, slskmessages.UploadQueueNotification(None))
 
         for fn in self.selected_files:
             self.frame.np.transfers.push_file(user, "\\".join([folder, fn]), "\\".join([realpath, fn]), prefix)

--- a/pynicotine/gtkgui/userbrowse.py
+++ b/pynicotine/gtkgui/userbrowse.py
@@ -30,7 +30,6 @@ from gi.repository import GObject
 from gi.repository import Gtk
 
 from _thread import start_new_thread
-from pynicotine import slskmessages
 from pynicotine.gtkgui.dirchooser import choose_dir
 from pynicotine.gtkgui.dialogs import combo_box_dialog
 from pynicotine.gtkgui.utils import hide_columns
@@ -762,8 +761,6 @@ class UserBrowse:
         if user is None or user == "":
             return
 
-        self.frame.np.process_request_to_peer(user, slskmessages.UploadQueueNotification(None))
-
         self.upload_directory_to(user, folder, recurse)
 
     def on_upload_directory_recursive_to(self, widget):
@@ -817,8 +814,6 @@ class UserBrowse:
 
         if user is None or user == "":
             return
-
-        self.frame.np.process_request_to_peer(user, slskmessages.UploadQueueNotification(None))
 
         for fn in self.selected_files:
             self.frame.np.transfers.push_file(user, "\\".join([folder, fn]), "\\".join([realpath, fn]), prefix)

--- a/pynicotine/gtkgui/utils.py
+++ b/pynicotine/gtkgui/utils.py
@@ -441,7 +441,7 @@ def on_soul_seek_uri(url):
         user, file = urllib.parse.unquote(url[7:]).split("/", 1)
 
         if file[-1] == "/":
-            NICOTINE.np.process_request_to_peer(user, slskmessages.FolderContentsRequest(None, file[:-1].replace("/", "\\")))
+            NICOTINE.np.send_message_to_peer(user, slskmessages.FolderContentsRequest(None, file[:-1].replace("/", "\\")))
         else:
             NICOTINE.np.transfers.get_file(user, file.replace("/", "\\"), "")
 

--- a/pynicotine/pynicotine.py
+++ b/pynicotine/pynicotine.py
@@ -60,9 +60,9 @@ class PeerConnection:
     slskmessages docstrings for explanation of these)
     """
 
-    __slots__ = "addr", "username", "conn", "msgs", "token", "init", "type", "conntimer", "tryaddr"
+    __slots__ = "addr", "username", "conn", "msgs", "token", "init", "type", "conntimer", "tryaddr", "direction"
 
-    def __init__(self, addr=None, username=None, conn=None, msgs=None, token=None, init=None, conntimer=None, tryaddr=None):
+    def __init__(self, addr=None, username=None, conn=None, msgs=None, token=None, init=None, conntimer=None, tryaddr=None, direction=None):
         self.addr = addr
         self.username = username
         self.conn = conn
@@ -72,6 +72,7 @@ class PeerConnection:
         self.type = init.type
         self.conntimer = conntimer
         self.tryaddr = tryaddr
+        self.direction = direction
 
 
 class Timeout:
@@ -135,7 +136,6 @@ class NetworkEventProcessor:
         self.ip_requested = set()
         self.private_message_queue = {}
         self.users = {}
-        self.user_addr_requested = set()
 
         self.queue = queue.Queue(0)
         self.shares = Shares(self, self.config, self.queue, self.ui_callback)
@@ -296,248 +296,263 @@ class NetworkEventProcessor:
             slskmessages.UnknownPeerMessage: self.ignore
         }
 
-    def process_request_to_peer(self, user, message, window=None, address=None):
-        """
-        Sends message to a peer and possibly sets up a window to display
-        the result.
-        """
+    def send_message_to_peer(self, user, message, address=None):
+
+        """ Sends message to a peer. Used primarily when we know the username of a peer,
+        but don't have an active connection. """
 
         conn = None
 
-        if message.__class__ is not slskmessages.FileRequest:
+        # Check if there's already a connection object for the specified username
+        if message.__class__ is slskmessages.FileRequest:
             for i in self.peerconns:
-                if i.username == user and i.type == 'P':
+                if i.username == user and i.direction == message.direction:
+                    conn = i
+                    break
+
+        else:
+            for i in self.peerconns:
+                if i.username == user and i.type == "P":
                     conn = i
                     break
 
         if conn is not None and conn.conn is not None:
+            """ We have initiated a connection previously, and it's ready """
 
             message.conn = conn.conn
-
             self.queue.put(message)
 
-            if window is not None:
-                window.show_user(conn.username, conn=conn.conn)
+        elif conn is not None:
+            """ Connection exists but is not ready yet, add new messages to it """
+
+            conn.msgs.append(message)
+
+        else:
+            """ This is a new peer, initiate a connection """
+
+            print("hit")
+            print(user)
+            self.initiate_connection_to_peer(user, message, address)
+
+    def initiate_connection_to_peer(self, user, message, address=None):
+
+        """ Initiates a connection with a peer """
+
+        if message.__class__ is slskmessages.FileRequest:
+            message_type = 'F'
+
+        elif message.__class__ is slskmessages.DistribConn:
+            message_type = 'D'
+
+        else:
+            message_type = 'P'
+
+        init = slskmessages.PeerInit(None, self.config.sections["server"]["login"], message_type, 0)
+        addr = None
+        direction = None
+
+        if user in self.users:
+            addr = self.users[user].addr
+
+        elif address is not None:
+            self.users[user] = UserAddr(status=-1, addr=address)
+            addr = address
+
+        if message.__class__ is slskmessages.FileRequest:
+            direction = message.direction
+
+        if addr is None:
+            self.queue.put(slskmessages.GetPeerAddress(user))
 
             if message.__class__ is slskmessages.TransferRequest and self.transfers is not None:
-                self.transfers.got_connect(message.req, conn.conn, message.direction)
-
-            return
+                self.transfers.getting_address(message.req, message.direction)
 
         else:
+            self.queue.put(slskmessages.OutConn(None, addr))
 
-            if message.__class__ is slskmessages.FileRequest:
-                message_type = 'F'
-            elif message.__class__ is slskmessages.DistribConn:
-                message_type = 'D'
-            else:
-                message_type = 'P'
+        self.peerconns.append(
+            PeerConnection(
+                addr=addr,
+                username=user,
+                msgs=[message],
+                init=init,
+                direction=direction
+            )
+        )
+        print(self.peerconns)
 
-            init = slskmessages.PeerInit(None, self.config.sections["server"]["login"], message_type, 0)
-            firewalled = self.config.sections["server"]["firewalled"]
-            addr = None
-            behindfw = None
-            token = None
+    def get_peer_address(self, msg):
 
-            if user in self.users:
-                addr = self.users[user].addr
-                behindfw = self.users[user].behindfw
-            elif address is not None:
-                self.users[user] = UserAddr(status=-1, addr=address)
-                addr = address
-
-            if firewalled:
-                if addr is None:
-                    if user not in self.user_addr_requested:
-                        self.queue.put(slskmessages.GetPeerAddress(user))
-                        self.user_addr_requested.add(user)
-                elif behindfw is None:
-                    self.queue.put(slskmessages.OutConn(None, addr))
-                else:
-                    firewalled = 0
-
-            if not firewalled:
-                token = new_id()
-                self.queue.put(slskmessages.ConnectToPeer(token, user, message_type))
-
-            conn = PeerConnection(addr=addr, username=user, msgs=[message], token=token, init=init)
-            self.peerconns.append(conn)
-
-            if token is not None:
-                timeout = 120.0
-                conntimeout = ConnectToPeerTimeout(self.peerconns[-1], self.network_callback)
-                timer = threading.Timer(timeout, conntimeout.timeout)
-                timer.setDaemon(True)
-                self.peerconns[-1].conntimer = timer
-                timer.start()
-
-        if message.__class__ is slskmessages.TransferRequest and self.transfers is not None:
-
-            if conn.addr is None:
-                self.transfers.getting_address(message.req, message.direction)
-            elif conn.token is None:
-                self.transfers.got_address(message.req, message.direction)
-            else:
-                self.transfers.got_connect_error(message.req, message.direction)
-
-    def set_server_timer(self):
-
-        if self.server_timeout_value == -1:
-            self.server_timeout_value = 15
-        elif 0 < self.server_timeout_value < 600:
-            self.server_timeout_value = self.server_timeout_value * 2
-
-        self.servertimer = threading.Timer(self.server_timeout_value, self.server_timeout)
-        self.servertimer.setDaemon(True)
-        self.servertimer.start()
-
-        self.set_status(_("The server seems to be down or not responding, retrying in %i seconds"), (self.server_timeout_value))
-
-    def server_timeout(self):
-        if self.config.need_config() <= 1:
-            self.network_callback([slskmessages.ConnectToServer()])
-
-    def stop_timers(self):
+        user = msg.user
 
         for i in self.peerconns:
-            if i.conntimer is not None:
-                i.conntimer.cancel()
+            if i.username == user and i.addr is None:
+                if msg.port != 0 or i.tryaddr == 10:
+                    if i.tryaddr == 10:
+                        log.add_conn(
+                            _("Server reported port 0 for the 10th time for user %(user)s, giving up"), {
+                                'user': user
+                            }
+                        )
 
-        if self.servertimer is not None:
-            self.servertimer.cancel()
+                    elif i.tryaddr is not None:
+                        log.add_conn(
+                            _("Server reported non-zero port for user %(user)s after %(tries)i retries"), {
+                                'user': user,
+                                'tries': i.tryaddr
+                            }
+                        )
 
-        if self.transfers is not None:
-            self.transfers.abort_transfers()
+                    i.addr = (msg.ip, msg.port)
+                    i.tryaddr = None
 
-    def connect_to_server(self, msg):
-        self.ui_callback.on_connect(None)
+                    self.queue.put(slskmessages.OutConn(None, i.addr))
 
-    # notify user of error when recieving or sending a message
-    # @param self NetworkEventProcessor (Class)
-    # @param string a string containing an error message
-    def notify(self, string):
-        log.add_msg_contents("%s", string)
-
-    def contents(self, obj):
-        """ Returns variables for object, for debug output """
-        try:
-            return {s: getattr(obj, s) for s in obj.__slots__ if hasattr(obj, s)}
-        except AttributeError:
-            return vars(obj)
-
-    def popup_message(self, msg):
-        self.set_status(_(msg.title))
-        self.ui_callback.popup_message(msg)
-
-    def set_current_connection_count(self, msg):
-        self.ui_callback.set_socket_status(msg.msg)
-
-    def connect_error(self, msg):
-
-        if msg.connobj.__class__ is slskmessages.ServerConn:
-
-            self.set_status(
-                _("Can't connect to server %(host)s:%(port)s: %(error)s"), {
-                    'host': msg.connobj.addr[0],
-                    'port': msg.connobj.addr[1],
-                    'error': msg.err
-                }
-            )
-
-            self.set_server_timer()
-
-            if self.active_server_conn is not None:
-                self.active_server_conn = None
-
-            self.ui_callback.connect_error(msg)
-
-        elif msg.connobj.__class__ is slskmessages.OutConn:
-
-            addr = msg.connobj.addr
-
-            for i in self.peerconns:
-
-                if i.addr == addr and i.conn is None:
-
-                    if i.token is None:
-
-                        i.token = new_id()
-                        self.queue.put(slskmessages.ConnectToPeer(i.token, i.username, i.type))
-
-                        if i.username in self.users:
-                            self.users[i.username].behindfw = "yes"
-
-                        for j in i.msgs:
-                            if j.__class__ is slskmessages.TransferRequest and self.transfers is not None:
-                                self.transfers.got_connect_error(j.req, j.direction)
-
-                        conntimeout = ConnectToPeerTimeout(i, self.network_callback)
-                        timer = threading.Timer(120.0, conntimeout.timeout)
-                        timer.setDaemon(True)
-                        timer.start()
-
-                        if i.conntimer is not None:
-                            i.conntimer.cancel()
-
-                        i.conntimer = timer
-
+                    for j in i.msgs:
+                        if j.__class__ is slskmessages.TransferRequest and self.transfers is not None:
+                            self.transfers.got_address(j.req, j.direction)
+                else:
+                    if i.tryaddr is None:
+                        i.tryaddr = 1
+                        log.add_conn(
+                            _("Server reported port 0 for user %(user)s, retrying"), {
+                                'user': user
+                            }
+                        )
                     else:
-                        for j in i.msgs:
-                            if j.__class__ in [slskmessages.TransferRequest, slskmessages.FileRequest] and self.transfers is not None:
-                                self.transfers.got_cant_connect(j.req)
+                        i.tryaddr += 1
 
-                        log.add_conn(_("Can't connect to %s, sending notification via the server"), i.username)
-                        self.queue.put(slskmessages.CantConnectToPeer(i.token, i.username))
+                    self.queue.put(slskmessages.GetPeerAddress(user))
+                    return
 
-                        if i.conntimer is not None:
-                            i.conntimer.cancel()
-
-                        self.peerconns.remove(i)
-
-                    break
-            else:
-                log.add_msg_contents("%s %s %s", (msg.err, msg.__class__, self.contents(msg)))
-
+        if user in self.users:
+            self.users[user].addr = (msg.ip, msg.port)
         else:
-            log.add_msg_contents("%s %s %s", (msg.err, msg.__class__, self.contents(msg)))
+            self.users[user] = UserAddr(addr=(msg.ip, msg.port))
 
-            self.closed_connection(msg.connobj.conn, msg.connobj.addr, msg.err)
+        if user in self.ipblock_requested:
 
-    def inc_port(self, msg):
-        self.waitport = msg.port
-        self.set_status(_("Listening on port %i"), msg.port)
+            if self.ipblock_requested[user]:
+                self.ui_callback.on_un_block_user(user)
+            else:
+                self.ui_callback.on_block_user(user)
 
-    def server_conn(self, msg):
+            del self.ipblock_requested[user]
+            return
 
-        self.set_status(
-            _("Connected to server %(host)s:%(port)s, logging in..."), {
-                'host': msg.addr[0],
-                'port': msg.addr[1]
-            }
-        )
+        if user in self.ipignore_requested:
 
-        self.active_server_conn = msg.conn
-        self.server_timeout_value = -1
-        self.users = {}
-        self.queue.put(
-            slskmessages.Login(
-                self.config.sections["server"]["login"],
-                self.config.sections["server"]["passw"],
+            if self.ipignore_requested[user]:
+                self.ui_callback.on_un_ignore_user(user)
+            else:
+                self.ui_callback.on_ignore_user(user)
 
-                # Soulseek client version; 155, 156, 157
-                # SoulseekQt seems to be using 157
-                157,
+            del self.ipignore_requested[user]
+            return
 
-                # Soulseek client minor version
-                # 17 stands for 157 ns 13c, 19 for 157 ns 13e
-                # SoulseekQt seems to go higher than this
-                19,
+        ip_record = self.geoip.get_all(msg.ip)
+        cc = ip_record.country_short
+
+        if cc == "-":
+            cc = ""
+
+        self.ui_callback.has_user_flag(user, "flag_" + cc)
+
+        # From this point on all paths should call
+        # self.pluginhandler.user_resolve_notification precisely once
+        if user in self.private_message_queue:
+            self.private_message_queue_process(user)
+
+        if user not in self.ip_requested:
+            self.pluginhandler.user_resolve_notification(user, msg.ip, msg.port)
+            return
+
+        self.ip_requested.remove(user)
+        self.pluginhandler.user_resolve_notification(user, msg.ip, msg.port, cc)
+
+        if cc != "":
+            country = " (%(cc)s / %(country)s)" % {'cc': cc, 'country': ip_record.country_long}
+        else:
+            country = ""
+
+        log.add(_("IP address of %(user)s is %(ip)s, port %(port)i%(country)s"), {
+            'user': user,
+            'ip': msg.ip,
+            'port': msg.port,
+            'country': country
+        })
+
+    def process_conn_messages(self, peerconn, conn):
+
+        for j in peerconn.msgs:
+
+            if j.__class__ is slskmessages.UserInfoRequest and self.userinfo is not None:
+                self.userinfo.show_user(peerconn.username, conn=conn)
+
+            if j.__class__ is slskmessages.GetSharedFileList and self.userbrowse is not None:
+                self.userbrowse.show_user(peerconn.username, conn=conn)
+
+            if j.__class__ is slskmessages.FileRequest and self.transfers is not None:
+                self.transfers.got_file_connect(j.req, conn)
+
+            if j.__class__ is slskmessages.TransferRequest and self.transfers is not None:
+                self.transfers.got_connect(j.req, conn, j.direction)
+
+            j.conn = conn
+            self.queue.put(j)
+
+        peerconn.msgs = []
+
+    def inc_conn(self, msg):
+        log.add_msg_contents("%s %s", (msg.__class__, self.contents(msg)))
+
+    def out_conn(self, msg):
+
+        addr = msg.addr
+
+        for i in self.peerconns:
+            if i.addr == addr and i.conn is None:
+                conn = msg.conn
+
+                if i.token is None:
+                    i.init.conn = conn
+                    self.queue.put(i.init)
+
+                else:
+                    self.queue.put(slskmessages.PierceFireWall(conn, i.token))
+
+                i.conn = conn
+
+                # Update UI with contents from messages
+                self.process_conn_messages(i, conn)
+
+                break
+
+        log.add_msg_contents("%s %s", (msg.__class__, self.contents(msg)))
+
+    def connect_to_peer(self, msg):
+
+        user = msg.user
+        ip = msg.ip
+        port = msg.port
+
+        init = slskmessages.PeerInit(None, user, msg.type, 0)
+
+        self.queue.put(slskmessages.OutConn(None, (ip, port), init))
+        self.peerconns.append(
+            PeerConnection(
+                addr=(ip, port),
+                username=user,
+                msgs=[],
+                token=msg.token,
+                init=init
             )
         )
-        if self.waitport is not None:
-            self.queue.put(slskmessages.SetWaitPort(self.waitport))
+
+        log.add_msg_contents("%s %s", (msg.__class__, self.contents(msg)))
 
     def peer_init(self, msg):
+
         self.peerconns.append(
             PeerConnection(
                 addr=msg.conn.addr,
@@ -548,8 +563,66 @@ class NetworkEventProcessor:
             )
         )
 
-    def conn_close(self, msg):
-        self.closed_connection(msg.conn, msg.addr)
+        log.add_msg_contents("%s %s", (msg.__class__, self.contents(msg)))
+
+    def pierce_fire_wall(self, msg):
+        token = msg.token
+
+        for i in self.peerconns:
+            if i.token == token and i.conn is None:
+                conn = msg.conn.conn
+
+                if i.conntimer is not None:
+                    i.conntimer.cancel()
+
+                i.init.conn = conn
+                self.queue.put(i.init)
+                i.conn = conn
+
+                # Update UI with contents from messages
+                self.process_conn_messages(i, conn)
+
+                break
+
+        log.add_msg_contents("%s %s", (msg.__class__, self.contents(msg)))
+
+    def cant_connect_to_peer(self, msg):
+        token = msg.token
+
+        for i in self.peerconns:
+            if i.token == token:
+
+                if i.conntimer is not None:
+                    i.conntimer.cancel()
+
+                if i == self.get_parent_conn():
+                    self.parent_conn_closed()
+
+                self.peerconns.remove(i)
+
+                log.add_conn(_("Can't connect to %s (either way), giving up"), i.username)
+
+                for j in i.msgs:
+                    if j.__class__ in [slskmessages.TransferRequest, slskmessages.FileRequest] and self.transfers is not None:
+                        self.transfers.got_cant_connect(j.req)
+                break
+
+    def connect_to_peer_timeout(self, msg):
+        conn = msg.conn
+
+        if conn == self.get_parent_conn():
+            self.parent_conn_closed()
+
+        try:
+            self.peerconns.remove(conn)
+        except ValueError:
+            pass
+
+        log.add(_("User %s does not respond to connect request, giving up"), conn.username)
+
+        for i in conn.msgs:
+            if i.__class__ in [slskmessages.TransferRequest, slskmessages.FileRequest] and self.transfers is not None:
+                self.transfers.got_cant_connect(i.req)
 
     def closed_connection(self, conn, addr, error=None):
 
@@ -603,6 +676,159 @@ class NetworkEventProcessor:
                         'address': addr
                     }
                 )
+
+    def conn_close(self, msg):
+        self.closed_connection(msg.conn, msg.addr)
+
+    def connect_error(self, msg):
+
+        if msg.connobj.__class__ is slskmessages.ServerConn:
+
+            self.set_status(
+                _("Can't connect to server %(host)s:%(port)s: %(error)s"), {
+                    'host': msg.connobj.addr[0],
+                    'port': msg.connobj.addr[1],
+                    'error': msg.err
+                }
+            )
+
+            self.set_server_timer()
+
+            if self.active_server_conn is not None:
+                self.active_server_conn = None
+
+            self.ui_callback.connect_error(msg)
+
+        elif msg.connobj.__class__ is slskmessages.OutConn:
+
+            addr = msg.connobj.addr
+
+            for i in self.peerconns:
+                if i.addr == addr and i.conn is None:
+                    if i.token is None:
+
+                        i.token = new_id()
+                        self.queue.put(slskmessages.ConnectToPeer(i.token, i.username, i.type))
+
+                        for j in i.msgs:
+                            if j.__class__ is slskmessages.TransferRequest and self.transfers is not None:
+                                self.transfers.got_connect_error(j.req, j.direction)
+
+                        conntimeout = ConnectToPeerTimeout(i, self.network_callback)
+                        timer = threading.Timer(20.0, conntimeout.timeout)
+                        timer.setDaemon(True)
+                        timer.start()
+
+                        if i.conntimer is not None:
+                            i.conntimer.cancel()
+
+                        i.conntimer = timer
+
+                    else:
+                        for j in i.msgs:
+                            if j.__class__ in [slskmessages.TransferRequest, slskmessages.FileRequest] and self.transfers is not None:
+                                self.transfers.got_cant_connect(j.req)
+
+                        log.add_conn(_("Can't connect to %s, sending notification via the server"), i.username)
+                        self.queue.put(slskmessages.CantConnectToPeer(i.token, i.username))
+
+                        if i.conntimer is not None:
+                            i.conntimer.cancel()
+
+                        self.peerconns.remove(i)
+
+                    break
+
+        else:
+            self.closed_connection(msg.connobj.conn, msg.connobj.addr, msg.err)
+
+        log.add_msg_contents("%s %s %s", (msg.err, msg.__class__, self.contents(msg)))
+
+    def set_server_timer(self):
+
+        if self.server_timeout_value == -1:
+            self.server_timeout_value = 15
+        elif 0 < self.server_timeout_value < 600:
+            self.server_timeout_value = self.server_timeout_value * 2
+
+        self.servertimer = threading.Timer(self.server_timeout_value, self.server_timeout)
+        self.servertimer.setDaemon(True)
+        self.servertimer.start()
+
+        self.set_status(_("The server seems to be down or not responding, retrying in %i seconds"), (self.server_timeout_value))
+
+    def server_timeout(self):
+        if self.config.need_config() <= 1:
+            self.network_callback([slskmessages.ConnectToServer()])
+
+    def stop_timers(self):
+
+        for i in self.peerconns:
+            if i.conntimer is not None:
+                i.conntimer.cancel()
+
+        if self.servertimer is not None:
+            self.servertimer.cancel()
+
+        if self.transfers is not None:
+            self.transfers.abort_transfers()
+
+    def connect_to_server(self, msg):
+        self.ui_callback.on_connect(None)
+
+    # notify user of error when recieving or sending a message
+    # @param self NetworkEventProcessor (Class)
+    # @param string a string containing an error message
+    def notify(self, string):
+        log.add_msg_contents("%s", string)
+
+    def contents(self, obj):
+        """ Returns variables for object, for debug output """
+        try:
+            return {s: getattr(obj, s) for s in obj.__slots__ if hasattr(obj, s)}
+        except AttributeError:
+            return vars(obj)
+
+    def popup_message(self, msg):
+        self.set_status(_(msg.title))
+        self.ui_callback.popup_message(msg)
+
+    def set_current_connection_count(self, msg):
+        self.ui_callback.set_socket_status(msg.msg)
+
+    def inc_port(self, msg):
+        self.waitport = msg.port
+        self.set_status(_("Listening on port %i"), msg.port)
+
+    def server_conn(self, msg):
+
+        self.set_status(
+            _("Connected to server %(host)s:%(port)s, logging in..."), {
+                'host': msg.addr[0],
+                'port': msg.addr[1]
+            }
+        )
+
+        self.active_server_conn = msg.conn
+        self.server_timeout_value = -1
+        self.users = {}
+        self.queue.put(
+            slskmessages.Login(
+                self.config.sections["server"]["login"],
+                self.config.sections["server"]["passw"],
+
+                # Soulseek client version; 155, 156, 157
+                # SoulseekQt seems to be using 157
+                157,
+
+                # Soulseek client minor version
+                # 17 stands for 157 ns 13c, 19 for 157 ns 13e
+                # SoulseekQt seems to go higher than this
+                19,
+            )
+        )
+        if self.waitport is not None:
+            self.queue.put(slskmessages.SetWaitPort(self.waitport))
 
     def login(self, msg):
 
@@ -1029,173 +1255,10 @@ class NetworkEventProcessor:
         else:
             log.add_msg_contents("%s %s", (msg.__class__, self.contents(msg)))
 
-    def get_peer_address(self, msg):
-
-        user = msg.user
-
-        for i in self.peerconns:
-            if i.username == user and i.addr is None:
-                if msg.port != 0 or i.tryaddr == 10:
-                    if i.tryaddr == 10:
-                        log.add_conn(
-                            _("Server reported port 0 for the 10th time for user %(user)s, giving up"), {
-                                'user': user
-                            }
-                        )
-                    elif i.tryaddr is not None:
-                        log.add_conn(
-                            _("Server reported non-zero port for user %(user)s after %(tries)i retries"), {
-                                'user': user,
-                                'tries': i.tryaddr
-                            }
-                        )
-
-                    if user in self.user_addr_requested:
-                        self.user_addr_requested.remove(user)
-
-                    i.addr = (msg.ip, msg.port)
-                    i.tryaddr = None
-
-                    self.queue.put(slskmessages.OutConn(None, i.addr))
-
-                    for j in i.msgs:
-                        if j.__class__ is slskmessages.TransferRequest and self.transfers is not None:
-                            self.transfers.got_address(j.req, j.direction)
-                else:
-                    if i.tryaddr is None:
-                        i.tryaddr = 1
-                        log.add_conn(
-                            _("Server reported port 0 for user %(user)s, retrying"), {
-                                'user': user
-                            }
-                        )
-                    else:
-                        i.tryaddr += 1
-
-                    self.queue.put(slskmessages.GetPeerAddress(user))
-                    return
-
-        if user in self.users:
-            self.users[user].addr = (msg.ip, msg.port)
-        else:
-            self.users[user] = UserAddr(addr=(msg.ip, msg.port))
-
-        if user in self.ipblock_requested:
-
-            if self.ipblock_requested[user]:
-                self.ui_callback.on_un_block_user(user)
-            else:
-                self.ui_callback.on_block_user(user)
-
-            del self.ipblock_requested[user]
-            return
-
-        if user in self.ipignore_requested:
-
-            if self.ipignore_requested[user]:
-                self.ui_callback.on_un_ignore_user(user)
-            else:
-                self.ui_callback.on_ignore_user(user)
-
-            del self.ipignore_requested[user]
-            return
-
-        ip_record = self.geoip.get_all(msg.ip)
-        cc = ip_record.country_short
-
-        if cc == "-":
-            cc = ""
-
-        self.ui_callback.has_user_flag(user, "flag_" + cc)
-
-        # From this point on all paths should call
-        # self.pluginhandler.user_resolve_notification precisely once
-        if user in self.private_message_queue:
-            self.private_message_queue_process(user)
-        if user not in self.ip_requested:
-            self.pluginhandler.user_resolve_notification(user, msg.ip, msg.port)
-            return
-
-        self.ip_requested.remove(user)
-        self.pluginhandler.user_resolve_notification(user, msg.ip, msg.port, cc)
-
-        if cc != "":
-            country = " (%(cc)s / %(country)s)" % {'cc': cc, 'country': ip_record.country_long}
-        else:
-            country = ""
-
-        log.add(_("IP address of %(user)s is %(ip)s, port %(port)i%(country)s"), {
-            'user': user,
-            'ip': msg.ip,
-            'port': msg.port,
-            'country': country
-        })
-
     def relogged(self, msg):
         log.add(_("Someone else is logging in with the same nickname, server is going to disconnect us"))
         self.manualdisconnect = True
         self.pluginhandler.server_disconnect_notification(False)
-
-    def out_conn(self, msg):
-
-        addr = msg.addr
-
-        for i in self.peerconns:
-
-            if i.addr == addr and i.conn is None:
-                conn = msg.conn
-
-                if i.token is None:
-                    i.init.conn = conn
-                    self.queue.put(i.init)
-                else:
-                    self.queue.put(slskmessages.PierceFireWall(conn, i.token))
-
-                i.conn = conn
-
-                for j in i.msgs:
-
-                    if j.__class__ is slskmessages.UserInfoRequest and self.userinfo is not None:
-                        self.userinfo.show_user(i.username, conn=conn)
-
-                    if j.__class__ is slskmessages.GetSharedFileList and self.userbrowse is not None:
-                        self.userbrowse.show_user(i.username, conn=conn)
-
-                    if j.__class__ is slskmessages.FileRequest and self.transfers is not None:
-                        self.transfers.got_file_connect(j.req, conn)
-
-                    if j.__class__ is slskmessages.TransferRequest and self.transfers is not None:
-                        self.transfers.got_connect(j.req, conn, j.direction)
-
-                    j.conn = conn
-                    self.queue.put(j)
-
-                i.msgs = []
-                break
-
-        log.add_conn("%s %s", (msg.__class__, self.contents(msg)))
-
-    def inc_conn(self, msg):
-        log.add_conn("%s %s", (msg.__class__, self.contents(msg)))
-
-    def connect_to_peer(self, msg):
-        user = msg.user
-        ip = msg.ip
-        port = msg.port
-
-        init = slskmessages.PeerInit(None, user, msg.type, 0)
-
-        self.queue.put(slskmessages.OutConn(None, (ip, port), init))
-        self.peerconns.append(
-            PeerConnection(
-                addr=(ip, port),
-                username=user,
-                msgs=[],
-                token=msg.token,
-                init=init
-            )
-        )
-        log.add_conn("%s %s", (msg.__class__, self.contents(msg)))
 
     def check_user(self, user, ip):
         """
@@ -1405,82 +1468,6 @@ class NetworkEventProcessor:
             self.close_peer_connection(conn)
 
         log.add_msg_contents("%s %s", (msg.__class__, self.contents(msg)))
-
-    def pierce_fire_wall(self, msg):
-        token = msg.token
-
-        for i in self.peerconns:
-
-            if i.token == token and i.conn is None:
-                conn = msg.conn.conn
-
-                if i.conntimer is not None:
-                    i.conntimer.cancel()
-
-                i.init.conn = conn
-                self.queue.put(i.init)
-                i.conn = conn
-
-                for j in i.msgs:
-
-                    if j.__class__ is slskmessages.UserInfoRequest and self.userinfo is not None:
-                        self.userinfo.show_user(i.username, conn=conn)
-
-                    if j.__class__ is slskmessages.GetSharedFileList and self.userbrowse is not None:
-                        self.userbrowse.show_user(i.username, conn=conn)
-
-                    if j.__class__ is slskmessages.FileRequest and self.transfers is not None:
-                        self.transfers.got_file_connect(j.req, conn)
-
-                    if j.__class__ is slskmessages.TransferRequest and self.transfers is not None:
-                        self.transfers.got_connect(j.req, conn, j.direction)
-
-                    j.conn = conn
-                    self.queue.put(j)
-
-                i.msgs = []
-                break
-
-        log.add_conn("%s %s", (msg.__class__, self.contents(msg)))
-
-    def cant_connect_to_peer(self, msg):
-        token = msg.token
-
-        for i in self.peerconns:
-
-            if i.token == token:
-
-                if i.conntimer is not None:
-                    i.conntimer.cancel()
-
-                if i == self.get_parent_conn():
-                    self.parent_conn_closed()
-
-                self.peerconns.remove(i)
-
-                log.add_conn(_("Can't connect to %s (either way), giving up"), i.username)
-
-                for j in i.msgs:
-                    if j.__class__ in [slskmessages.TransferRequest, slskmessages.FileRequest] and self.transfers is not None:
-                        self.transfers.got_cant_connect(j.req)
-                break
-
-    def connect_to_peer_timeout(self, msg):
-        conn = msg.conn
-
-        if conn == self.get_parent_conn():
-            self.parent_conn_closed()
-
-        try:
-            self.peerconns.remove(conn)
-        except ValueError:
-            pass
-
-        log.add_conn(_("User %s does not respond to connect request, giving up"), conn.username)
-
-        for i in conn.msgs:
-            if i.__class__ in [slskmessages.TransferRequest, slskmessages.FileRequest] and self.transfers is not None:
-                self.transfers.got_cant_connect(i.req)
 
     def transfer_timeout(self, msg):
         if self.transfers is not None:
@@ -1801,7 +1788,7 @@ class NetworkEventProcessor:
             for user in potential_parents:
                 addr = potential_parents[user]
 
-                self.process_request_to_peer(user, slskmessages.DistribConn(), None, addr)
+                self.send_message_to_peer(user, slskmessages.DistribConn(), address=addr)
 
         log.add_msg_contents("%s %s", (msg.__class__, self.contents(msg)))
 
@@ -1918,7 +1905,6 @@ class NetworkEventProcessor:
 
 class UserAddr:
 
-    def __init__(self, addr=None, behindfw=None, status=None):
+    def __init__(self, addr=None, status=None):
         self.addr = addr
-        self.behindfw = behindfw
         self.status = status

--- a/pynicotine/pynicotine.py
+++ b/pynicotine/pynicotine.py
@@ -323,8 +323,6 @@ class NetworkEventProcessor:
         else:
             """ This is a new peer, initiate a connection """
 
-            print("hit")
-            print(user)
             self.initiate_connection_to_peer(user, message, address)
 
     def initiate_connection_to_peer(self, user, message, address=None):
@@ -366,6 +364,13 @@ class NetworkEventProcessor:
                 msgs=[message],
                 init=init
             )
+        )
+
+        log.add_conn(
+            _("Initialising new connection to user %(user)s, type %(type)s"), {
+                'user': user,
+                'type': message_type
+            }
         )
 
     def get_peer_address(self, msg):
@@ -606,7 +611,7 @@ class NetworkEventProcessor:
         except ValueError:
             pass
 
-        log.add(_("User %s does not respond to connect request, giving up"), conn.username)
+        log.add_conn(_("User %s does not respond to connect request, giving up"), conn.username)
 
         for i in conn.msgs:
             if i.__class__ in [slskmessages.TransferRequest, slskmessages.FileRequest] and self.transfers is not None:
@@ -711,6 +716,13 @@ class NetworkEventProcessor:
                             i.conntimer.cancel()
 
                         i.conntimer = timer
+
+                        log.add_conn(
+                            _("Direct connection of type %(type)s to user %(username)s failed, attempting indirect connection"), {
+                                "type": i.type,
+                                "username": i.username
+                            }
+                        )
 
                     else:
                         for j in i.msgs:

--- a/pynicotine/shares.py
+++ b/pynicotine/shares.py
@@ -804,7 +804,7 @@ class Shares:
                 self.np.speed, queuesizes, fifoqueue, numresults
             )
 
-            self.np.process_request_to_peer(user, message)
+            self.np.send_message_to_peer(user, message)
 
             if direct:
                 log.add_search(

--- a/pynicotine/slskmessages.py
+++ b/pynicotine/slskmessages.py
@@ -2497,9 +2497,10 @@ class FileRequest(PeerMessage):
     """ Request a file from peer, or tell a peer that we want to send a file to
     them. """
 
-    def __init__(self, conn, req=None):
+    def __init__(self, conn, req=None, direction=None):
         self.conn = conn
         self.req = req
+        self.direction = direction
 
     def make_network_message(self):
         msg = self.pack_object(self.req)

--- a/pynicotine/transfers.py
+++ b/pynicotine/transfers.py
@@ -254,8 +254,10 @@ class Transfers:
         self.transfer_file(1, user, filename, path, transfer, size, bitrate, length, realfilename)
 
     def transfer_file(self, direction, user, filename, path="", transfer=None, size=None, bitrate=None, length=None, realfilename=None):
+
         """ Get a single file. path is a local path. if transfer object is
         not None, update it, otherwise create a new one."""
+
         if transfer is None:
             transfer = Transfer(
                 user=user, filename=filename, realfilename=realfilename, path=path,
@@ -299,7 +301,7 @@ class Transfers:
             transfer.req = new_id()
             realpath = self.eventprocessor.shares.virtual2real(filename)
             request = slskmessages.TransferRequest(None, direction, transfer.req, filename, self.get_file_size(realpath), realpath)
-            self.eventprocessor.process_request_to_peer(user, request)
+            self.eventprocessor.send_message_to_peer(user, request)
 
         if shouldupdate:
             if direction == 0:
@@ -469,13 +471,11 @@ class Transfers:
             for i in self.peerconns:
                 if i.conn is msg.conn.conn:
                     user = i.username
-                    conn = msg.conn.conn
                     addr = msg.conn.addr[0]
                     break
 
         elif msg.tunneleduser is not None:  # Deprecated
             user = msg.tunneleduser
-            conn = None
             addr = "127.0.0.1"
 
         if user is None:
@@ -483,16 +483,13 @@ class Transfers:
             return
 
         if msg.direction == 1:
-            response = self.transfer_request_downloads(msg, user, conn, addr)
+            response = self.transfer_request_downloads(msg, user)
         else:
-            response = self.transfer_request_uploads(msg, user, conn, addr)
+            response = self.transfer_request_uploads(msg, user, addr)
 
-        if msg.conn is not None:
-            self.queue.put(response)
-        else:
-            self.eventprocessor.process_request_to_peer(user, response)
+        self.eventprocessor.send_message_to_peer(user, response)
 
-    def transfer_request_downloads(self, msg, user, conn, addr):
+    def transfer_request_downloads(self, msg, user):
 
         for i in self.downloads:
             if i.filename == msg.file and user == i.user and i.status not in ["Aborted", "Paused"]:
@@ -502,6 +499,7 @@ class Transfers:
                 send a malformed file size (0 bytes) in the TransferRequest response.
                 In that case, we rely on the cached, correct file size we received when
                 we initially added the download. """
+
                 if msg.filesize > 0:
                     i.size = msg.filesize
 
@@ -516,7 +514,7 @@ class Transfers:
                 i.transfertimer.setDaemon(True)
                 i.transfertimer.start()
 
-                response = slskmessages.TransferResponse(conn, 1, req=i.req)
+                response = slskmessages.TransferResponse(None, 1, req=i.req)
                 self.downloadsview.update(i)
                 break
         else:
@@ -537,46 +535,46 @@ class Transfers:
                 if user not in self.eventprocessor.watchedusers:
                     self.queue.put(slskmessages.AddUser(user))
 
-                response = slskmessages.TransferResponse(conn, 0, reason="Queued", req=transfer.req)
+                response = slskmessages.TransferResponse(None, 0, reason="Queued", req=transfer.req)
                 self.downloadsview.update(transfer)
             else:
-                response = slskmessages.TransferResponse(conn, 0, reason="Cancelled", req=msg.req)
+                response = slskmessages.TransferResponse(None, 0, reason="Cancelled", req=msg.req)
                 log.add_transfer(_("Denied file request: User %(user)s, %(msg)s"), {
                     'user': user,
                     'msg': str(vars(msg))
                 })
         return response
 
-    def transfer_request_uploads(self, msg, user, conn, addr):
+    def transfer_request_uploads(self, msg, user, addr):
         """
         Remote peer is requesting to download a file through
         your Upload queue
         """
 
-        response = self._transfer_request_uploads(msg, user, conn, addr)
+        response = self._transfer_request_uploads(msg, user, addr)
         log.add_transfer(_("Upload request: %(req)s Response: %(resp)s"), {
             'req': str(vars(msg)),
             'resp': response
         })
         return response
 
-    def _transfer_request_uploads(self, msg, user, conn, addr):
+    def _transfer_request_uploads(self, msg, user, addr):
 
         # Is user allowed to download?
         checkuser, reason = self.eventprocessor.check_user(user, addr)
 
         if not checkuser:
-            return slskmessages.TransferResponse(conn, 0, reason=reason, req=msg.req)
+            return slskmessages.TransferResponse(None, 0, reason=reason, req=msg.req)
 
         # Do we actually share that file with the world?
         realpath = self.eventprocessor.shares.virtual2real(msg.file)
 
         if not self.file_is_shared(user, msg.file, realpath):
-            return slskmessages.TransferResponse(conn, 0, reason="File not shared", req=msg.req)
+            return slskmessages.TransferResponse(None, 0, reason="File not shared", req=msg.req)
 
         # Is that file already in the queue?
         if self.file_is_upload_queued(user, msg.file):
-            return slskmessages.TransferResponse(conn, 0, reason="Queued", req=msg.req)
+            return slskmessages.TransferResponse(None, 0, reason="Queued", req=msg.req)
 
         # Has user hit queue limit?
         limits = True
@@ -589,12 +587,12 @@ class Transfers:
 
         if limits and self.queue_limit_reached(user):
             uploadslimit = self.eventprocessor.config.sections["transfers"]["queuelimit"]
-            return slskmessages.TransferResponse(conn, 0, reason="User limit of %i megabytes exceeded" % (uploadslimit), req=msg.req)
+            return slskmessages.TransferResponse(None, 0, reason="User limit of %i megabytes exceeded" % (uploadslimit), req=msg.req)
 
         if limits and self.file_limit_reached(user):
             filelimit = self.eventprocessor.config.sections["transfers"]["filelimit"]
             limitmsg = "User limit of %i files exceeded" % (filelimit)
-            return slskmessages.TransferResponse(conn, 0, reason=limitmsg, req=msg.req)
+            return slskmessages.TransferResponse(None, 0, reason=limitmsg, req=msg.req)
 
         # All checks passed, user can queue file!
         if self.pluginhandler:
@@ -603,7 +601,7 @@ class Transfers:
         # Is user already downloading/negotiating a download?
         if not self.allow_new_uploads() or user in self.get_transferring_users():
 
-            response = slskmessages.TransferResponse(conn, 0, reason="Queued", req=msg.req)
+            response = slskmessages.TransferResponse(None, 0, reason="Queued", req=msg.req)
             newupload = Transfer(
                 user=user, filename=msg.file, realfilename=realpath,
                 path=os.path.dirname(realpath), status="Queued",
@@ -617,7 +615,7 @@ class Transfers:
 
         # All checks passed, starting a new upload.
         size = self.get_file_size(realpath)
-        response = slskmessages.TransferResponse(conn, 1, req=msg.req, filesize=size)
+        response = slskmessages.TransferResponse(None, 1, req=msg.req, filesize=size)
 
         transfertimeout = TransferTimeout(msg.req, self.network_callback)
         transferobj = Transfer(
@@ -908,6 +906,7 @@ class Transfers:
         return size
 
     def transfer_response(self, msg):
+
         """ Got a response to the file request from the peer."""
 
         if msg.reason is not None:
@@ -927,7 +926,7 @@ class Transfers:
                         if i.user not in self.eventprocessor.watchedusers:
                             self.queue.put(slskmessages.AddUser(i.user))
 
-                    self.eventprocessor.process_request_to_peer(i.user, slskmessages.PlaceInQueueRequest(None, i.filename))
+                    self.queue.put(slskmessages.PlaceInQueueRequest(msg.conn.conn, i.filename))
 
                 self.check_upload_queue()
                 break
@@ -969,7 +968,7 @@ class Transfers:
                 i.size = msg.filesize
                 i.status = "Establishing connection"
                 # Have to establish 'F' connection here
-                self.eventprocessor.process_request_to_peer(i.user, slskmessages.FileRequest(None, msg.req))
+                self.eventprocessor.send_message_to_peer(i.user, slskmessages.FileRequest(None, msg.req, direction=0))
                 self.downloadsview.update(i)
                 break
         else:
@@ -979,7 +978,7 @@ class Transfers:
                     continue
 
                 i.status = "Establishing connection"
-                self.eventprocessor.process_request_to_peer(i.user, slskmessages.FileRequest(None, msg.req))
+                self.eventprocessor.send_message_to_peer(i.user, slskmessages.FileRequest(None, msg.req, direction=1))
                 self.uploadsview.update(i)
                 self.check_upload_queue()
                 break
@@ -1475,7 +1474,7 @@ class Transfers:
                 continue
 
             if upload.status == "Queued":
-                self.eventprocessor.process_request_to_peer(user, slskmessages.QueueFailed(None, file=upload.filename, reason=banmsg))
+                self.eventprocessor.send_message_to_peer(user, slskmessages.QueueFailed(None, file=upload.filename, reason=banmsg))
             else:
                 self.abort_transfer(upload, reason=banmsg)
 
@@ -1503,8 +1502,9 @@ class Transfers:
             if transfer.status in statuslist:
                 self.abort_transfer(transfer)
                 self.get_file(transfer.user, transfer.filename, transfer.path, transfer)
+
             elif transfer.status == "Queued":
-                self.eventprocessor.process_request_to_peer(transfer.user, slskmessages.PlaceInQueueRequest(None, transfer.filename))
+                self.eventprocessor.send_message_to_peer(transfer.user, slskmessages.PlaceInQueueRequest(None, transfer.filename))
 
         self.start_check_download_queue_timer()
 
@@ -1955,7 +1955,7 @@ class Transfers:
         transfer.timeleft = ""
 
         if send_fail_message and transfer in self.uploads:
-            self.eventprocessor.process_request_to_peer(transfer.user, slskmessages.QueueFailed(None, file=transfer.filename, reason=reason))
+            self.eventprocessor.send_message_to_peer(transfer.user, slskmessages.QueueFailed(None, file=transfer.filename, reason=reason))
 
         if transfer.conn is not None:
             transfer.conn = None

--- a/pynicotine/transfers.py
+++ b/pynicotine/transfers.py
@@ -968,7 +968,7 @@ class Transfers:
                 i.size = msg.filesize
                 i.status = "Establishing connection"
                 # Have to establish 'F' connection here
-                self.eventprocessor.send_message_to_peer(i.user, slskmessages.FileRequest(None, msg.req, direction=0))
+                self.eventprocessor.send_message_to_peer(i.user, slskmessages.FileRequest(None, msg.req))
                 self.downloadsview.update(i)
                 break
         else:
@@ -978,7 +978,7 @@ class Transfers:
                     continue
 
                 i.status = "Establishing connection"
-                self.eventprocessor.send_message_to_peer(i.user, slskmessages.FileRequest(None, msg.req, direction=1))
+                self.eventprocessor.send_message_to_peer(i.user, slskmessages.FileRequest(None, msg.req))
                 self.uploadsview.update(i)
                 self.check_upload_queue()
                 break


### PR DESCRIPTION
I'm going to propose these changes for master now, to hopefully receive wider testing and detect potential issues. Testing has looked promising so far however.

- Remove "I can receive direct connections" option, which made Nicotine+ only initialize indirect connections to other peers. Instead, we always attempt a direct connection to the peer first, and fall back to indirect ones in case of failure.
- Don't create multiple PeerConnection objects for a single user, if we attempt to send multiple messages before the connection has been established. Instead, add subsequent messages to the existing connection object.

Closes https://github.com/Nicotine-Plus/nicotine-plus/issues/663