### PR TITLE
Minor connection improvements

### DIFF
--- a/pynicotine/gtkgui/userbrowse.py
+++ b/pynicotine/gtkgui/userbrowse.py
@@ -923,7 +923,6 @@ class UserBrowse:
     def on_close(self, widget):
 
         del self.userbrowses.users[self.user]
-        self.frame.np.close_peer_connection(self.conn)
 
         self.userbrowses.remove_page(self.Main)
         self.Main.destroy()

--- a/pynicotine/gtkgui/userinfo.py
+++ b/pynicotine/gtkgui/userinfo.py
@@ -428,7 +428,6 @@ class UserInfo:
     def on_close(self, widget):
 
         del self.userinfos.users[self.user]
-        self.frame.np.close_peer_connection(self.conn)
 
         self.userinfos.remove_page(self.Main)
         self.Main.destroy()

--- a/pynicotine/slskmessages.py
+++ b/pynicotine/slskmessages.py
@@ -83,7 +83,13 @@ class IncConn(Conn):
 
 class ConnClose(Conn):
     """ Sent by networking thread to indicate a connection has been closed."""
-    pass
+
+    __slots__ = "conn", "addr", "callback"
+
+    def __init__(self, conn=None, addr=None, callback=True):
+        self.conn = conn
+        self.addr = addr
+        self.callback = callback
 
 
 class ServerConn(OutConn):

--- a/pynicotine/slskproto.py
+++ b/pynicotine/slskproto.py
@@ -1002,7 +1002,9 @@ class SlskProtoThread(threading.Thread):
                             server_socket.close()
 
                 elif msg_obj.__class__ is ConnClose and msg_obj.conn in conns:
-                    self._ui_callback([ConnClose(msg_obj.conn, conns[msg_obj.conn].addr)])
+                    if msg_obj.callback:
+                        self._ui_callback([ConnClose(msg_obj.conn, conns[msg_obj.conn].addr)])
+
                     self.close_connection(conns, msg_obj.conn)
 
                 elif msg_obj.__class__ is OutConn:

--- a/pynicotine/transfers.py
+++ b/pynicotine/transfers.py
@@ -1958,6 +1958,7 @@ class Transfers:
             self.eventprocessor.send_message_to_peer(transfer.user, slskmessages.QueueFailed(None, file=transfer.filename, reason=reason))
 
         if transfer.conn is not None:
+            self.queue.put(slskmessages.ConnClose(transfer.conn))
             transfer.conn = None
 
         if transfer.transfertimer is not None:


### PR DESCRIPTION
- When searching files, avoid closing peer connections if a file connection is in progress for the same user
- Let peer connections time out instead of forcibly closing them when closing user browse/info tabs
- In cases where we remove a connection on the UI side, and also request the network thread to remove the connection, there's no need for the network thread to call back to the UI again
- Performance improvement for detecting parent connections