### PR TITLE
Only display tab status text when option is enabled

### DIFF
--- a/pynicotine/gtkgui/frame.py
+++ b/pynicotine/gtkgui/frame.py
@@ -2379,6 +2379,7 @@ class NicotineFrame:
             w.set_tab_closers(config["ui"]["tabclosers"])
             w.set_reorderable(config["ui"]["tab_reorderable"])
             w.show_hilite_images(config["notifications"]["notification_tab_icons"])
+            w.show_status_images(config["ui"]["tab_status_icons"])
             w.set_text_colors(None)
 
         # Main notebook

--- a/pynicotine/gtkgui/privatechat.py
+++ b/pynicotine/gtkgui/privatechat.py
@@ -145,7 +145,13 @@ class PrivateChats(IconNotebook):
         if user not in self.users:
             tab = PrivateChat(self, user)
             self.users[user] = tab
-            self.append_page(tab.Main, user, tab.on_close)
+
+            if not self.frame.np.config.sections["ui"]["tab_status_icons"]:
+                userlabel = "%s (%s)" % (user[:15], _("Offline"))
+            else:
+                userlabel = user
+
+            self.append_page(tab.Main, userlabel, tab.on_close)
             self.frame.np.queue.put(slskmessages.AddUser(user))
 
         if show_user:
@@ -304,10 +310,16 @@ class PrivateChats(IconNotebook):
     def conn_close(self):
 
         self.connected = 0
+
         for user in self.users:
             self.users[user].conn_close()
             tab = self.users[user]
-            self.set_text(tab.Main, "%s (%s)" % (user[:15], _("Offline")))
+
+            if not self.frame.np.config.sections["ui"]["tab_status_icons"]:
+                self.set_text(tab.Main, "%s (%s)" % (user[:15], _("Offline")))
+            else:
+                self.set_text(tab.Main, user)
+
             self.set_status_image(tab.Main, 0)
             tab.get_user_status(0)
 

--- a/pynicotine/gtkgui/userinfo.py
+++ b/pynicotine/gtkgui/userinfo.py
@@ -72,7 +72,13 @@ class UserTabs(IconNotebook):
     def init_window(self, user):
 
         w = self.users[user] = self.subwindow(self, user)
-        self.append_page(w.Main, user[:15], w.on_close)
+
+        if not self.frame.np.config.sections["ui"]["tab_status_icons"]:
+            userlabel = "%s (%s)" % (user[:15], _("Offline"))
+        else:
+            userlabel = user
+
+        self.append_page(w.Main, userlabel, w.on_close)
         self.frame.np.queue.put(slskmessages.AddUser(user))
 
     def show_user(self, user, conn=None, msg=None):
@@ -194,8 +200,13 @@ class UserTabs(IconNotebook):
         for user in self.users:
             tab = self.users[user]
             tab.status = 0
-            status = _("Offline")
-            self.set_text(tab.Main, "%s (%s)" % (user[:15], status))
+
+            if not self.frame.np.config.sections["ui"]["tab_status_icons"]:
+                self.set_text(tab.Main, "%s (%s)" % (user[:15], _("Offline")))
+            else:
+                self.set_text(tab.Main, user)
+
+            self.set_status_image(tab.Main, 0)
 
 
 class UserInfo:

--- a/pynicotine/gtkgui/utils.py
+++ b/pynicotine/gtkgui/utils.py
@@ -859,6 +859,10 @@ class IconNotebook:
 
             tab_label.show_hilite_image(self._show_hilite_image)
 
+    def show_status_images(self, show_image=True):
+
+        self._show_status_image = show_image
+
     def set_tab_angle(self, angle):
 
         if angle == self.angle:


### PR DESCRIPTION
When disconnecting from the server, tabs would display status text even though the option was disabled.