### PR TITLE
Stricter type checking for config items

### DIFF
--- a/pynicotine/config.py
+++ b/pynicotine/config.py
@@ -72,14 +72,14 @@ class Config:
 
         self.filename = filename
         self.data_dir = data_dir
-        self.parser = configparser.RawConfigParser()
+        self.parser = configparser.RawConfigParser(strict=False)
 
         try:
-            self.parser.read([self.filename], encoding="utf-8")
+            self.parse_config()
 
         except UnicodeDecodeError:
             self.convert_config()
-            self.parser.read([self.filename], encoding="utf-8")
+            self.parse_config()
 
         log_dir = os.path.join(data_dir, "logs")
 
@@ -418,6 +418,16 @@ class Config:
         except Exception:
             self.aliases = {}
 
+    def parse_config(self):
+        """ Parses the config file """
+
+        try:
+            self.parser.read([self.filename], encoding="utf-8")
+
+        except configparser.ParsingError as e:
+            # Ignore parsing errors, the offending lines are removed later
+            pass
+
     def convert_config(self):
         """ Converts the config to utf-8.
         Mainly for upgrading Windows build. (22 July, 2020) """
@@ -641,10 +651,12 @@ class Config:
         self.remove_old_option("server", "firewalled")
 
     def remove_old_option(self, section, option):
+
         if section in self.parser.sections() and option in self.parser.options(section):
             self.parser.remove_option(section, option)
 
     def remove_old_section(self, section):
+
         if section in self.parser.sections():
             self.parser.remove_section(section)
 

--- a/pynicotine/config.py
+++ b/pynicotine/config.py
@@ -424,7 +424,7 @@ class Config:
         try:
             self.parser.read([self.filename], encoding="utf-8")
 
-        except configparser.ParsingError as e:
+        except configparser.ParsingError:
             # Ignore parsing errors, the offending lines are removed later
             pass
 
@@ -536,8 +536,10 @@ class Config:
 
                     try:
                         if not isinstance(default_val, str):
-                            # Values are read as strings, evaluate them
+                            # Values are always read as strings, evaluate them if they aren't
+                            # supposed to remain as strings
                             eval_val = literal_eval(val)
+
                         else:
                             eval_val = val
 
@@ -545,7 +547,7 @@ class Config:
                             if (isinstance(default_val, bool) and isinstance(eval_val, int) and eval_val != 0 and eval_val != 1) or \
                                     (not isinstance(default_val, bool) and type(eval_val) != type(default_val)):
 
-                                raise Exception("Invalid config value type detected")
+                                raise TypeError("Invalid config value type detected")
 
                         self.sections[i][j] = eval_val
 
@@ -553,10 +555,10 @@ class Config:
                         # Value was unexpected, reset option
                         self.sections[i][j] = default_val
 
-                        log.add_warning("CONFIG ERROR: Couldn't decode '%s' section '%s' value '%s', value has been reset", (
-                            str((i[:120] + '..') if len(i) > 120 else i),
-                            str((j[:120] + '..') if len(j) > 120 else j),
-                            str((val[:120] + '..') if len(val) > 120 else val)
+                        log.add_warning("Config error: Couldn't decode '%s' section '%s' value '%s', value has been reset", (
+                            (i[:120] + '..') if len(i) > 120 else i,
+                            (j[:120] + '..') if len(j) > 120 else j,
+                            (val[:120] + '..') if len(val) > 120 else val
                         )
                         )
 

--- a/pynicotine/gtkgui/frame.py
+++ b/pynicotine/gtkgui/frame.py
@@ -384,17 +384,13 @@ class NicotineFrame:
 
         """ Connect """
 
-        config_unset = self.np.config.need_config()
-        if config_unset:
-            if config_unset > 1:
-                self.connect_action.set_enabled(False)
-                self.rescan_public_action.set_enabled(True)
+        if self.np.config.need_config():
+            self.connect_action.set_enabled(False)
+            self.rescan_public_action.set_enabled(True)
 
-                # Set up fast configure dialog
-                self.on_fast_configure(show=False)
-            else:
-                # Connect anyway
-                self.on_connect(getmessage=False)
+            # Set up fast configure dialog
+            self.on_fast_configure()
+
         else:
             self.on_connect(getmessage=False)
 
@@ -838,6 +834,7 @@ class NicotineFrame:
                 self.np.queue.get(0)
 
         self.set_user_status("...")
+
         server = self.np.config.sections["server"]["server"]
         self.set_status_text(_("Connecting to %(host)s:%(port)s"), {'host': server[0], 'port': server[1]})
         self.np.queue.put(slskmessages.ServerConn(None, server))
@@ -2469,12 +2466,12 @@ class NicotineFrame:
             if self.np.config.sections["transfers"]["enablebuddyshares"]:
                 self.on_buddy_rescan()
 
-        config_unset = self.np.config.need_config()
-
-        if config_unset > 1:
+        if self.np.config.need_config():
             if self.np.transfers is not None:
                 self.connect_action.set_enabled(False)
+
             self.on_fast_configure()
+
         else:
             if self.np.transfers is None:
                 self.connect_action.set_enabled(True)

--- a/pynicotine/pynicotine.py
+++ b/pynicotine/pynicotine.py
@@ -874,7 +874,7 @@ class NetworkEventProcessor:
         self.set_status(_("The server seems to be down or not responding, retrying in %i seconds"), (self.server_timeout_value))
 
     def server_timeout(self):
-        if self.config.need_config() <= 1:
+        if not self.config.need_config():
             self.network_callback([slskmessages.ConnectToServer()])
 
     def stop_timers(self):

--- a/pynicotine/pynicotine.py
+++ b/pynicotine/pynicotine.py
@@ -115,7 +115,7 @@ class NetworkEventProcessor:
             corruptfile = ".".join([config, clean_file(time.strftime("%Y-%m-%d_%H_%M_%S")), "corrupt"])
             shutil.move(config, corruptfile)
             short = _("Your config file is corrupt")
-            long = _("We're sorry, but it seems your configuration file is corrupt. Please reconfigure Nicotine+.\n\nWe renamed your old configuration file to\n%(corrupt)s\nIf you open this file with a text editor you might be able to rescue some of your settings."), {'corrupt': corruptfile}
+            long = _("We're sorry, but it seems your configuration file is corrupt. Please reconfigure Nicotine+.\n\nWe renamed your old configuration file to\n%(corrupt)s\nIf you open this file with a text editor you might be able to rescue some of your settings.") % {'corrupt': corruptfile}
             self.config = Config(config, data_dir)
             self.network_callback([slskmessages.PopupMessage(short, long)])
 

--- a/pynicotine/utils.py
+++ b/pynicotine/utils.py
@@ -336,8 +336,12 @@ def unescape(string):
 
     string = string.encode('latin-1', 'backslashreplace').decode('unicode-escape')
 
-    if (string[0] == string[-1]) and string.startswith(("'", '"')):
-        return string[1:-1]
+    try:
+        if (string[0] == string[-1]) and string.startswith(("'", '"')):
+            return string[1:-1]
+    except IndexError:
+        pass
+
     return string
 
 


### PR DESCRIPTION
Adds stricter, less hard-coded checks for config file values, to make it harder for someone to break Nicotine+ by messing with the config file. If the type of a custom value differs from the default one, the value is reverted.