### PR TITLE
Replace old keyboard shortcuts with non-conflicting ones

### DIFF
--- a/pynicotine/gtkgui/ui/menus/menubar.ui
+++ b/pynicotine/gtkgui/ui/menus/menubar.ui
@@ -7,19 +7,19 @@
         <item>
           <attribute name="label" translatable="yes">_Connect</attribute>
           <attribute name="action">app.connect</attribute>
-          <attribute name="accel">&lt;Alt&gt;c</attribute>
+          <attribute name="accel">&lt;Shift&gt;&lt;Primary&gt;c</attribute>
         </item>
         <item>
           <attribute name="label" translatable="yes">_Disconnect</attribute>
           <attribute name="action">app.disconnect</attribute>
-          <attribute name="accel">&lt;Alt&gt;d</attribute>
+          <attribute name="accel">&lt;Shift&gt;&lt;Primary&gt;d</attribute>
         </item>
       </section>
       <section>
         <item>
           <attribute name="label" translatable="yes">_Away</attribute>
           <attribute name="action">app.away</attribute>
-          <attribute name="accel">&lt;Alt&gt;a</attribute>
+          <attribute name="accel">&lt;Primary&gt;h</attribute>
         </item>
       </section>
       <section>
@@ -40,7 +40,7 @@
         <item>
           <attribute name="label" translatable="yes">_Preferences</attribute>
           <attribute name="action">app.settings</attribute>
-          <attribute name="accel">&lt;Alt&gt;s</attribute>
+          <attribute name="accel">&lt;Primary&gt;p</attribute>
         </item>
       </section>
       <section>
@@ -57,7 +57,7 @@
         <item>
           <attribute name="label" translatable="yes">Show _log window</attribute>
           <attribute name="action">win.showlog</attribute>
-          <attribute name="accel">&lt;Alt&gt;l</attribute>
+          <attribute name="accel">&lt;Primary&gt;l</attribute>
         </item>
         <item>
           <attribute name="label" translatable="yes">Show _debug output controls</attribute>
@@ -68,17 +68,17 @@
         <item>
           <attribute name="label" translatable="yes">Show _room list</attribute>
           <attribute name="action">win.showroomlist</attribute>
-          <attribute name="accel">&lt;Alt&gt;r</attribute>
+          <attribute name="accel">&lt;Primary&gt;r</attribute>
         </item>
         <item>
           <attribute name="label" translatable="yes">Show _flag columns in user lists</attribute>
           <attribute name="action">win.showflags</attribute>
-          <attribute name="accel">&lt;Alt&gt;g</attribute>
+          <attribute name="accel">&lt;Primary&gt;u</attribute>
         </item>
         <item>
           <attribute name="label" translatable="yes">Show _buttons in transfer tabs</attribute>
           <attribute name="action">win.showtransferbuttons</attribute>
-          <attribute name="accel">&lt;Alt&gt;b</attribute>
+          <attribute name="accel">&lt;Primary&gt;b</attribute>
         </item>
       </section>
       <section>
@@ -116,10 +116,12 @@
         <item>
           <attribute name="label" translatable="yes">_Rescan Public shares</attribute>
           <attribute name="action">app.publicrescan</attribute>
+          <attribute name="accel">&lt;Shift&gt;&lt;Primary&gt;p</attribute>
         </item>
         <item>
           <attribute name="label" translatable="yes">Rescan B_uddy shares</attribute>
           <attribute name="action">app.buddyrescan</attribute>
+          <attribute name="accel">&lt;Shift&gt;&lt;Primary&gt;b</attribute>
         </item>
       </section>
       <section>


### PR DESCRIPTION
`Alt` should not be used in shortcuts, otherwise conflicts with accelerator keys will most likely occur. In Nicotine+, an example of this is the Alt+S shortcut for the preferences window, which currently opens the Shares menu instead.

I've tried to choose shortcuts that aren't reserved by the system or have a different meaning in a majority of other programs. Here's the list:

- Shift+Ctrl+C: connect
- Shift+Ctrl+D: disconnect
- Ctrl+H: away
- Ctrl+P: preferences
- Ctrl+Q: quit

- Ctrl+L: show log window
- Ctrl+R: show room list
- Ctrl+U: show flag columns in user lists
- Ctrl+B: show buttons in transfer tabs

- Shift+Ctrl+P: rescan public shares
- Shift+Ctrl+B: rescan buddy shares