### PR TITLE
Automatically open user tab when requesting info/share

### DIFF
--- a/pynicotine/gtkgui/downloads.py
+++ b/pynicotine/gtkgui/downloads.py
@@ -43,10 +43,10 @@ from pynicotine.gtkgui.utils import set_treeview_selected_row
 
 class Downloads(TransferList):
 
-    def __init__(self, frame, tab):
+    def __init__(self, frame, tab_label):
 
         TransferList.__init__(self, frame, frame.DownloadList, type='download')
-        self.tab = tab
+        self.tab_label = tab_label
 
         self.popup_menu_users = PopupMenu(self.frame, False)
         self.popup_menu_clear = popup2 = PopupMenu(self.frame, False)

--- a/pynicotine/gtkgui/frame.py
+++ b/pynicotine/gtkgui/frame.py
@@ -87,7 +87,7 @@ class NicotineFrame:
         self.clip = Gtk.Clipboard.get(Gdk.SELECTION_CLIPBOARD)
         self.clip_data = ""
         self.data_dir = data_dir
-        self.current_tab = 0
+        self.current_tab_label = None
         self.checking_update = False
         self.rescanning = False
         self.brescanning = False
@@ -284,11 +284,11 @@ class NicotineFrame:
         self.sPrivateChatButton.connect("clicked", self.on_get_private_chat)
         self.UserPrivateCombo.get_child().connect("activate", self.on_get_private_chat)
 
-        self.userinfo = UserTabs(self, UserInfo, self.UserInfoNotebookRaw, self.UserInfoTabLabel)
+        self.userinfo = UserTabs(self, UserInfo, self.UserInfoNotebookRaw, self.UserInfoTabLabel, "userinfo")
         self.sUserinfoButton.connect("clicked", self.on_get_user_info)
         self.UserInfoCombo.get_child().connect("activate", self.on_get_user_info)
 
-        self.userbrowse = UserTabs(self, UserBrowse, self.UserBrowseNotebookRaw, self.UserBrowseTabLabel)
+        self.userbrowse = UserTabs(self, UserBrowse, self.UserBrowseNotebookRaw, self.UserBrowseTabLabel, "userbrowse")
         self.sSharesButton.connect("clicked", self.on_get_shares)
         self.UserBrowseCombo.get_child().connect("activate", self.on_get_shares)
 
@@ -633,20 +633,20 @@ class NicotineFrame:
         self.UserBrowseCombo.set_sensitive(status)
         self.sSharesButton.set_sensitive(status)
 
-        if self.current_tab == self.UserBrowseTabLabel:
+        if self.current_tab_label == self.UserBrowseTabLabel:
             GLib.idle_add(self.UserBrowseCombo.get_child().grab_focus)
 
         self.UserInfoCombo.set_sensitive(status)
         self.sUserinfoButton.set_sensitive(status)
 
-        if self.current_tab == self.UserInfoTabLabel:
+        if self.current_tab_label == self.UserInfoTabLabel:
             GLib.idle_add(self.UserInfoCombo.get_child().grab_focus)
 
         self.UserSearchCombo.set_sensitive(status)
         self.SearchEntryCombo.set_sensitive(status)
         self.SearchButton.set_sensitive(status)
 
-        if self.current_tab == self.SearchTabLabel:
+        if self.current_tab_label == self.SearchTabLabel:
             GLib.idle_add(self.search_entry.grab_focus)
 
         self.interests.SimilarUsersButton.set_sensitive(status)
@@ -1279,7 +1279,7 @@ class NicotineFrame:
 
     def request_tab_icon(self, tab_label, status=1):
 
-        if self.current_tab == tab_label:
+        if self.current_tab_label == tab_label:
             return
 
         icon_tab_label = self.get_tab_label(tab_label)
@@ -1306,7 +1306,7 @@ class NicotineFrame:
 
         tab_label = self.MainNotebook.get_tab_label(page)
         icon_tab_label = self.get_tab_label(tab_label)
-        self.current_tab = tab_label
+        self.current_tab_label = tab_label
 
         if icon_tab_label is not None:
             # Defaults
@@ -1430,12 +1430,18 @@ class NicotineFrame:
 
                 if 0 <= lasttabid <= self.MainNotebook.get_n_pages():
                     self.MainNotebook.set_current_page(lasttabid)
+
+                    page = self.MainNotebook.get_nth_page(lasttabid)
+                    self.current_tab_label = self.MainNotebook.get_tab_label(page)
                     return
 
         except Exception:
             pass
 
         self.MainNotebook.set_current_page(0)
+
+        page = self.MainNotebook.get_nth_page(0)
+        self.current_tab_label = self.MainNotebook.get_tab_label(page)
 
     def hide_tab(self, widget, lista):
 

--- a/pynicotine/gtkgui/transferlist.py
+++ b/pynicotine/gtkgui/transferlist.py
@@ -175,7 +175,7 @@ class TransferList:
         self.widget.get_selection().selected_foreach(self.selected_transfers_callback)
 
     def new_transfer_notification(self):
-        self.frame.request_tab_icon(self.tab)
+        self.frame.request_tab_icon(self.tab_label)
 
     def on_ban(self, widget):
         self.select_transfers()
@@ -247,7 +247,7 @@ class TransferList:
             self.last_save = curtime
 
         if not forceupdate:
-            if self.frame.current_tab != self.tab:
+            if self.frame.current_tab_label != self.tab_label:
                 """ No need to do unnecessary work if transfers are not visible """
                 return
 

--- a/pynicotine/gtkgui/uploads.py
+++ b/pynicotine/gtkgui/uploads.py
@@ -41,10 +41,10 @@ from pynicotine.gtkgui.utils import set_treeview_selected_row
 
 class Uploads(TransferList):
 
-    def __init__(self, frame, tab):
+    def __init__(self, frame, tab_label):
 
         TransferList.__init__(self, frame, frame.UploadList, type='upload')
-        self.tab = tab
+        self.tab_label = tab_label
 
         self.popup_menu_users = PopupMenu(self.frame, False)
         self.popup_menu_clear = popup2 = PopupMenu(self.frame, False)

--- a/pynicotine/gtkgui/userbrowse.py
+++ b/pynicotine/gtkgui/userbrowse.py
@@ -577,6 +577,11 @@ class UserBrowse:
 
         self.progressbar1.set_fraction(fraction)
 
+        if fraction == 1.0:
+            # Tab notification
+            self.frame.request_tab_icon(self.frame.UserBrowseTabLabel)
+            self.userbrowses.request_changed(self.Main)
+
     def on_select_dir(self, selection):
 
         model, iterator = selection.get_selected()

--- a/pynicotine/gtkgui/userinfo.py
+++ b/pynicotine/gtkgui/userinfo.py
@@ -45,7 +45,7 @@ from pynicotine.logfacility import log
 # User Info and User Browse Notebooks
 class UserTabs(IconNotebook):
 
-    def __init__(self, frame, subwindow, notebookraw, tab):
+    def __init__(self, frame, subwindow, notebookraw, tab_label, tab_name):
 
         self.frame = frame
 
@@ -67,7 +67,8 @@ class UserTabs(IconNotebook):
         self.subwindow = subwindow
 
         self.users = {}
-        self.tab = tab
+        self.tab_label = tab_label
+        self.tab_name = tab_name
 
     def init_window(self, user):
 
@@ -89,13 +90,9 @@ class UserTabs(IconNotebook):
             self.init_window(user)
 
         self.users[user].show_user(msg)
-        self.request_changed(self.users[user].Main)
 
-        if self.tab is not None:
-            self.frame.request_tab_icon(self.tab)
-
-        tab_name = self.frame.match_main_notebox(self.tab)
-        self.frame.change_main_page(tab_name)
+        self.set_current_page(self.page_num(self.users[user].Main))
+        self.frame.change_main_page(self.tab_name)
 
     def show_connection_error(self, user):
         self.users[user].show_connection_error()


### PR DESCRIPTION
It seems like this was the intention from the beginning, but never worked/stopped working. Also fixes an issue where self.current_tab wouldn't point at a tab label until changing tabs, which made hilite icons appear on notebook tabs when not supposed to.

Closes https://github.com/Nicotine-Plus/nicotine-plus/issues/651