### PR TITLE
Parse local shares list in a new thread

### DIFF
--- a/pynicotine/gtkgui/userbrowse.py
+++ b/pynicotine/gtkgui/userbrowse.py
@@ -541,7 +541,9 @@ class UserBrowse:
         self.frame.np.config.sections["columns"]["userbrowse"] = columns
         self.frame.np.config.sections["columns"]["userbrowse_widths"] = widths
 
-    def show_user(self, msg):
+    def show_user(self, msg, indeterminate_progress=False):
+
+        self.set_in_progress(indeterminate_progress)
 
         if msg is None:
             return
@@ -557,14 +559,36 @@ class UserBrowse:
         else:
             self.InfoBar.set_revealed(False)
 
+        self.set_finished()
+
     def show_connection_error(self):
 
         InfoBar(self.InfoBar, Gtk.MessageType.INFO).show_message(
             _("Unable to request shared files from user. Either the user is offline, you both have a closed listening port, or there's a temporary connectivity issue.")
         )
 
+        self.set_finished()
+
     def load_shares(self, list):
         self.make_new_model(list)
+
+    def set_in_progress(self, indeterminate_progress):
+
+        if not indeterminate_progress:
+            self.progressbar1.set_fraction(0.0)
+        else:
+            self.progressbar1.set_fraction(0.5)
+
+        self.RefreshButton.set_sensitive(False)
+
+    def set_finished(self):
+
+        # Tab notification
+        self.frame.request_tab_icon(self.frame.UserBrowseTabLabel)
+        self.userbrowses.request_changed(self.Main)
+
+        self.progressbar1.set_fraction(1.0)
+        self.RefreshButton.set_sensitive(True)
 
     def update_gauge(self, msg):
 
@@ -576,11 +600,6 @@ class UserBrowse:
             fraction = float(msg.bytes) / msg.total
 
         self.progressbar1.set_fraction(fraction)
-
-        if fraction == 1.0:
-            # Tab notification
-            self.frame.request_tab_icon(self.frame.UserBrowseTabLabel)
-            self.userbrowses.request_changed(self.Main)
 
     def on_select_dir(self, selection):
 

--- a/pynicotine/gtkgui/userinfo.py
+++ b/pynicotine/gtkgui/userinfo.py
@@ -82,17 +82,18 @@ class UserTabs(IconNotebook):
         self.append_page(w.Main, userlabel, w.on_close)
         self.frame.np.queue.put(slskmessages.AddUser(user))
 
-    def show_user(self, user, conn=None, msg=None):
+    def show_user(self, user, conn=None, msg=None, indeterminate_progress=False, change_page=True):
 
         if user in self.users:
             self.users[user].conn = conn
         else:
             self.init_window(user)
 
-        self.users[user].show_user(msg)
+        self.users[user].show_user(msg, indeterminate_progress)
 
-        self.set_current_page(self.page_num(self.users[user].Main))
-        self.frame.change_main_page(self.tab_name)
+        if change_page:
+            self.set_current_page(self.page_num(self.users[user].Main))
+            self.frame.change_main_page(self.tab_name)
 
     def show_connection_error(self, user):
         self.users[user].show_connection_error()

--- a/pynicotine/pynicotine.py
+++ b/pynicotine/pynicotine.py
@@ -1444,7 +1444,8 @@ class NetworkEventProcessor:
             if i.conn is conn and self.userinfo is not None:
                 # probably impossible to do this
                 if i.username != self.config.sections["server"]["login"]:
-                    self.userinfo.show_user(i.username, msg.conn, msg)
+                    indeterminate_progress = change_page = False
+                    self.userinfo.show_user(i.username, msg.conn, msg, indeterminate_progress, change_page)
                     break
 
     def user_info_request(self, msg):
@@ -1540,7 +1541,8 @@ class NetworkEventProcessor:
         for i in self.peerconns:
             if i.conn is conn and self.userbrowse is not None:
                 if i.username != self.config.sections["server"]["login"]:
-                    self.userbrowse.show_user(i.username, msg.conn, msg)
+                    indeterminate_progress = change_page = False
+                    self.userbrowse.show_user(i.username, msg.conn, msg, indeterminate_progress, change_page)
                     break
 
     def file_search_result(self, msg):
@@ -1709,6 +1711,7 @@ class NetworkEventProcessor:
         if checkuser == 1:
             # Send Normal Shares
             if self.shares.newnormalshares:
+                self.shares.create_compressed_shares_message("normal")
                 self.shares.compress_shares("normal")
                 self.shares.newnormalshares = False
             m = self.shares.compressed_shares_normal
@@ -1716,6 +1719,7 @@ class NetworkEventProcessor:
         elif checkuser == 2:
             # Send Buddy Shares
             if self.shares.newbuddyshares:
+                self.shares.create_compressed_shares_message("buddy")
                 self.shares.compress_shares("buddy")
                 self.shares.newbuddyshares = False
             m = self.shares.compressed_shares_buddy


### PR DESCRIPTION
- When browsing our own shared files, parse the file list in a new thread instead of blocking the UI
- Parse our pre-built, compressed share list instead of rebuilding it, to save memory and speed up the process a bit
- On startup, immediately create the message for holding our compressed shares list, otherwise browsing our shares could trigger an exception between the time the program has started and the shares list has been fully compressed