### PR TITLE
Explicitly hide tray icon before exiting Nicotine+

### DIFF
--- a/pynicotine/gtkgui/frame.py
+++ b/pynicotine/gtkgui/frame.py
@@ -2541,6 +2541,9 @@ class NicotineFrame:
         self.np.protothread.abort()
         self.np.stop_timers()
 
+        # Explicitly hide tray icon, otherwise it will not disappear on Windows
+        self.tray.hide()
+
         if not self.np.manualdisconnect:
             self.on_disconnect(None)
 

--- a/pynicotine/gtkgui/tray.py
+++ b/pynicotine/gtkgui/tray.py
@@ -252,6 +252,7 @@ class Tray:
             else:
                 # GtkStatusIcon fallback
                 trayicon = self.gtk.StatusIcon()
+                trayicon.set_tooltip_text("Nicotine+")
                 trayicon.connect("activate", self.on_hide_unhide_window)
                 trayicon.connect("popup-menu", self.on_status_icon_popup)
 


### PR DESCRIPTION
On Windows, it seems like the tray icon doesn't disappear until you move the cursor over the tray area. Hiding the tray icon before quitting Nicotine+ fixes this.