### PR TITLE
Properly check if socket has data available

### DIFF
--- a/pynicotine/slskproto.py
+++ b/pynicotine/slskproto.py
@@ -1280,7 +1280,8 @@ class SlskProtoThread(threading.Thread):
 
                 try:
                     if connection_in_progress in input_list:
-                        connection_in_progress.recv(0)
+                        # Check if the socket has any data for us
+                        connection_in_progress.recv(1, socket.MSG_PEEK)
 
                 except socket.error as err:
 


### PR DESCRIPTION
I'm quite sure this code was originally supposed to check if a socket has any data available. However, the code essentially did nothing due to reading 0 bytes, letting firewalled connections through, and skipping any attempts of initializing indirect connections in the process (leading to "Cannot connect" errors for uploads, even though your port is open).

Actually attempting to read some data from the socket, and not consuming the data yet (MSG_PEEK), seems to have the intended effect.