### PR TITLE
UPnP: minor corrections 

### DIFF
--- a/pynicotine/gtkgui/fastconfigure.py
+++ b/pynicotine/gtkgui/fastconfigure.py
@@ -176,7 +176,6 @@ class FastConfigureAssistant(object):
             self.lowerport.get_value_as_int(),
             self.upperport.get_value_as_int()
         )
-        self.config.sections['server']['firewalled'] = not self.portopen.get_active()
 
         # sharepage
         self.config.sections['transfers']['downloaddir'] = self.downloaddir.get_file().get_path()

--- a/pynicotine/gtkgui/fastconfigure.py
+++ b/pynicotine/gtkgui/fastconfigure.py
@@ -125,13 +125,6 @@ class FastConfigureAssistant(object):
             self.config.sections["server"]["passw"]
         )
 
-        self.lowerport.set_value(
-            self.config.sections["server"]["portrange"][0]
-        )
-        self.upperport.set_value(
-            self.config.sections["server"]["portrange"][1]
-        )
-
         # sharepage
         if self.config.sections['transfers']['downloaddir']:
             self.downloaddir.set_current_folder(
@@ -170,12 +163,6 @@ class FastConfigureAssistant(object):
         # userpasspage
         self.config.sections["server"]["login"] = self.username.get_text()
         self.config.sections["server"]["passw"] = self.password.get_text()
-
-        # portpage
-        self.config.sections['server']['portrange'] = (
-            self.lowerport.get_value_as_int(),
-            self.upperport.get_value_as_int()
-        )
 
         # sharepage
         self.config.sections['transfers']['downloaddir'] = self.downloaddir.get_file().get_path()
@@ -473,28 +460,5 @@ class FastConfigureAssistant(object):
 
         if self.initphase:
             return
-
-        self.resetcompleteness()
-
-    def on_spinbutton_change_value(self, widget, scrolltype):
-
-        if self.initphase:
-            return
-
-        self.resetcompleteness()
-
-    def on_spinbutton_value_changed(self, widget):
-
-        if self.initphase:
-            return
-
-        name = Gtk.Buildable.get_name(widget)
-
-        if name == "lowerport":
-            if widget.get_value() > self.upperport.get_value():
-                self.upperport.set_value(widget.get_value())
-        if name == "upperport":
-            if widget.get_value() < self.lowerport.get_value():
-                self.lowerport.set_value(widget.get_value())
 
         self.resetcompleteness()

--- a/pynicotine/gtkgui/ui/fastconfigure.ui
+++ b/pynicotine/gtkgui/ui/fastconfigure.ui
@@ -1,16 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <interface>
   <requires lib="gtk+" version="3.18"/>
-  <object class="GtkAdjustment" id="lowerportadjuster">
-    <property name="upper">65535</property>
-    <property name="step_increment">1</property>
-    <property name="page_increment">100</property>
-  </object>
-  <object class="GtkAdjustment" id="upperportadjuster">
-    <property name="upper">65535</property>
-    <property name="step_increment">1</property>
-    <property name="page_increment">100</property>
-  </object>
   <object class="GtkAssistant" id="FastConfigureAssistant">
     <property name="can_focus">False</property>
     <property name="modal">True</property>
@@ -55,11 +45,7 @@
             <property name="can_focus">False</property>
             <property name="halign">center</property>
             <property name="valign">center</property>
-            <property name="margin_start">5</property>
-            <property name="margin_end">5</property>
-            <property name="margin_top">5</property>
-            <property name="margin_bottom">5</property>
-            <property name="label" translatable="yes">In order to start, you need to fill in a few details. Press "Next" to start configuring Nicotine+.</property>
+            <property name="label" translatable="yes">Nicotine+ is a graphical client for the Soulseek peer-to-peer file sharing network.</property>
             <property name="justify">center</property>
             <property name="wrap">True</property>
             <property name="width_chars">60</property>
@@ -69,6 +55,24 @@
             <property name="expand">False</property>
             <property name="fill">True</property>
             <property name="position">1</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkLabel">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <property name="halign">center</property>
+            <property name="valign">center</property>
+            <property name="label" translatable="yes">Press "Next" to start configuring Nicotine+.</property>
+            <property name="justify">center</property>
+            <property name="wrap">True</property>
+            <property name="width_chars">60</property>
+            <property name="max_width_chars">60</property>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">2</property>
           </packing>
         </child>
       </object>
@@ -93,9 +97,9 @@
           <object class="GtkLabel">
             <property name="visible">True</property>
             <property name="can_focus">False</property>
-            <property name="label" translatable="yes">To create a new user, fill in the username and password you want. If you already have an account at the server, fill in those details.
+            <property name="label" translatable="yes">To create a new user, fill in the username and password you want. If you already have a Soulseek account, fill in your chosen details.
 
-Please keep in mind that more common usernames may be taken. If you're unable to connect later, change your username in the settings.</property>
+Please keep in mind that more common usernames may be taken. If you're unable to connect, you can change your username in the preferences later.</property>
             <property name="justify">center</property>
             <property name="wrap">True</property>
             <property name="width_chars">60</property>
@@ -242,7 +246,7 @@ Please keep in mind that more common usernames may be taken. If you're unable to
               <object class="GtkLabel">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
-                <property name="label" translatable="yes">The Nicotine+ port is called open when other people can connect to your computer without being blocked by your firewall or router. An open port is crucial to prevent connection trouble.</property>
+                <property name="label" translatable="yes">Nicotine+ uses peer-to-peer networking to connect to other users. An open listening port is crucial to allow users to connect to you without trouble.</property>
                 <property name="justify">center</property>
                 <property name="wrap">True</property>
                 <property name="width_chars">60</property>
@@ -252,6 +256,38 @@ Please keep in mind that more common usernames may be taken. If you're unable to
                 <property name="expand">True</property>
                 <property name="fill">True</property>
                 <property name="position">0</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkLabel">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="label" translatable="yes">The default listening port should work fine in most cases. If you need to use a different port, you can change it in the preferences later.</property>
+                <property name="justify">center</property>
+                <property name="wrap">True</property>
+                <property name="width_chars">60</property>
+                <property name="max_width_chars">60</property>
+              </object>
+              <packing>
+                <property name="expand">True</property>
+                <property name="fill">True</property>
+                <property name="position">1</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkLabel">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="label" translatable="yes">Nicotine+ will still work to some degree if your port is closed. However, do keep in mind that you won't be able to connect to users whose port is also closed.</property>
+                <property name="justify">center</property>
+                <property name="wrap">True</property>
+                <property name="width_chars">60</property>
+                <property name="max_width_chars">60</property>
+              </object>
+              <packing>
+                <property name="expand">True</property>
+                <property name="fill">True</property>
+                <property name="position">2</property>
               </packing>
             </child>
             <child>
@@ -266,7 +302,7 @@ Please keep in mind that more common usernames may be taken. If you're unable to
               <packing>
                 <property name="expand">True</property>
                 <property name="fill">True</property>
-                <property name="position">1</property>
+                <property name="position">3</property>
               </packing>
             </child>
           </object>
@@ -274,96 +310,6 @@ Please keep in mind that more common usernames may be taken. If you're unable to
             <property name="expand">True</property>
             <property name="fill">True</property>
             <property name="position">0</property>
-          </packing>
-        </child>
-        <child>
-          <object class="GtkSeparator">
-            <property name="visible">True</property>
-            <property name="can_focus">False</property>
-            <property name="margin_top">10</property>
-            <property name="margin_bottom">10</property>
-          </object>
-          <packing>
-            <property name="expand">True</property>
-            <property name="fill">True</property>
-            <property name="position">1</property>
-          </packing>
-        </child>
-        <child>
-          <object class="GtkBox">
-            <property name="visible">True</property>
-            <property name="can_focus">False</property>
-            <property name="spacing">10</property>
-            <child>
-              <object class="GtkLabel">
-                <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="label" translatable="yes">Use the first available port in the range from </property>
-                <property name="xalign">0</property>
-              </object>
-              <packing>
-                <property name="expand">False</property>
-                <property name="fill">False</property>
-                <property name="position">0</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkSpinButton" id="lowerport">
-                <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <property name="max_length">6</property>
-                <property name="invisible_char">●</property>
-                <property name="width_chars">6</property>
-                <property name="primary_icon_activatable">False</property>
-                <property name="secondary_icon_activatable">False</property>
-                <property name="adjustment">lowerportadjuster</property>
-                <property name="numeric">True</property>
-                <signal name="change-value" handler="on_spinbutton_change_value" swapped="no"/>
-                <signal name="value-changed" handler="on_spinbutton_value_changed" swapped="no"/>
-              </object>
-              <packing>
-                <property name="expand">True</property>
-                <property name="fill">True</property>
-                <property name="position">1</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkLabel">
-                <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="label" translatable="yes">to</property>
-              </object>
-              <packing>
-                <property name="expand">False</property>
-                <property name="fill">False</property>
-                <property name="position">2</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkSpinButton" id="upperport">
-                <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <property name="max_length">6</property>
-                <property name="invisible_char">●</property>
-                <property name="width_chars">6</property>
-                <property name="primary_icon_activatable">False</property>
-                <property name="secondary_icon_activatable">False</property>
-                <property name="adjustment">upperportadjuster</property>
-                <property name="numeric">True</property>
-                <signal name="change-value" handler="on_spinbutton_change_value" swapped="no"/>
-                <signal name="value-changed" handler="on_spinbutton_value_changed" swapped="no"/>
-              </object>
-              <packing>
-                <property name="expand">True</property>
-                <property name="fill">True</property>
-                <property name="position">3</property>
-              </packing>
-            </child>
-          </object>
-          <packing>
-            <property name="expand">False</property>
-            <property name="fill">True</property>
-            <property name="position">3</property>
           </packing>
         </child>
       </object>
@@ -387,7 +333,7 @@ Please keep in mind that more common usernames may be taken. If you're unable to
             <property name="visible">True</property>
             <property name="can_focus">False</property>
             <property name="halign">center</property>
-            <property name="label" translatable="yes">Download to the following directory:</property>
+            <property name="label" translatable="yes">Download files to the following directory:</property>
           </object>
           <packing>
             <property name="expand">True</property>
@@ -495,7 +441,7 @@ Please keep in mind that more common usernames may be taken. If you're unable to
             </child>
             <child>
               <object class="GtkCheckButton" id="onlysharewithfriends">
-                <property name="label" translatable="yes">Only share with friends</property>
+                <property name="label" translatable="yes">Only share files with friends</property>
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
                 <property name="receives_default">False</property>
@@ -564,11 +510,11 @@ Please keep in mind that more common usernames may be taken. If you're unable to
           </packing>
         </child>
         <child>
-          <object class="GtkLabel" id="labelclosedport">
+          <object class="GtkLabel" id="labelnoshare">
             <property name="visible">True</property>
             <property name="can_focus">False</property>
             <property name="halign">start</property>
-            <property name="label" translatable="yes">If your port is closed, you will be unable to connect to other users with closed ports. This is inherent to Peer-to-Peer and not specifically a problem of Nicotine+.</property>
+            <property name="label" translatable="yes">You do not publicly share any files. Sharing files is crucial for the health of the Soulseek network, and many people will ban you if you download from them without sharing anything yourself.</property>
             <property name="justify">fill</property>
             <property name="wrap">True</property>
             <property name="width_chars">60</property>
@@ -578,24 +524,6 @@ Please keep in mind that more common usernames may be taken. If you're unable to
             <property name="expand">False</property>
             <property name="fill">False</property>
             <property name="position">2</property>
-          </packing>
-        </child>
-        <child>
-          <object class="GtkLabel" id="labelnoshare">
-            <property name="visible">True</property>
-            <property name="can_focus">False</property>
-            <property name="halign">start</property>
-            <property name="label" translatable="yes">You do not publicly share any files. This in itself is not a problem, but many people will ban you if you're downloading from them for this reason.</property>
-            <property name="use_markup">True</property>
-            <property name="justify">fill</property>
-            <property name="wrap">True</property>
-            <property name="width_chars">60</property>
-            <property name="max_width_chars">60</property>
-          </object>
-          <packing>
-            <property name="expand">False</property>
-            <property name="fill">False</property>
-            <property name="position">3</property>
           </packing>
         </child>
       </object>

--- a/pynicotine/gtkgui/ui/settings/server.ui
+++ b/pynicotine/gtkgui/ui/settings/server.ui
@@ -196,7 +196,7 @@
         <property name="visible">True</property>
         <property name="can_focus">False</property>
         <property name="xalign">0</property>
-        <property name="label" translatable="yes">Use the first available listening port from the following range:</property>
+        <property name="label" translatable="yes">Use the first available listening port from the following range (requires a restart):</property>
       </object>
       <packing>
         <property name="expand">False</property>

--- a/pynicotine/upnp/portmapper.py
+++ b/pynicotine/upnp/portmapper.py
@@ -35,8 +35,7 @@ class UPnPPortMapping:
         # List of existing port mappings
         self.existingportsmappings = []
 
-        # Initial value that determine if a port mapping already exist to the
-        # client
+        # Initial value that determine if a port mapping already exist to the client
         self.foundexistingmapping = False
 
     def add_port_mapping(self, np):
@@ -92,8 +91,7 @@ class UPnPPortMapping:
         router = UPnp.find_router()
 
         if not router:
-            log.add_debug('UPnP does not work on this network')
-            return
+            raise RuntimeError('UPnP does not work on this network')
 
         # Create a UDP socket
         s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
@@ -138,7 +136,8 @@ class UPnPPortMapping:
                 public_port=self.externalwanport,
                 private_ip=self.internalipaddress,
                 private_port=self.internallanport,
-                mapping_description='Nicotine+'
+                mapping_description='Nicotine+',
+                lease_duration=86400  # Expires in 24 hours
             )
 
         except Exception as e:

--- a/pynicotine/upnp/portmapper.py
+++ b/pynicotine/upnp/portmapper.py
@@ -29,15 +29,6 @@ from pynicotine.upnp.upnp import UPnp
 class UPnPPortMapping:
     """ Class that handles UPnP Port Mapping """
 
-    def __init__(self):
-        """ Initialize the UPnP Port Mapping object """
-
-        # List of existing port mappings
-        self.existingportsmappings = []
-
-        # Initial value that determine if a port mapping already exist to the client
-        self.foundexistingmapping = False
-
     def add_port_mapping(self, np):
         """
         This function supports creating a Port Mapping via the UPnP
@@ -80,13 +71,6 @@ class UPnPPortMapping:
 
         log.add_debug('Creating Port Mapping rule via UPnP...')
 
-        # Placeholder LAN IP address, updated in AddPortMappingBinary or AddPortMappingModule
-        self.internalipaddress = "127.0.0.1"
-
-        # Store the Local LAN port
-        self.internallanport = np.protothread._p.getsockname()[1]
-        self.externalwanport = self.internallanport
-
         # Find router
         router = UPnp.find_router()
 
@@ -105,22 +89,9 @@ class UPnPPortMapping:
         # Close the socket
         s.close()
 
-        # Get existing port mappings
-        for i in UPnp.list_port_mappings(router):
-            self.existingportsmappings.append(
-                (
-                    i.public_port,
-                    i.protocol,
-                    (i.private_ip, i.private_port),
-                    i.description,
-                    i.is_enabled,
-                    i.remote_host,
-                    i.lease_duration
-                )
-            )
-
-        # Find a suitable external WAN port to map to based on the existing mappings
-        self.find_suitable_external_wan_port()
+        # Store the Local LAN port
+        self.internallanport = np.protothread._p.getsockname()[1]
+        self.externalwanport = self.internallanport
 
         # Do the port mapping
         log.add_debug('Trying to redirect external WAN port %s TCP => %s port %s TCP', (
@@ -145,38 +116,3 @@ class UPnPPortMapping:
                 _('Failed to map the external WAN port: %(error)s') %
                 {'error': str(e)}
             )
-
-    def find_suitable_external_wan_port(self):
-        """ Function to find a suitable external WAN port to map to the client.
-        It will detect if a port mapping to the client already exists. """
-
-        # Analyze ports mappings
-        for m in sorted(self.existingportsmappings):
-
-            e_port, protocol, (int_client, iport), desc, enabled, rhost, duration = m
-
-            # A Port Mapping is already in place with the client: we will
-            # rewrite it to avoid a timeout on the duration of the mapping
-            if protocol == "TCP" and \
-                    str(int_client) == str(self.internalipaddress) and \
-                    str(iport) == str(self.internallanport):
-
-                log.add_debug('Port Mapping already in place: %s', str(m))
-                self.externalwanport = e_port
-                self.foundexistingmapping = True
-                break
-
-        # If no mapping already in place we try to found a suitable external WAN port
-        if not self.foundexistingmapping:
-
-            # Find the first external WAN port > requestedwanport that's not already reserved
-            tcpportsreserved = [x[0] for x in sorted(self.existingportsmappings) if x[1] == "TCP"]
-
-            while str(self.externalwanport) in tcpportsreserved:
-                if self.externalwanport + 1 <= 65535:
-                    self.externalwanport += 1
-
-                else:
-                    raise AssertionError(
-                        _('Failed to find a suitable external WAN port, bailing out.')
-                    )

--- a/pynicotine/upnp/ssdp.py
+++ b/pynicotine/upnp/ssdp.py
@@ -88,15 +88,28 @@ class SSDP:
         headers = {
             'HOST': "{}:{}".format(SSDP.multicast_host, SSDP.multicast_port),
             'MAN': '"ssdp:discover"',
-            'MX': str(SSDP.response_time_secs),
-            'USER-AGENT': '{}/1.0 UPnP/1.1 Nicotine/1.0'.format(sys.platform)
+            'MX': str(SSDP.response_time_secs)
         }
 
+        # Protocol 1
         wan_ip1_sent = False
         wan_ip1 = SSDP._create_msearch_request('urn:schemas-upnp-org:service:WANIPConnection:1', headers=headers)
 
+        wan_ppp1_sent = False
+        wan_ppp1 = SSDP._create_msearch_request('urn:schemas-upnp-org:service:WANPPPConnection:1', headers=headers)
+
+        wan_igd1_sent = False
+        wan_igd1 = SSDP._create_msearch_request('urn:schemas-upnp-org:device:InternetGatewayDevice:1', headers=headers)
+
+        # Protocol 2
         wan_ip2_sent = False
         wan_ip2 = SSDP._create_msearch_request('urn:schemas-upnp-org:service:WANIPConnection:2', headers=headers)
+
+        wan_ppp2_sent = False
+        wan_ppp2 = SSDP._create_msearch_request('urn:schemas-upnp-org:service:WANPPPConnection:2', headers=headers)
+
+        wan_igd2_sent = False
+        wan_igd2 = SSDP._create_msearch_request('urn:schemas-upnp-org:device:InternetGatewayDevice:2', headers=headers)
 
         inputs = [sock]
         outputs = [sock]
@@ -111,6 +124,8 @@ class SSDP:
             for _sock in readable:
                 msg, sender = _sock.recvfrom(SSDP.buffer_size)
                 response = SSDPResponse.parse(msg.decode())
+                log.add_debug('UPnP: Device search response: %s', bytes(response))
+
                 router = Router.parse_ssdp_response(response, sender)
 
                 if router:
@@ -119,13 +134,39 @@ class SSDP:
             for _sock in writable:
                 if not wan_ip1_sent:
                     wan_ip1.sendto(_sock, (SSDP.multicast_host, SSDP.multicast_port))
+                    log.add_debug('UPnP: Sent M-SEARCH IP request 1')
                     time_end = time.time() + SSDP.response_time_secs
                     wan_ip1_sent = True
 
+                if not wan_ppp1_sent:
+                    wan_ppp1.sendto(_sock, (SSDP.multicast_host, SSDP.multicast_port))
+                    log.add_debug('UPnP: Sent M-SEARCH PPP request 1')
+                    time_end = time.time() + SSDP.response_time_secs
+                    wan_ppp1_sent = True
+
+                if not wan_igd1_sent:
+                    wan_igd1.sendto(_sock, (SSDP.multicast_host, SSDP.multicast_port))
+                    log.add_debug('UPnP: Sent M-SEARCH IGD request 1')
+                    time_end = time.time() + SSDP.response_time_secs
+                    wan_igd1_sent = True
+
                 if not wan_ip2_sent:
                     wan_ip2.sendto(_sock, (SSDP.multicast_host, SSDP.multicast_port))
+                    log.add_debug('UPnP: Sent M-SEARCH IP request 2')
                     time_end = time.time() + SSDP.response_time_secs
                     wan_ip2_sent = True
+
+                if not wan_ppp2_sent:
+                    wan_ppp2.sendto(_sock, (SSDP.multicast_host, SSDP.multicast_port))
+                    log.add_debug('UPnP: Sent M-SEARCH PPP request 2')
+                    time_end = time.time() + SSDP.response_time_secs
+                    wan_ppp2_sent = True
+
+                if not wan_igd2_sent:
+                    wan_igd2.sendto(_sock, (SSDP.multicast_host, SSDP.multicast_port))
+                    log.add_debug('UPnP: Sent M-SEARCH IGD request 2')
+                    time_end = time.time() + SSDP.response_time_secs
+                    wan_igd2_sent = True
 
             # Cooldown
             time.sleep(0.4)
@@ -262,6 +303,7 @@ class SSDPRequest(SSDPMessage):
     @classmethod
     def parse(cls, msg):
         """ Parse message string to request object """
+
         lines = msg.splitlines()
         method, uri, version = lines[0].split()
         headers = cls.parse_headers('\r\n'.join(lines[1:]))
@@ -278,10 +320,12 @@ class SSDPRequest(SSDPMessage):
                 IP address and port pair to send the message to.
         """
         msg = bytes(self) + b'\r\n'
+        log.add_debug('UPnP: SSDP request: %s', msg)
         transport.sendto(msg, addr)
 
     def __str__(self):
         """ Return complete SSDP request """
+
         lines = list()
         lines.append(' '.join(
             [self.method, self.uri, self.version]

--- a/pynicotine/upnp/ssdp.py
+++ b/pynicotine/upnp/ssdp.py
@@ -27,7 +27,6 @@
 import time
 import select
 import socket
-import sys
 
 from pynicotine.logfacility import log
 from pynicotine.utils import http_request

--- a/pynicotine/upnp/upnp.py
+++ b/pynicotine/upnp/upnp.py
@@ -112,12 +112,12 @@ class PortMapping:
 
 class UPnp:
 
-    _add_port_mapping_template = '<s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/" s:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"><s:Body><u:AddPortMapping xmlns:u="urn:schemas-upnp-org:service:WANIPConnection:1"><NewExternalPort>{}</NewExternalPort><NewProtocol>{}</NewProtocol><NewInternalPort>{}</NewInternalPort><NewInternalClient>{}</NewInternalClient><NewEnabled>1</NewEnabled><NewPortMappingDescription>{}</NewPortMappingDescription><NewLeaseDuration>0</NewLeaseDuration></u:AddPortMapping></s:Body></s:Envelope>'
-    _delete_port_mapping_template = '<s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/" s:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"><s:Body><u:DeletePortMapping xmlns:u="urn:schemas-upnp-org:service:WANIPConnection:1"><NewExternalPort>{}</NewExternalPort><NewProtocol>{}</NewProtocol></u:AddPortMapping></s:Body></s:Envelope>'
-    _list_port_mappings_template = '<s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/" s:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"><s:Body><u:GetGenericPortMappingEntry xmlns:u="urn:schemas-upnp-org:service:WANIPConnection:1"><NewPortMappingIndex>{}</NewPortMappingIndex></u:GetGenericPortMappingEntry></s:Body></s:Envelope>'
+    _add_port_mapping_template = '<s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/" s:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"><s:Body><u:AddPortMapping xmlns:u="{}"><NewExternalPort>{}</NewExternalPort><NewProtocol>{}</NewProtocol><NewInternalPort>{}</NewInternalPort><NewInternalClient>{}</NewInternalClient><NewEnabled>1</NewEnabled><NewPortMappingDescription>{}</NewPortMappingDescription><NewLeaseDuration>{}</NewLeaseDuration></u:AddPortMapping></s:Body></s:Envelope>'
+    _delete_port_mapping_template = '<s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/" s:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"><s:Body><u:DeletePortMapping xmlns:u="{}"><NewExternalPort>{}</NewExternalPort><NewProtocol>{}</NewProtocol></u:AddPortMapping></s:Body></s:Envelope>'
+    _list_port_mappings_template = '<s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/" s:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"><s:Body><u:GetGenericPortMappingEntry xmlns:u="{}"><NewPortMappingIndex>{}</NewPortMappingIndex></u:GetGenericPortMappingEntry></s:Body></s:Envelope>'
 
     @classmethod
-    def add_port_mapping(cls, router, protocol, public_port, private_ip, private_port, mapping_description):
+    def add_port_mapping(cls, router, protocol, public_port, private_ip, private_port, mapping_description, lease_duration):
         """ Adds a port mapping to a router """
 
         from xml.etree import ElementTree
@@ -134,19 +134,23 @@ class UPnp:
         }
 
         data = UPnp._add_port_mapping_template.format(
+            router.type,
             public_port,
             protocol,
             private_port,
             private_ip,
-            mapping_description
+            mapping_description,
+            lease_duration
         )
+
+        log.add_debug('UPnP: Add port mapping request: %s', data)
 
         response = http_request(
             router.url_scheme, router.base_url, router.control_url,
             request_type="POST", body=data, headers=headers
         )
 
-        log.add_debug(response)
+        log.add_debug('UPnP: Add port mapping response: %s', response.encode())
 
         xml = ElementTree.fromstring(response)
 
@@ -178,14 +182,15 @@ class UPnp:
             'SOAPACTION': '{}#DeletePortMapping'.format(router.type)
         }
 
-        data = UPnp._delete_port_mapping_template.format(public_port, protocol)
+        data = UPnp._delete_port_mapping_template.format(router.type, public_port, protocol)
+        log.add_debug('UPnP: Delete port mapping request: %s', data)
 
         response = http_request(
             router.url_scheme, router.base_url, router.control_url,
             request_type="POST", body=data, headers=headers
         )
 
-        log.add_debug(response)
+        log.add_debug('UPnP: Delete port mapping response: %s', response.encode())
 
     @classmethod
     def list_port_mappings(cls, router):
@@ -205,12 +210,15 @@ class UPnp:
 
         while portmap_found:
             index += 1
-            data = UPnp._list_port_mappings_template.format(index)
+            data = UPnp._list_port_mappings_template.format(router.type, index)
+            log.add_debug('UPnP: List port mappings request: %s', data)
 
             response = http_request(
                 router.url_scheme, router.base_url, router.control_url,
                 request_type="POST", body=data, headers=headers
             )
+
+            log.add_debug('UPnP: List port mappings response: %s', response.encode())
 
             portmap = PortMapping.parse_port_map_xml(response, router.type)
 


### PR DESCRIPTION
- Some minor changes to improve UPnP compatibility with different routers
- Add more debug logging for UPnP
- Remove port spinbuttons from fast configure assistant. There isn't a good way to change the port and UPnP mapping at this point (requires restart), and changing the port should only be necessary in special cases anyway. The port can be changed in the preferences if necessary.
- Remove WAN port checker from UPnP code. Having a different WAN port from LAN port doesn't make sense, as the server is only aware of the LAN port.