### PR TITLE
show_user: add missing parameter

### DIFF
--- a/pynicotine/gtkgui/userinfo.py
+++ b/pynicotine/gtkgui/userinfo.py
@@ -335,7 +335,7 @@ class UserInfo:
         for hate in hates:
             self.hates_store.append([hate])
 
-    def show_user(self, msg):
+    def show_user(self, msg, indeterminate_progress=False):
 
         if msg is None:
             return
@@ -390,6 +390,8 @@ class UserInfo:
 
                 self.image.set_from_file(name)
                 os.remove(name)
+
+        self.progressbar.set_fraction(1.0)
 
     def show_connection_error(self):
 


### PR DESCRIPTION
Fix for the following traceback:
```
Traceback (most recent call last):
  File "/home/default/Documents/nicotine-plus/pynicotine/gtkgui/frame.py", line 1743, in on_get_user_info
    self.local_user_info_request(text)
  File "/home/default/Documents/nicotine-plus/pynicotine/gtkgui/frame.py", line 1780, in local_user_info_request
    self.userinfo.show_user(user, msg=msg)
  File "/home/default/Documents/nicotine-plus/pynicotine/gtkgui/userinfo.py", line 92, in show_user
    self.users[user].show_user(msg, indeterminate_progress)
TypeError: show_user() takes 2 positional arguments but 3 were given
```