### PR TITLE
Optimize tinytag to better suit our needs

### DIFF
--- a/pynicotine/pynicotine.py
+++ b/pynicotine/pynicotine.py
@@ -47,7 +47,6 @@ from pynicotine.logfacility import log
 from pynicotine.pluginsystem import PluginHandler
 from pynicotine.shares import Shares
 from pynicotine.slskmessages import new_id
-from pynicotine.upnp.portmapper import UPnPPortMapping
 from pynicotine.utils import clean_file
 from pynicotine.utils import unescape
 
@@ -865,6 +864,7 @@ class NetworkEventProcessor:
         if self.config.sections["server"]["upnp"]:
 
             # Initialise a UPnPPortMapping object
+            from pynicotine.upnp.portmapper import UPnPPortMapping
             upnp = UPnPPortMapping()
 
             # Do the port mapping

--- a/pynicotine/shares.py
+++ b/pynicotine/shares.py
@@ -638,7 +638,7 @@ class Shares:
             """ We skip metadata scanning of files without meaningful content """
             if size > 128:
                 try:
-                    audio = self.tinytag.get(pathname, size)
+                    audio = self.tinytag.get(pathname, size, tags=False)
 
                 except Exception as errtuple:
                     log.add(

--- a/pynicotine/shares.py
+++ b/pynicotine/shares.py
@@ -54,6 +54,7 @@ class Shares:
         self.queue = queue
         self.connected = connected
         self.translatepunctuation = str.maketrans(dict.fromkeys(string.punctuation, ' '))
+        self.tinytag = TinyTag()
 
         self.convert_shares()
         self.load_shares(
@@ -637,7 +638,7 @@ class Shares:
             """ We skip metadata scanning of files without meaningful content """
             if size > 128:
                 try:
-                    audio = TinyTag.get(pathname, size)
+                    audio = self.tinytag.get(pathname, size)
 
                 except Exception as errtuple:
                     log.add(


### PR DESCRIPTION
Since we need to be able to scan massive libraries of music in a short amount of time, and our usage of the tinytag library is very specific and predictable, we can take a few shortcuts in the code and shave off some time from the scanning process.