### PR TITLE
When backing up config, make 'Cancel' button actually cancel the action

### DIFF
--- a/pynicotine/config.py
+++ b/pynicotine/config.py
@@ -32,7 +32,6 @@ import configparser
 import os
 import pickle
 import sys
-import time
 
 from ast import literal_eval
 from gettext import gettext as _
@@ -781,14 +780,10 @@ class Config:
         except OSError as error:
             log.add_warning(_("Can't rename config file, error: %s"), error)
 
-    def write_config_backup(self, filename=None):
+    def write_config_backup(self, filename):
 
-        if filename is None:
-            filename = "%s backup %s.tar.bz2" % (self.filename, time.strftime("%Y-%m-%d %H_%M_%S"))
-
-        else:
-            if filename[-8:-1] != ".tar.bz2":
-                filename += ".tar.bz2"
+        if filename[-8:-1] != ".tar.bz2":
+            filename += ".tar.bz2"
 
         try:
             if os.path.exists(filename):
@@ -809,9 +804,9 @@ class Config:
 
         except Exception as e:
             print(e)
-            return (1, "Cannot write backup archive: %s" % e)
+            return (True, "Cannot write backup archive: %s" % e)
 
-        return (0, filename)
+        return (False, filename)
 
     def write_aliases(self):
 

--- a/pynicotine/gtkgui/settingswindow.py
+++ b/pynicotine/gtkgui/settingswindow.py
@@ -25,6 +25,8 @@
 import os
 import re
 import sys
+import time
+
 from gettext import gettext as _
 
 from gi.repository import Gdk
@@ -3751,18 +3753,19 @@ class Settings:
         response = save_file(
             self.SettingsWindow.get_toplevel(),
             os.path.dirname(self.frame.np.config.filename),
-            title="Pick a filename for config backup, or cancel to use a timestamp"
+            "config backup %s.tar.bz2" % (time.strftime("%Y-%m-%d %H_%M_%S")),
+            title=_("Pick a filename for config backup")
         )
 
-        if response:
-            error, message = self.frame.np.config.write_config_backup(response[0])
-        else:
-            error, message = self.frame.np.config.write_config_backup()
+        if not response:
+            return
+
+        error, message = self.frame.np.config.write_config_backup(response[0])
 
         if error:
-            log.add("Error backing up config: %s", message)
+            log.add(_("Error backing up config: %s"), message)
         else:
-            log.add("Config backed up to: %s", message)
+            log.add(_("Config backed up to: %s"), message)
 
     def on_apply(self, widget):
         self.SettingsWindow.emit("settings-updated", "apply")


### PR DESCRIPTION
Like the title says, drop the current behavior of creating a timestamped backup when pressing "Cancel", as this goes against expectations.