### PR TITLE
Use default theme for GitHub pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,15 @@
 # Nicotine+
+<img src="files/org.nicotine_plus.Nicotine.svg" align="right" width="128" style="margin: 0 10px">
 
 Nicotine+ is a graphical client for the [Soulseek](https://www.slsknet.org/news/) peer-to-peer file sharing network.
 
 Nicotine+ aims to be a pleasant, Free and Open Source (FOSS) alternative to the official Soulseek client, providing additional functionality while keeping current with the Soulseek protocol.
 
-[Screenshots](files/screenshots/SCREENSHOTS.md)
+Check out the [screenshots](files/screenshots/SCREENSHOTS.md) and [source code](https://github.com/Nicotine-Plus/nicotine-plus).
+<br clear="right">
 
 # Download Nicotine+
-The current stable version of Nicotine+ is 2.1.2, released on 12 October 2020. See the [changelog](NEWS.md).
+The current stable version of Nicotine+ is 2.1.2, released on 12 October 2020. See the [release notes](NEWS.md).
 
 ## GNU/Linux
 If you have no need to modify the Nicotine+ source, you are strongly recommended to use precompiled packages for your distribution. This will save you time.
@@ -15,51 +17,51 @@ If you have no need to modify the Nicotine+ source, you are strongly recommended
 ### Ubuntu PPA/Debian (Stable)
 To use [stable packages](https://launchpad.net/~nicotine-team/+archive/ubuntu/stable) on Ubuntu and Debian, run the following:
 
-```console
-$ sudo apt install software-properties-common
-$ sudo add-apt-repository ppa:nicotine-team/stable
-$ sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 6CEB6050A30E5769
-$ sudo apt update
-$ sudo apt install nicotine
+```sh
+sudo apt install software-properties-common
+sudo add-apt-repository ppa:nicotine-team/stable
+sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 6CEB6050A30E5769
+sudo apt update
+sudo apt install nicotine
 ```
 
 ### Ubuntu PPA/Debian (Unstable)
 The project builds [daily unstable snapshots](https://code.launchpad.net/~nicotine-team/+recipe/nicotine+-daily) in a separate [unstable PPA](https://code.launchpad.net/~nicotine-team/+archive/ubuntu/unstable). To use it, run the following:
 
-```console
-$ sudo apt install software-properties-common
-$ sudo add-apt-repository ppa:nicotine-team/unstable
-$ sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 6CEB6050A30E5769
-$ sudo apt update
-$ sudo apt install nicotine
+```sh
+sudo apt install software-properties-common
+sudo add-apt-repository ppa:nicotine-team/unstable
+sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 6CEB6050A30E5769
+sudo apt update
+sudo apt install nicotine
 ```
 
 ### Arch Linux/Manjaro/Parabola (Stable)
 Nicotine+ is available in the community repository of Arch Linux, Manjaro and Parabola. To install, run the following:
 
-```console
-$ sudo pacman -S nicotine+
+```sh
+sudo pacman -S nicotine+
 ```
 
 ### Void Linux (Stable)
 To install Nicotine+ on Void Linux, run the following:
 
-```console
-$ sudo xbps-install -S nicotine+
+```sh
+sudo xbps-install -S nicotine+
 ```
 
 ### Fedora (Stable)
 To install Nicotine+ on Fedora, run the following:
 
-```console
-$ sudo dnf install nicotine+
+```sh
+sudo dnf install nicotine+
 ```
 
 ### Guix (Stable)
 To install Nicotine+ on Guix, run the following:
 
-```console
-$ guix install nicotine+
+```sh
+guix install nicotine+
 ```
 
 ### Flathub (Stable)
@@ -133,26 +135,30 @@ There are [different ways](https://wiki.debian.org/qa.debian.org#Other_distribut
 
 ## Autopkgtest
 On Debian based distributions, `autopkgtest` implements the DEP-8 standard. To create and use a build image environment for Ubuntu, follow these steps. First install the autopkgtest(1) tools:
-```
-$ sudo apt install autopkgtest
+
+```sh
+sudo apt install autopkgtest
 ```
 
 Next create the test image, substituting `groovy` or `amd64` for other releases or architectures:
-```
-$ autopkgtest-buildvm-ubuntu-cloud -r groovy -a amd64
+
+```sh
+autopkgtest-buildvm-ubuntu-cloud -r groovy -a amd64
 ```
 
 Generate a Nicotine+ source package in the parent directory of `nicotine_source`:
-```
-$ cd nicotine_source
-$ sudo apt build-dep nicotine
-$ ./debian/rules get-orig-source
-$ debuild -S -sa
+
+```sh
+cd nicotine_source
+sudo apt build-dep nicotine
+./debian/rules get-orig-source
+debuild -S -sa
 ```
 
 Test the source package on the host architecture in QEMU with KVM support and 8GB of RAM and four CPUs:
-```
-$ autopkgtest --shell-fail --apt-upgrade ../nicotine_(...).dsc -- \
+
+```sh
+autopkgtest --shell-fail --apt-upgrade ../nicotine_(...).dsc -- \
       qemu --ram-size=8192 --cpus=4 --show-boot path_to_build_image.img \
       --qemu-options='-enable-kvm'
 ```

--- a/TRANSLATORS.md
+++ b/TRANSLATORS.md
@@ -1,61 +1,61 @@
-# List of translators for Nicotine & Nicotine+:
+# Nicotine+ Translators
 
-##### English
+## English
  * mathiascode (2020)
- * Michael Labouebe (2016) < gfarmerfr (at) free.fr >
+ * Michael Labouebe (2016) [gfarmerfr(at)free(dot)fr]
  * hyriand
  * daelstorm
 
-##### Dutch
+## Dutch
  * nince78 (2007)
  * hyriand
 
-##### German
+## German
  * Meokater (2007)
  * (.\_.) (2007)
  * lippel (2004)
  * hyriand (2003)
 
-##### Spanish
+## Spanish
  * Silvio Orta (2007)
  * Dreslo
 
-##### French
+## French
  * m-balthazar (2020)
- * Michael Labouebe (2016-2017) < gfarmerfr (at) free.fr >
+ * Michael Labouebe (2016-2017) [gfarmerfr(at)free(dot)fr]
  * ManWell (2007)
  * zniavre (2007)
  * flashfr
  * systr
 
-##### Italian
+## Italian
  * Gianluca Boiano
- * Nicola (2007) < info (at) nicoladimaria.info >
+ * Nicola (2007) [info(at)nicoladimaria(dot)info]
  * dbazza
 
-##### Polish
+## Polish
  * Amun-Ra (2007)
  * thine (2007)
  * owczi
 
-##### Swedish
- * alimony < markus (at) samsonrourke.com >
+## Swedish
+ * alimony [markus(at)samsonrourke(dot)com]
 
-##### Hungarian
- * djbaloo < dj_baloo (at) freemail.hu >
+## Hungarian
+ * djbaloo [dj_baloo(at)freemail(dot)hu]
 
-##### Slovak
- * Josef Riha (2006) < jose1711 (at) gmail.com >
+## Slovak
+ * Josef Riha (2006) [jose1711(at)gmail(dot)com]
 
-##### Portuguese Brazilian
- * Suicide|Solution (2006) < felipe (at) bunghole.com.br >
+## Portuguese Brazilian
+ * Suicide\|Solution (2006) [felipe(at)bunghole(dot)com(dot)br]
  * yyyyyyyan (2020)
 
-##### Lithuanian
- * Žygimantas (2006) < uid0 (at) akl.lt >
+## Lithuanian
+ * Žygimantas (2006) [uid0(at)akl(dot)lt]
 
-##### Finnish
- * Kalevi < mr_auer (at) welho.net >
+## Finnish
+ * Kalevi [mr_auer(at)welho(dot)net]
 
-##### Euskara
- * The Librezale.org Team < librezale (at) librezale.org >
+## Euskara
+ * The Librezale.org Team [librezale(at)librezale(dot)org]

--- a/_config.yml
+++ b/_config.yml
@@ -1,12 +1,3 @@
+# This file is responsible for generating the main website from our GitHub repository
 title: Nicotine+
-logo: /files/org.nicotine_plus.Nicotine.svg
 description: A graphical client for Soulseek
-
-plugins:
-  - jekyll-relative-links
-
-relative_links:
-  enabled: true
-  collections: true
-
-theme: jekyll-theme-minimal

--- a/doc/DEPENDENCIES.md
+++ b/doc/DEPENDENCIES.md
@@ -26,44 +26,55 @@
 ### GNU/Linux
 
 #### Installing the required runtime dependencies
-* On Redhat/Fedora based distributions:
-```
-sudo dnf install gobject-introspection gtk3 python3-gobject
-```
 * On Debian/Ubuntu based distributions:
-```
+
+```sh
 sudo apt install gobject-introspection gir1.2-gtk-3.0 python3-gi
 ```
 
-#### Installing the optional runtime dependencies
 * On Redhat/Fedora based distributions:
+
+```sh
+sudo dnf install gobject-introspection gtk3 python3-gobject
 ```
-sudo dnf install gspell libappindicator-gtk3
-```
+
+#### Installing the optional runtime dependencies
 * On Debian/Ubuntu based distributions:
-```
+
+```sh
 sudo apt install gir1.2-appindicator3-0.1 gir1.2-gspell-1
 ```
 
-#### Installing the test dependencies
 * On Redhat/Fedora based distributions:
+
+```sh
+sudo dnf install gspell libappindicator-gtk3
 ```
-sudo dnf install python3-flake8 python3-pep8-naming python3-pytest
-```
+
+#### Installing the test dependencies
 * On Debian/Ubuntu based distributions:
-```
+
+```sh
 sudo apt install python3-flake8 python3-pep8-naming python3-pytest
 ```
 
-#### Check the Python version.
-To check that the Python version you are using is 3.5 or newer, use `python -V`. On a lot of older systems, the response will look something like this:  
+* On Redhat/Fedora based distributions:
+
+```sh
+sudo dnf install python3-flake8 python3-pep8-naming python3-pytest
 ```
+
+#### Check the Python version.
+To check that the Python version you are using is 3.5 or newer, use `python -V`. On a lot of older systems, the response will look something like this:
+
+```console
 % python -V
 Python 2.7.16
 ```
 
-Not to worry, Python 3 is often installed alongside and can be used like this:  
-```
+Not to worry, Python 3 is often installed alongside and can be used like this:
+
+```console
 % python3 -V
 Python 3.7.3
 ```

--- a/doc/PACKAGING.md
+++ b/doc/PACKAGING.md
@@ -13,7 +13,9 @@ The dependencies for Nicotine+ are described in [DEPENDENCIES.md](DEPENDENCIES.m
 
 To build source distribution files (.tar.bz2 & .tar.gz) from the git repository run:
 
-`python setup.py sdist --formats=bztar,gztar`
+```console
+python setup.py sdist --formats=bztar,gztar
+```
 
 The source distribution files will be located in the `dist` subdirectory of your git repository.
 
@@ -22,32 +24,45 @@ The source distribution files will be located in the `dist` subdirectory of your
 Unstable and stable PPAs are already provided for pre-compiled packages, as described in the `README.md`. However, if you wish to build your own package perform the following.
 
 Start by generating the "upstream" tarball:
-```
-$ cd nicotine_source
-$ ./debian/rules get-orig-source
+
+```console
+cd nicotine_source
+./debian/rules get-orig-source
 ```
 
 Build the Debian source package:
-```
-$ debuild -S -sa
+
+```console
+debuild -S -sa
 ```
 
 Build the binary from the source package and upstream tarball via `sbuild`:
-```
-$ sbuild ../nicotine(...).dsc
+
+```console
+sbuild ../nicotine(...).dsc
 ```
 
 #### Building a RPM package
 
 You need to install the RPM building tools first:
 
-* On Redhat/Fedora based distributions: `sudo dnf install rpm-build python3-gobject-devel`
+* On Redhat/Fedora based distributions:
 
-* On Debian/Ubuntu based distributions: `sudo apt install rpm`
+```console
+sudo dnf install rpm-build python3-gobject-devel
+```
+
+* On Debian/Ubuntu based distributions:
+
+```console
+sudo apt install rpm
+```
 
 Then you can create an RPM with:
 
-`python setup.py bdist_rpm`
+```console
+python setup.py bdist_rpm
+```
 
 The RPM package will be located in the `dist` subdirectory of your git repository.
 
@@ -62,19 +77,25 @@ First, follow the instructions on installing MSYS2: [https://pygobject.readthedo
 
 Then, install dependencies:
 
-`export ARCH=x86_64`  
-`files/windows/dependencies-core.sh`
-`files/windows/dependencies-packaging.sh`
+```console
+export ARCH=x86_64
+files/windows/dependencies-core.sh
+files/windows/dependencies-packaging.sh
+```
 
 Clone the Nicotine+ git repository:
 
-`pacman -S git`  
-`git clone https://github.com/Nicotine-Plus/nicotine-plus`  
-`cd nicotine-plus`
+```console
+pacman -S git
+git clone https://github.com/Nicotine-Plus/nicotine-plus
+cd nicotine-plus
+```
 
 Run PyInstaller:
 
-`pyinstaller files/windows/nicotine.spec`
+```console
+pyinstaller files/windows/nicotine.spec
+```
 
 After the frozen application build finished you can find it in the `dist\Nicotine+` subdirectory.
 
@@ -84,8 +105,10 @@ If you want to run the frozen application you can launch the executable `dist\Ni
 
 Run the following:
 
-`cd files/windows`  
-`makensis -DARCH=x86_64 nicotine.nsi`
+```console
+cd files/windows
+makensis -DARCH=x86_64 nicotine.nsi
+```
 
 You should now find a `Nicotine+-$(version).exe` installer in the `files\windows` directory.
 

--- a/doc/RUNFROMGIT.md
+++ b/doc/RUNFROMGIT.md
@@ -4,22 +4,24 @@ This is not particularly hard, but it may come with some additional required ski
 
 ## Clone the repository and run Nicotine+
 This is great if you're the only Nicotine+ user on your system and you want to test the latest version. Using a Python virtual environment (venv) is recommended, as this ensures you have the correct dependencies to run Nicotine+.
-```
-$ git clone https://github.com/Nicotine-Plus/nicotine-plus.git
-$ cd nicotine-plus
-$ python3 -m venv .env
-$ .env/bin/pip install -r requirements.txt
-$ .env/bin/python3 setup.py install
-$ .env/bin/nicotine
+
+```console
+git clone https://github.com/Nicotine-Plus/nicotine-plus.git
+cd nicotine-plus
+python3 -m venv .env
+.env/bin/pip install -r requirements.txt
+.env/bin/python3 setup.py install
+.env/bin/nicotine
 ```
 
 For Windows, follow the instructions in [PACKAGING.md](PACKAGING.md#windows) instead.
 
 ## Updating your cloned Nicotine+
 If you want to update to the latest version of Nicotine+, proceed like this:
-```
-$ cd nicotine-plus
-$ git pull
-$ .env/bin/python3 setup.py install
-$ .env/bin/nicotine
+
+```console
+cd nicotine-plus
+git pull
+.env/bin/python3 setup.py install
+.env/bin/nicotine
 ```

--- a/doc/TRANSLATIONS.md
+++ b/doc/TRANSLATIONS.md
@@ -1,8 +1,6 @@
 # Translations
 
-For a list of translators, see [TRANSLATORS.md](../TRANSLATORS.md)
-
-If your name is missing, please contact us.
+For a list of translators, see [TRANSLATORS.md](../TRANSLATORS.md). If your name is missing, please contact us.
 
 ## For Translators
 
@@ -30,7 +28,11 @@ To update the template (.pot) file:
 
 - Enter the `po` folder by running `cd po`
 
-- Run `intltool-update -p -g nicotine`
+- Run the following command:
+
+```console
+intltool-update -p -g nicotine
+```
 
 A developer part of the [Nicotine+ Launchpad team](https://launchpad.net/~nicotine-team) should then [upload the updated .pot file](https://translations.launchpad.net/nicotine+/trunk/+translations-upload) to Launchpad, and [approve it](https://translations.launchpad.net/nicotine+/+imports).
 
@@ -54,14 +56,20 @@ Nicotine+ will try to autodetect your language based on what locale you're using
 
 For testing purposes Nicotine+ can be forced to use a specific language. You can do it by setting your locale before starting Nicotine+ ex:
 
-    * English: `LC_ALL=en_US.UTF-8 python nicotine`
-    * French: `LC_ALL=fr_FR.UTF-8 python nicotine`
-    * ...
+* English: `LC_ALL=en_US.UTF-8 python nicotine`
+* French: `LC_ALL=fr_FR.UTF-8 python nicotine`
+* ...
 
 Nicotine+ will first try to find your translation files in your project folder.
 It's particularly useful for testing translations from the git source tree or if your are using Python virtualenv framework.
 
-To use translations when running Nicotine+ from your project folder, you need to generate .mo files by running `python3 setup.py build`. The files will be located in the `mo` folder.
+To use translations when running Nicotine+ from your project folder, you need to generate .mo files by running
+
+```console
+python3 setup.py build
+```
+
+The files will be located in the `mo` folder.
 
 If Nicotine+ doesn't find the .mo files in your project folder, it will fall back to searching in your system locale path which is OS specific. A GNU/Linux distribution package will put them in the system locale path.
 

--- a/files/screenshots/SCREENSHOTS.md
+++ b/files/screenshots/SCREENSHOTS.md
@@ -1,4 +1,4 @@
-# Nicotine+ Screenshots
+# Screenshots
 
 [![Search Group View](screenshot1.png)](screenshot1.png?raw=1)  
 [![Search](screenshot2.png)](screenshot2.png?raw=1)  

--- a/pynicotine/gtkgui/ui/about/about.ui
+++ b/pynicotine/gtkgui/ui/about/about.ui
@@ -230,7 +230,7 @@ Spanish
 
 French
  * m-balthazar (2020)
- * Michael Labouebe (2016-2017) &lt;gfarmerfr@free.fr&gt;
+ * Michael Labouebe (2016-2017) [gfarmerfr(at)free(dot)fr]
  * ManWell (2007)
  * zniavre (2007-2009)
  * flashfr
@@ -238,7 +238,7 @@ French
 
 Italian
  * Gianluca Boiano
- * Nicola (2007) &lt;info@nicoladimaria.info&gt;
+ * Nicola (2007) [info(at)nicoladimaria(dot)info]
  * dbazza
 
 Polish
@@ -247,25 +247,25 @@ Polish
  * owczi
 
 Swedish
- * alimony &lt;markus@samsonrourke.com&gt;
+ * alimony [markus(at)samsonrourke(dot)com]
 
 Hungarian
- * djbaloo &lt;dj_baloo@freemail.hu&gt;
+ * djbaloo [dj_baloo(at)freemail(dot)hu]
 
 Slovak
- * Josef Riha (2006) &lt;jose1711@gmail.com&gt;
+ * Josef Riha (2006) [jose1711(at)gmail(dot)com]
 
 Portuguese Brazilian
- * Suicide|Solution (2006) &lt;felipe@bunghole.com.br&gt;
+ * Suicide|Solution (2006) [felipe(at)bunghole(dot)com(dot)br]
  * yyyyyyyan (2020)
 
 Lithuanian
- * Žygimantas Beručka (2006) &lt;uid0@akl.lt&gt;
+ * Žygimantas Beručka (2006) [uid0(at)akl(dot)lt]
 
 Finnish
- * Kalevi &lt;mr_auer@welho.net&gt;
+ * Kalevi [mr_auer(at)welho(dot)net]
 
 Euskara
- * The Librezale.org Team &lt;librezale@librezale.org&gt;</property>
+ * The Librezale.org Team [librezale(at)librezale(dot)org]</property>
   </object>
 </interface>


### PR DESCRIPTION
I much prefer the element styling and spacing of the default Primer theme (which mirrors the README style on GitHub) compared to the Minimal theme. I've also fixed some consistency issues across our Markdown files, and removed the $ sign from command examples, since it made it more difficult to copy commands.

Preview: https://mathiascode.github.io/nicotine-plus/