### PR TITLE
Bug fixes for peer connections and transfers (part 1)

### DIFF
--- a/pynicotine/gtkgui/downloads.py
+++ b/pynicotine/gtkgui/downloads.py
@@ -248,7 +248,7 @@ class Downloads(TransferList):
             elif key in ("R", "r"):
                 self.on_retry_transfer(widget)
             elif key == "Delete":
-                self.on_abort_transfer(widget, True, True)
+                self.on_abort_transfer(widget, clear=True)
             else:
                 # No key match, continue event
                 return False
@@ -294,7 +294,7 @@ class Downloads(TransferList):
         elif dc == 3:  # Search
             self.on_file_search(None)
         elif dc == 4:  # Abort
-            self.on_abort_transfer(None, False)
+            self.on_abort_transfer(None)
         elif dc == 5:  # Clear
             self.on_clear_transfer(None)
         elif dc == 6:  # Retry
@@ -357,9 +357,9 @@ class Downloads(TransferList):
 
         return True
 
-    def on_abort_transfer(self, widget):
+    def on_abort_transfer(self, widget, remove_file=False, clear=False):
         self.select_transfers()
-        self.abort_transfers()
+        self.abort_transfers(remove_file, clear)
 
     def on_clear_queued(self, widget):
         self.clear_transfers(["Queued"])

--- a/pynicotine/gtkgui/frame.py
+++ b/pynicotine/gtkgui/frame.py
@@ -398,7 +398,7 @@ class NicotineFrame:
             self.on_fast_configure()
 
         else:
-            self.on_connect(getmessage=False)
+            self.on_connect()
 
         self.update_bandwidth()
 
@@ -902,7 +902,7 @@ class NicotineFrame:
 
     # File
 
-    def on_connect(self, *args, getmessage=True):
+    def on_connect(self, *args):
 
         self.tray.set_connected(True)
         self.np.protothread.server_connect()
@@ -910,9 +910,9 @@ class NicotineFrame:
         if self.np.active_server_conn is not None:
             return
 
-        if getmessage:
-            while not self.np.queue.empty():
-                self.np.queue.get(0)
+        # Clear any potential messages queued up to this point (should not happen)
+        while not self.np.queue.empty():
+            self.np.queue.get(0)
 
         self.set_user_status("...")
 

--- a/pynicotine/gtkgui/frame.py
+++ b/pynicotine/gtkgui/frame.py
@@ -2628,8 +2628,8 @@ class NicotineFrame:
         # Explicitly hide tray icon, otherwise it will not disappear on Windows
         self.tray.hide()
 
-        if not self.np.manualdisconnect:
-            self.on_disconnect(None)
+        # Inform networking thread we've disconnected from server
+        self.np.protothread.server_disconnect()
 
         self.save_columns()
 

--- a/pynicotine/gtkgui/frame.py
+++ b/pynicotine/gtkgui/frame.py
@@ -905,6 +905,7 @@ class NicotineFrame:
     def on_connect(self, *args, getmessage=True):
 
         self.tray.set_connected(True)
+        self.np.protothread.server_connect()
 
         if self.np.active_server_conn is not None:
             return

--- a/pynicotine/gtkgui/ui/mainwindow.ui
+++ b/pynicotine/gtkgui/ui/mainwindow.ui
@@ -557,7 +557,7 @@
                                       <object class="GtkLabel">
                                         <property name="visible">True</property>
                                         <property name="can_focus">False</property>
-                                        <property name="label" translatable="yes">Delete</property>
+                                        <property name="label" translatable="yes">Clear</property>
                                         <property name="use_underline">True</property>
                                       </object>
                                     </child>

--- a/pynicotine/pynicotine.py
+++ b/pynicotine/pynicotine.py
@@ -805,8 +805,8 @@ class NetworkEventProcessor:
             self.active_server_conn = None
 
             # Clear messages in progress
-            with self.queue.mutex:
-                self.queue.queue.clear()
+            while not self.queue.empty():
+                self.queue.get(0)
 
             # Inform networking thread we've disconnected from server
             self.protothread.server_disconnect()
@@ -967,7 +967,7 @@ class NetworkEventProcessor:
             self.transfers.abort_transfers()
 
     def connect_to_server(self, msg):
-        self.ui_callback.on_connect(None)
+        self.ui_callback.on_connect()
 
     # notify user of error when recieving or sending a message
     # @param self NetworkEventProcessor (Class)

--- a/pynicotine/pynicotine.py
+++ b/pynicotine/pynicotine.py
@@ -436,7 +436,7 @@ class NetworkEventProcessor:
             }
         )
 
-    def connect_to_peer_indirect(self, conn):
+    def connect_to_peer_indirect(self, conn, error):
 
         """ Send a message to the server to ask the peer to connect to us instead (indirect connection) """
 
@@ -459,9 +459,10 @@ class NetworkEventProcessor:
         conn.conntimer = timer
 
         log.add_conn(
-            _("Direct connection of type %(type)s to user %(user)s failed, attempting indirect connection"), {
+            _("Direct connection of type %(type)s to user %(user)s failed, attempting indirect connection. Error: %(error)s"), {
                 "type": conn.type,
-                "user": conn.username
+                "user": conn.username,
+                "error": error
             }
         )
 
@@ -871,7 +872,7 @@ class NetworkEventProcessor:
 
                         """ We can't correct to peer directly, request indirect connection """
 
-                        self.connect_to_peer_indirect(i)
+                        self.connect_to_peer_indirect(i, msg.err)
 
                     else:
 

--- a/pynicotine/pynicotine.py
+++ b/pynicotine/pynicotine.py
@@ -1597,94 +1597,96 @@ class NetworkEventProcessor:
     def transfer_timeout(self, msg):
         if self.transfers is not None:
             self.transfers.transfer_timeout(msg)
-        else:
-            log.add_msg_contents("%s %s", (msg.__class__, self.contents(msg)))
+
+        log.add_msg_contents("%s %s", (msg.__class__, self.contents(msg)))
 
     def file_download(self, msg):
         if self.transfers is not None:
             self.transfers.file_download(msg)
-        else:
-            log.add_msg_contents("%s %s", (msg.__class__, self.contents(msg)))
+
+        log.add_msg_contents("%s %s", (msg.__class__, self.contents(msg)))
 
     def file_upload(self, msg):
         if self.transfers is not None:
             self.transfers.file_upload(msg)
-        else:
-            log.add_msg_contents("%s %s", (msg.__class__, self.contents(msg)))
+
+        log.add_msg_contents("%s %s", (msg.__class__, self.contents(msg)))
 
     def file_request(self, msg):
         if self.transfers is not None:
             self.transfers.file_request(msg)
-        else:
-            log.add_msg_contents("%s %s", (msg.__class__, self.contents(msg)))
+
+        log.add_msg_contents("%s %s", (msg.__class__, self.contents(msg)))
 
     def file_error(self, msg):
         if self.transfers is not None:
             self.transfers.file_error(msg)
-        else:
-            log.add_msg_contents("%s %s", (msg.__class__, self.contents(msg)))
+
+        log.add_msg_contents("%s %s", (msg.__class__, self.contents(msg)))
 
     def transfer_request(self, msg):
         """ Peer code: 40 """
 
         if self.transfers is not None:
             self.transfers.transfer_request(msg)
-        else:
-            log.add_msg_contents("%s %s", (msg.__class__, self.contents(msg)))
+
+        log.add_msg_contents("%s %s", (msg.__class__, self.contents(msg)))
 
     def transfer_response(self, msg):
         """ Peer code: 41 """
 
         if self.transfers is not None:
             self.transfers.transfer_response(msg)
-        else:
-            log.add_msg_contents("%s %s", (msg.__class__, self.contents(msg)))
+
+        log.add_msg_contents("%s %s", (msg.__class__, self.contents(msg)))
 
     def queue_upload(self, msg):
         """ Peer code: 43 """
 
         if self.transfers is not None:
             self.transfers.queue_upload(msg)
-        else:
-            log.add_msg_contents("%s %s", (msg.__class__, self.contents(msg)))
+
+        log.add_msg_contents("%s %s", (msg.__class__, self.contents(msg)))
 
     def queue_failed(self, msg):
         """ Peer code: 50 """
 
         if self.transfers is not None:
             self.transfers.queue_failed(msg)
-        else:
-            log.add_msg_contents("%s %s", (msg.__class__, self.contents(msg)))
+
+        log.add_msg_contents("%s %s", (msg.__class__, self.contents(msg)))
 
     def place_in_queue_request(self, msg):
         """ Peer code: 51 """
 
         if self.transfers is not None:
             self.transfers.place_in_queue_request(msg)
-        else:
-            log.add_msg_contents("%s %s", (msg.__class__, self.contents(msg)))
+
+        log.add_msg_contents("%s %s", (msg.__class__, self.contents(msg)))
 
     def upload_queue_notification(self, msg):
         """ Peer code: 52 """
 
+        if self.transfers is not None:
+            self.transfers.upload_queue_notification(msg)
+
         log.add_msg_contents("%s %s", (msg.__class__, self.contents(msg)))
-        self.transfers.upload_queue_notification(msg)
 
     def upload_failed(self, msg):
         """ Peer code: 46 """
 
         if self.transfers is not None:
             self.transfers.upload_failed(msg)
-        else:
-            log.add_msg_contents("%s %s", (msg.__class__, self.contents(msg)))
+
+        log.add_msg_contents("%s %s", (msg.__class__, self.contents(msg)))
 
     def place_in_queue(self, msg):
         """ Peer code: 44 """
 
         if self.transfers is not None:
             self.transfers.place_in_queue(msg)
-        else:
-            log.add_msg_contents("%s %s", (msg.__class__, self.contents(msg)))
+
+        log.add_msg_contents("%s %s", (msg.__class__, self.contents(msg)))
 
     def get_shared_file_list(self, msg):
         """ Peer code: 4 """

--- a/pynicotine/pynicotine.py
+++ b/pynicotine/pynicotine.py
@@ -311,7 +311,7 @@ class NetworkEventProcessor:
 
         if user != self.config.sections["server"]["login"]:  # We need two connections in our name if we're downloading from ourselves
             for i in self.peerconns:
-                if i.username == user and i.type == msg_type:
+                if i.username == user and i.type != 'F' and i.type == msg_type:
                     i.addr = addr
                     i.conn = conn
                     i.token = None
@@ -483,7 +483,7 @@ class NetworkEventProcessor:
 
         if user != self.config.sections["server"]["login"]:
             for i in self.peerconns:
-                if i.username == user and i.type == msg_type:
+                if i.username == user and i.type != 'F' and i.type == msg_type:
                     i.addr = addr
                     i.token = token
                     i.init = init

--- a/pynicotine/pynicotine.py
+++ b/pynicotine/pynicotine.py
@@ -329,7 +329,10 @@ class NetworkEventProcessor:
             for i in self.peerconns:
                 if i.username == user and i.type == 'P':
                     conn = i
-                    log.add_conn(_("Found existing connection of type %(type)s for user %(user)s, using it") % {'type': i.type, 'user': user})
+                    log.add_conn(_("Found existing connection of type %(type)s for user %(user)s, using it.") % {
+                        'type': i.type,
+                        'user': user
+                    })
                     break
 
         if conn is not None and conn.conn is not None:
@@ -347,6 +350,11 @@ class NetworkEventProcessor:
             """ This is a new peer, initiate a connection """
 
             self.initiate_connection_to_peer(user, message, address)
+
+        log.add_conn(_("Sending message of type %(type)s to user %(user)s") % {
+            'type': message.__class__,
+            'user': user
+        })
 
     def initiate_connection_to_peer(self, user, message, address=None):
 

--- a/pynicotine/pynicotine.py
+++ b/pynicotine/pynicotine.py
@@ -628,23 +628,28 @@ class NetworkEventProcessor:
         log.add_msg_contents("%s %s", (msg.__class__, self.contents(msg)))
 
     def pierce_fire_wall(self, msg):
+
+        # Sometimes a token is seemingly not sent by the peer, check if the
+        # IP address matches in that case
         token = msg.token
 
         for i in self.peerconns:
-            if i.token == token and i.conn is None:
-                conn = msg.conn.conn
+            if i.conn is None:
+                if token is not None and i.token == token or \
+                        token is None and i.token is not None and i.addr == msg.conn.addr:
+                    conn = msg.conn.conn
 
-                if i.conntimer is not None:
-                    i.conntimer.cancel()
+                    if i.conntimer is not None:
+                        i.conntimer.cancel()
 
-                i.init.conn = conn
-                self.queue.put(i.init)
-                i.conn = conn
+                    i.init.conn = conn
+                    self.queue.put(i.init)
+                    i.conn = conn
 
-                # Update UI with contents from messages
-                self.process_conn_messages(i, conn)
+                    # Update UI with contents from messages
+                    self.process_conn_messages(i, conn)
 
-                break
+                    break
 
         log.add_msg_contents("%s %s", (msg.__class__, self.contents(msg)))
 

--- a/pynicotine/pynicotine.py
+++ b/pynicotine/pynicotine.py
@@ -802,11 +802,17 @@ class NetworkEventProcessor:
                 self.manualdisconnect = False
 
             self.active_server_conn = None
+
+            # Clean up connections
+            for i in self.peerconns[:]:
+                self.peerconns.remove(i)
+                self.queue.put(slskmessages.ConnClose(i.conn, callback=False))
+
             self.watchedusers.clear()
             self.shares.set_connected(False)
 
             if self.transfers is not None:
-                self.transfers.abort_transfers()
+                self.transfers.abort_transfers(send_fail_message=False)
                 self.transfers.save_downloads()
 
             self.privatechat = self.chatrooms = self.userinfo = self.userbrowse = self.search = self.transfers = self.userlist = None

--- a/pynicotine/pynicotine.py
+++ b/pynicotine/pynicotine.py
@@ -804,10 +804,16 @@ class NetworkEventProcessor:
 
             self.active_server_conn = None
 
+            # Clear messages in progress
+            with self.queue.mutex:
+                self.queue.queue.clear()
+
+            # Inform networking thread we've disconnected from server
+            self.protothread.server_disconnect()
+
             # Clean up connections
             for i in self.peerconns[:]:
                 self.peerconns.remove(i)
-                self.queue.put(slskmessages.ConnClose(i.conn, callback=False))
 
             self.watchedusers.clear()
             self.shares.set_connected(False)

--- a/pynicotine/pynicotine.py
+++ b/pynicotine/pynicotine.py
@@ -804,16 +804,8 @@ class NetworkEventProcessor:
 
             self.active_server_conn = None
 
-            # Clear messages in progress
-            while not self.queue.empty():
-                self.queue.get(0)
-
-            # Inform networking thread we've disconnected from server
-            self.protothread.server_disconnect()
-
             # Clean up connections
-            for i in self.peerconns[:]:
-                self.peerconns.remove(i)
+            self.peerconns.clear()
 
             self.watchedusers.clear()
             self.shares.set_connected(False)

--- a/pynicotine/slskmessages.py
+++ b/pynicotine/slskmessages.py
@@ -1909,7 +1909,9 @@ class PierceFireWall(PeerMessage):
         return self.pack_object(self.token, unsignedint=True)
 
     def parse_network_message(self, message):
-        pos, self.token = self.get_object(message, int)
+        if len(message) > 0:
+            # A token is not guaranteed to be sent
+            pos, self.token = self.get_object(message, int)
 
 
 class PeerInit(PeerMessage):
@@ -1935,7 +1937,10 @@ class PeerInit(PeerMessage):
     def parse_network_message(self, message):
         pos, self.user = self.get_object(message, str)
         pos, self.type = self.get_object(message, str, pos)
-        pos, self.token = self.get_object(message, int, pos)
+
+        if len(message[pos:]) > 0:
+            # A token is not guaranteed to be sent
+            pos, self.token = self.get_object(message, int, pos)
 
 
 class GetSharedFileList(PeerMessage):

--- a/pynicotine/slskproto.py
+++ b/pynicotine/slskproto.py
@@ -1003,11 +1003,18 @@ class SlskProtoThread(threading.Thread):
                             self._ui_callback([ConnectError(msg_obj, err)])
                             server_socket.close()
 
-                elif msg_obj.__class__ is ConnClose and msg_obj.conn in conns:
-                    if msg_obj.callback:
-                        self._ui_callback([ConnClose(msg_obj.conn, conns[msg_obj.conn].addr)])
+                elif msg_obj.__class__ is ConnClose:
+                    if msg_obj.conn in connsinprogress:
+                        if msg_obj.callback:
+                            self._ui_callback([ConnClose(msg_obj.conn, connsinprogress[msg_obj.conn].addr)])
 
-                    self.close_connection(conns, msg_obj.conn)
+                        self.close_connection(connsinprogress, msg_obj.conn)
+
+                    elif msg_obj.conn in conns:
+                        if msg_obj.callback:
+                            self._ui_callback([ConnClose(msg_obj.conn, conns[msg_obj.conn].addr)])
+
+                        self.close_connection(conns, msg_obj.conn)
 
                 elif msg_obj.__class__ is OutConn:
                     if msg_obj.addr[1] == 0:

--- a/pynicotine/slskproto.py
+++ b/pynicotine/slskproto.py
@@ -1011,7 +1011,7 @@ class SlskProtoThread(threading.Thread):
 
                 elif msg_obj.__class__ is OutConn:
                     if msg_obj.addr[1] == 0:
-                        self._ui_callback([ConnectError(msg_obj, (0, "Port cannot be zero"))])
+                        self._ui_callback([ConnectError(msg_obj, "Port cannot be zero")])
 
                     elif maxsockets == -1 or numsockets < maxsockets:
                         try:
@@ -1033,7 +1033,7 @@ class SlskProtoThread(threading.Thread):
                             self._ui_callback([ConnectError(msg_obj, err)])
                             conn.close()
                     else:
-                        self._ui_callback([ConnectError(msg_obj)])
+                        self._ui_callback([ConnectError(msg_obj, "Connection limit reached")])
 
                 elif msg_obj.__class__ is DownloadFile and msg_obj.conn in conns:
                     conns[msg_obj.conn].filedown = msg_obj
@@ -1274,7 +1274,7 @@ class SlskProtoThread(threading.Thread):
 
                 if (curtime - conn_obj.lastactive) > self.IN_PROGRESS_STALE_AFTER:
 
-                    self._ui_callback([ConnectError(msg_obj)])
+                    self._ui_callback([ConnectError(msg_obj, "Timed out")])
                     self.close_connection(connsinprogress, connection_in_progress)
                     continue
 

--- a/pynicotine/transfers.py
+++ b/pynicotine/transfers.py
@@ -224,10 +224,7 @@ class Transfers:
 
         for i in self.uploads[:]:
             if msg.user == i.user and i.status != "Finished":
-                if msg.status != 0:
-                    if i.status == "Getting status":
-                        self.push_file(i.user, i.filename, i.realfilename, i.path, i)
-                else:
+                if msg.status == 0:
                     if i.transfertimer is not None:
                         i.transfertimer.cancel()
                     self.uploads.remove(i)

--- a/pynicotine/transfers.py
+++ b/pynicotine/transfers.py
@@ -1764,7 +1764,7 @@ class Transfers:
             elif type == "download":
                 i.status = "Connection closed by peer"
 
-            elif type == "upload" and i.status in self.TRANSFER:
+            elif type == "upload" and i.status == "Transferring":
                 """ Only cancel files being transferred, queued files will take care of
                 themselves. We don't want to cancel all queued files at once, in case
                 it's just a connectivity fluke. """

--- a/pynicotine/transfers.py
+++ b/pynicotine/transfers.py
@@ -1948,15 +1948,15 @@ class Transfers:
 
         return destination
 
-    def abort_transfers(self):
+    def abort_transfers(self, send_fail_message=True):
         """ Stop all transfers """
 
         for i in self.downloads + self.uploads:
             if i.status in ("Aborted", "Paused"):
-                self.abort_transfer(i)
+                self.abort_transfer(i, send_fail_message=send_fail_message)
                 i.status = "Paused"
             elif i.status != "Finished":
-                self.abort_transfer(i)
+                self.abort_transfer(i, send_fail_message=send_fail_message)
                 i.status = "Old"
 
     def abort_transfer(self, transfer, remove=False, reason="Aborted", send_fail_message=True):

--- a/test/unit/test_login.py
+++ b/test/unit/test_login.py
@@ -46,6 +46,7 @@ def test_instantiate_proto(config) -> None:
         ui_callback=Mock(), queue=Mock(), bindip='',
         port=None, config=config, eventprocessor=Mock()
     )
+    proto.server_connect()
     proto.abort()
 
 
@@ -56,6 +57,7 @@ def test_server_conn(config, monkeypatch) -> None:
         ui_callback=Mock(), queue=Queue(0), bindip='',
         port=None, config=config, eventprocessor=Mock()
     )
+    proto.server_connect()
     proto._queue.put(ServerConn())
 
     sleep(SLSKPROTO_RUN_TIME)
@@ -88,6 +90,7 @@ def test_login(config, monkeypatch) -> None:
         ui_callback=Mock(), queue=Queue(0), bindip='',
         port=None, config=config, eventprocessor=Mock()
     )
+    proto.server_connect()
     proto._queue.put(ServerConn())
 
     sleep(SLSKPROTO_RUN_TIME / 2)


### PR DESCRIPTION
This PR is the result of several days of debugging connectivity and transfer issues (many thanks to @alekksander for helping me test).

Some of the changes include:
- Properly close and clean up peer connections immediately after disconnecting from the server. Thanks to this, SoulseekQt clients are informed about us logging out, and the files they're downloading from the Nicotine+ client won't be permanently stuck on queued after we log in again.
- Don't attempt to send any QueueFailed messages after disconnecting from the server.
- Avoid adding two PeerConnection objects for a user, if we receive a direct and indirect connection attempt at the same time. This fixes issues where uploads would be stuck on "Cannot connect" due to messages being sent on the previous, obsolete connection, and never going anywhere.
- Avoid sending duplicate TransferRequest when attempting to upload files in certain cases.
- Prevent 0 byte file uploads from being stuck on "Initializing transfer"
- Fix minor argument inconsistencies for abort download function
- More comprehensive connection debug logging