### PR TITLE
Bug fixes for peer connections and transfers (part 2)

### DIFF
--- a/doc/SLSKPROTOCOL.md
+++ b/doc/SLSKPROTOCOL.md
@@ -187,7 +187,7 @@ and callbacks for the messages are set in pynicotine.py.
 | 151  | [Stop Public Chat](#server-code-151)              |            |
 | 152  | [Public Chat Message](#server-code-152)           |            |
 | 153  | [Related Searches](#server-code-153)              | Deprecated |
-| 1001 | [Can't Connect To Peer](#server-code-1001)        |            |
+| 1001 | [Can't Connect To Peer](#server-code-1001)        | Deprecated |
 | 1002 | [Can't Create Room](#server-code-1002)            | Deprecated |
 
 ### Server Code 1
@@ -2392,6 +2392,8 @@ Museekd: SCannotConnect
 Nicotine: CantConnectToPeer
 
 #### Description
+
+**DEPRECATED. Since direct and indirect connection attempts are made simultaneously by the official client nowadays, it's not safe to send this message, as we can't be certain that both connection methods have been fully attempted. The order of the attempts is also unpredictable.**
 
 We send this to say we can't connect to peer after it has asked us to connect. We receive this if we asked peer to connect and it can't do this. This message means a connection can't be established either way.
 

--- a/pynicotine/gtkgui/transferlist.py
+++ b/pynicotine/gtkgui/transferlist.py
@@ -349,7 +349,7 @@ class TransferList:
             iterator = self.transfersmodel.iter_next(iterator)
 
         if totalsize > 0:
-            percent = ((100 * position) / totalsize)
+            percent = min(((100 * position) / totalsize), 100)
 
         if speed > 0:
             hspeed = human_speed(speed)
@@ -422,10 +422,7 @@ class TransferList:
 
         try:
             icurrentbytes = int(currentbytes)
-            if icurrentbytes == int(transfer.size):
-                percent = 100
-            else:
-                percent = ((100 * icurrentbytes) / int(size))
+            percent = min(((100 * icurrentbytes) / int(size)), 100)
         except Exception:
             icurrentbytes = 0
             percent = 0

--- a/pynicotine/pynicotine.py
+++ b/pynicotine/pynicotine.py
@@ -756,6 +756,8 @@ class NetworkEventProcessor:
 
         """ Server informs us that an indirect connection with a peer has failed.
         Game over. """
+        """ DEPRECATED. While we can still receive CantConnectToPeer messages by
+        other clients, Nicotine+ does not send such messages anymore. """
 
         log.add_msg_contents("%s %s", (msg.__class__, self.contents(msg)))
 

--- a/pynicotine/pynicotine.py
+++ b/pynicotine/pynicotine.py
@@ -895,17 +895,16 @@ class NetworkEventProcessor:
                     else:
 
                         """ Peer sent us an indirect connection request, and we weren't able to
-                        connect to them. Send a notification to them via the server. """
+                        connect to them. """
 
                         for j in i.msgs:
                             if j.__class__ in (slskmessages.TransferRequest, slskmessages.FileRequest) and self.transfers is not None:
                                 self.transfers.got_cant_connect(j.req)
 
-                        log.add_conn(_("Can't connect to user %(user)s neither directly nor indirectly, informing user via the server. Error: %(error)s"), {
+                        log.add_conn(_("Can't connect to user %(user)s indirectly. Error: %(error)s"), {
                             'user': i.username,
                             'error': msg.err
                         })
-                        self.queue.put(slskmessages.CantConnectToPeer(i.token, i.username))
 
                         if i.conntimer is not None:
                             i.conntimer.cancel()

--- a/pynicotine/pynicotine.py
+++ b/pynicotine/pynicotine.py
@@ -303,6 +303,8 @@ class NetworkEventProcessor:
 
         """ Peer wants to connect to us, remember them """
 
+        log.add_msg_contents("%s %s", (msg.__class__, self.contents(msg)))
+
         user = msg.user
         addr = msg.conn.addr
         conn = msg.conn.conn
@@ -334,7 +336,6 @@ class NetworkEventProcessor:
             )
 
         log.add_conn(_("Received incoming connection of type %(type)s from user %(user)s") % {'type': msg_type, 'user': user})
-        log.add_msg_contents("%s %s", (msg.__class__, self.contents(msg)))
 
     def send_message_to_peer(self, user, message, address=None):
 
@@ -471,10 +472,10 @@ class NetworkEventProcessor:
         """ Peer sent us an indirect connection request via the server, attempt to
         connect to them """
 
+        log.add_msg_contents("%s %s", (msg.__class__, self.contents(msg)))
+
         user = msg.user
-        ip = msg.ip
-        port = msg.port
-        addr = (ip, port)
+        addr = (msg.ip, msg.port)
         token = msg.token
         msg_type = msg.type
         found_conn = False
@@ -516,11 +517,11 @@ class NetworkEventProcessor:
                 )
             )
 
-        log.add_msg_contents("%s %s", (msg.__class__, self.contents(msg)))
-
     def get_peer_address(self, msg):
 
         """ Server responds with the IP address and port of the user we requested """
+
+        log.add_msg_contents("%s %s", (msg.__class__, self.contents(msg)))
 
         user = msg.user
 
@@ -659,6 +660,8 @@ class NetworkEventProcessor:
         """ Direct connection to peer was successful, send pierce firewall message
         and process any messages associated with the connection """
 
+        log.add_msg_contents("%s %s", (msg.__class__, self.contents(msg)))
+
         addr = msg.addr
 
         for i in self.peerconns:
@@ -684,9 +687,9 @@ class NetworkEventProcessor:
 
                 break
 
-        log.add_msg_contents("%s %s", (msg.__class__, self.contents(msg)))
-
     def pierce_fire_wall(self, msg):
+
+        log.add_msg_contents("%s %s", (msg.__class__, self.contents(msg)))
 
         # Sometimes a token is seemingly not sent by the peer, check if the
         # IP address matches in that case
@@ -714,8 +717,6 @@ class NetworkEventProcessor:
                     self.process_conn_messages(i, conn)
 
                     break
-
-        log.add_msg_contents("%s %s", (msg.__class__, self.contents(msg)))
 
     def close_peer_connection(self, conn, username):
 
@@ -757,6 +758,8 @@ class NetworkEventProcessor:
         """ Server informs us that an indirect connection with a peer has failed.
         Game over. """
 
+        log.add_msg_contents("%s %s", (msg.__class__, self.contents(msg)))
+
         token = msg.token
 
         for i in self.peerconns:
@@ -777,6 +780,8 @@ class NetworkEventProcessor:
     def connect_to_peer_timeout(self, msg):
 
         """ Peer was not able to repond to our indirect connection request """
+
+        log.add_msg_contents("%s %s", (msg.__class__, self.contents(msg)))
 
         conn = msg.conn
 
@@ -850,9 +855,14 @@ class NetworkEventProcessor:
                     return
 
     def conn_close(self, msg):
+
+        log.add_msg_contents("%s %s", (msg.__class__, self.contents(msg)))
+
         self.closed_connection(msg.conn, msg.addr)
 
     def connect_error(self, msg):
+
+        log.add_msg_contents("%s %s", (msg.__class__, self.contents(msg)))
 
         if msg.connobj.__class__ is slskmessages.ServerConn:
 
@@ -907,8 +917,6 @@ class NetworkEventProcessor:
 
         else:
             self.closed_connection(msg.connobj.conn, msg.connobj.addr, msg.err)
-
-        log.add_msg_contents("%s %s %s", (msg.err, msg.__class__, self.contents(msg)))
 
     def start_upnp_timer(self):
         """ Port mapping entries last 24 hours, we need to regularly renew them """
@@ -970,6 +978,7 @@ class NetworkEventProcessor:
             self.transfers.abort_transfers()
 
     def connect_to_server(self, msg):
+        log.add_msg_contents("%s %s", (msg.__class__, self.contents(msg)))
         self.ui_callback.on_connect()
 
     # notify user of error when recieving or sending a message
@@ -997,6 +1006,8 @@ class NetworkEventProcessor:
         self.set_status(_("Listening on port %i"), msg.port)
 
     def server_conn(self, msg):
+
+        log.add_msg_contents("%s %s", (msg.__class__, self.contents(msg)))
 
         self.set_status(
             _("Connected to server %(host)s:%(port)s, logging in..."), {
@@ -1027,6 +1038,8 @@ class NetworkEventProcessor:
             self.queue.put(slskmessages.SetWaitPort(self.waitport))
 
     def login(self, msg):
+
+        log.add_msg_contents("%s %s", (msg.__class__, self.contents(msg)))
 
         if msg.success:
 
@@ -1064,6 +1077,9 @@ class NetworkEventProcessor:
             self.set_status(_("Can not log in, reason: %s"), (msg.reason))
 
     def change_password(self, msg):
+
+        log.add_msg_contents("%s %s", (msg.__class__, self.contents(msg)))
+
         password = msg.password
         self.config.sections["server"]["passw"] = password
         self.config.write_configuration()
@@ -1071,25 +1087,30 @@ class NetworkEventProcessor:
 
     def notify_privileges(self, msg):
 
+        log.add_msg_contents("%s %s", (msg.__class__, self.contents(msg)))
+
         if msg.token is not None:
             pass
 
+    def user_privileged(self, msg):
+
         log.add_msg_contents("%s %s", (msg.__class__, self.contents(msg)))
 
-    def user_privileged(self, msg):
         if self.transfers is not None:
             if msg.privileged is True:
                 self.transfers.add_to_privileged(msg.user)
 
     def ack_notify_privileges(self, msg):
 
+        log.add_msg_contents("%s %s", (msg.__class__, self.contents(msg)))
+
         if msg.token is not None:
             # Until I know the syntax, sending this message is probably a bad idea
             self.queue.put(slskmessages.AckNotifyPrivileges(msg.token))
 
-        log.add_msg_contents("%s %s", (msg.__class__, self.contents(msg)))
-
     def p_message_user(self, msg):
+
+        log.add_msg_contents("%s %s", (msg.__class__, self.contents(msg)))
 
         conn = msg.conn.conn
         user = None
@@ -1113,12 +1134,11 @@ class NetworkEventProcessor:
         if self.privatechat is not None:
             self.privatechat.show_message(msg, text)
 
-        log.add_msg_contents("%s %s", (msg.__class__, self.contents(msg)))
-
     def message_user(self, msg):
 
-        if self.privatechat is not None:
+        log.add_msg_contents("%s %s", (msg.__class__, self.contents(msg)))
 
+        if self.privatechat is not None:
             event = self.pluginhandler.incoming_private_chat_event(msg.user, msg.msg)
 
             if event is not None:
@@ -1129,96 +1149,118 @@ class NetworkEventProcessor:
 
             self.queue.put(slskmessages.MessageAcked(msg.msgid))
 
-        log.add_msg_contents("%s %s", (msg.__class__, self.contents(msg)))
-
     def user_joined_room(self, msg):
+
+        log.add_msg_contents("%s %s", (msg.__class__, self.contents(msg)))
 
         if self.chatrooms is not None:
             self.chatrooms.roomsctrl.user_joined_room(msg)
 
-        log.add_msg_contents("%s %s", (msg.__class__, self.contents(msg)))
-
     def public_room_message(self, msg):
+
+        log.add_msg_contents("%s %s", (msg.__class__, self.contents(msg)))
 
         if self.chatrooms is not None:
             self.chatrooms.roomsctrl.public_room_message(msg, msg.msg)
             self.pluginhandler.public_room_message_notification(msg.room, msg.user, msg.msg)
-        else:
-            log.add_msg_contents("%s %s", (msg.__class__, self.contents(msg)))
 
     def join_room(self, msg):
 
-        if self.chatrooms is not None:
+        log.add_msg_contents("%s %s", (msg.__class__, self.contents(msg)))
 
+        if self.chatrooms is not None:
             self.chatrooms.roomsctrl.join_room(msg)
 
+    def private_room_users(self, msg):
+
         log.add_msg_contents("%s %s", (msg.__class__, self.contents(msg)))
 
-    def private_room_users(self, msg):
         if self.chatrooms is not None:
             self.chatrooms.roomsctrl.private_room_users(msg)
-        log.add_msg_contents("%s %s", (msg.__class__, self.contents(msg)))
 
     def private_room_owned(self, msg):
+
+        log.add_msg_contents("%s %s", (msg.__class__, self.contents(msg)))
+
         if self.chatrooms is not None:
             self.chatrooms.roomsctrl.private_room_owned(msg)
-        log.add_msg_contents("%s %s", (msg.__class__, self.contents(msg)))
 
     def private_room_add_user(self, msg):
+
+        log.add_msg_contents("%s %s", (msg.__class__, self.contents(msg)))
+
         if self.chatrooms is not None:
             self.chatrooms.roomsctrl.private_room_add_user(msg)
-        log.add_msg_contents("%s %s", (msg.__class__, self.contents(msg)))
 
     def private_room_remove_user(self, msg):
+
+        log.add_msg_contents("%s %s", (msg.__class__, self.contents(msg)))
+
         if self.chatrooms is not None:
             self.chatrooms.roomsctrl.private_room_remove_user(msg)
-        log.add_msg_contents("%s %s", (msg.__class__, self.contents(msg)))
 
     def private_room_operator_added(self, msg):
+
+        log.add_msg_contents("%s %s", (msg.__class__, self.contents(msg)))
+
         if self.chatrooms is not None:
             self.chatrooms.roomsctrl.private_room_operator_added(msg)
-        log.add_msg_contents("%s %s", (msg.__class__, self.contents(msg)))
 
     def private_room_operator_removed(self, msg):
+
+        log.add_msg_contents("%s %s", (msg.__class__, self.contents(msg)))
+
         if self.chatrooms is not None:
             self.chatrooms.roomsctrl.private_room_operator_removed(msg)
-        log.add_msg_contents("%s %s", (msg.__class__, self.contents(msg)))
 
     def private_room_add_operator(self, msg):
+
+        log.add_msg_contents("%s %s", (msg.__class__, self.contents(msg)))
+
         if self.chatrooms is not None:
             self.chatrooms.roomsctrl.private_room_add_operator(msg)
-        log.add_msg_contents("%s %s", (msg.__class__, self.contents(msg)))
 
     def private_room_remove_operator(self, msg):
+
+        log.add_msg_contents("%s %s", (msg.__class__, self.contents(msg)))
+
         if self.chatrooms is not None:
             self.chatrooms.roomsctrl.private_room_remove_operator(msg)
-        log.add_msg_contents("%s %s", (msg.__class__, self.contents(msg)))
 
     def private_room_added(self, msg):
+
+        log.add_msg_contents("%s %s", (msg.__class__, self.contents(msg)))
+
         if self.chatrooms is not None:
             self.chatrooms.roomsctrl.private_room_added(msg)
-        log.add_msg_contents("%s %s", (msg.__class__, self.contents(msg)))
 
     def private_room_removed(self, msg):
+
+        log.add_msg_contents("%s %s", (msg.__class__, self.contents(msg)))
+
         if self.chatrooms is not None:
             self.chatrooms.roomsctrl.private_room_removed(msg)
-        log.add_msg_contents("%s %s", (msg.__class__, self.contents(msg)))
 
     def private_room_disown(self, msg):
+
+        log.add_msg_contents("%s %s", (msg.__class__, self.contents(msg)))
+
         if self.chatrooms is not None:
             self.chatrooms.roomsctrl.private_room_disown(msg)
-        log.add_msg_contents("%s %s", (msg.__class__, self.contents(msg)))
 
     def private_room_toggle(self, msg):
-        if self.chatrooms is not None:
-            self.chatrooms.roomsctrl.toggle_private_rooms(msg.enabled)
+
         log.add_msg_contents("%s %s", (msg.__class__, self.contents(msg)))
 
+        if self.chatrooms is not None:
+            self.chatrooms.roomsctrl.toggle_private_rooms(msg.enabled)
+
     def leave_room(self, msg):
+
+        log.add_msg_contents("%s %s", (msg.__class__, self.contents(msg)))
+
         if self.chatrooms is not None:
             self.chatrooms.roomsctrl.leave_room(msg)
-        else:
-            log.add_msg_contents("%s %s", (msg.__class__, self.contents(msg)))
 
     def private_message_queue_add(self, msg, text):
 
@@ -1274,16 +1316,18 @@ class NetworkEventProcessor:
 
     def say_chat_room(self, msg):
 
+        log.add_msg_contents("%s %s", (msg.__class__, self.contents(msg)))
+
         if self.chatrooms is not None:
             event = self.pluginhandler.incoming_public_chat_event(msg.room, msg.user, msg.msg)
             if event is not None:
                 (r, n, msg.msg) = event
                 self.chatrooms.roomsctrl.say_chat_room(msg, msg.msg)
                 self.pluginhandler.incoming_public_chat_notification(msg.room, msg.user, msg.msg)
-        else:
-            log.add_msg_contents("%s %s", (msg.__class__, self.contents(msg)))
 
     def add_user(self, msg):
+
+        log.add_msg_contents("%s %s", (msg.__class__, self.contents(msg)))
 
         self.watchedusers.add(msg.user)
 
@@ -1299,9 +1343,9 @@ class NetworkEventProcessor:
         if msg.files is not None:
             self.get_user_stats(msg)
 
-        log.add_msg_contents("%s %s", (msg.__class__, self.contents(msg)))
-
     def privileged_users(self, msg):
+
+        log.add_msg_contents("%s %s", (msg.__class__, self.contents(msg)))
 
         if self.transfers is not None:
             self.transfers.set_privileged_users(msg.users)
@@ -1309,16 +1353,17 @@ class NetworkEventProcessor:
             self.queue.put(slskmessages.HaveNoParent(1))
             self.queue.put(slskmessages.AddUser(self.config.sections["server"]["login"]))
             self.pluginhandler.server_connect_notification()
-        else:
-            log.add_msg_contents("%s %s", (msg.__class__, self.contents(msg)))
 
     def add_to_privileged(self, msg):
+
+        log.add_msg_contents("%s %s", (msg.__class__, self.contents(msg)))
+
         if self.transfers is not None:
             self.transfers.add_to_privileged(msg.user)
-        else:
-            log.add_msg_contents("%s %s", (msg.__class__, self.contents(msg)))
 
     def check_privileges(self, msg):
+
+        log.add_msg_contents("%s %s", (msg.__class__, self.contents(msg)))
 
         mins = msg.seconds // 60
         hours = mins // 60
@@ -1364,12 +1409,15 @@ class NetworkEventProcessor:
         log.add_msg_contents("%s %s", (msg.__class__, self.contents(msg)))
 
     def wishlist_interval(self, msg):
+
+        log.add_msg_contents("%s %s", (msg.__class__, self.contents(msg)))
+
         if self.search is not None:
             self.search.wish_list.set_interval(msg)
-        else:
-            log.add_msg_contents("%s %s", (msg.__class__, self.contents(msg)))
 
     def get_user_status(self, msg):
+
+        log.add_msg_contents("%s %s", (msg.__class__, self.contents(msg)))
 
         # Causes recursive requests when privileged?
         # self.queue.put(slskmessages.AddUser(msg.user))
@@ -1408,17 +1456,17 @@ class NetworkEventProcessor:
 
         if self.chatrooms is not None:
             self.chatrooms.roomsctrl.get_user_status(msg)
-        else:
-            log.add_msg_contents("%s %s", (msg.__class__, self.contents(msg)))
 
     def user_interests(self, msg):
+
+        log.add_msg_contents("%s %s", (msg.__class__, self.contents(msg)))
 
         if self.userinfo is not None:
             self.userinfo.show_interests(msg)
 
-        log.add_msg_contents("%s %s", (msg.__class__, self.contents(msg)))
-
     def get_user_stats(self, msg):
+
+        log.add_msg_contents("%s %s", (msg.__class__, self.contents(msg)))
 
         if msg.user == self.config.sections["server"]["login"]:
             self.speed = msg.avgspeed
@@ -1443,13 +1491,13 @@ class NetworkEventProcessor:
         }
 
         self.pluginhandler.user_stats_notification(msg.user, stats)
-        log.add_msg_contents("%s %s", (msg.__class__, self.contents(msg)))
 
     def user_left_room(self, msg):
+
+        log.add_msg_contents("%s %s", (msg.__class__, self.contents(msg)))
+
         if self.chatrooms is not None:
             self.chatrooms.roomsctrl.user_left_room(msg)
-        else:
-            log.add_msg_contents("%s %s", (msg.__class__, self.contents(msg)))
 
     def relogged(self, msg):
         log.add(_("Someone else is logging in with the same nickname, server is going to disconnect us"))
@@ -1518,6 +1566,9 @@ class NetworkEventProcessor:
         return 0
 
     def user_info_reply(self, msg):
+
+        log.add_msg_contents("%s %s", (msg.__class__, self.contents(msg)))
+
         conn = msg.conn.conn
 
         for i in self.peerconns:
@@ -1529,6 +1580,8 @@ class NetworkEventProcessor:
                     break
 
     def user_info_request(self, msg):
+
+        log.add_msg_contents("%s %s", (msg.__class__, self.contents(msg)))
 
         user = ip = port = None
         conn = msg.conn.conn
@@ -1616,6 +1669,9 @@ class NetworkEventProcessor:
         )
 
     def shared_file_list(self, msg):
+
+        log.add_msg_contents("%s %s", (msg.__class__, self.contents(msg)))
+
         conn = msg.conn.conn
 
         for i in self.peerconns:
@@ -1626,6 +1682,8 @@ class NetworkEventProcessor:
                     break
 
     def file_search_result(self, msg):
+
+        log.add_msg_contents("%s %s", (msg.__class__, self.contents(msg)))
 
         conn = msg.conn
         addr = conn.addr
@@ -1644,106 +1702,110 @@ class NetworkEventProcessor:
             # Close peer connection immediately, otherwise we exhaust our connection limit
             self.close_peer_connection(conn, msg.user)
 
+    def transfer_timeout(self, msg):
+
         log.add_msg_contents("%s %s", (msg.__class__, self.contents(msg)))
 
-    def transfer_timeout(self, msg):
         if self.transfers is not None:
             self.transfers.transfer_timeout(msg)
 
+    def file_download(self, msg):
+
         log.add_msg_contents("%s %s", (msg.__class__, self.contents(msg)))
 
-    def file_download(self, msg):
         if self.transfers is not None:
             self.transfers.file_download(msg)
 
+    def file_upload(self, msg):
+
         log.add_msg_contents("%s %s", (msg.__class__, self.contents(msg)))
 
-    def file_upload(self, msg):
         if self.transfers is not None:
             self.transfers.file_upload(msg)
 
+    def file_request(self, msg):
+
         log.add_msg_contents("%s %s", (msg.__class__, self.contents(msg)))
 
-    def file_request(self, msg):
         if self.transfers is not None:
             self.transfers.file_request(msg)
 
+    def file_error(self, msg):
+
         log.add_msg_contents("%s %s", (msg.__class__, self.contents(msg)))
 
-    def file_error(self, msg):
         if self.transfers is not None:
             self.transfers.file_error(msg)
-
-        log.add_msg_contents("%s %s", (msg.__class__, self.contents(msg)))
 
     def transfer_request(self, msg):
         """ Peer code: 40 """
 
+        log.add_msg_contents("%s %s", (msg.__class__, self.contents(msg)))
+
         if self.transfers is not None:
             self.transfers.transfer_request(msg)
-
-        log.add_msg_contents("%s %s", (msg.__class__, self.contents(msg)))
 
     def transfer_response(self, msg):
         """ Peer code: 41 """
 
+        log.add_msg_contents("%s %s", (msg.__class__, self.contents(msg)))
+
         if self.transfers is not None:
             self.transfers.transfer_response(msg)
-
-        log.add_msg_contents("%s %s", (msg.__class__, self.contents(msg)))
 
     def queue_upload(self, msg):
         """ Peer code: 43 """
 
+        log.add_msg_contents("%s %s", (msg.__class__, self.contents(msg)))
+
         if self.transfers is not None:
             self.transfers.queue_upload(msg)
-
-        log.add_msg_contents("%s %s", (msg.__class__, self.contents(msg)))
 
     def queue_failed(self, msg):
         """ Peer code: 50 """
 
+        log.add_msg_contents("%s %s", (msg.__class__, self.contents(msg)))
+
         if self.transfers is not None:
             self.transfers.queue_failed(msg)
-
-        log.add_msg_contents("%s %s", (msg.__class__, self.contents(msg)))
 
     def place_in_queue_request(self, msg):
         """ Peer code: 51 """
 
+        log.add_msg_contents("%s %s", (msg.__class__, self.contents(msg)))
+
         if self.transfers is not None:
             self.transfers.place_in_queue_request(msg)
-
-        log.add_msg_contents("%s %s", (msg.__class__, self.contents(msg)))
 
     def upload_queue_notification(self, msg):
         """ Peer code: 52 """
 
+        log.add_msg_contents("%s %s", (msg.__class__, self.contents(msg)))
+
         if self.transfers is not None:
             self.transfers.upload_queue_notification(msg)
-
-        log.add_msg_contents("%s %s", (msg.__class__, self.contents(msg)))
 
     def upload_failed(self, msg):
         """ Peer code: 46 """
 
+        log.add_msg_contents("%s %s", (msg.__class__, self.contents(msg)))
+
         if self.transfers is not None:
             self.transfers.upload_failed(msg)
-
-        log.add_msg_contents("%s %s", (msg.__class__, self.contents(msg)))
 
     def place_in_queue(self, msg):
         """ Peer code: 44 """
 
+        log.add_msg_contents("%s %s", (msg.__class__, self.contents(msg)))
+
         if self.transfers is not None:
             self.transfers.place_in_queue(msg)
-
-        log.add_msg_contents("%s %s", (msg.__class__, self.contents(msg)))
 
     def get_shared_file_list(self, msg):
         """ Peer code: 4 """
 
         log.add_msg_contents("%s %s", (msg.__class__, self.contents(msg)))
+
         user = ip = port = None
         conn = msg.conn.conn
 
@@ -1817,6 +1879,8 @@ class NetworkEventProcessor:
     def folder_contents_request(self, msg):
         """ Peer code: 36 """
 
+        log.add_msg_contents("%s %s", (msg.__class__, self.contents(msg)))
+
         conn = msg.conn.conn
         ip, port = msg.conn.addr
         username = None
@@ -1856,10 +1920,10 @@ class NetworkEventProcessor:
                     elif msg.dir.rstrip("\\") in shares:
                         self.queue.put(slskmessages.FolderContentsResponse(conn, msg.dir, shares[msg.dir.rstrip("\\")]))
 
-        log.add_msg_contents("%s %s", (msg.__class__, self.contents(msg)))
-
     def folder_contents_response(self, msg):
         """ Peer code: 37 """
+
+        log.add_msg_contents("%s %s", (msg.__class__, self.contents(msg)))
 
         if self.transfers is not None:
             conn = msg.conn.conn
@@ -1886,25 +1950,23 @@ class NetworkEventProcessor:
                 self.transfers.downloadsview.download_large_folder(username, folder, numfiles, conn, file_list)
             else:
                 self.transfers.folder_contents_response(conn, file_list)
-        else:
-            log.add_msg_contents("%s %s", (msg.__class__, self.contents(msg)))
 
     def room_list(self, msg):
         """ Server code: 64 """
 
+        log.add_msg_contents("%s %s", (msg.__class__, self.contents(msg)))
+
         if self.chatrooms is not None:
             self.chatrooms.roomsctrl.set_room_list(msg)
             self.set_status("")
-        else:
-            log.add_msg_contents("%s %s", (msg.__class__, self.contents(msg)))
 
     def global_user_list(self, msg):
         """ Server code: 67 """
 
+        log.add_msg_contents("%s %s", (msg.__class__, self.contents(msg)))
+
         if self.globallist is not None:
             self.globallist.set_global_users_list(msg)
-        else:
-            log.add_msg_contents("%s %s", (msg.__class__, self.contents(msg)))
 
     def peer_transfer(self, msg):
         if self.userinfo is not None and msg.msg is slskmessages.UserInfoReply:
@@ -1929,6 +1991,9 @@ class NetworkEventProcessor:
 
     def file_search_request(self, msg):
         """ Peer code: 8 """
+
+        log.add_msg_contents("%s %s", (msg.__class__, self.contents(msg)))
+
         conn = msg.conn.conn
 
         for i in self.peerconns:
@@ -1937,14 +2002,13 @@ class NetworkEventProcessor:
                 self.shares.process_search_request(msg.searchterm, user, msg.searchid, direct=1)
                 break
 
-        log.add_msg_contents("%s %s", (msg.__class__, self.contents(msg)))
-
     def search_request(self, msg):
         """ Server code: 93 """
 
+        log.add_msg_contents("%s %s", (msg.__class__, self.contents(msg)))
+
         self.shares.process_search_request(msg.searchterm, msg.user, msg.searchid, direct=0)
         self.pluginhandler.search_request_notification(msg.searchterm, msg.user, msg.searchid)
-        log.add_msg_contents("%s %s", (msg.__class__, self.contents(msg)))
 
     def room_search_request(self, msg):
         log.add_msg_contents("%s %s", (msg.__class__, self.contents(msg)))
@@ -1962,6 +2026,8 @@ class NetworkEventProcessor:
         """ Server sent a list of 10 potential parents, whose purpose is to forward us search requests.
         We attempt to connect to them all at once, since connection errors are fairly common. """
 
+        log.add_msg_contents("%s %s", (msg.__class__, self.contents(msg)))
+
         potential_parents = msg.list
 
         if potential_parents:
@@ -1970,8 +2036,6 @@ class NetworkEventProcessor:
                 addr = potential_parents[user]
 
                 self.send_message_to_peer(user, slskmessages.DistribConn(), address=addr)
-
-        log.add_msg_contents("%s %s", (msg.__class__, self.contents(msg)))
 
     def get_parent_conn(self):
 
@@ -1993,6 +2057,8 @@ class NetworkEventProcessor:
 
         """ This message is received when we have a successful connection with a potential
         parent. Tell the server who our parent is, and stop requesting new potential parents. """
+
+        log.add_msg_contents("%s %s", (msg.__class__, self.contents(msg)))
 
         if not self.has_parent:
 
@@ -2019,10 +2085,10 @@ class NetworkEventProcessor:
             else:
                 self.parent_conn_closed()
 
-        log.add_msg_contents("%s %s", (msg.__class__, self.contents(msg)))
-
     def global_recommendations(self, msg):
         """ Server code: 56 """
+
+        log.add_msg_contents("%s %s", (msg.__class__, self.contents(msg)))
 
         if self.interests is not None:
             self.interests.global_recommendations(msg)
@@ -2030,11 +2096,15 @@ class NetworkEventProcessor:
     def recommendations(self, msg):
         """ Server code: 54 """
 
+        log.add_msg_contents("%s %s", (msg.__class__, self.contents(msg)))
+
         if self.interests is not None:
             self.interests.recommendations(msg)
 
     def item_recommendations(self, msg):
         """ Server code: 111 """
+
+        log.add_msg_contents("%s %s", (msg.__class__, self.contents(msg)))
 
         if self.interests is not None:
             self.interests.item_recommendations(msg)
@@ -2042,32 +2112,34 @@ class NetworkEventProcessor:
     def similar_users(self, msg):
         """ Server code: 110 """
 
+        log.add_msg_contents("%s %s", (msg.__class__, self.contents(msg)))
+
         if self.interests is not None:
             self.interests.similar_users(msg)
 
     def room_ticker_state(self, msg):
         """ Server code: 113 """
 
+        log.add_msg_contents("%s %s", (msg.__class__, self.contents(msg)))
+
         if self.chatrooms is not None:
             self.chatrooms.roomsctrl.ticker_set(msg)
-
-        log.add_msg_contents("%s %s", (msg.__class__, self.contents(msg)))
 
     def room_ticker_add(self, msg):
         """ Server code: 114 """
 
+        log.add_msg_contents("%s %s", (msg.__class__, self.contents(msg)))
+
         if self.chatrooms is not None:
             self.chatrooms.roomsctrl.ticker_add(msg)
-
-        log.add_msg_contents("%s %s", (msg.__class__, self.contents(msg)))
 
     def room_ticker_remove(self, msg):
         """ Server code: 115 """
 
+        log.add_msg_contents("%s %s", (msg.__class__, self.contents(msg)))
+
         if self.chatrooms is not None:
             self.chatrooms.roomsctrl.ticker_remove(msg)
-
-        log.add_msg_contents("%s %s", (msg.__class__, self.contents(msg)))
 
     def update_debug_log_options(self):
         """ Gives the logger updated logging settings """

--- a/pynicotine/pynicotine.py
+++ b/pynicotine/pynicotine.py
@@ -479,7 +479,7 @@ class NetworkEventProcessor:
         token = msg.token
         msg_type = msg.type
         found_conn = False
-        should_connect = False
+        should_connect = True
 
         init = slskmessages.PeerInit(None, user, msg_type, 0)
 
@@ -489,17 +489,16 @@ class NetworkEventProcessor:
                     """ Only update existing connection if it hasn't been established yet,
                     otherwise ignore indirect connection request. """
 
+                    found_conn = True
+
                     if i.conn is None:
                         i.addr = addr
                         i.token = token
                         i.init = init
-                        should_connect = True
+                        break
 
-                    found_conn = True
+                    should_connect = False
                     break
-
-            else:
-                should_connect = True
 
         if should_connect:
             self.connect_to_peer_direct(user, addr, msg_type, init)

--- a/pynicotine/pynicotine.py
+++ b/pynicotine/pynicotine.py
@@ -449,7 +449,7 @@ class NetworkEventProcessor:
                 self.transfers.got_connect_error(j.req, j.direction)
 
         conntimeout = ConnectToPeerTimeout(conn, self.network_callback)
-        timer = threading.Timer(20.0, conntimeout.timeout)
+        timer = threading.Timer(10.0, conntimeout.timeout)
         timer.setName("ConnectionTimer")
         timer.setDaemon(True)
         timer.start()

--- a/pynicotine/slskmessages.py
+++ b/pynicotine/slskmessages.py
@@ -1860,8 +1860,12 @@ class CantConnectToPeer(ServerMessage):
     """ Server code: 1001 """
     """ We send this to say we can't connect to peer after it has asked us
     to connect. We receive this if we asked peer to connect and it can't do
-    this. This message means a connection can't be established either way.
-    """
+    this. This message means a connection can't be established either way. """
+
+    """ DEPRECATED. Since direct and indirect connection attempts are made
+    simultaneously by the official client nowadays, it's not safe to send this
+    message, as we can't be certain that both connection methods have been
+    fully attempted. The order of the attempts is also unpredictable. """
 
     def __init__(self, token=None, user=None):
         self.token = token

--- a/pynicotine/slskproto.py
+++ b/pynicotine/slskproto.py
@@ -399,7 +399,7 @@ class SlskProtoThread(threading.Thread):
         93: DistribServerSearch
     }
 
-    IN_PROGRESS_STALE_AFTER = 5
+    IN_PROGRESS_STALE_AFTER = 2
     CONNECTION_MAX_IDLE = 60
     CONNCOUNT_UI_INTERVAL = 0.5
 

--- a/pynicotine/slskproto.py
+++ b/pynicotine/slskproto.py
@@ -364,7 +364,7 @@ class SlskProtoThread(threading.Thread):
         LeavePublicRoom: 151,
         PublicRoomMessage: 152,
         RelatedSearch: 153,           # Deprecated ?
-        CantConnectToPeer: 1001,
+        CantConnectToPeer: 1001,      # Deprecated
         CantCreateRoom: 1002          # Deprecated
     }
 


### PR DESCRIPTION
- If a connection to a peer is already established, ensure indirect connection attempts from the peer can't override the active connection.
- Stop sending CantConnectToPeer messages to users, if they send us an indirect connection request, and we can't connect to their port. We can no longer be sure that the peer has actually finished an attempt at connecting to us directly before sending us the indirect connection request, as the official client attempts both connection methods simultaneously nowadays.
- Slightly reduce timeout period for connections
- Ensure percentage bar for transfers can never exceed 100%