### PR TITLE
Check stuck downloads in the main thread

### DIFF
--- a/pynicotine/pynicotine.py
+++ b/pynicotine/pynicotine.py
@@ -217,6 +217,7 @@ class NetworkEventProcessor:
             slskmessages.GetUserStats: self.get_user_stats,
             slskmessages.Relogged: self.relogged,
             slskmessages.PeerInit: self.peer_init,
+            slskmessages.CheckDownloadQueue: self.check_download_queue,
             slskmessages.DownloadFile: self.file_download,
             slskmessages.UploadFile: self.file_upload,
             slskmessages.FileRequest: self.file_request,
@@ -1708,6 +1709,13 @@ class NetworkEventProcessor:
 
         if self.transfers is not None:
             self.transfers.transfer_timeout(msg)
+
+    def check_download_queue(self, msg):
+
+        log.add_msg_contents("%s %s", (msg.__class__, self.contents(msg)))
+
+        if self.transfers is not None:
+            self.transfers.check_download_queue()
 
     def file_download(self, msg):
 

--- a/pynicotine/slskmessages.py
+++ b/pynicotine/slskmessages.py
@@ -128,6 +128,12 @@ class PeerTransfer(InternalMessage):
         self.msg = msg
 
 
+class CheckDownloadQueue(InternalMessage):
+    """ Sent from a timer to the main thread to indicate that stuck downloads
+    should be checked. """
+    pass
+
+
 class DownloadFile(InternalMessage):
     """ Sent by networking thread to indicate file transfer progress.
     Sent by UI to pass the file object to write and offset to resume download

--- a/pynicotine/transfers.py
+++ b/pynicotine/transfers.py
@@ -120,7 +120,7 @@ class Transfers:
     PRE_TRANSFER = ["Queued"]
     TRANSFER = ["Requesting file", "Initializing transfer", "Transferring"]
 
-    def __init__(self, peerconns, queue, eventprocessor, users, network_callback, notifications=None, pluginhandler=None):
+    def __init__(self, peerconns, queue, eventprocessor, users, ui_callback, notifications=None, pluginhandler=None):
 
         self.peerconns = peerconns
         self.queue = queue
@@ -176,7 +176,7 @@ class Transfers:
                 self.queue.put(slskmessages.AddUser(i))
 
         self.users = users
-        self.network_callback = network_callback
+        self.ui_callback = ui_callback
         self.notifications = notifications
         self.pluginhandler = pluginhandler
         self.downloadsview = None
@@ -550,7 +550,7 @@ class Transfers:
 
                 i.req = msg.req
                 i.status = "Waiting for download"
-                transfertimeout = TransferTimeout(i.req, self.network_callback)
+                transfertimeout = TransferTimeout(i.req, self.ui_callback)
 
                 if i.transfertimer is not None:
                     i.transfertimer.cancel()
@@ -663,7 +663,7 @@ class Transfers:
         size = self.get_file_size(realpath)
         response = slskmessages.TransferResponse(None, 1, req=msg.req, filesize=size)
 
-        transfertimeout = TransferTimeout(msg.req, self.network_callback)
+        transfertimeout = TransferTimeout(msg.req, self.ui_callback)
         transferobj = Transfer(
             user=user, realfilename=realpath, filename=msg.file,
             path=os.path.dirname(realpath), status="Waiting for upload",
@@ -1585,7 +1585,7 @@ class Transfers:
             self.eventprocessor.config.write_download_queue()
 
     def start_check_download_queue_timer(self):
-        timer = threading.Timer(60.0, self.check_download_queue)
+        timer = threading.Timer(60.0, self.ui_callback, [[slskmessages.CheckDownloadQueue()]])
         timer.setName("DownloadQueueTimer")
         timer.setDaemon(True)
         timer.start()


### PR DESCRIPTION
The timer that checks if downloads are stuck currently runs in a separate thread. When a new download attempt is made, the UI is updated directly from this thread. This can sometimes result in a crash, as GTK is not thread safe.

Run the check_download_queue function in the main thread instead, to prevent this issue.

(Partial?) solution for https://github.com/Nicotine-Plus/nicotine-plus/issues/882