### PR TITLE
Allow completing entry dialogs by pressing enter

### DIFF
--- a/pynicotine/gtkgui/dialogs.py
+++ b/pynicotine/gtkgui/dialogs.py
@@ -31,6 +31,10 @@ from gi.repository import Gtk
 """ General Dialogs """
 
 
+def activate(self, dialog):
+    dialog.response(Gtk.ResponseType.OK)
+
+
 def combo_box_dialog(parent, title, message, default_text="",
                      option=False, optionmessage="",
                      optionvalue=False, droplist=[]):
@@ -55,6 +59,7 @@ def combo_box_dialog(parent, title, message, default_text="",
     for i in droplist:
         self.combo_list.append([i])
 
+    self.combo.get_child().connect("activate", activate, self)
     self.combo.get_child().set_text(default_text)
 
     self.get_message_area().pack_start(self.combo, False, False, 0)
@@ -97,6 +102,7 @@ def entry_dialog(parent, title, message, default=""):
     self.format_secondary_text(message)
 
     entry = Gtk.Entry()
+    entry.connect("activate", activate, self)
     entry.set_activates_default(True)
     entry.set_text(default)
     self.get_message_area().pack_start(entry, True, True, 0)

--- a/pynicotine/gtkgui/tray.py
+++ b/pynicotine/gtkgui/tray.py
@@ -116,7 +116,7 @@ class Tray:
             droplist=users
         )
 
-        if user is not None:
+        if user:
             self.frame.privatechats.send_message(user, show_user=True)
             self.frame.change_main_page("private")
             self.show_window()
@@ -137,7 +137,7 @@ class Tray:
             droplist=users
         )
 
-        if user is not None:
+        if user:
             self.frame.local_user_info_request(user)
 
     def on_get_a_users_ip(self, widget, prefix=""):
@@ -155,7 +155,7 @@ class Tray:
             droplist=users
         )
 
-        if user is not None:
+        if user:
             self.frame.np.ip_requested.add(user)
             self.frame.np.queue.put(slskmessages.GetPeerAddress(user))
 
@@ -174,7 +174,7 @@ class Tray:
             droplist=users
         )
 
-        if user is not None:
+        if user:
             self.frame.browse_user(user)
 
     # GtkStatusIcon fallback

--- a/pynicotine/gtkgui/utils.py
+++ b/pynicotine/gtkgui/utils.py
@@ -1229,7 +1229,7 @@ class PopupMenu(Gtk.Menu):
     def on_copy_user(self, widget):
         self.frame.clip.set_text(self.user, -1)
 
-    def on_give_privileges(self, widget):
+    def on_give_privileges(self, widget, error=None):
 
         self.frame.np.queue.put(slskmessages.CheckPrivileges())
 
@@ -1238,18 +1238,24 @@ class PopupMenu(Gtk.Menu):
         else:
             days = self.frame.np.privileges_left // 60 // 60 // 24
 
-        text = entry_dialog(
+        message = _("Give how many days of global privileges to this user?") + " (" + _("%(days)s days left") % {'days': days} + ")"
+
+        if error:
+            message += "\n\n" + error
+
+        days = entry_dialog(
             self.frame.MainWindow,
             _("Give privileges") + " " + _("to %(user)s") % {"user": self.user},
-            _("Give how many days of global privileges to this user?") + " (" + _("%(days)s days left") % {'days': days} + ")"
+            message
         )
 
-        if text:
+        if days:
             try:
-                days = int(text)
+                days = int(days)
                 self.frame.np.queue.put(slskmessages.GivePrivileges(self.user, days))
-            except Exception as e:
-                log.add_warning("%s", e)
+
+            except ValueError:
+                self.on_give_privileges(widget, error=_("Please enter a whole number!"))
 
     def on_private_rooms(self, widget, popup):
 


### PR DESCRIPTION
Entry dialogs previously required you to press the "OK" button to finish them, which was very frustrating at times.