### PR TITLE
Ensure either gdbm or semidbm is installed

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -10,6 +10,7 @@ Build-Depends:
     gettext,
     lintian,
     python3 (>= 3.5),
+    python3-gdbm,
     python3-pep8-naming,
     python3-pytest
 Vcs-Git: https://github.com/Nicotine-Plus/nicotine-plus.git
@@ -25,6 +26,7 @@ Depends:
     ${misc:Depends},
     gir1.2-gtk-3.0,
     python3 (>= 3.5),
+    python3-gdbm,
     python3-gi
 Recommends:
     gir1.2-ayatanaappindicator3-0.1 | gir1.2-appindicator3-0.1,

--- a/doc/DEPENDENCIES.md
+++ b/doc/DEPENDENCIES.md
@@ -7,6 +7,7 @@
 * [python3](https://www.python.org/) >= 3.5 for interpreter;
 * [python3-gi](https://pygobject.readthedocs.io/en/latest/getting_started.html) for using GObject introspection with Python 3;
 * [gir1.2-gtk-3.0](https://www.gtk.org/) for GObject introspection bindings for GTK.
+* [gdbm](https://www.gnu.org.ua/software/gdbm/) or [semidbm](https://semidbm.readthedocs.io/en/latest/) for scanning shared files;
 
 ### Recommended
 
@@ -28,13 +29,13 @@
 * On Debian/Ubuntu based distributions:
 
 ```sh
-sudo apt install gir1.2-gtk-3.0 python3-gi
+sudo apt install gir1.2-gtk-3.0 python3-gi python3-gdbm
 ```
 
 * On Redhat/Fedora based distributions:
 
 ```sh
-sudo dnf install gtk3 python3-gobject
+sudo dnf install gtk3 python3-gobject gdbm
 ```
 
 #### Installing the recommended runtime dependencies

--- a/nicotine
+++ b/nicotine
@@ -76,9 +76,13 @@ You should install GTK 3.0 or newer.""") % e
     except ImportError:
         return _("Cannot import the Gtk module. Bad install of the python-gobject module?")
 
-    # Require semidbm on Windows, for faster loading of shelves
-    if sys.platform == "win32" and not importlib.util.find_spec("semidbm"):
-        return _("Cannot find %s, please install it.") % "semidbm"
+    # Require gdbm or semidbm, for faster loading of shelves
+    if not importlib.util.find_spec("_gdbm") and \
+            not importlib.util.find_spec("semidbm"):
+        return _("Cannot find %(option1)s or %(option2)s, please install either one.") % {
+            "option1": "gdbm",
+            "option2": "semidbm"
+        }
 
     # Require pynicotine
     if not importlib.util.find_spec("pynicotine"):

--- a/pynicotine/shares.py
+++ b/pynicotine/shares.py
@@ -20,6 +20,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+import importlib
 import os
 import pickle
 import re
@@ -35,12 +36,20 @@ from pynicotine import slskmessages
 from pynicotine.logfacility import log
 from pynicotine.metadata.tinytag import TinyTag
 
-if sys.platform == "win32":
-    # Use semidbm for faster shelves on Windows
+if not importlib.util.find_spec("_gdbm"):
+    # gdbm not found, use semidbm instead
 
     def shelve_open_semidbm(filename, flag='c', protocol=None, writeback=False):
-        import semidbm
-        return shelve.Shelf(semidbm.open(filename, flag), protocol, writeback)
+        try:
+            import semidbm
+            return shelve.Shelf(semidbm.open(filename, flag), protocol, writeback)
+
+        except ImportError:
+            print(_("Cannot find %(option1)s or %(option2)s, please install either one.") % {
+                "option1": "gdbm",
+                "option2": "semidbm"
+            })
+            sys.exit()
 
     shelve.open = shelve_open_semidbm
 


### PR DESCRIPTION
Even though gdbm should be preinstalled on most systems, I don't want to receive bug reports about slow file scanning due to falling back to dumbdbm.