### PR TITLE
Fix error in exception handling when invalid audio metadata is found

### DIFF
--- a/pynicotine/shares.py
+++ b/pynicotine/shares.py
@@ -677,26 +677,33 @@ class Shares:
             stream.extend(message.pack_object(fileinfo[1], unsignedlonglong=True))
 
             if fileinfo[2] is not None and fileinfo[3] is not None:
-                try:
-                    stream.extend(message.pack_object('mp3'))
-                    stream.extend(message.pack_object(3))
+                stream.extend(message.pack_object('mp3'))
+                stream.extend(message.pack_object(3))
 
-                    stream.extend(message.pack_object(0))
+                stream.extend(message.pack_object(0))
+                try:
                     stream.extend(message.pack_object(fileinfo[2][0], unsignedint=True))
-                    stream.extend(message.pack_object(1))
+
+                except Exception:
+                    # Invalid bitrate
+                    stream.extend(message.pack_object(0))
+
+                stream.extend(message.pack_object(1))
+                try:
                     stream.extend(message.pack_object(fileinfo[3], unsignedint=True))
-                    stream.extend(message.pack_object(2))
+
+                except Exception:
+                    # Invalid length
+                    stream.extend(message.pack_object(0))
+
+                stream.extend(message.pack_object(2))
+                try:
                     stream.extend(message.pack_object(fileinfo[2][1]))
 
                 except Exception:
-                    log.add(_("Found meta data that couldn't be encoded, possible corrupt file: '%(file)s' has a bitrate of %(bitrate)s kbs, a length of %(length)s seconds and a VBR of %(vbr)s"), {
-                        'file': fileinfo[0],
-                        'bitrate': fileinfo[2][0],
-                        'length': fileinfo[3],
-                        'vbr': fileinfo[2][1]
-                    })
-                    stream.extend(message.pack_object(''))
+                    # Invalid VBR value
                     stream.extend(message.pack_object(0))
+
             else:
                 stream.extend(message.pack_object(''))
                 stream.extend(message.pack_object(0))

--- a/pynicotine/slskmessages.py
+++ b/pynicotine/slskmessages.py
@@ -2170,11 +2170,28 @@ class FileSearchResult(PeerMessage):
                 msg.extend(self.pack_object(3))
 
                 msg.extend(self.pack_object(0))
-                msg.extend(self.pack_object(fileinfo[2][0], unsignedint=True))
+                try:
+                    msg.extend(self.pack_object(fileinfo[2][0], unsignedint=True))
+
+                except Exception:
+                    # Invalid bitrate
+                    msg.extend(self.pack_object(0))
+
                 msg.extend(self.pack_object(1))
-                msg.extend(self.pack_object(fileinfo[3], unsignedint=True))
+                try:
+                    msg.extend(self.pack_object(fileinfo[3], unsignedint=True))
+
+                except Exception:
+                    # Invalid duration
+                    msg.extend(self.pack_object(0))
+
                 msg.extend(self.pack_object(2))
-                msg.extend(self.pack_object(fileinfo[2][1]))
+                try:
+                    msg.extend(self.pack_object(fileinfo[2][1]))
+
+                except Exception:
+                    # Invalid VBR value
+                    msg.extend(self.pack_object(0))
 
         msg.extend(bytes([self.freeulslots]))
         msg.extend(self.pack_object(self.ulspeed, unsignedint=True))


### PR DESCRIPTION
The current exception handling in shares.py doesn't work, as a few metadata objects will already be packed before the exception is thrown. This creates an invalid folder stream.