### PR TITLE
Remove incorrect usage of gettext across codebase

### DIFF
--- a/nicotine
+++ b/nicotine
@@ -28,7 +28,6 @@ Nicotine+ Launcher.
 
 import importlib
 import sys
-from gettext import gettext as _
 
 from pynicotine.utils import apply_translation
 from pynicotine.utils import get_user_directories

--- a/pynicotine/config.py
+++ b/pynicotine/config.py
@@ -35,7 +35,6 @@ import sys
 
 from ast import literal_eval
 from collections import defaultdict
-from gettext import gettext as _
 
 from pynicotine.logfacility import log
 from pynicotine.utils import RestrictedUnpickler

--- a/pynicotine/gtkgui/chatrooms.py
+++ b/pynicotine/gtkgui/chatrooms.py
@@ -25,7 +25,6 @@
 import os
 import re
 from collections import deque
-from gettext import gettext as _
 from os.path import commonprefix
 
 from gi.repository import Gdk

--- a/pynicotine/gtkgui/dialogs.py
+++ b/pynicotine/gtkgui/dialogs.py
@@ -22,8 +22,6 @@
 
 import os
 
-from gettext import gettext as _
-
 from gi.repository import GObject
 from gi.repository import Gtk
 

--- a/pynicotine/gtkgui/downloads.py
+++ b/pynicotine/gtkgui/downloads.py
@@ -22,8 +22,8 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 import os
-from gettext import gettext as _
 
 from gi.repository import Gdk
 from gi.repository import Gtk

--- a/pynicotine/gtkgui/fastconfigure.py
+++ b/pynicotine/gtkgui/fastconfigure.py
@@ -19,7 +19,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import os
-from gettext import gettext as _
+
 from os.path import getsize
 from os.path import join
 

--- a/pynicotine/gtkgui/fileproperties.py
+++ b/pynicotine/gtkgui/fileproperties.py
@@ -21,8 +21,6 @@
 
 import os
 
-from gettext import gettext as _
-
 from pynicotine.gtkgui.utils import load_ui_elements
 
 

--- a/pynicotine/gtkgui/frame.py
+++ b/pynicotine/gtkgui/frame.py
@@ -28,8 +28,6 @@ import signal
 import sys
 import threading
 
-from gettext import gettext as _
-
 import gi
 from gi.repository import Gdk
 from gi.repository import GdkPixbuf

--- a/pynicotine/gtkgui/interests.py
+++ b/pynicotine/gtkgui/interests.py
@@ -20,8 +20,6 @@
 
 import os
 
-from gettext import gettext as _
-
 from gi.repository import Gdk
 from gi.repository import Gtk
 from gi.repository import GObject

--- a/pynicotine/gtkgui/notifications.py
+++ b/pynicotine/gtkgui/notifications.py
@@ -19,8 +19,6 @@
 import sys
 import _thread
 
-from gettext import gettext as _
-
 from gi.repository import Gdk
 from gi.repository import Gio
 

--- a/pynicotine/gtkgui/privatechat.py
+++ b/pynicotine/gtkgui/privatechat.py
@@ -20,9 +20,10 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 import os
+
 from collections import deque
-from gettext import gettext as _
 from time import altzone
 from time import daylight
 

--- a/pynicotine/gtkgui/roomlist.py
+++ b/pynicotine/gtkgui/roomlist.py
@@ -21,6 +21,7 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 import os
 
 from pynicotine import slskmessages

--- a/pynicotine/gtkgui/search.py
+++ b/pynicotine/gtkgui/search.py
@@ -26,7 +26,6 @@ import os
 import random
 import re
 import sre_constants
-from gettext import gettext as _
 
 from gi.repository import Gdk
 from gi.repository import GObject

--- a/pynicotine/gtkgui/settingswindow.py
+++ b/pynicotine/gtkgui/settingswindow.py
@@ -27,8 +27,6 @@ import re
 import sys
 import time
 
-from gettext import gettext as _
-
 from gi.repository import Gdk
 from gi.repository import GLib
 from gi.repository import GdkPixbuf

--- a/pynicotine/gtkgui/transferlist.py
+++ b/pynicotine/gtkgui/transferlist.py
@@ -22,7 +22,6 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-from gettext import gettext as _
 from sys import maxsize
 from time import time
 

--- a/pynicotine/gtkgui/tray.py
+++ b/pynicotine/gtkgui/tray.py
@@ -20,8 +20,6 @@ import gi
 import os
 import sys
 
-from gettext import gettext as _
-
 from pynicotine import slskmessages
 from pynicotine.gtkgui.dialogs import combo_box_dialog
 from pynicotine.gtkgui.utils import PopupMenu

--- a/pynicotine/gtkgui/uploads.py
+++ b/pynicotine/gtkgui/uploads.py
@@ -23,7 +23,6 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import os
-from gettext import gettext as _
 
 from gi.repository import Gdk
 from gi.repository import Gtk

--- a/pynicotine/gtkgui/userbrowse.py
+++ b/pynicotine/gtkgui/userbrowse.py
@@ -22,7 +22,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import os
-from gettext import gettext as _
+
 from sys import maxsize
 
 from gi.repository import Gdk

--- a/pynicotine/gtkgui/userinfo.py
+++ b/pynicotine/gtkgui/userinfo.py
@@ -22,7 +22,6 @@
 
 import os
 import time
-from gettext import gettext as _
 
 from gi.repository import Gdk
 from gi.repository import GdkPixbuf

--- a/pynicotine/gtkgui/userlist.py
+++ b/pynicotine/gtkgui/userlist.py
@@ -23,7 +23,6 @@
 
 import os
 import time
-from gettext import gettext as _
 
 from gi.repository import Gdk
 from gi.repository import GLib

--- a/pynicotine/gtkgui/utils.py
+++ b/pynicotine/gtkgui/utils.py
@@ -26,8 +26,6 @@ import re
 import sys
 import time
 
-from gettext import gettext as _
-
 from gi.repository import Gdk
 from gi.repository import Gio
 from gi.repository import GLib

--- a/pynicotine/gtkgui/wishlist.py
+++ b/pynicotine/gtkgui/wishlist.py
@@ -23,8 +23,6 @@
 
 import os
 
-from gettext import gettext as _
-
 from gi.repository import GLib
 from gi.repository import GObject
 from gi.repository import Gtk

--- a/pynicotine/nowplaying.py
+++ b/pynicotine/nowplaying.py
@@ -20,8 +20,6 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-from gettext import gettext as _
-
 from pynicotine.logfacility import log
 from pynicotine.utils import execute_command
 

--- a/pynicotine/pluginsystem.py
+++ b/pynicotine/pluginsystem.py
@@ -25,7 +25,6 @@ import sys
 import _thread
 
 from ast import literal_eval
-from gettext import gettext as _
 from time import time
 
 from pynicotine import slskmessages

--- a/pynicotine/pynicotine.py
+++ b/pynicotine/pynicotine.py
@@ -35,8 +35,6 @@ import threading
 import time
 import _thread
 
-from gettext import gettext as _
-
 from pynicotine import slskmessages
 from pynicotine import slskproto
 from pynicotine import transfers

--- a/pynicotine/shares.py
+++ b/pynicotine/shares.py
@@ -30,8 +30,6 @@ import string
 import sys
 import _thread
 
-from gettext import gettext as _
-
 from pynicotine import slskmessages
 from pynicotine.logfacility import log
 from pynicotine.metadata.tinytag import TinyTag

--- a/pynicotine/slskmessages.py
+++ b/pynicotine/slskmessages.py
@@ -23,7 +23,6 @@ import socket
 import struct
 import zlib
 
-from gettext import gettext as _
 from hashlib import md5
 from itertools import count
 from itertools import islice

--- a/pynicotine/slskproto.py
+++ b/pynicotine/slskproto.py
@@ -30,7 +30,6 @@ import threading
 import time
 
 from errno import EINTR
-from gettext import gettext as _
 from itertools import islice
 from random import uniform
 

--- a/pynicotine/transfers.py
+++ b/pynicotine/transfers.py
@@ -36,7 +36,6 @@ import stat
 import threading
 import time
 
-from gettext import gettext as _
 from hashlib import md5
 from time import sleep
 

--- a/pynicotine/utils.py
+++ b/pynicotine/utils.py
@@ -32,8 +32,6 @@ import pickle
 import sys
 import time
 
-from gettext import gettext as _
-
 version = "2.2.3.dev1"
 
 win32 = sys.platform.startswith("win")

--- a/setup.cfg
+++ b/setup.cfg
@@ -8,4 +8,5 @@ requires =
     python3-gobject
 
 [flake8]
+builtins = _
 ignore = E501, W504

--- a/test/unit/shares/test_shares.py
+++ b/test/unit/shares/test_shares.py
@@ -17,15 +17,23 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import os
+import pytest
 import queue
 
 from time import sleep
 
 from pynicotine.shares import Shares
 from pynicotine.config import Config
+from pynicotine.utils import apply_translation
 
 DB_DIR = os.path.join(os.path.dirname(os.path.realpath(__file__)), "dbs")
 SHARES_DIR = os.path.join(os.path.dirname(os.path.realpath(__file__)), "sharedfiles")
+
+
+@pytest.fixture(scope="module", autouse=True)
+def translation():
+    # Setting gettext and locale
+    apply_translation()
 
 
 def test_shares_scan():

--- a/test/unit/test_login.py
+++ b/test/unit/test_login.py
@@ -27,11 +27,18 @@ import pytest
 
 from pynicotine.slskproto import SlskProtoThread
 from pynicotine.slskmessages import ServerConn, Login, SetWaitPort
+from pynicotine.utils import apply_translation
 from test.unit.mock_socket import monkeypatch_socket, monkeypatch_select
 
 # Time (in s) needed for SlskProtoThread main loop to run at least once
 SLSKPROTO_RUN_TIME = 0.5
 LOGIN_DATAFILE = 'data/login/socket_localhost_22420.log'
+
+
+@pytest.fixture(scope="module", autouse=True)
+def translation():
+    # Setting gettext and locale
+    apply_translation()
 
 
 @pytest.fixture


### PR DESCRIPTION
Currently, Nicotine+ attempts to access a bunch of different paths for translation files each time a string needs to be translated. This PR changes the behavior to the intended one, which is to install translations once at startup, and load needed strings from memory later.