### PR TITLE
UI file preparations for GTK 4 (part 1)

### DIFF
--- a/pynicotine/gtkgui/frame.py
+++ b/pynicotine/gtkgui/frame.py
@@ -221,43 +221,45 @@ class NicotineFrame:
         hide_tab_template = _("Hide %(tab)s")
 
         # Initialize tabs labels
-        for tab_box in self.MainNotebook.get_children():
-            tab_label = self.MainNotebook.get_tab_label(tab_box)
+        for i in range(self.MainNotebook.get_n_pages()):
+            tab_box = self.MainNotebook.get_nth_page(i)
+            placehold_tab_label = self.MainNotebook.get_tab_label(tab_box)
+            eventbox_name = Gtk.Buildable.get_name(placehold_tab_label)
 
             # Initialize the image label
-            img_label = ImageLabel(
-                translated_tablabels[tab_label], angle=config["ui"]["labelmain"],
+            tab_label = ImageLabel(
+                translated_tablabels[placehold_tab_label], angle=config["ui"]["labelmain"],
                 show_hilite_image=config["notifications"]["notification_tab_icons"],
                 show_status_image=True
             )
 
             # Set tab text color
-            img_label.set_text_color(0)
-            img_label.show()
+            tab_label.set_text_color(0)
+            tab_label.show()
+
+            self.__dict__[eventbox_name] = tab_label
 
             # Add it to the eventbox
-            tab_label.add(img_label)
+            self.MainNotebook.set_tab_label(tab_box, tab_label)
 
             # Set the menu to hide the tab
-            eventbox_name = Gtk.Buildable.get_name(tab_label)
-
             tab_label.connect('button_press_event', self.on_tab_click, eventbox_name + "Menu")
 
             self.__dict__[eventbox_name + "Menu"] = PopupMenu(self).setup(
                 (
-                    "#" + hide_tab_template % {"tab": translated_tablabels[tab_label]}, self.hide_tab, [tab_label, tab_box]
+                    "#" + hide_tab_template % {"tab": translated_tablabels[placehold_tab_label]}, self.hide_tab, [tab_label, tab_box]
                 )
             )
 
         # Tab icons
-        self.SearchTabLabel.get_child().set_icon("system-search-symbolic")
-        self.DownloadsTabLabel.get_child().set_icon("document-save-symbolic")
-        self.UploadsTabLabel.get_child().set_icon("emblem-shared-symbolic")
-        self.UserBrowseTabLabel.get_child().set_icon("folder-symbolic")
-        self.UserInfoTabLabel.get_child().set_icon("avatar-default-symbolic")
-        self.PrivateChatTabLabel.get_child().set_icon("mail-send-symbolic")
-        self.ChatTabLabel.get_child().set_icon("user-available-symbolic")
-        self.InterestsTabLabel.get_child().set_icon("emblem-default-symbolic")
+        self.SearchTabLabel.set_icon("system-search-symbolic")
+        self.DownloadsTabLabel.set_icon("document-save-symbolic")
+        self.UploadsTabLabel.set_icon("emblem-shared-symbolic")
+        self.UserBrowseTabLabel.set_icon("folder-symbolic")
+        self.UserInfoTabLabel.set_icon("avatar-default-symbolic")
+        self.PrivateChatTabLabel.set_icon("mail-send-symbolic")
+        self.ChatTabLabel.set_icon("user-available-symbolic")
+        self.InterestsTabLabel.set_icon("emblem-default-symbolic")
 
         # Create Search combo ListStores
         self.search_entry_combo_model = Gtk.ListStore(str)
@@ -1367,21 +1369,12 @@ class NicotineFrame:
 
     """ Main Notebook """
 
-    def get_tab_label(self, tab_label):
-
-        try:
-            return tab_label.get_child()
-        except AttributeError:
-            return tab_label
-
     def request_tab_icon(self, tab_label, status=1):
 
         if self.current_tab_label == tab_label:
             return
 
-        icon_tab_label = self.get_tab_label(tab_label)
-
-        if not icon_tab_label:
+        if not tab_label:
             return
 
         if status == 1:
@@ -1389,26 +1382,25 @@ class NicotineFrame:
         else:
             hilite_icon = self.images["hilite3"]
 
-            if icon_tab_label.get_hilite_image() == self.images["hilite"]:
+            if tab_label.get_hilite_image() == self.images["hilite"]:
                 # Chat mentions have priority over normal notifications
                 return
 
-        if hilite_icon == icon_tab_label.get_hilite_image():
+        if hilite_icon == tab_label.get_hilite_image():
             return
 
-        icon_tab_label.set_hilite_image(hilite_icon)
-        icon_tab_label.set_text_color(status + 1)
+        tab_label.set_hilite_image(hilite_icon)
+        tab_label.set_text_color(status + 1)
 
     def on_switch_page(self, notebook, page, page_num):
 
         tab_label = self.MainNotebook.get_tab_label(page)
-        icon_tab_label = self.get_tab_label(tab_label)
         self.current_tab_label = tab_label
 
-        if icon_tab_label is not None:
+        if tab_label is not None:
             # Defaults
-            icon_tab_label.set_hilite_image(None)
-            icon_tab_label.set_text_color(0)
+            tab_label.set_hilite_image(None)
+            tab_label.set_text_color(0)
 
         if tab_label == self.ChatTabLabel:
             curr_page_num = self.chatrooms.get_current_page()
@@ -1447,8 +1439,9 @@ class NicotineFrame:
 
         tab_names = []
 
-        for children in self.MainNotebook.get_children():
-            tab_names.append(self.match_main_notebox(children))
+        for i in range(self.MainNotebook.get_n_pages()):
+            tab_box = self.MainNotebook.get_nth_page(i)
+            tab_names.append(self.match_main_notebox(tab_box))
 
         self.np.config.sections["ui"]["modes_order"] = tab_names
 
@@ -1476,7 +1469,8 @@ class NicotineFrame:
 
         reorderable = self.np.config.sections["ui"]["tab_reorderable"]
 
-        for tab_box in self.MainNotebook.get_children():
+        for i in range(self.MainNotebook.get_n_pages()):
+            tab_box = self.MainNotebook.get_nth_page(i)
             self.MainNotebook.set_tab_reorderable(tab_box, reorderable)
 
     def set_main_tabs_order(self):
@@ -1505,7 +1499,7 @@ class NicotineFrame:
                 continue
 
             if not tab_names[name]:
-                if tab_box not in self.MainNotebook.get_children():
+                if tab_box not in (self.MainNotebook.get_nth_page(i) for i in range(self.MainNotebook.get_n_pages())):
                     continue
 
                 if tab_box in self.hidden_tabs:
@@ -1544,7 +1538,7 @@ class NicotineFrame:
 
         event_box, tab_box = lista
 
-        if tab_box not in self.MainNotebook.get_children():
+        if tab_box not in (self.MainNotebook.get_nth_page(i) for i in range(self.MainNotebook.get_n_pages())):
             return
 
         if tab_box in self.hidden_tabs:
@@ -1557,7 +1551,7 @@ class NicotineFrame:
 
     def show_tab(self, tab_box):
 
-        if tab_box in self.MainNotebook.get_children():
+        if tab_box in (self.MainNotebook.get_nth_page(i) for i in range(self.MainNotebook.get_n_pages())):
             return
 
         if tab_box not in self.hidden_tabs:
@@ -1601,9 +1595,9 @@ class NicotineFrame:
         # Main notebook
         self.MainNotebook.set_tab_pos(self.get_tab_position(ui["tabmain"]))
 
-        for page in self.MainNotebook.get_children():
-            tab_label = self.MainNotebook.get_tab_label(page)
-            tab_label = self.get_tab_label(tab_label)
+        for i in range(self.MainNotebook.get_n_pages()):
+            tab_box = self.MainNotebook.get_nth_page(i)
+            tab_label = self.MainNotebook.get_tab_label(tab_box)
 
             tab_label.set_angle(ui["labelmain"])
 
@@ -1679,7 +1673,7 @@ class NicotineFrame:
 
         tab_box = self.match_main_name_page(tab_name)
 
-        if tab_box in self.MainNotebook.get_children():
+        if tab_box in (self.MainNotebook.get_nth_page(i) for i in range(self.MainNotebook.get_n_pages())):
             page_num = self.MainNotebook.page_num
             self.MainNotebook.set_current_page(page_num(tab_box))
         else:
@@ -2535,14 +2529,14 @@ class NicotineFrame:
             w.show_status_images(config["ui"]["tab_status_icons"])
 
         # Main notebook
-        for page in self.MainNotebook.get_children():
-            tab_label = self.MainNotebook.get_tab_label(page)
-            icon_tab_label = self.get_tab_label(tab_label)
+        for i in range(self.MainNotebook.get_n_pages()):
+            tab_box = self.MainNotebook.get_nth_page(i)
+            tab_label = self.MainNotebook.get_tab_label(tab_box)
 
-            icon_tab_label.show_hilite_image(config["notifications"]["notification_tab_icons"])
-            icon_tab_label.set_text_color(0)
+            tab_label.show_hilite_image(config["notifications"]["notification_tab_icons"])
+            tab_label.set_text_color(0)
 
-            self.MainNotebook.set_tab_reorderable(page, config["ui"]["tab_reorderable"])
+            self.MainNotebook.set_tab_reorderable(tab_box, config["ui"]["tab_reorderable"])
 
         self.set_tab_positions()
 

--- a/pynicotine/gtkgui/ui/about/about.ui
+++ b/pynicotine/gtkgui/ui/about/about.ui
@@ -2,18 +2,17 @@
 <interface>
   <requires lib="gtk+" version="3.18"/>
   <object class="GtkAboutDialog" id="About">
-    <property name="can_focus">False</property>
     <property name="title" translatable="yes">About Nicotine+</property>
-    <property name="modal">True</property>
-    <property name="window_position">center-on-parent</property>
-    <property name="logo_icon_name">org.nicotine_plus.Nicotine</property>
-    <property name="program_name">Nicotine+</property>
+    <property name="modal">1</property>
+    <property name="window-position">center-on-parent</property>
+    <property name="logo-icon-name">org.nicotine_plus.Nicotine</property>
+    <property name="program-name">Nicotine+</property>
     <property name="comments" translatable="yes">Graphical client for the Soulseek file sharing network</property>
     <property name="website">https://nicotine-plus.org</property>
     <property name="copyright">© 2001 PySoulSeek Contributors
 © 2003 Nicotine Team
 © 2004 Nicotine+ Team</property>
-    <property name="license_type">GTK_LICENSE_GPL_3_0</property>
+    <property name="license-type">GTK_LICENSE_GPL_3_0</property>
     <property name="authors"># Nicotine+ Contributors
 
 ### Active
@@ -53,7 +52,7 @@ daelstorm
 - Developer
 - [daelstorm(at)gmail(dot)com]
 
-gallows (aka 'burp O')
+gallows (aka &apos;burp O&apos;)
 - Developer, Packager
 - Submitted Slack.Build file
 - [g4ll0ws(at)gmail(dot)com]
@@ -79,7 +78,7 @@ INMCM
 suser-guru
 - Suse Linux packager
   https://dev-loki.blogspot.fr/
-- Nicotine+ RPM's for Suse 9.1, 9.2, 9.3, 10.0, 10.1
+- Nicotine+ RPM&apos;s for Suse 9.1, 9.2, 9.3, 10.0, 10.1
 
 osiris
 - handy-man
@@ -214,7 +213,7 @@ Jason Green
   pyupnp is licensed under the MIT License.
   Copyright (c) 2019 Dave Mulford
   https://github.com/davemulford/pyupnp</property>
-    <property name="translator_credits">Dutch
+    <property name="translator-credits">Dutch
  * nince78 (2007)
  * hyriand
 

--- a/pynicotine/gtkgui/ui/about/chatroomcommands.ui
+++ b/pynicotine/gtkgui/ui/about/chatroomcommands.ui
@@ -17,8 +17,8 @@
             <property name="vexpand">1</property>
             <child>
               <object class="GtkGrid">
-                <property name="border-width">10</property>
                 <property name="visible">1</property>
+                <property name="margin">10</property>
                 <property name="row-spacing">10</property>
                 <property name="column-homogeneous">1</property>
                 <property name="column-spacing">5</property>

--- a/pynicotine/gtkgui/ui/about/chatroomcommands.ui
+++ b/pynicotine/gtkgui/ui/about/chatroomcommands.ui
@@ -2,957 +2,939 @@
 <interface>
   <requires lib="gtk+" version="3.18"/>
   <object class="GtkDialog" id="AboutChatRoomCommands">
-    <property name="can_focus">False</property>
     <property name="title" translatable="yes">About chat room commands</property>
-    <property name="modal">True</property>
-    <property name="window_position">center-on-parent</property>
-    <property name="default_width">650</property>
-    <property name="default_height">500</property>
+    <property name="modal">1</property>
+    <property name="window-position">center-on-parent</property>
+    <property name="default-width">650</property>
+    <property name="default-height">500</property>
     <child internal-child="vbox">
       <object class="GtkBox">
-        <property name="visible">True</property>
-        <property name="can_focus">False</property>
+        <property name="visible">1</property>
         <property name="orientation">vertical</property>
         <child>
           <object class="GtkScrolledWindow">
-            <property name="visible">True</property>
-            <property name="can_focus">False</property>
+            <property name="visible">1</property>
+            <property name="vexpand">1</property>
             <child>
               <object class="GtkGrid">
-                <property name="border_width">10</property>
-                <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="row_spacing">10</property>
-                <property name="column_homogeneous">True</property>
-                <property name="column_spacing">5</property>
+                <property name="border-width">10</property>
+                <property name="visible">1</property>
+                <property name="row-spacing">10</property>
+                <property name="column-homogeneous">1</property>
+                <property name="column-spacing">5</property>
                 <child>
                   <object class="GtkLabel">
-                    <property name="visible">True</property>
-                    <property name="can_focus">True</property>
+                    <property name="visible">1</property>
+                    <property name="can-focus">1</property>
                     <property name="xalign">0</property>
-                    <property name="label" translatable="yes">/join /j 'room'</property>
-                    <property name="selectable">True</property>
+                    <property name="label" translatable="yes">/join /j &apos;room&apos;</property>
+                    <property name="selectable">1</property>
                     <attributes>
                       <attribute name="style" value="italic"/>
                     </attributes>
                   </object>
                   <packing>
-                    <property name="left_attach">0</property>
-                    <property name="top_attach">0</property>
+                    <property name="left-attach">0</property>
+                    <property name="top-attach">0</property>
                   </packing>
                 </child>
                 <child>
                   <object class="GtkLabel">
-                    <property name="visible">True</property>
-                    <property name="can_focus">True</property>
+                    <property name="visible">1</property>
+                    <property name="can-focus">1</property>
                     <property name="xalign">0</property>
-                    <property name="label" translatable="yes">Join room 'room'</property>
-                    <property name="selectable">True</property>
+                    <property name="label" translatable="yes">Join room &apos;room&apos;</property>
+                    <property name="selectable">1</property>
                   </object>
                   <packing>
-                    <property name="left_attach">1</property>
-                    <property name="top_attach">0</property>
+                    <property name="left-attach">1</property>
+                    <property name="top-attach">0</property>
                   </packing>
                 </child>
                 <child>
                   <object class="GtkLabel">
-                    <property name="visible">True</property>
-                    <property name="can_focus">True</property>
+                    <property name="visible">1</property>
+                    <property name="can-focus">1</property>
                     <property name="xalign">0</property>
-                    <property name="label" translatable="yes">/leave /l /part /p 'room'</property>
-                    <property name="selectable">True</property>
+                    <property name="label" translatable="yes">/leave /l /part /p &apos;room&apos;</property>
+                    <property name="selectable">1</property>
                     <attributes>
                       <attribute name="style" value="italic"/>
                     </attributes>
                   </object>
                   <packing>
-                    <property name="left_attach">0</property>
-                    <property name="top_attach">1</property>
+                    <property name="left-attach">0</property>
+                    <property name="top-attach">1</property>
                   </packing>
                 </child>
                 <child>
                   <object class="GtkLabel">
-                    <property name="visible">True</property>
-                    <property name="can_focus">True</property>
+                    <property name="visible">1</property>
+                    <property name="can-focus">1</property>
                     <property name="xalign">0</property>
-                    <property name="label" translatable="yes">Leave room 'room'</property>
-                    <property name="selectable">True</property>
+                    <property name="label" translatable="yes">Leave room &apos;room&apos;</property>
+                    <property name="selectable">1</property>
                   </object>
                   <packing>
-                    <property name="left_attach">1</property>
-                    <property name="top_attach">1</property>
+                    <property name="left-attach">1</property>
+                    <property name="top-attach">1</property>
                   </packing>
                 </child>
                 <child>
                   <object class="GtkLabel">
-                    <property name="visible">True</property>
-                    <property name="can_focus">True</property>
+                    <property name="visible">1</property>
+                    <property name="can-focus">1</property>
                     <property name="xalign">0</property>
                     <property name="label" translatable="yes">/clear /cl</property>
-                    <property name="selectable">True</property>
+                    <property name="selectable">1</property>
                     <attributes>
                       <attribute name="style" value="italic"/>
                     </attributes>
                   </object>
                   <packing>
-                    <property name="left_attach">0</property>
-                    <property name="top_attach">2</property>
+                    <property name="left-attach">0</property>
+                    <property name="top-attach">2</property>
                   </packing>
                 </child>
                 <child>
                   <object class="GtkLabel">
-                    <property name="visible">True</property>
-                    <property name="can_focus">True</property>
+                    <property name="visible">1</property>
+                    <property name="can-focus">1</property>
                     <property name="xalign">0</property>
                     <property name="label" translatable="yes">Clear the chat window</property>
-                    <property name="selectable">True</property>
+                    <property name="selectable">1</property>
                   </object>
                   <packing>
-                    <property name="left_attach">1</property>
-                    <property name="top_attach">2</property>
+                    <property name="left-attach">1</property>
+                    <property name="top-attach">2</property>
                   </packing>
                 </child>
                 <child>
                   <object class="GtkLabel">
-                    <property name="visible">True</property>
-                    <property name="can_focus">True</property>
+                    <property name="visible">1</property>
+                    <property name="can-focus">1</property>
                     <property name="xalign">0</property>
                     <property name="label" translatable="yes">/tick /t</property>
-                    <property name="selectable">True</property>
+                    <property name="selectable">1</property>
                     <attributes>
                       <attribute name="style" value="italic"/>
                     </attributes>
                   </object>
                   <packing>
-                    <property name="left_attach">0</property>
-                    <property name="top_attach">3</property>
+                    <property name="left-attach">0</property>
+                    <property name="top-attach">3</property>
                   </packing>
                 </child>
                 <child>
                   <object class="GtkLabel">
-                    <property name="visible">True</property>
-                    <property name="can_focus">True</property>
+                    <property name="visible">1</property>
+                    <property name="can-focus">1</property>
                     <property name="xalign">0</property>
                     <property name="label" translatable="yes">Set your personal ticker</property>
-                    <property name="selectable">True</property>
+                    <property name="selectable">1</property>
                   </object>
                   <packing>
-                    <property name="left_attach">1</property>
-                    <property name="top_attach">3</property>
+                    <property name="left-attach">1</property>
+                    <property name="top-attach">3</property>
                   </packing>
                 </child>
                 <child>
                   <object class="GtkLabel">
-                    <property name="visible">True</property>
-                    <property name="can_focus">True</property>
+                    <property name="visible">1</property>
+                    <property name="can-focus">1</property>
                     <property name="xalign">0</property>
                     <property name="label" translatable="yes">/tickers</property>
-                    <property name="selectable">True</property>
+                    <property name="selectable">1</property>
                     <attributes>
                       <attribute name="style" value="italic"/>
                     </attributes>
                   </object>
                   <packing>
-                    <property name="left_attach">0</property>
-                    <property name="top_attach">4</property>
+                    <property name="left-attach">0</property>
+                    <property name="top-attach">4</property>
                   </packing>
                 </child>
                 <child>
                   <object class="GtkLabel">
-                    <property name="visible">True</property>
-                    <property name="can_focus">True</property>
+                    <property name="visible">1</property>
+                    <property name="can-focus">1</property>
                     <property name="xalign">0</property>
                     <property name="label" translatable="yes">Show all the tickers</property>
-                    <property name="selectable">True</property>
+                    <property name="selectable">1</property>
                   </object>
                   <packing>
-                    <property name="left_attach">1</property>
-                    <property name="top_attach">4</property>
+                    <property name="left-attach">1</property>
+                    <property name="top-attach">4</property>
                   </packing>
                 </child>
                 <child>
                   <object class="GtkLabel">
-                    <property name="visible">True</property>
-                    <property name="can_focus">True</property>
+                    <property name="visible">1</property>
+                    <property name="can-focus">1</property>
                     <property name="xalign">0</property>
-                    <property name="label" translatable="yes">/me 'message'</property>
-                    <property name="selectable">True</property>
+                    <property name="label" translatable="yes">/me &apos;message&apos;</property>
+                    <property name="selectable">1</property>
                     <attributes>
                       <attribute name="style" value="italic"/>
                     </attributes>
                   </object>
                   <packing>
-                    <property name="left_attach">0</property>
-                    <property name="top_attach">6</property>
+                    <property name="left-attach">0</property>
+                    <property name="top-attach">6</property>
                   </packing>
                 </child>
                 <child>
                   <object class="GtkLabel">
-                    <property name="visible">True</property>
-                    <property name="can_focus">True</property>
+                    <property name="visible">1</property>
+                    <property name="can-focus">1</property>
                     <property name="xalign">0</property>
                     <property name="label" translatable="yes">Say something in the third-person</property>
-                    <property name="selectable">True</property>
+                    <property name="selectable">1</property>
                   </object>
                   <packing>
-                    <property name="left_attach">1</property>
-                    <property name="top_attach">6</property>
+                    <property name="left-attach">1</property>
+                    <property name="top-attach">6</property>
                   </packing>
                 </child>
                 <child>
                   <object class="GtkLabel">
-                    <property name="visible">True</property>
-                    <property name="can_focus">False</property>
+                    <property name="visible">1</property>
                   </object>
                   <packing>
-                    <property name="left_attach">0</property>
-                    <property name="top_attach">5</property>
+                    <property name="left-attach">0</property>
+                    <property name="top-attach">5</property>
                   </packing>
                 </child>
                 <child>
                   <object class="GtkLabel">
-                    <property name="visible">True</property>
-                    <property name="can_focus">True</property>
+                    <property name="visible">1</property>
+                    <property name="can-focus">1</property>
                     <property name="xalign">0</property>
                     <property name="label" translatable="yes">/now</property>
-                    <property name="selectable">True</property>
+                    <property name="selectable">1</property>
                     <attributes>
                       <attribute name="style" value="italic"/>
                     </attributes>
                   </object>
                   <packing>
-                    <property name="left_attach">0</property>
-                    <property name="top_attach">7</property>
+                    <property name="left-attach">0</property>
+                    <property name="top-attach">7</property>
                   </packing>
                 </child>
                 <child>
                   <object class="GtkLabel">
-                    <property name="visible">True</property>
-                    <property name="can_focus">True</property>
+                    <property name="visible">1</property>
+                    <property name="can-focus">1</property>
                     <property name="xalign">0</property>
-                    <property name="label" translatable="yes">Display the Now Playing script's output</property>
-                    <property name="selectable">True</property>
+                    <property name="label" translatable="yes">Display the Now Playing script&apos;s output</property>
+                    <property name="selectable">1</property>
                   </object>
                   <packing>
-                    <property name="left_attach">1</property>
-                    <property name="top_attach">7</property>
+                    <property name="left-attach">1</property>
+                    <property name="top-attach">7</property>
                   </packing>
                 </child>
                 <child>
                   <object class="GtkLabel">
-                    <property name="visible">True</property>
-                    <property name="can_focus">False</property>
+                    <property name="visible">1</property>
                   </object>
                   <packing>
-                    <property name="left_attach">0</property>
-                    <property name="top_attach">8</property>
+                    <property name="left-attach">0</property>
+                    <property name="top-attach">8</property>
                   </packing>
                 </child>
                 <child>
                   <object class="GtkLabel">
-                    <property name="visible">True</property>
-                    <property name="can_focus">True</property>
+                    <property name="visible">1</property>
+                    <property name="can-focus">1</property>
                     <property name="xalign">0</property>
                     <property name="label" translatable="yes">Users</property>
-                    <property name="selectable">True</property>
+                    <property name="selectable">1</property>
                     <attributes>
                       <attribute name="weight" value="bold"/>
                     </attributes>
                   </object>
                   <packing>
-                    <property name="left_attach">0</property>
-                    <property name="top_attach">9</property>
+                    <property name="left-attach">0</property>
+                    <property name="top-attach">9</property>
                   </packing>
                 </child>
                 <child>
                   <object class="GtkLabel">
-                    <property name="visible">True</property>
-                    <property name="can_focus">True</property>
+                    <property name="visible">1</property>
+                    <property name="can-focus">1</property>
                     <property name="xalign">0</property>
-                    <property name="label" translatable="yes">/add /ad 'user'</property>
-                    <property name="selectable">True</property>
+                    <property name="label" translatable="yes">/add /ad &apos;user&apos;</property>
+                    <property name="selectable">1</property>
                     <attributes>
                       <attribute name="style" value="italic"/>
                     </attributes>
                   </object>
                   <packing>
-                    <property name="left_attach">0</property>
-                    <property name="top_attach">10</property>
+                    <property name="left-attach">0</property>
+                    <property name="top-attach">10</property>
                   </packing>
                 </child>
                 <child>
                   <object class="GtkLabel">
-                    <property name="visible">True</property>
-                    <property name="can_focus">True</property>
+                    <property name="visible">1</property>
+                    <property name="can-focus">1</property>
                     <property name="xalign">0</property>
-                    <property name="label" translatable="yes">Add user 'user' to your user list</property>
-                    <property name="selectable">True</property>
+                    <property name="label" translatable="yes">Add user &apos;user&apos; to your user list</property>
+                    <property name="selectable">1</property>
                   </object>
                   <packing>
-                    <property name="left_attach">1</property>
-                    <property name="top_attach">10</property>
+                    <property name="left-attach">1</property>
+                    <property name="top-attach">10</property>
                   </packing>
                 </child>
                 <child>
                   <object class="GtkLabel">
-                    <property name="visible">True</property>
-                    <property name="can_focus">True</property>
+                    <property name="visible">1</property>
+                    <property name="can-focus">1</property>
                     <property name="xalign">0</property>
-                    <property name="label" translatable="yes">/rem /unbuddy 'user'</property>
-                    <property name="selectable">True</property>
+                    <property name="label" translatable="yes">/rem /unbuddy &apos;user&apos;</property>
+                    <property name="selectable">1</property>
                     <attributes>
                       <attribute name="style" value="italic"/>
                     </attributes>
                   </object>
                   <packing>
-                    <property name="left_attach">0</property>
-                    <property name="top_attach">11</property>
+                    <property name="left-attach">0</property>
+                    <property name="top-attach">11</property>
                   </packing>
                 </child>
                 <child>
                   <object class="GtkLabel">
-                    <property name="visible">True</property>
-                    <property name="can_focus">True</property>
+                    <property name="visible">1</property>
+                    <property name="can-focus">1</property>
                     <property name="xalign">0</property>
-                    <property name="label" translatable="yes">Remove user 'user' from your user list</property>
-                    <property name="selectable">True</property>
+                    <property name="label" translatable="yes">Remove user &apos;user&apos; from your user list</property>
+                    <property name="selectable">1</property>
                   </object>
                   <packing>
-                    <property name="left_attach">1</property>
-                    <property name="top_attach">11</property>
+                    <property name="left-attach">1</property>
+                    <property name="top-attach">11</property>
                   </packing>
                 </child>
                 <child>
                   <object class="GtkLabel">
-                    <property name="visible">True</property>
-                    <property name="can_focus">True</property>
+                    <property name="visible">1</property>
+                    <property name="can-focus">1</property>
                     <property name="xalign">0</property>
-                    <property name="label" translatable="yes">/ban 'user'</property>
-                    <property name="selectable">True</property>
+                    <property name="label" translatable="yes">/ban &apos;user&apos;</property>
+                    <property name="selectable">1</property>
                     <attributes>
                       <attribute name="style" value="italic"/>
                     </attributes>
                   </object>
                   <packing>
-                    <property name="left_attach">0</property>
-                    <property name="top_attach">12</property>
+                    <property name="left-attach">0</property>
+                    <property name="top-attach">12</property>
                   </packing>
                 </child>
                 <child>
                   <object class="GtkLabel">
-                    <property name="visible">True</property>
-                    <property name="can_focus">True</property>
+                    <property name="visible">1</property>
+                    <property name="can-focus">1</property>
                     <property name="xalign">0</property>
-                    <property name="label" translatable="yes">Add user 'user' to your ban list</property>
-                    <property name="selectable">True</property>
+                    <property name="label" translatable="yes">Add user &apos;user&apos; to your ban list</property>
+                    <property name="selectable">1</property>
                   </object>
                   <packing>
-                    <property name="left_attach">1</property>
-                    <property name="top_attach">12</property>
+                    <property name="left-attach">1</property>
+                    <property name="top-attach">12</property>
                   </packing>
                 </child>
                 <child>
                   <object class="GtkLabel">
-                    <property name="visible">True</property>
-                    <property name="can_focus">True</property>
+                    <property name="visible">1</property>
+                    <property name="can-focus">1</property>
                     <property name="xalign">0</property>
-                    <property name="label" translatable="yes">/unban 'user'</property>
-                    <property name="selectable">True</property>
+                    <property name="label" translatable="yes">/unban &apos;user&apos;</property>
+                    <property name="selectable">1</property>
                     <attributes>
                       <attribute name="style" value="italic"/>
                     </attributes>
                   </object>
                   <packing>
-                    <property name="left_attach">0</property>
-                    <property name="top_attach">13</property>
+                    <property name="left-attach">0</property>
+                    <property name="top-attach">13</property>
                   </packing>
                 </child>
                 <child>
                   <object class="GtkLabel">
-                    <property name="visible">True</property>
-                    <property name="can_focus">True</property>
+                    <property name="visible">1</property>
+                    <property name="can-focus">1</property>
                     <property name="xalign">0</property>
-                    <property name="label" translatable="yes">Remove user 'user' from your ban list</property>
-                    <property name="selectable">True</property>
+                    <property name="label" translatable="yes">Remove user &apos;user&apos; from your ban list</property>
+                    <property name="selectable">1</property>
                   </object>
                   <packing>
-                    <property name="left_attach">1</property>
-                    <property name="top_attach">13</property>
+                    <property name="left-attach">1</property>
+                    <property name="top-attach">13</property>
                   </packing>
                 </child>
                 <child>
                   <object class="GtkLabel">
-                    <property name="visible">True</property>
-                    <property name="can_focus">True</property>
+                    <property name="visible">1</property>
+                    <property name="can-focus">1</property>
                     <property name="xalign">0</property>
-                    <property name="label" translatable="yes">/ignore 'user'</property>
-                    <property name="selectable">True</property>
+                    <property name="label" translatable="yes">/ignore &apos;user&apos;</property>
+                    <property name="selectable">1</property>
                     <attributes>
                       <attribute name="style" value="italic"/>
                     </attributes>
                   </object>
                   <packing>
-                    <property name="left_attach">0</property>
-                    <property name="top_attach">14</property>
+                    <property name="left-attach">0</property>
+                    <property name="top-attach">14</property>
                   </packing>
                 </child>
                 <child>
                   <object class="GtkLabel">
-                    <property name="visible">True</property>
-                    <property name="can_focus">True</property>
+                    <property name="visible">1</property>
+                    <property name="can-focus">1</property>
                     <property name="xalign">0</property>
-                    <property name="label" translatable="yes">Add user 'user' to your ignore list</property>
-                    <property name="selectable">True</property>
+                    <property name="label" translatable="yes">Add user &apos;user&apos; to your ignore list</property>
+                    <property name="selectable">1</property>
                   </object>
                   <packing>
-                    <property name="left_attach">1</property>
-                    <property name="top_attach">14</property>
+                    <property name="left-attach">1</property>
+                    <property name="top-attach">14</property>
                   </packing>
                 </child>
                 <child>
                   <object class="GtkLabel">
-                    <property name="visible">True</property>
-                    <property name="can_focus">True</property>
+                    <property name="visible">1</property>
+                    <property name="can-focus">1</property>
                     <property name="xalign">0</property>
-                    <property name="label" translatable="yes">/unignore 'user'</property>
-                    <property name="selectable">True</property>
+                    <property name="label" translatable="yes">/unignore &apos;user&apos;</property>
+                    <property name="selectable">1</property>
                     <attributes>
                       <attribute name="style" value="italic"/>
                     </attributes>
                   </object>
                   <packing>
-                    <property name="left_attach">0</property>
-                    <property name="top_attach">15</property>
+                    <property name="left-attach">0</property>
+                    <property name="top-attach">15</property>
                   </packing>
                 </child>
                 <child>
                   <object class="GtkLabel">
-                    <property name="visible">True</property>
-                    <property name="can_focus">True</property>
+                    <property name="visible">1</property>
+                    <property name="can-focus">1</property>
                     <property name="xalign">0</property>
-                    <property name="label" translatable="yes">Remove user 'user' from your ignore list</property>
-                    <property name="selectable">True</property>
+                    <property name="label" translatable="yes">Remove user &apos;user&apos; from your ignore list</property>
+                    <property name="selectable">1</property>
                   </object>
                   <packing>
-                    <property name="left_attach">1</property>
-                    <property name="top_attach">15</property>
+                    <property name="left-attach">1</property>
+                    <property name="top-attach">15</property>
                   </packing>
                 </child>
                 <child>
                   <object class="GtkLabel">
-                    <property name="visible">True</property>
-                    <property name="can_focus">False</property>
+                    <property name="visible">1</property>
                   </object>
                   <packing>
-                    <property name="left_attach">0</property>
-                    <property name="top_attach">16</property>
+                    <property name="left-attach">0</property>
+                    <property name="top-attach">16</property>
                   </packing>
                 </child>
                 <child>
                   <object class="GtkLabel">
-                    <property name="visible">True</property>
-                    <property name="can_focus">True</property>
+                    <property name="visible">1</property>
+                    <property name="can-focus">1</property>
                     <property name="xalign">0</property>
-                    <property name="label" translatable="yes">/browse /b 'user'</property>
-                    <property name="selectable">True</property>
+                    <property name="label" translatable="yes">/browse /b &apos;user&apos;</property>
+                    <property name="selectable">1</property>
                     <attributes>
                       <attribute name="style" value="italic"/>
                     </attributes>
                   </object>
                   <packing>
-                    <property name="left_attach">0</property>
-                    <property name="top_attach">17</property>
+                    <property name="left-attach">0</property>
+                    <property name="top-attach">17</property>
                   </packing>
                 </child>
                 <child>
                   <object class="GtkLabel">
-                    <property name="visible">True</property>
-                    <property name="can_focus">True</property>
+                    <property name="visible">1</property>
+                    <property name="can-focus">1</property>
                     <property name="xalign">0</property>
-                    <property name="label" translatable="yes">Browse files of user 'user'</property>
-                    <property name="selectable">True</property>
+                    <property name="label" translatable="yes">Browse files of user &apos;user&apos;</property>
+                    <property name="selectable">1</property>
                   </object>
                   <packing>
-                    <property name="left_attach">1</property>
-                    <property name="top_attach">17</property>
+                    <property name="left-attach">1</property>
+                    <property name="top-attach">17</property>
                   </packing>
                 </child>
                 <child>
                   <object class="GtkLabel">
-                    <property name="visible">True</property>
-                    <property name="can_focus">True</property>
+                    <property name="visible">1</property>
+                    <property name="can-focus">1</property>
                     <property name="xalign">0</property>
-                    <property name="label" translatable="yes">/whois /w 'user'</property>
-                    <property name="selectable">True</property>
+                    <property name="label" translatable="yes">/whois /w &apos;user&apos;</property>
+                    <property name="selectable">1</property>
                     <attributes>
                       <attribute name="style" value="italic"/>
                     </attributes>
                   </object>
                   <packing>
-                    <property name="left_attach">0</property>
-                    <property name="top_attach">18</property>
+                    <property name="left-attach">0</property>
+                    <property name="top-attach">18</property>
                   </packing>
                 </child>
                 <child>
                   <object class="GtkLabel">
-                    <property name="visible">True</property>
-                    <property name="can_focus">True</property>
+                    <property name="visible">1</property>
+                    <property name="can-focus">1</property>
                     <property name="xalign">0</property>
-                    <property name="label" translatable="yes">Request user info for user 'user'</property>
-                    <property name="selectable">True</property>
+                    <property name="label" translatable="yes">Request user info for user &apos;user&apos;</property>
+                    <property name="selectable">1</property>
                   </object>
                   <packing>
-                    <property name="left_attach">1</property>
-                    <property name="top_attach">18</property>
+                    <property name="left-attach">1</property>
+                    <property name="top-attach">18</property>
                   </packing>
                 </child>
                 <child>
                   <object class="GtkLabel">
-                    <property name="visible">True</property>
-                    <property name="can_focus">True</property>
+                    <property name="visible">1</property>
+                    <property name="can-focus">1</property>
                     <property name="xalign">0</property>
-                    <property name="label" translatable="yes">/ip 'user'</property>
-                    <property name="selectable">True</property>
+                    <property name="label" translatable="yes">/ip &apos;user&apos;</property>
+                    <property name="selectable">1</property>
                     <attributes>
                       <attribute name="style" value="italic"/>
                     </attributes>
                   </object>
                   <packing>
-                    <property name="left_attach">0</property>
-                    <property name="top_attach">19</property>
+                    <property name="left-attach">0</property>
+                    <property name="top-attach">19</property>
                   </packing>
                 </child>
                 <child>
                   <object class="GtkLabel">
-                    <property name="visible">True</property>
-                    <property name="can_focus">True</property>
+                    <property name="visible">1</property>
+                    <property name="can-focus">1</property>
                     <property name="xalign">0</property>
-                    <property name="label" translatable="yes">Show IP for user 'user'</property>
-                    <property name="selectable">True</property>
+                    <property name="label" translatable="yes">Show IP for user &apos;user&apos;</property>
+                    <property name="selectable">1</property>
                   </object>
                   <packing>
-                    <property name="left_attach">1</property>
-                    <property name="top_attach">19</property>
+                    <property name="left-attach">1</property>
+                    <property name="top-attach">19</property>
                   </packing>
                 </child>
                 <child>
                   <object class="GtkLabel">
-                    <property name="visible">True</property>
-                    <property name="can_focus">False</property>
+                    <property name="visible">1</property>
                   </object>
                   <packing>
-                    <property name="left_attach">0</property>
-                    <property name="top_attach">20</property>
+                    <property name="left-attach">0</property>
+                    <property name="top-attach">20</property>
                   </packing>
                 </child>
                 <child>
                   <object class="GtkLabel">
-                    <property name="visible">True</property>
-                    <property name="can_focus">True</property>
+                    <property name="visible">1</property>
+                    <property name="can-focus">1</property>
                     <property name="xalign">0</property>
                     <property name="label" translatable="yes">Aliases</property>
-                    <property name="selectable">True</property>
+                    <property name="selectable">1</property>
                     <attributes>
                       <attribute name="weight" value="bold"/>
                     </attributes>
                   </object>
                   <packing>
-                    <property name="left_attach">0</property>
-                    <property name="top_attach">21</property>
+                    <property name="left-attach">0</property>
+                    <property name="top-attach">21</property>
                   </packing>
                 </child>
                 <child>
                   <object class="GtkLabel">
-                    <property name="visible">True</property>
-                    <property name="can_focus">True</property>
+                    <property name="visible">1</property>
+                    <property name="can-focus">1</property>
                     <property name="xalign">0</property>
-                    <property name="label" translatable="yes">/alias /al 'command' 'definition'</property>
-                    <property name="selectable">True</property>
+                    <property name="label" translatable="yes">/alias /al &apos;command&apos; &apos;definition&apos;</property>
+                    <property name="selectable">1</property>
                     <attributes>
                       <attribute name="style" value="italic"/>
                     </attributes>
                   </object>
                   <packing>
-                    <property name="left_attach">0</property>
-                    <property name="top_attach">22</property>
+                    <property name="left-attach">0</property>
+                    <property name="top-attach">22</property>
                   </packing>
                 </child>
                 <child>
                   <object class="GtkLabel">
-                    <property name="visible">True</property>
-                    <property name="can_focus">True</property>
+                    <property name="visible">1</property>
+                    <property name="can-focus">1</property>
                     <property name="xalign">0</property>
                     <property name="label" translatable="yes">Add a new alias</property>
-                    <property name="selectable">True</property>
+                    <property name="selectable">1</property>
                   </object>
                   <packing>
-                    <property name="left_attach">1</property>
-                    <property name="top_attach">22</property>
+                    <property name="left-attach">1</property>
+                    <property name="top-attach">22</property>
                   </packing>
                 </child>
                 <child>
                   <object class="GtkLabel">
-                    <property name="visible">True</property>
-                    <property name="can_focus">True</property>
+                    <property name="visible">1</property>
+                    <property name="can-focus">1</property>
                     <property name="xalign">0</property>
-                    <property name="label" translatable="yes">/unalias /un 'command'</property>
-                    <property name="selectable">True</property>
+                    <property name="label" translatable="yes">/unalias /un &apos;command&apos;</property>
+                    <property name="selectable">1</property>
                     <attributes>
                       <attribute name="style" value="italic"/>
                     </attributes>
                   </object>
                   <packing>
-                    <property name="left_attach">0</property>
-                    <property name="top_attach">23</property>
+                    <property name="left-attach">0</property>
+                    <property name="top-attach">23</property>
                   </packing>
                 </child>
                 <child>
                   <object class="GtkLabel">
-                    <property name="visible">True</property>
-                    <property name="can_focus">True</property>
+                    <property name="visible">1</property>
+                    <property name="can-focus">1</property>
                     <property name="xalign">0</property>
                     <property name="label" translatable="yes">Remove an alias</property>
-                    <property name="selectable">True</property>
+                    <property name="selectable">1</property>
                   </object>
                   <packing>
-                    <property name="left_attach">1</property>
-                    <property name="top_attach">23</property>
+                    <property name="left-attach">1</property>
+                    <property name="top-attach">23</property>
                   </packing>
                 </child>
                 <child>
                   <object class="GtkLabel">
-                    <property name="visible">True</property>
-                    <property name="can_focus">False</property>
+                    <property name="visible">1</property>
                   </object>
                   <packing>
-                    <property name="left_attach">0</property>
-                    <property name="top_attach">24</property>
+                    <property name="left-attach">0</property>
+                    <property name="top-attach">24</property>
                   </packing>
                 </child>
                 <child>
                   <object class="GtkLabel">
-                    <property name="visible">True</property>
-                    <property name="can_focus">True</property>
+                    <property name="visible">1</property>
+                    <property name="can-focus">1</property>
                     <property name="xalign">0</property>
                     <property name="label" translatable="yes">Search</property>
-                    <property name="selectable">True</property>
+                    <property name="selectable">1</property>
                     <attributes>
                       <attribute name="weight" value="bold"/>
                     </attributes>
                   </object>
                   <packing>
-                    <property name="left_attach">0</property>
-                    <property name="top_attach">25</property>
+                    <property name="left-attach">0</property>
+                    <property name="top-attach">25</property>
                   </packing>
                 </child>
                 <child>
                   <object class="GtkLabel">
-                    <property name="visible">True</property>
-                    <property name="can_focus">True</property>
+                    <property name="visible">1</property>
+                    <property name="can-focus">1</property>
                     <property name="xalign">0</property>
-                    <property name="label" translatable="yes">/search /s 'query'</property>
-                    <property name="selectable">True</property>
+                    <property name="label" translatable="yes">/search /s &apos;query&apos;</property>
+                    <property name="selectable">1</property>
                     <attributes>
                       <attribute name="style" value="italic"/>
                     </attributes>
                   </object>
                   <packing>
-                    <property name="left_attach">0</property>
-                    <property name="top_attach">26</property>
+                    <property name="left-attach">0</property>
+                    <property name="top-attach">26</property>
                   </packing>
                 </child>
                 <child>
                   <object class="GtkLabel">
-                    <property name="visible">True</property>
-                    <property name="can_focus">True</property>
+                    <property name="visible">1</property>
+                    <property name="can-focus">1</property>
                     <property name="xalign">0</property>
-                    <property name="label" translatable="yes">Start a new search for 'query'</property>
-                    <property name="selectable">True</property>
+                    <property name="label" translatable="yes">Start a new search for &apos;query&apos;</property>
+                    <property name="selectable">1</property>
                   </object>
                   <packing>
-                    <property name="left_attach">1</property>
-                    <property name="top_attach">26</property>
+                    <property name="left-attach">1</property>
+                    <property name="top-attach">26</property>
                   </packing>
                 </child>
                 <child>
                   <object class="GtkLabel">
-                    <property name="visible">True</property>
-                    <property name="can_focus">True</property>
+                    <property name="visible">1</property>
+                    <property name="can-focus">1</property>
                     <property name="xalign">0</property>
-                    <property name="label" translatable="yes">/rsearch /rs 'query'</property>
-                    <property name="selectable">True</property>
+                    <property name="label" translatable="yes">/rsearch /rs &apos;query&apos;</property>
+                    <property name="selectable">1</property>
                     <attributes>
                       <attribute name="style" value="italic"/>
                     </attributes>
                   </object>
                   <packing>
-                    <property name="left_attach">0</property>
-                    <property name="top_attach">27</property>
+                    <property name="left-attach">0</property>
+                    <property name="top-attach">27</property>
                   </packing>
                 </child>
                 <child>
                   <object class="GtkLabel">
-                    <property name="visible">True</property>
-                    <property name="can_focus">True</property>
+                    <property name="visible">1</property>
+                    <property name="can-focus">1</property>
                     <property name="xalign">0</property>
-                    <property name="label" translatable="yes">Search the joined rooms for 'query'</property>
-                    <property name="selectable">True</property>
+                    <property name="label" translatable="yes">Search the joined rooms for &apos;query&apos;</property>
+                    <property name="selectable">1</property>
                   </object>
                   <packing>
-                    <property name="left_attach">1</property>
-                    <property name="top_attach">27</property>
+                    <property name="left-attach">1</property>
+                    <property name="top-attach">27</property>
                   </packing>
                 </child>
                 <child>
                   <object class="GtkLabel">
-                    <property name="visible">True</property>
-                    <property name="can_focus">True</property>
+                    <property name="visible">1</property>
+                    <property name="can-focus">1</property>
                     <property name="xalign">0</property>
-                    <property name="label" translatable="yes">/bsearch /bs '%s'</property>
-                    <property name="selectable">True</property>
+                    <property name="label" translatable="yes">/bsearch /bs &apos;%s&apos;</property>
+                    <property name="selectable">1</property>
                     <attributes>
                       <attribute name="style" value="italic"/>
                     </attributes>
                   </object>
                   <packing>
-                    <property name="left_attach">0</property>
-                    <property name="top_attach">28</property>
+                    <property name="left-attach">0</property>
+                    <property name="top-attach">28</property>
                   </packing>
                 </child>
                 <child>
                   <object class="GtkLabel">
-                    <property name="visible">True</property>
-                    <property name="can_focus">True</property>
+                    <property name="visible">1</property>
+                    <property name="can-focus">1</property>
                     <property name="xalign">0</property>
-                    <property name="label" translatable="yes">Search the buddy list for 'query'</property>
-                    <property name="selectable">True</property>
+                    <property name="label" translatable="yes">Search the buddy list for &apos;query&apos;</property>
+                    <property name="selectable">1</property>
                   </object>
                   <packing>
-                    <property name="left_attach">1</property>
-                    <property name="top_attach">28</property>
+                    <property name="left-attach">1</property>
+                    <property name="top-attach">28</property>
                   </packing>
                 </child>
                 <child>
                   <object class="GtkLabel">
-                    <property name="visible">True</property>
-                    <property name="can_focus">True</property>
+                    <property name="visible">1</property>
+                    <property name="can-focus">1</property>
                     <property name="xalign">0</property>
-                    <property name="label" translatable="yes">/usearch /us 'user' 'query'</property>
-                    <property name="selectable">True</property>
+                    <property name="label" translatable="yes">/usearch /us &apos;user&apos; &apos;query&apos;</property>
+                    <property name="selectable">1</property>
                     <attributes>
                       <attribute name="style" value="italic"/>
                     </attributes>
                   </object>
                   <packing>
-                    <property name="left_attach">0</property>
-                    <property name="top_attach">29</property>
+                    <property name="left-attach">0</property>
+                    <property name="top-attach">29</property>
                   </packing>
                 </child>
                 <child>
                   <object class="GtkLabel">
-                    <property name="visible">True</property>
-                    <property name="can_focus">True</property>
+                    <property name="visible">1</property>
+                    <property name="can-focus">1</property>
                     <property name="xalign">0</property>
-                    <property name="label" translatable="yes">Search a user's shares for 'query'</property>
-                    <property name="selectable">True</property>
+                    <property name="label" translatable="yes">Search a user&apos;s shares for &apos;query&apos;</property>
+                    <property name="selectable">1</property>
                   </object>
                   <packing>
-                    <property name="left_attach">1</property>
-                    <property name="top_attach">29</property>
+                    <property name="left-attach">1</property>
+                    <property name="top-attach">29</property>
                   </packing>
                 </child>
                 <child>
                   <object class="GtkLabel">
-                    <property name="visible">True</property>
-                    <property name="can_focus">False</property>
+                    <property name="visible">1</property>
                   </object>
                   <packing>
-                    <property name="left_attach">0</property>
-                    <property name="top_attach">30</property>
+                    <property name="left-attach">0</property>
+                    <property name="top-attach">30</property>
                   </packing>
                 </child>
                 <child>
                   <object class="GtkLabel">
-                    <property name="visible">True</property>
-                    <property name="can_focus">True</property>
+                    <property name="visible">1</property>
+                    <property name="can-focus">1</property>
                     <property name="xalign">0</property>
                     <property name="label" translatable="yes">Private Chat</property>
-                    <property name="selectable">True</property>
+                    <property name="selectable">1</property>
                     <attributes>
                       <attribute name="weight" value="bold"/>
                     </attributes>
                   </object>
                   <packing>
-                    <property name="left_attach">0</property>
-                    <property name="top_attach">31</property>
+                    <property name="left-attach">0</property>
+                    <property name="top-attach">31</property>
                   </packing>
                 </child>
                 <child>
                   <object class="GtkLabel">
-                    <property name="visible">True</property>
-                    <property name="can_focus">True</property>
+                    <property name="visible">1</property>
+                    <property name="can-focus">1</property>
                     <property name="xalign">0</property>
-                    <property name="label" translatable="yes">/msg 'user' 'message'</property>
-                    <property name="selectable">True</property>
+                    <property name="label" translatable="yes">/msg &apos;user&apos; &apos;message&apos;</property>
+                    <property name="selectable">1</property>
                     <attributes>
                       <attribute name="style" value="italic"/>
                     </attributes>
                   </object>
                   <packing>
-                    <property name="left_attach">0</property>
-                    <property name="top_attach">32</property>
+                    <property name="left-attach">0</property>
+                    <property name="top-attach">32</property>
                   </packing>
                 </child>
                 <child>
                   <object class="GtkLabel">
-                    <property name="visible">True</property>
-                    <property name="can_focus">True</property>
+                    <property name="visible">1</property>
+                    <property name="can-focus">1</property>
                     <property name="xalign">0</property>
-                    <property name="label" translatable="yes">Send message 'message' to user 'user'</property>
-                    <property name="selectable">True</property>
+                    <property name="label" translatable="yes">Send message &apos;message&apos; to user &apos;user&apos;</property>
+                    <property name="selectable">1</property>
                   </object>
                   <packing>
-                    <property name="left_attach">1</property>
-                    <property name="top_attach">32</property>
+                    <property name="left-attach">1</property>
+                    <property name="top-attach">32</property>
                   </packing>
                 </child>
                 <child>
                   <object class="GtkLabel">
-                    <property name="visible">True</property>
-                    <property name="can_focus">True</property>
+                    <property name="visible">1</property>
+                    <property name="can-focus">1</property>
                     <property name="xalign">0</property>
-                    <property name="label" translatable="yes">/pm 'user'</property>
-                    <property name="selectable">True</property>
+                    <property name="label" translatable="yes">/pm &apos;user&apos;</property>
+                    <property name="selectable">1</property>
                     <attributes>
                       <attribute name="style" value="italic"/>
                     </attributes>
                   </object>
                   <packing>
-                    <property name="left_attach">0</property>
-                    <property name="top_attach">33</property>
+                    <property name="left-attach">0</property>
+                    <property name="top-attach">33</property>
                   </packing>
                 </child>
                 <child>
                   <object class="GtkLabel">
-                    <property name="visible">True</property>
-                    <property name="can_focus">True</property>
+                    <property name="visible">1</property>
+                    <property name="can-focus">1</property>
                     <property name="xalign">0</property>
-                    <property name="label" translatable="yes">Open private chat window for user 'user'</property>
-                    <property name="selectable">True</property>
+                    <property name="label" translatable="yes">Open private chat window for user &apos;user&apos;</property>
+                    <property name="selectable">1</property>
                   </object>
                   <packing>
-                    <property name="left_attach">1</property>
-                    <property name="top_attach">33</property>
+                    <property name="left-attach">1</property>
+                    <property name="top-attach">33</property>
                   </packing>
                 </child>
                 <child>
                   <object class="GtkLabel">
-                    <property name="visible">True</property>
-                    <property name="can_focus">False</property>
+                    <property name="visible">1</property>
                   </object>
                   <packing>
-                    <property name="left_attach">0</property>
-                    <property name="top_attach">34</property>
+                    <property name="left-attach">0</property>
+                    <property name="top-attach">34</property>
                   </packing>
                 </child>
                 <child>
                   <object class="GtkLabel">
-                    <property name="visible">True</property>
-                    <property name="can_focus">True</property>
+                    <property name="visible">1</property>
+                    <property name="can-focus">1</property>
                     <property name="xalign">0</property>
                     <property name="label" translatable="yes">/away /a</property>
-                    <property name="selectable">True</property>
+                    <property name="selectable">1</property>
                     <attributes>
                       <attribute name="style" value="italic"/>
                     </attributes>
                   </object>
                   <packing>
-                    <property name="left_attach">0</property>
-                    <property name="top_attach">35</property>
+                    <property name="left-attach">0</property>
+                    <property name="top-attach">35</property>
                   </packing>
                 </child>
                 <child>
                   <object class="GtkLabel">
-                    <property name="visible">True</property>
-                    <property name="can_focus">True</property>
+                    <property name="visible">1</property>
+                    <property name="can-focus">1</property>
                     <property name="xalign">0</property>
                     <property name="label" translatable="yes">Toggles your away status</property>
-                    <property name="selectable">True</property>
+                    <property name="selectable">1</property>
                   </object>
                   <packing>
-                    <property name="left_attach">1</property>
-                    <property name="top_attach">35</property>
+                    <property name="left-attach">1</property>
+                    <property name="top-attach">35</property>
                   </packing>
                 </child>
                 <child>
                   <object class="GtkLabel">
-                    <property name="visible">True</property>
-                    <property name="can_focus">True</property>
+                    <property name="visible">1</property>
+                    <property name="can-focus">1</property>
                     <property name="xalign">0</property>
                     <property name="label" translatable="yes">/rescan</property>
-                    <property name="selectable">True</property>
+                    <property name="selectable">1</property>
                     <attributes>
                       <attribute name="style" value="italic"/>
                     </attributes>
                   </object>
                   <packing>
-                    <property name="left_attach">0</property>
-                    <property name="top_attach">36</property>
+                    <property name="left-attach">0</property>
+                    <property name="top-attach">36</property>
                   </packing>
                 </child>
                 <child>
                   <object class="GtkLabel">
-                    <property name="visible">True</property>
-                    <property name="can_focus">True</property>
+                    <property name="visible">1</property>
+                    <property name="can-focus">1</property>
                     <property name="xalign">0</property>
                     <property name="label" translatable="yes">Rescan shares</property>
-                    <property name="selectable">True</property>
+                    <property name="selectable">1</property>
                   </object>
                   <packing>
-                    <property name="left_attach">1</property>
-                    <property name="top_attach">36</property>
+                    <property name="left-attach">1</property>
+                    <property name="top-attach">36</property>
                   </packing>
                 </child>
                 <child>
                   <object class="GtkLabel">
-                    <property name="visible">True</property>
-                    <property name="can_focus">True</property>
+                    <property name="visible">1</property>
+                    <property name="can-focus">1</property>
                     <property name="xalign">0</property>
                     <property name="label" translatable="yes">/quit /q /exit</property>
-                    <property name="selectable">True</property>
+                    <property name="selectable">1</property>
                     <attributes>
                       <attribute name="style" value="italic"/>
                     </attributes>
                   </object>
                   <packing>
-                    <property name="left_attach">0</property>
-                    <property name="top_attach">37</property>
+                    <property name="left-attach">0</property>
+                    <property name="top-attach">37</property>
                   </packing>
                 </child>
                 <child>
                   <object class="GtkLabel">
-                    <property name="visible">True</property>
-                    <property name="can_focus">True</property>
+                    <property name="visible">1</property>
+                    <property name="can-focus">1</property>
                     <property name="xalign">0</property>
                     <property name="label" translatable="yes">Quit Nicotine+</property>
-                    <property name="selectable">True</property>
+                    <property name="selectable">1</property>
                   </object>
                   <packing>
-                    <property name="left_attach">1</property>
-                    <property name="top_attach">37</property>
+                    <property name="left-attach">1</property>
+                    <property name="top-attach">37</property>
                   </packing>
                 </child>
               </object>
-              <packing>
-                <property name="expand">True</property>
-                <property name="fill">True</property>
-              </packing>
             </child>
           </object>
-          <packing>
-            <property name="expand">True</property>
-            <property name="fill">True</property>
-          </packing>
         </child>
       </object>
     </child>

--- a/pynicotine/gtkgui/ui/about/chatroomcommands.ui
+++ b/pynicotine/gtkgui/ui/about/chatroomcommands.ui
@@ -18,7 +18,10 @@
             <child>
               <object class="GtkGrid">
                 <property name="visible">1</property>
-                <property name="margin">10</property>
+                <property name="margin-start">10</property>
+                <property name="margin-end">10</property>
+                <property name="margin-top">10</property>
+                <property name="margin-bottom">10</property>
                 <property name="row-spacing">10</property>
                 <property name="column-homogeneous">1</property>
                 <property name="column-spacing">5</property>

--- a/pynicotine/gtkgui/ui/about/privatechatcommands.ui
+++ b/pynicotine/gtkgui/ui/about/privatechatcommands.ui
@@ -2,909 +2,890 @@
 <interface>
   <requires lib="gtk+" version="3.18"/>
   <object class="GtkDialog" id="AboutPrivateChatCommands">
-    <property name="can_focus">False</property>
     <property name="title" translatable="yes">About private chat commands</property>
-    <property name="modal">True</property>
-    <property name="window_position">center-on-parent</property>
-    <property name="default_width">650</property>
-    <property name="default_height">500</property>
+    <property name="modal">1</property>
+    <property name="window-position">center-on-parent</property>
+    <property name="default-width">650</property>
+    <property name="default-height">500</property>
     <child internal-child="vbox">
       <object class="GtkBox">
-        <property name="visible">True</property>
-        <property name="can_focus">False</property>
+        <property name="visible">1</property>
         <property name="orientation">vertical</property>
         <child>
           <object class="GtkScrolledWindow">
-            <property name="visible">True</property>
-            <property name="can_focus">False</property>
+            <property name="visible">1</property>
+            <property name="vexpand">1</property>
             <child>
               <object class="GtkGrid">
-                <property name="border_width">10</property>
-                <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="row_spacing">10</property>
-                <property name="column_homogeneous">True</property>
-                <property name="column_spacing">5</property>
+                <property name="border-width">10</property>
+                <property name="visible">1</property>
+                <property name="row-spacing">10</property>
+                <property name="column-homogeneous">1</property>
+                <property name="column-spacing">5</property>
                 <child>
                   <object class="GtkLabel">
-                    <property name="visible">True</property>
-                    <property name="can_focus">True</property>
+                    <property name="visible">1</property>
+                    <property name="can-focus">1</property>
                     <property name="label" translatable="yes">/close /c</property>
-                    <property name="selectable">True</property>
+                    <property name="selectable">1</property>
                     <property name="xalign">0</property>
                     <attributes>
                       <attribute name="style" value="italic"/>
                     </attributes>
                   </object>
                   <packing>
-                    <property name="left_attach">0</property>
-                    <property name="top_attach">0</property>
+                    <property name="left-attach">0</property>
+                    <property name="top-attach">0</property>
                   </packing>
                 </child>
                 <child>
                   <object class="GtkLabel">
-                    <property name="visible">True</property>
-                    <property name="can_focus">True</property>
+                    <property name="visible">1</property>
+                    <property name="can-focus">1</property>
                     <property name="label" translatable="yes">Close the current private chat</property>
-                    <property name="selectable">True</property>
+                    <property name="selectable">1</property>
                     <property name="xalign">0</property>
                   </object>
                   <packing>
-                    <property name="left_attach">1</property>
-                    <property name="top_attach">0</property>
+                    <property name="left-attach">1</property>
+                    <property name="top-attach">0</property>
                   </packing>
                 </child>
                 <child>
                   <object class="GtkLabel">
-                    <property name="visible">True</property>
-                    <property name="can_focus">True</property>
+                    <property name="visible">1</property>
+                    <property name="can-focus">1</property>
                     <property name="label" translatable="yes">/clear /cl</property>
-                    <property name="selectable">True</property>
+                    <property name="selectable">1</property>
                     <property name="xalign">0</property>
                     <attributes>
                       <attribute name="style" value="italic"/>
                     </attributes>
                   </object>
                   <packing>
-                    <property name="left_attach">0</property>
-                    <property name="top_attach">1</property>
+                    <property name="left-attach">0</property>
+                    <property name="top-attach">1</property>
                   </packing>
                 </child>
                 <child>
                   <object class="GtkLabel">
-                    <property name="visible">True</property>
-                    <property name="can_focus">True</property>
+                    <property name="visible">1</property>
+                    <property name="can-focus">1</property>
                     <property name="label" translatable="yes">Clear the chat window</property>
-                    <property name="selectable">True</property>
+                    <property name="selectable">1</property>
                     <property name="xalign">0</property>
                   </object>
                   <packing>
-                    <property name="left_attach">1</property>
-                    <property name="top_attach">1</property>
+                    <property name="left-attach">1</property>
+                    <property name="top-attach">1</property>
                   </packing>
                 </child>
                 <child>
                   <object class="GtkLabel">
-                    <property name="visible">True</property>
-                    <property name="can_focus">True</property>
+                    <property name="visible">1</property>
+                    <property name="can-focus">1</property>
                     <property name="label" translatable="yes">/clear /cl</property>
-                    <property name="selectable">True</property>
+                    <property name="selectable">1</property>
                     <property name="xalign">0</property>
                     <attributes>
                       <attribute name="style" value="italic"/>
                     </attributes>
                   </object>
                   <packing>
-                    <property name="left_attach">0</property>
-                    <property name="top_attach">2</property>
+                    <property name="left-attach">0</property>
+                    <property name="top-attach">2</property>
                   </packing>
                 </child>
                 <child>
                   <object class="GtkLabel">
-                    <property name="visible">True</property>
-                    <property name="can_focus">True</property>
+                    <property name="visible">1</property>
+                    <property name="can-focus">1</property>
                     <property name="label" translatable="yes">Clear the chat window</property>
-                    <property name="selectable">True</property>
+                    <property name="selectable">1</property>
                     <property name="xalign">0</property>
                   </object>
                   <packing>
-                    <property name="left_attach">1</property>
-                    <property name="top_attach">2</property>
+                    <property name="left-attach">1</property>
+                    <property name="top-attach">2</property>
                   </packing>
                 </child>
                 <child>
                   <object class="GtkLabel">
-                    <property name="visible">True</property>
-                    <property name="can_focus">False</property>
+                    <property name="visible">1</property>
                   </object>
                   <packing>
-                    <property name="left_attach">0</property>
-                    <property name="top_attach">3</property>
+                    <property name="left-attach">0</property>
+                    <property name="top-attach">3</property>
                   </packing>
                 </child>
                 <child>
                   <object class="GtkLabel">
-                    <property name="visible">True</property>
-                    <property name="can_focus">True</property>
-                    <property name="label" translatable="yes">/me 'message'</property>
-                    <property name="selectable">True</property>
+                    <property name="visible">1</property>
+                    <property name="can-focus">1</property>
+                    <property name="label" translatable="yes">/me &apos;message&apos;</property>
+                    <property name="selectable">1</property>
                     <property name="xalign">0</property>
                     <attributes>
                       <attribute name="style" value="italic"/>
                     </attributes>
                   </object>
                   <packing>
-                    <property name="left_attach">0</property>
-                    <property name="top_attach">4</property>
+                    <property name="left-attach">0</property>
+                    <property name="top-attach">4</property>
                   </packing>
                 </child>
                 <child>
                   <object class="GtkLabel">
-                    <property name="visible">True</property>
-                    <property name="can_focus">True</property>
+                    <property name="visible">1</property>
+                    <property name="can-focus">1</property>
                     <property name="label" translatable="yes">Say something in the third-person</property>
-                    <property name="selectable">True</property>
+                    <property name="selectable">1</property>
                     <property name="xalign">0</property>
                   </object>
                   <packing>
-                    <property name="left_attach">1</property>
-                    <property name="top_attach">4</property>
+                    <property name="left-attach">1</property>
+                    <property name="top-attach">4</property>
                   </packing>
                 </child>
                 <child>
                   <object class="GtkLabel">
-                    <property name="visible">True</property>
-                    <property name="can_focus">True</property>
+                    <property name="visible">1</property>
+                    <property name="can-focus">1</property>
                     <property name="label" translatable="yes">/now</property>
-                    <property name="selectable">True</property>
+                    <property name="selectable">1</property>
                     <property name="xalign">0</property>
                     <attributes>
                       <attribute name="style" value="italic"/>
                     </attributes>
                   </object>
                   <packing>
-                    <property name="left_attach">0</property>
-                    <property name="top_attach">5</property>
+                    <property name="left-attach">0</property>
+                    <property name="top-attach">5</property>
                   </packing>
                 </child>
                 <child>
                   <object class="GtkLabel">
-                    <property name="visible">True</property>
-                    <property name="can_focus">True</property>
-                    <property name="label" translatable="yes">Display the Now Playing script's output</property>
-                    <property name="selectable">True</property>
+                    <property name="visible">1</property>
+                    <property name="can-focus">1</property>
+                    <property name="label" translatable="yes">Display the Now Playing script&apos;s output</property>
+                    <property name="selectable">1</property>
                     <property name="xalign">0</property>
                   </object>
                   <packing>
-                    <property name="left_attach">1</property>
-                    <property name="top_attach">5</property>
+                    <property name="left-attach">1</property>
+                    <property name="top-attach">5</property>
                   </packing>
                 </child>
                 <child>
                   <object class="GtkLabel">
-                    <property name="visible">True</property>
-                    <property name="can_focus">False</property>
+                    <property name="visible">1</property>
                   </object>
                   <packing>
-                    <property name="left_attach">0</property>
-                    <property name="top_attach">6</property>
+                    <property name="left-attach">0</property>
+                    <property name="top-attach">6</property>
                   </packing>
                 </child>
                 <child>
                   <object class="GtkLabel">
-                    <property name="visible">True</property>
-                    <property name="can_focus">True</property>
-                    <property name="label" translatable="yes">/toggle 'plugin'</property>
-                    <property name="selectable">True</property>
+                    <property name="visible">1</property>
+                    <property name="can-focus">1</property>
+                    <property name="label" translatable="yes">/toggle &apos;plugin&apos;</property>
+                    <property name="selectable">1</property>
                     <property name="xalign">0</property>
                     <attributes>
                       <attribute name="style" value="italic"/>
                     </attributes>
                   </object>
                   <packing>
-                    <property name="left_attach">0</property>
-                    <property name="top_attach">7</property>
+                    <property name="left-attach">0</property>
+                    <property name="top-attach">7</property>
                   </packing>
                 </child>
                 <child>
                   <object class="GtkLabel">
-                    <property name="visible">True</property>
-                    <property name="can_focus">True</property>
+                    <property name="visible">1</property>
+                    <property name="can-focus">1</property>
                     <property name="label" translatable="yes">Toggle plugin on/off state</property>
-                    <property name="selectable">True</property>
+                    <property name="selectable">1</property>
                     <property name="xalign">0</property>
                   </object>
                   <packing>
-                    <property name="left_attach">1</property>
-                    <property name="top_attach">7</property>
+                    <property name="left-attach">1</property>
+                    <property name="top-attach">7</property>
                   </packing>
                 </child>
                 <child>
                   <object class="GtkLabel">
-                    <property name="visible">True</property>
-                    <property name="can_focus">False</property>
+                    <property name="visible">1</property>
                   </object>
                   <packing>
-                    <property name="left_attach">0</property>
-                    <property name="top_attach">8</property>
+                    <property name="left-attach">0</property>
+                    <property name="top-attach">8</property>
                   </packing>
                 </child>
                 <child>
                   <object class="GtkLabel">
-                    <property name="visible">True</property>
-                    <property name="can_focus">True</property>
+                    <property name="visible">1</property>
+                    <property name="can-focus">1</property>
                     <property name="label" translatable="yes">Users</property>
-                    <property name="selectable">True</property>
+                    <property name="selectable">1</property>
                     <property name="xalign">0</property>
                     <attributes>
                       <attribute name="weight" value="bold"/>
                     </attributes>
                   </object>
                   <packing>
-                    <property name="left_attach">0</property>
-                    <property name="top_attach">9</property>
+                    <property name="left-attach">0</property>
+                    <property name="top-attach">9</property>
                   </packing>
                 </child>
                 <child>
                   <object class="GtkLabel">
-                    <property name="visible">True</property>
-                    <property name="can_focus">True</property>
-                    <property name="label" translatable="yes">/add /ad 'user'</property>
-                    <property name="selectable">True</property>
+                    <property name="visible">1</property>
+                    <property name="can-focus">1</property>
+                    <property name="label" translatable="yes">/add /ad &apos;user&apos;</property>
+                    <property name="selectable">1</property>
                     <property name="xalign">0</property>
                     <attributes>
                       <attribute name="style" value="italic"/>
                     </attributes>
                   </object>
                   <packing>
-                    <property name="left_attach">0</property>
-                    <property name="top_attach">10</property>
+                    <property name="left-attach">0</property>
+                    <property name="top-attach">10</property>
                   </packing>
                 </child>
                 <child>
                   <object class="GtkLabel">
-                    <property name="visible">True</property>
-                    <property name="can_focus">True</property>
-                    <property name="label" translatable="yes">Add user 'user' to your user list</property>
-                    <property name="selectable">True</property>
+                    <property name="visible">1</property>
+                    <property name="can-focus">1</property>
+                    <property name="label" translatable="yes">Add user &apos;user&apos; to your user list</property>
+                    <property name="selectable">1</property>
                     <property name="xalign">0</property>
                   </object>
                   <packing>
-                    <property name="left_attach">1</property>
-                    <property name="top_attach">10</property>
+                    <property name="left-attach">1</property>
+                    <property name="top-attach">10</property>
                   </packing>
                 </child>
                 <child>
                   <object class="GtkLabel">
-                    <property name="visible">True</property>
-                    <property name="can_focus">True</property>
-                    <property name="label" translatable="yes">/rem /unbuddy 'user'</property>
-                    <property name="selectable">True</property>
-                    <property name="xalign">0</property>
-                    <attributes>
-                      <attribute name="style" value="italic"/>
-                    </attributes>
-                  </object>
-                  <packing>
-                    <property name="left_attach">0</property>
-                    <property name="top_attach">11</property>
-                  </packing>
-                </child>
-                <child>
-                  <object class="GtkLabel">
-                    <property name="visible">True</property>
-                    <property name="can_focus">True</property>
-                    <property name="label" translatable="yes">Remove user 'user' from your user list</property>
-                    <property name="selectable">True</property>
-                    <property name="xalign">0</property>
-                  </object>
-                  <packing>
-                    <property name="left_attach">1</property>
-                    <property name="top_attach">11</property>
-                  </packing>
-                </child>
-                <child>
-                  <object class="GtkLabel">
-                    <property name="visible">True</property>
-                    <property name="can_focus">True</property>
-                    <property name="label" translatable="yes">/ban 'user'</property>
-                    <property name="selectable">True</property>
+                    <property name="visible">1</property>
+                    <property name="can-focus">1</property>
+                    <property name="label" translatable="yes">/rem /unbuddy &apos;user&apos;</property>
+                    <property name="selectable">1</property>
                     <property name="xalign">0</property>
                     <attributes>
                       <attribute name="style" value="italic"/>
                     </attributes>
                   </object>
                   <packing>
-                    <property name="left_attach">0</property>
-                    <property name="top_attach">12</property>
+                    <property name="left-attach">0</property>
+                    <property name="top-attach">11</property>
                   </packing>
                 </child>
                 <child>
                   <object class="GtkLabel">
-                    <property name="visible">True</property>
-                    <property name="can_focus">True</property>
-                    <property name="label" translatable="yes">Add user 'user' to your ban list</property>
-                    <property name="selectable">True</property>
+                    <property name="visible">1</property>
+                    <property name="can-focus">1</property>
+                    <property name="label" translatable="yes">Remove user &apos;user&apos; from your user list</property>
+                    <property name="selectable">1</property>
                     <property name="xalign">0</property>
                   </object>
                   <packing>
-                    <property name="left_attach">1</property>
-                    <property name="top_attach">12</property>
+                    <property name="left-attach">1</property>
+                    <property name="top-attach">11</property>
                   </packing>
                 </child>
                 <child>
                   <object class="GtkLabel">
-                    <property name="visible">True</property>
-                    <property name="can_focus">True</property>
-                    <property name="label" translatable="yes">/unban 'user'</property>
-                    <property name="selectable">True</property>
-                    <property name="xalign">0</property>
-                    <attributes>
-                      <attribute name="style" value="italic"/>
-                    </attributes>
-                  </object>
-                  <packing>
-                    <property name="left_attach">0</property>
-                    <property name="top_attach">13</property>
-                  </packing>
-                </child>
-                <child>
-                  <object class="GtkLabel">
-                    <property name="visible">True</property>
-                    <property name="can_focus">True</property>
-                    <property name="label" translatable="yes">Remove user 'user' from your ban list</property>
-                    <property name="selectable">True</property>
-                    <property name="xalign">0</property>
-                  </object>
-                  <packing>
-                    <property name="left_attach">1</property>
-                    <property name="top_attach">13</property>
-                  </packing>
-                </child>
-                <child>
-                  <object class="GtkLabel">
-                    <property name="visible">True</property>
-                    <property name="can_focus">True</property>
-                    <property name="label" translatable="yes">/ignore 'user'</property>
-                    <property name="selectable">True</property>
+                    <property name="visible">1</property>
+                    <property name="can-focus">1</property>
+                    <property name="label" translatable="yes">/ban &apos;user&apos;</property>
+                    <property name="selectable">1</property>
                     <property name="xalign">0</property>
                     <attributes>
                       <attribute name="style" value="italic"/>
                     </attributes>
                   </object>
                   <packing>
-                    <property name="left_attach">0</property>
-                    <property name="top_attach">14</property>
+                    <property name="left-attach">0</property>
+                    <property name="top-attach">12</property>
                   </packing>
                 </child>
                 <child>
                   <object class="GtkLabel">
-                    <property name="visible">True</property>
-                    <property name="can_focus">True</property>
-                    <property name="label" translatable="yes">Add user 'user' to your ignore list</property>
-                    <property name="selectable">True</property>
+                    <property name="visible">1</property>
+                    <property name="can-focus">1</property>
+                    <property name="label" translatable="yes">Add user &apos;user&apos; to your ban list</property>
+                    <property name="selectable">1</property>
                     <property name="xalign">0</property>
                   </object>
                   <packing>
-                    <property name="left_attach">1</property>
-                    <property name="top_attach">14</property>
+                    <property name="left-attach">1</property>
+                    <property name="top-attach">12</property>
                   </packing>
                 </child>
                 <child>
                   <object class="GtkLabel">
-                    <property name="visible">True</property>
-                    <property name="can_focus">True</property>
-                    <property name="label" translatable="yes">/unignore 'user'</property>
-                    <property name="selectable">True</property>
-                    <property name="xalign">0</property>
-                    <attributes>
-                      <attribute name="style" value="italic"/>
-                    </attributes>
-                  </object>
-                  <packing>
-                    <property name="left_attach">0</property>
-                    <property name="top_attach">15</property>
-                  </packing>
-                </child>
-                <child>
-                  <object class="GtkLabel">
-                    <property name="visible">True</property>
-                    <property name="can_focus">True</property>
-                    <property name="label" translatable="yes">Remove user 'user' from your ignore list</property>
-                    <property name="selectable">True</property>
-                    <property name="xalign">0</property>
-                  </object>
-                  <packing>
-                    <property name="left_attach">1</property>
-                    <property name="top_attach">15</property>
-                  </packing>
-                </child>
-                <child>
-                  <object class="GtkLabel">
-                    <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                  </object>
-                  <packing>
-                    <property name="left_attach">0</property>
-                    <property name="top_attach">16</property>
-                  </packing>
-                </child>
-                <child>
-                  <object class="GtkLabel">
-                    <property name="visible">True</property>
-                    <property name="can_focus">True</property>
-                    <property name="label" translatable="yes">/browse /b 'user'</property>
-                    <property name="selectable">True</property>
+                    <property name="visible">1</property>
+                    <property name="can-focus">1</property>
+                    <property name="label" translatable="yes">/unban &apos;user&apos;</property>
+                    <property name="selectable">1</property>
                     <property name="xalign">0</property>
                     <attributes>
                       <attribute name="style" value="italic"/>
                     </attributes>
                   </object>
                   <packing>
-                    <property name="left_attach">0</property>
-                    <property name="top_attach">17</property>
+                    <property name="left-attach">0</property>
+                    <property name="top-attach">13</property>
                   </packing>
                 </child>
                 <child>
                   <object class="GtkLabel">
-                    <property name="visible">True</property>
-                    <property name="can_focus">True</property>
-                    <property name="label" translatable="yes">Browse files of user 'user'</property>
-                    <property name="selectable">True</property>
+                    <property name="visible">1</property>
+                    <property name="can-focus">1</property>
+                    <property name="label" translatable="yes">Remove user &apos;user&apos; from your ban list</property>
+                    <property name="selectable">1</property>
                     <property name="xalign">0</property>
                   </object>
                   <packing>
-                    <property name="left_attach">1</property>
-                    <property name="top_attach">17</property>
+                    <property name="left-attach">1</property>
+                    <property name="top-attach">13</property>
                   </packing>
                 </child>
                 <child>
                   <object class="GtkLabel">
-                    <property name="visible">True</property>
-                    <property name="can_focus">True</property>
-                    <property name="label" translatable="yes">/whois /w 'user'</property>
-                    <property name="selectable">True</property>
-                    <property name="xalign">0</property>
-                    <attributes>
-                      <attribute name="style" value="italic"/>
-                    </attributes>
-                  </object>
-                  <packing>
-                    <property name="left_attach">0</property>
-                    <property name="top_attach">18</property>
-                  </packing>
-                </child>
-                <child>
-                  <object class="GtkLabel">
-                    <property name="visible">True</property>
-                    <property name="can_focus">True</property>
-                    <property name="label" translatable="yes">Request user info for user 'user'</property>
-                    <property name="selectable">True</property>
-                    <property name="xalign">0</property>
-                  </object>
-                  <packing>
-                    <property name="left_attach">1</property>
-                    <property name="top_attach">18</property>
-                  </packing>
-                </child>
-                <child>
-                  <object class="GtkLabel">
-                    <property name="visible">True</property>
-                    <property name="can_focus">True</property>
-                    <property name="label" translatable="yes">/ip 'user'</property>
-                    <property name="selectable">True</property>
+                    <property name="visible">1</property>
+                    <property name="can-focus">1</property>
+                    <property name="label" translatable="yes">/ignore &apos;user&apos;</property>
+                    <property name="selectable">1</property>
                     <property name="xalign">0</property>
                     <attributes>
                       <attribute name="style" value="italic"/>
                     </attributes>
                   </object>
                   <packing>
-                    <property name="left_attach">0</property>
-                    <property name="top_attach">19</property>
+                    <property name="left-attach">0</property>
+                    <property name="top-attach">14</property>
                   </packing>
                 </child>
                 <child>
                   <object class="GtkLabel">
-                    <property name="visible">True</property>
-                    <property name="can_focus">True</property>
-                    <property name="label" translatable="yes">Show IP for user 'user'</property>
-                    <property name="selectable">True</property>
+                    <property name="visible">1</property>
+                    <property name="can-focus">1</property>
+                    <property name="label" translatable="yes">Add user &apos;user&apos; to your ignore list</property>
+                    <property name="selectable">1</property>
                     <property name="xalign">0</property>
                   </object>
                   <packing>
-                    <property name="left_attach">1</property>
-                    <property name="top_attach">19</property>
+                    <property name="left-attach">1</property>
+                    <property name="top-attach">14</property>
                   </packing>
                 </child>
                 <child>
                   <object class="GtkLabel">
-                    <property name="visible">True</property>
-                    <property name="can_focus">False</property>
+                    <property name="visible">1</property>
+                    <property name="can-focus">1</property>
+                    <property name="label" translatable="yes">/unignore &apos;user&apos;</property>
+                    <property name="selectable">1</property>
+                    <property name="xalign">0</property>
+                    <attributes>
+                      <attribute name="style" value="italic"/>
+                    </attributes>
                   </object>
                   <packing>
-                    <property name="left_attach">0</property>
-                    <property name="top_attach">20</property>
+                    <property name="left-attach">0</property>
+                    <property name="top-attach">15</property>
                   </packing>
                 </child>
                 <child>
                   <object class="GtkLabel">
-                    <property name="visible">True</property>
-                    <property name="can_focus">True</property>
+                    <property name="visible">1</property>
+                    <property name="can-focus">1</property>
+                    <property name="label" translatable="yes">Remove user &apos;user&apos; from your ignore list</property>
+                    <property name="selectable">1</property>
+                    <property name="xalign">0</property>
+                  </object>
+                  <packing>
+                    <property name="left-attach">1</property>
+                    <property name="top-attach">15</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkLabel">
+                    <property name="visible">1</property>
+                  </object>
+                  <packing>
+                    <property name="left-attach">0</property>
+                    <property name="top-attach">16</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkLabel">
+                    <property name="visible">1</property>
+                    <property name="can-focus">1</property>
+                    <property name="label" translatable="yes">/browse /b &apos;user&apos;</property>
+                    <property name="selectable">1</property>
+                    <property name="xalign">0</property>
+                    <attributes>
+                      <attribute name="style" value="italic"/>
+                    </attributes>
+                  </object>
+                  <packing>
+                    <property name="left-attach">0</property>
+                    <property name="top-attach">17</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkLabel">
+                    <property name="visible">1</property>
+                    <property name="can-focus">1</property>
+                    <property name="label" translatable="yes">Browse files of user &apos;user&apos;</property>
+                    <property name="selectable">1</property>
+                    <property name="xalign">0</property>
+                  </object>
+                  <packing>
+                    <property name="left-attach">1</property>
+                    <property name="top-attach">17</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkLabel">
+                    <property name="visible">1</property>
+                    <property name="can-focus">1</property>
+                    <property name="label" translatable="yes">/whois /w &apos;user&apos;</property>
+                    <property name="selectable">1</property>
+                    <property name="xalign">0</property>
+                    <attributes>
+                      <attribute name="style" value="italic"/>
+                    </attributes>
+                  </object>
+                  <packing>
+                    <property name="left-attach">0</property>
+                    <property name="top-attach">18</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkLabel">
+                    <property name="visible">1</property>
+                    <property name="can-focus">1</property>
+                    <property name="label" translatable="yes">Request user info for user &apos;user&apos;</property>
+                    <property name="selectable">1</property>
+                    <property name="xalign">0</property>
+                  </object>
+                  <packing>
+                    <property name="left-attach">1</property>
+                    <property name="top-attach">18</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkLabel">
+                    <property name="visible">1</property>
+                    <property name="can-focus">1</property>
+                    <property name="label" translatable="yes">/ip &apos;user&apos;</property>
+                    <property name="selectable">1</property>
+                    <property name="xalign">0</property>
+                    <attributes>
+                      <attribute name="style" value="italic"/>
+                    </attributes>
+                  </object>
+                  <packing>
+                    <property name="left-attach">0</property>
+                    <property name="top-attach">19</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkLabel">
+                    <property name="visible">1</property>
+                    <property name="can-focus">1</property>
+                    <property name="label" translatable="yes">Show IP for user &apos;user&apos;</property>
+                    <property name="selectable">1</property>
+                    <property name="xalign">0</property>
+                  </object>
+                  <packing>
+                    <property name="left-attach">1</property>
+                    <property name="top-attach">19</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkLabel">
+                    <property name="visible">1</property>
+                  </object>
+                  <packing>
+                    <property name="left-attach">0</property>
+                    <property name="top-attach">20</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkLabel">
+                    <property name="visible">1</property>
+                    <property name="can-focus">1</property>
                     <property name="label" translatable="yes">Aliases</property>
-                    <property name="selectable">True</property>
+                    <property name="selectable">1</property>
                     <property name="xalign">0</property>
                     <attributes>
                       <attribute name="weight" value="bold"/>
                     </attributes>
                   </object>
                   <packing>
-                    <property name="left_attach">0</property>
-                    <property name="top_attach">21</property>
+                    <property name="left-attach">0</property>
+                    <property name="top-attach">21</property>
                   </packing>
                 </child>
                 <child>
                   <object class="GtkLabel">
-                    <property name="visible">True</property>
-                    <property name="can_focus">True</property>
-                    <property name="label" translatable="yes">/alias /al 'command' 'definition'</property>
-                    <property name="selectable">True</property>
+                    <property name="visible">1</property>
+                    <property name="can-focus">1</property>
+                    <property name="label" translatable="yes">/alias /al &apos;command&apos; &apos;definition&apos;</property>
+                    <property name="selectable">1</property>
                     <property name="xalign">0</property>
                     <attributes>
                       <attribute name="style" value="italic"/>
                     </attributes>
                   </object>
                   <packing>
-                    <property name="left_attach">0</property>
-                    <property name="top_attach">22</property>
+                    <property name="left-attach">0</property>
+                    <property name="top-attach">22</property>
                   </packing>
                 </child>
                 <child>
                   <object class="GtkLabel">
-                    <property name="visible">True</property>
-                    <property name="can_focus">True</property>
+                    <property name="visible">1</property>
+                    <property name="can-focus">1</property>
                     <property name="label" translatable="yes">Add a new alias</property>
-                    <property name="selectable">True</property>
+                    <property name="selectable">1</property>
                     <property name="xalign">0</property>
                   </object>
                   <packing>
-                    <property name="left_attach">1</property>
-                    <property name="top_attach">22</property>
+                    <property name="left-attach">1</property>
+                    <property name="top-attach">22</property>
                   </packing>
                 </child>
                 <child>
                   <object class="GtkLabel">
-                    <property name="visible">True</property>
-                    <property name="can_focus">True</property>
-                    <property name="label" translatable="yes">/unalias /un 'command'</property>
-                    <property name="selectable">True</property>
+                    <property name="visible">1</property>
+                    <property name="can-focus">1</property>
+                    <property name="label" translatable="yes">/unalias /un &apos;command&apos;</property>
+                    <property name="selectable">1</property>
                     <property name="xalign">0</property>
                     <attributes>
                       <attribute name="style" value="italic"/>
                     </attributes>
                   </object>
                   <packing>
-                    <property name="left_attach">0</property>
-                    <property name="top_attach">23</property>
+                    <property name="left-attach">0</property>
+                    <property name="top-attach">23</property>
                   </packing>
                 </child>
                 <child>
                   <object class="GtkLabel">
-                    <property name="visible">True</property>
-                    <property name="can_focus">True</property>
+                    <property name="visible">1</property>
+                    <property name="can-focus">1</property>
                     <property name="label" translatable="yes">Remove an alias</property>
-                    <property name="selectable">True</property>
+                    <property name="selectable">1</property>
                     <property name="xalign">0</property>
                   </object>
                   <packing>
-                    <property name="left_attach">1</property>
-                    <property name="top_attach">23</property>
+                    <property name="left-attach">1</property>
+                    <property name="top-attach">23</property>
                   </packing>
                 </child>
                 <child>
                   <object class="GtkLabel">
-                    <property name="visible">True</property>
-                    <property name="can_focus">False</property>
+                    <property name="visible">1</property>
                   </object>
                   <packing>
-                    <property name="left_attach">0</property>
-                    <property name="top_attach">24</property>
+                    <property name="left-attach">0</property>
+                    <property name="top-attach">24</property>
                   </packing>
                 </child>
                 <child>
                   <object class="GtkLabel">
-                    <property name="visible">True</property>
-                    <property name="can_focus">True</property>
+                    <property name="visible">1</property>
+                    <property name="can-focus">1</property>
                     <property name="label" translatable="yes">Search</property>
-                    <property name="selectable">True</property>
+                    <property name="selectable">1</property>
                     <property name="xalign">0</property>
                     <attributes>
                       <attribute name="weight" value="bold"/>
                     </attributes>
                   </object>
                   <packing>
-                    <property name="left_attach">0</property>
-                    <property name="top_attach">25</property>
+                    <property name="left-attach">0</property>
+                    <property name="top-attach">25</property>
                   </packing>
                 </child>
                 <child>
                   <object class="GtkLabel">
-                    <property name="visible">True</property>
-                    <property name="can_focus">True</property>
-                    <property name="label" translatable="yes">/search /s 'query'</property>
-                    <property name="selectable">True</property>
+                    <property name="visible">1</property>
+                    <property name="can-focus">1</property>
+                    <property name="label" translatable="yes">/search /s &apos;query&apos;</property>
+                    <property name="selectable">1</property>
                     <property name="xalign">0</property>
                     <attributes>
                       <attribute name="style" value="italic"/>
                     </attributes>
                   </object>
                   <packing>
-                    <property name="left_attach">0</property>
-                    <property name="top_attach">26</property>
+                    <property name="left-attach">0</property>
+                    <property name="top-attach">26</property>
                   </packing>
                 </child>
                 <child>
                   <object class="GtkLabel">
-                    <property name="visible">True</property>
-                    <property name="can_focus">True</property>
-                    <property name="label" translatable="yes">Start a new search for 'query'</property>
-                    <property name="selectable">True</property>
+                    <property name="visible">1</property>
+                    <property name="can-focus">1</property>
+                    <property name="label" translatable="yes">Start a new search for &apos;query&apos;</property>
+                    <property name="selectable">1</property>
                     <property name="xalign">0</property>
                   </object>
                   <packing>
-                    <property name="left_attach">1</property>
-                    <property name="top_attach">26</property>
+                    <property name="left-attach">1</property>
+                    <property name="top-attach">26</property>
                   </packing>
                 </child>
                 <child>
                   <object class="GtkLabel">
-                    <property name="visible">True</property>
-                    <property name="can_focus">True</property>
-                    <property name="label" translatable="yes">/rsearch /rs 'query'</property>
-                    <property name="selectable">True</property>
-                    <property name="xalign">0</property>
-                    <attributes>
-                      <attribute name="style" value="italic"/>
-                    </attributes>
-                  </object>
-                  <packing>
-                    <property name="left_attach">0</property>
-                    <property name="top_attach">27</property>
-                  </packing>
-                </child>
-                <child>
-                  <object class="GtkLabel">
-                    <property name="visible">True</property>
-                    <property name="can_focus">True</property>
-                    <property name="label" translatable="yes">Search the joined rooms for 'query'</property>
-                    <property name="selectable">True</property>
-                    <property name="xalign">0</property>
-                  </object>
-                  <packing>
-                    <property name="left_attach">1</property>
-                    <property name="top_attach">27</property>
-                  </packing>
-                </child>
-                <child>
-                  <object class="GtkLabel">
-                    <property name="visible">True</property>
-                    <property name="can_focus">True</property>
-                    <property name="label" translatable="yes">/bsearch /bs '%s'</property>
-                    <property name="selectable">True</property>
+                    <property name="visible">1</property>
+                    <property name="can-focus">1</property>
+                    <property name="label" translatable="yes">/rsearch /rs &apos;query&apos;</property>
+                    <property name="selectable">1</property>
                     <property name="xalign">0</property>
                     <attributes>
                       <attribute name="style" value="italic"/>
                     </attributes>
                   </object>
                   <packing>
-                    <property name="left_attach">0</property>
-                    <property name="top_attach">28</property>
+                    <property name="left-attach">0</property>
+                    <property name="top-attach">27</property>
                   </packing>
                 </child>
                 <child>
                   <object class="GtkLabel">
-                    <property name="visible">True</property>
-                    <property name="can_focus">True</property>
-                    <property name="label" translatable="yes">Search the buddy list for 'query'</property>
-                    <property name="selectable">True</property>
+                    <property name="visible">1</property>
+                    <property name="can-focus">1</property>
+                    <property name="label" translatable="yes">Search the joined rooms for &apos;query&apos;</property>
+                    <property name="selectable">1</property>
                     <property name="xalign">0</property>
                   </object>
                   <packing>
-                    <property name="left_attach">1</property>
-                    <property name="top_attach">28</property>
+                    <property name="left-attach">1</property>
+                    <property name="top-attach">27</property>
                   </packing>
                 </child>
                 <child>
                   <object class="GtkLabel">
-                    <property name="visible">True</property>
-                    <property name="can_focus">True</property>
-                    <property name="label" translatable="yes">/usearch /us 'user' 'query'</property>
-                    <property name="selectable">True</property>
+                    <property name="visible">1</property>
+                    <property name="can-focus">1</property>
+                    <property name="label" translatable="yes">/bsearch /bs &apos;%s&apos;</property>
+                    <property name="selectable">1</property>
                     <property name="xalign">0</property>
                     <attributes>
                       <attribute name="style" value="italic"/>
                     </attributes>
                   </object>
                   <packing>
-                    <property name="left_attach">0</property>
-                    <property name="top_attach">29</property>
+                    <property name="left-attach">0</property>
+                    <property name="top-attach">28</property>
                   </packing>
                 </child>
                 <child>
                   <object class="GtkLabel">
-                    <property name="visible">True</property>
-                    <property name="can_focus">True</property>
-                    <property name="label" translatable="yes">Search a user's shares for 'query'</property>
-                    <property name="selectable">True</property>
+                    <property name="visible">1</property>
+                    <property name="can-focus">1</property>
+                    <property name="label" translatable="yes">Search the buddy list for &apos;query&apos;</property>
+                    <property name="selectable">1</property>
                     <property name="xalign">0</property>
                   </object>
                   <packing>
-                    <property name="left_attach">1</property>
-                    <property name="top_attach">29</property>
+                    <property name="left-attach">1</property>
+                    <property name="top-attach">28</property>
                   </packing>
                 </child>
                 <child>
                   <object class="GtkLabel">
-                    <property name="visible">True</property>
-                    <property name="can_focus">False</property>
+                    <property name="visible">1</property>
+                    <property name="can-focus">1</property>
+                    <property name="label" translatable="yes">/usearch /us &apos;user&apos; &apos;query&apos;</property>
+                    <property name="selectable">1</property>
+                    <property name="xalign">0</property>
+                    <attributes>
+                      <attribute name="style" value="italic"/>
+                    </attributes>
                   </object>
                   <packing>
-                    <property name="left_attach">0</property>
-                    <property name="top_attach">30</property>
+                    <property name="left-attach">0</property>
+                    <property name="top-attach">29</property>
                   </packing>
                 </child>
                 <child>
                   <object class="GtkLabel">
-                    <property name="visible">True</property>
-                    <property name="can_focus">True</property>
+                    <property name="visible">1</property>
+                    <property name="can-focus">1</property>
+                    <property name="label" translatable="yes">Search a user&apos;s shares for &apos;query&apos;</property>
+                    <property name="selectable">1</property>
+                    <property name="xalign">0</property>
+                  </object>
+                  <packing>
+                    <property name="left-attach">1</property>
+                    <property name="top-attach">29</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkLabel">
+                    <property name="visible">1</property>
+                  </object>
+                  <packing>
+                    <property name="left-attach">0</property>
+                    <property name="top-attach">30</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkLabel">
+                    <property name="visible">1</property>
+                    <property name="can-focus">1</property>
                     <property name="label" translatable="yes">Chat Rooms</property>
-                    <property name="selectable">True</property>
+                    <property name="selectable">1</property>
                     <property name="xalign">0</property>
                     <attributes>
                       <attribute name="weight" value="bold"/>
                     </attributes>
                   </object>
                   <packing>
-                    <property name="left_attach">0</property>
-                    <property name="top_attach">31</property>
+                    <property name="left-attach">0</property>
+                    <property name="top-attach">31</property>
                   </packing>
                 </child>
                 <child>
                   <object class="GtkLabel">
-                    <property name="visible">True</property>
-                    <property name="can_focus">True</property>
-                    <property name="label" translatable="yes">/join /j 'room'</property>
-                    <property name="selectable">True</property>
+                    <property name="visible">1</property>
+                    <property name="can-focus">1</property>
+                    <property name="label" translatable="yes">/join /j &apos;room&apos;</property>
+                    <property name="selectable">1</property>
                     <property name="xalign">0</property>
                     <attributes>
                       <attribute name="style" value="italic"/>
                     </attributes>
                   </object>
                   <packing>
-                    <property name="left_attach">0</property>
-                    <property name="top_attach">32</property>
+                    <property name="left-attach">0</property>
+                    <property name="top-attach">32</property>
                   </packing>
                 </child>
                 <child>
                   <object class="GtkLabel">
-                    <property name="visible">True</property>
-                    <property name="can_focus">True</property>
-                    <property name="label" translatable="yes">Join room 'room'</property>
-                    <property name="selectable">True</property>
+                    <property name="visible">1</property>
+                    <property name="can-focus">1</property>
+                    <property name="label" translatable="yes">Join room &apos;room&apos;</property>
+                    <property name="selectable">1</property>
                     <property name="xalign">0</property>
                   </object>
                   <packing>
-                    <property name="left_attach">1</property>
-                    <property name="top_attach">32</property>
+                    <property name="left-attach">1</property>
+                    <property name="top-attach">32</property>
                   </packing>
                 </child>
                 <child>
                   <object class="GtkLabel">
-                    <property name="visible">True</property>
-                    <property name="can_focus">False</property>
+                    <property name="visible">1</property>
                   </object>
                   <packing>
-                    <property name="left_attach">0</property>
-                    <property name="top_attach">33</property>
+                    <property name="left-attach">0</property>
+                    <property name="top-attach">33</property>
                   </packing>
                 </child>
                 <child>
                   <object class="GtkLabel">
-                    <property name="visible">True</property>
-                    <property name="can_focus">True</property>
+                    <property name="visible">1</property>
+                    <property name="can-focus">1</property>
                     <property name="label" translatable="yes">/away /a</property>
-                    <property name="selectable">True</property>
+                    <property name="selectable">1</property>
                     <property name="xalign">0</property>
                     <attributes>
                       <attribute name="style" value="italic"/>
                     </attributes>
                   </object>
                   <packing>
-                    <property name="left_attach">0</property>
-                    <property name="top_attach">34</property>
+                    <property name="left-attach">0</property>
+                    <property name="top-attach">34</property>
                   </packing>
                 </child>
                 <child>
                   <object class="GtkLabel">
-                    <property name="visible">True</property>
-                    <property name="can_focus">True</property>
+                    <property name="visible">1</property>
+                    <property name="can-focus">1</property>
                     <property name="label" translatable="yes">Toggles your away status</property>
-                    <property name="selectable">True</property>
+                    <property name="selectable">1</property>
                     <property name="xalign">0</property>
                   </object>
                   <packing>
-                    <property name="left_attach">1</property>
-                    <property name="top_attach">34</property>
+                    <property name="left-attach">1</property>
+                    <property name="top-attach">34</property>
                   </packing>
                 </child>
                 <child>
                   <object class="GtkLabel">
-                    <property name="visible">True</property>
-                    <property name="can_focus">True</property>
+                    <property name="visible">1</property>
+                    <property name="can-focus">1</property>
                     <property name="label" translatable="yes">/rescan</property>
-                    <property name="selectable">True</property>
+                    <property name="selectable">1</property>
                     <property name="xalign">0</property>
                     <attributes>
                       <attribute name="style" value="italic"/>
                     </attributes>
                   </object>
                   <packing>
-                    <property name="left_attach">0</property>
-                    <property name="top_attach">35</property>
+                    <property name="left-attach">0</property>
+                    <property name="top-attach">35</property>
                   </packing>
                 </child>
                 <child>
                   <object class="GtkLabel">
-                    <property name="visible">True</property>
-                    <property name="can_focus">True</property>
+                    <property name="visible">1</property>
+                    <property name="can-focus">1</property>
                     <property name="label" translatable="yes">Rescan shares</property>
-                    <property name="selectable">True</property>
+                    <property name="selectable">1</property>
                     <property name="xalign">0</property>
                   </object>
                   <packing>
-                    <property name="left_attach">1</property>
-                    <property name="top_attach">35</property>
+                    <property name="left-attach">1</property>
+                    <property name="top-attach">35</property>
                   </packing>
                 </child>
                 <child>
                   <object class="GtkLabel">
-                    <property name="visible">True</property>
-                    <property name="can_focus">True</property>
+                    <property name="visible">1</property>
+                    <property name="can-focus">1</property>
                     <property name="label" translatable="yes">/quit /q /exit</property>
-                    <property name="selectable">True</property>
+                    <property name="selectable">1</property>
                     <property name="xalign">0</property>
                     <attributes>
                       <attribute name="style" value="italic"/>
                     </attributes>
                   </object>
                   <packing>
-                    <property name="left_attach">0</property>
-                    <property name="top_attach">36</property>
+                    <property name="left-attach">0</property>
+                    <property name="top-attach">36</property>
                   </packing>
                 </child>
                 <child>
                   <object class="GtkLabel">
-                    <property name="visible">True</property>
-                    <property name="can_focus">True</property>
+                    <property name="visible">1</property>
+                    <property name="can-focus">1</property>
                     <property name="label" translatable="yes">Quit Nicotine+</property>
-                    <property name="selectable">True</property>
+                    <property name="selectable">1</property>
                     <property name="xalign">0</property>
                   </object>
                   <packing>
-                    <property name="left_attach">1</property>
-                    <property name="top_attach">36</property>
+                    <property name="left-attach">1</property>
+                    <property name="top-attach">36</property>
                   </packing>
                 </child>
               </object>
-              <packing>
-                <property name="expand">True</property>
-                <property name="fill">True</property>
-              </packing>
             </child>
           </object>
-          <packing>
-            <property name="expand">True</property>
-            <property name="fill">True</property>
-          </packing>
         </child>
       </object>
     </child>

--- a/pynicotine/gtkgui/ui/about/privatechatcommands.ui
+++ b/pynicotine/gtkgui/ui/about/privatechatcommands.ui
@@ -17,8 +17,8 @@
             <property name="vexpand">1</property>
             <child>
               <object class="GtkGrid">
-                <property name="border-width">10</property>
                 <property name="visible">1</property>
+                <property name="margin">10</property>
                 <property name="row-spacing">10</property>
                 <property name="column-homogeneous">1</property>
                 <property name="column-spacing">5</property>

--- a/pynicotine/gtkgui/ui/about/privatechatcommands.ui
+++ b/pynicotine/gtkgui/ui/about/privatechatcommands.ui
@@ -18,7 +18,10 @@
             <child>
               <object class="GtkGrid">
                 <property name="visible">1</property>
-                <property name="margin">10</property>
+                <property name="margin-start">10</property>
+                <property name="margin-end">10</property>
+                <property name="margin-top">10</property>
+                <property name="margin-bottom">10</property>
                 <property name="row-spacing">10</property>
                 <property name="column-homogeneous">1</property>
                 <property name="column-spacing">5</property>

--- a/pynicotine/gtkgui/ui/about/searchfilters.ui
+++ b/pynicotine/gtkgui/ui/about/searchfilters.ui
@@ -2,22 +2,19 @@
 <interface>
   <requires lib="gtk+" version="3.18"/>
   <object class="GtkDialog" id="AboutSearchFilters">
-    <property name="border_width">10</property>
-    <property name="can_focus">False</property>
+    <property name="border-width">10</property>
     <property name="title" translatable="yes">About search filters</property>
-    <property name="modal">True</property>
-    <property name="window_position">center-on-parent</property>
+    <property name="modal">1</property>
+    <property name="window-position">center-on-parent</property>
     <child internal-child="vbox">
       <object class="GtkBox">
-        <property name="visible">True</property>
-        <property name="can_focus">False</property>
+        <property name="visible">1</property>
         <property name="orientation">vertical</property>
-        <property name="margin_start">5</property>
-        <property name="margin_end">5</property>
+        <property name="margin-start">5</property>
+        <property name="margin-end">5</property>
         <child>
           <object class="GtkLabel">
-            <property name="visible">True</property>
-            <property name="can_focus">False</property>
+            <property name="visible">1</property>
             <property name="label" translatable="yes">You can use this to refine which results are displayed. The full results
 from the server are always available if you clear all the search terms.
 
@@ -26,7 +23,7 @@ You can filter by:
 - Included text:
       Files are shown if they contain this text.
       Case is insensitive, but word order is important.
-      'Spears Brittany' will not show any 'Brittany Spears'
+      &apos;Spears Brittany&apos; will not show any &apos;Brittany Spears&apos;
 
 - Excluded text:
       As above, but files will not be displayed if the text matches
@@ -51,14 +48,8 @@ You can filter by:
 - To set the filter, press Enter. This will apply to any existing results, and any more that are returned.
 - To filter in a different way, just set the relevant terms.
 - You do not need to do another search to apply a different filter.</property>
-            <property name="selectable">True</property>
+            <property name="selectable">1</property>
           </object>
-          <packing>
-            <property name="expand">True</property>
-            <property name="fill">True</property>
-            <property name="padding">5</property>
-            <property name="position">0</property>
-          </packing>
         </child>
       </object>
     </child>

--- a/pynicotine/gtkgui/ui/about/searchfilters.ui
+++ b/pynicotine/gtkgui/ui/about/searchfilters.ui
@@ -2,7 +2,6 @@
 <interface>
   <requires lib="gtk+" version="3.18"/>
   <object class="GtkDialog" id="AboutSearchFilters">
-    <property name="border-width">10</property>
     <property name="title" translatable="yes">About search filters</property>
     <property name="modal">1</property>
     <property name="window-position">center-on-parent</property>
@@ -10,8 +9,10 @@
       <object class="GtkBox">
         <property name="visible">1</property>
         <property name="orientation">vertical</property>
-        <property name="margin-start">5</property>
-        <property name="margin-end">5</property>
+        <property name="margin-start">15</property>
+        <property name="margin-end">15</property>
+        <property name="margin-top">10</property>
+        <property name="margin-bottom">10</property>
         <child>
           <object class="GtkLabel">
             <property name="visible">1</property>

--- a/pynicotine/gtkgui/ui/buddylist.ui
+++ b/pynicotine/gtkgui/ui/buddylist.ui
@@ -2,91 +2,66 @@
 <interface>
   <requires lib="gtk+" version="3.18"/>
   <object class="GtkBox" id="userlistvbox">
-    <property name="visible">True</property>
-    <property name="can_focus">False</property>
+    <property name="visible">1</property>
     <property name="orientation">vertical</property>
     <child>
       <object class="GtkBox">
-        <property name="visible">True</property>
-        <property name="can_focus">False</property>
-        <property name="border_width">6</property>
+        <property name="visible">1</property>
+        <property name="border-width">6</property>
         <property name="spacing">6</property>
         <child>
           <object class="GtkLabel" id="BuddiesLabel">
-            <property name="visible">True</property>
-            <property name="can_focus">False</property>
+            <property name="visible">1</property>
             <property name="label" translatable="yes">Buddy List</property>
-            <property name="use_markup">True</property>
-            <property name="margin_start">5</property>
-            <property name="margin_end">10</property>
+            <property name="use-markup">1</property>
+            <property name="margin-start">5</property>
+            <property name="margin-end">10</property>
           </object>
-          <packing>
-            <property name="expand">False</property>
-            <property name="fill">True</property>
-            <property name="position">0</property>
-          </packing>
         </child>
         <child>
           <object class="GtkLabel" id="UserLabel">
-            <property name="visible">True</property>
-            <property name="can_focus">False</property>
+            <property name="visible">1</property>
+            <property name="margin-start">5</property>
+            <property name="margin-end">5</property>
             <property name="label" translatable="yes">User:</property>
           </object>
-          <packing>
-            <property name="expand">False</property>
-            <property name="fill">False</property>
-            <property name="padding">5</property>
-            <property name="position">1</property>
-          </packing>
         </child>
         <child>
           <object class="GtkEntry" id="AddUserEntry">
-            <property name="visible">True</property>
-            <property name="can_focus">True</property>
-            <property name="invisible_char">•</property>
+            <property name="visible">1</property>
+            <property name="can-focus">1</property>
+            <property name="invisible-char">•</property>
             <signal name="activate" handler="on_add_user" swapped="no"/>
           </object>
-          <packing>
-            <property name="expand">False</property>
-            <property name="fill">True</property>
-            <property name="position">2</property>
-          </packing>
         </child>
         <child>
           <object class="GtkButton">
-            <property name="visible">True</property>
-            <property name="can_focus">True</property>
-            <property name="receives_default">True</property>
-            <property name="tooltip_text" translatable="yes">Add</property>
+            <property name="visible">1</property>
+            <property name="can-focus">1</property>
+            <property name="receives-default">1</property>
+            <property name="tooltip-text" translatable="yes">Add</property>
             <property name="image">add</property>
-            <property name="always_show_image">True</property>
+            <property name="always-show-image">1</property>
             <signal name="clicked" handler="on_add_user" swapped="no"/>
             <child>
               <object class="GtkImage" id="add">
-                <property name="can_focus">False</property>
-                <property name="icon_name">list-add-symbolic</property>
+                <property name="icon-name">list-add-symbolic</property>
               </object>
             </child>
           </object>
-          <packing>
-            <property name="expand">False</property>
-            <property name="fill">False</property>
-            <property name="position">3</property>
-          </packing>
         </child>
         <child>
           <object class="GtkButton">
-            <property name="visible">True</property>
-            <property name="can_focus">True</property>
-            <property name="receives_default">True</property>
-            <property name="tooltip_text" translatable="yes">Configure banned users</property>
+            <property name="visible">1</property>
+            <property name="can-focus">1</property>
+            <property name="receives-default">1</property>
+            <property name="tooltip-text" translatable="yes">Configure banned users</property>
             <property name="image">configure</property>
-            <property name="always_show_image">True</property>
+            <property name="always-show-image">1</property>
             <signal name="clicked" handler="on_settings_ban_ignore" swapped="no"/>
             <child>
               <object class="GtkImage" id="configure">
-                <property name="can_focus">False</property>
-                <property name="icon_name">applications-system-symbolic</property>
+                <property name="icon-name">applications-system-symbolic</property>
               </object>
             </child>
             <style>
@@ -94,39 +69,25 @@
             </style>
           </object>
           <packing>
-            <property name="expand">False</property>
-            <property name="fill">False</property>
-            <property name="pack_type">end</property>
-            <property name="position">4</property>
+            <property name="pack-type">end</property>
           </packing>
         </child>
       </object>
-      <packing>
-        <property name="expand">False</property>
-        <property name="fill">True</property>
-        <property name="position">0</property>
-      </packing>
     </child>
     <child>
       <object class="GtkScrolledWindow">
-        <property name="visible">True</property>
-        <property name="can_focus">True</property>
-        <property name="hscrollbar_policy">automatic</property>
-        <property name="vscrollbar_policy">automatic</property>
+        <property name="visible">1</property>
+        <property name="can-focus">1</property>
+        <property name="vexpand">1</property>
         <child>
           <object class="GtkTreeView" id="UserListTree">
-            <property name="visible">True</property>
-            <property name="can_focus">True</property>
-            <property name="has_tooltip">True</property>
+            <property name="visible">1</property>
+            <property name="can-focus">1</property>
+            <property name="has-tooltip">1</property>
             <signal name="query-tooltip" handler="on_tooltip" swapped="no"/>
           </object>
         </child>
       </object>
-      <packing>
-        <property name="expand">True</property>
-        <property name="fill">True</property>
-        <property name="position">1</property>
-      </packing>
     </child>
   </object>
 </interface>

--- a/pynicotine/gtkgui/ui/buddylist.ui
+++ b/pynicotine/gtkgui/ui/buddylist.ui
@@ -7,7 +7,10 @@
     <child>
       <object class="GtkBox">
         <property name="visible">1</property>
-        <property name="margin">6</property>
+        <property name="margin-start">6</property>
+        <property name="margin-end">6</property>
+        <property name="margin-top">6</property>
+        <property name="margin-bottom">6</property>
         <property name="spacing">6</property>
         <child>
           <object class="GtkLabel" id="BuddiesLabel">
@@ -40,14 +43,16 @@
             <property name="can-focus">1</property>
             <property name="receives-default">1</property>
             <property name="tooltip-text" translatable="yes">Add</property>
-            <property name="image">add</property>
-            <property name="always-show-image">1</property>
             <signal name="clicked" handler="on_add_user" swapped="no"/>
             <child>
-              <object class="GtkImage" id="add">
+              <object class="GtkImage">
+                <property name="visible">1</property>
                 <property name="icon-name">list-add-symbolic</property>
               </object>
             </child>
+            <style>
+                <class name="image-button"/>
+            </style>
           </object>
         </child>
         <child>
@@ -56,18 +61,18 @@
             <property name="can-focus">1</property>
             <property name="receives-default">1</property>
             <property name="tooltip-text" translatable="yes">Configure banned users</property>
-            <property name="image">configure</property>
-            <property name="always-show-image">1</property>
             <property name="halign">end</property>
             <property name="hexpand">True</property>
             <signal name="clicked" handler="on_settings_ban_ignore" swapped="no"/>
             <child>
-              <object class="GtkImage" id="configure">
+              <object class="GtkImage">
+                <property name="visible">1</property>
                 <property name="icon-name">applications-system-symbolic</property>
               </object>
             </child>
             <style>
               <class name="circular"/>
+              <class name="image-button"/>
             </style>
           </object>
         </child>

--- a/pynicotine/gtkgui/ui/buddylist.ui
+++ b/pynicotine/gtkgui/ui/buddylist.ui
@@ -7,7 +7,7 @@
     <child>
       <object class="GtkBox">
         <property name="visible">1</property>
-        <property name="border-width">6</property>
+        <property name="margin">6</property>
         <property name="spacing">6</property>
         <child>
           <object class="GtkLabel" id="BuddiesLabel">

--- a/pynicotine/gtkgui/ui/buddylist.ui
+++ b/pynicotine/gtkgui/ui/buddylist.ui
@@ -58,6 +58,8 @@
             <property name="tooltip-text" translatable="yes">Configure banned users</property>
             <property name="image">configure</property>
             <property name="always-show-image">1</property>
+            <property name="halign">end</property>
+            <property name="hexpand">True</property>
             <signal name="clicked" handler="on_settings_ban_ignore" swapped="no"/>
             <child>
               <object class="GtkImage" id="configure">
@@ -68,9 +70,6 @@
               <class name="circular"/>
             </style>
           </object>
-          <packing>
-            <property name="pack-type">end</property>
-          </packing>
         </child>
       </object>
     </child>

--- a/pynicotine/gtkgui/ui/chatrooms.ui
+++ b/pynicotine/gtkgui/ui/chatrooms.ui
@@ -2,330 +2,234 @@
 <interface>
   <requires lib="gtk+" version="3.18"/>
   <object class="GtkBox" id="Main">
-    <property name="visible">True</property>
-    <property name="can_focus">False</property>
+    <property name="visible">1</property>
     <property name="orientation">vertical</property>
     <child>
       <object class="GtkPaned">
-        <property name="visible">True</property>
-        <property name="can_focus">True</property>
+        <property name="visible">1</property>
+        <property name="can-focus">1</property>
         <child>
           <object class="GtkPaned">
-            <property name="visible">True</property>
-            <property name="can_focus">True</property>
+            <property name="visible">1</property>
+            <property name="can-focus">1</property>
             <property name="orientation">vertical</property>
             <child>
               <object class="GtkBox">
-                <property name="visible">True</property>
-                <property name="can_focus">False</property>
+                <property name="visible">1</property>
                 <property name="orientation">vertical</property>
                 <child>
                   <object class="GtkSearchBar" id="LogSearchBar">
-                    <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <property name="show_close_button">True</property>
+                    <property name="visible">1</property>
+                    <property name="show-close-button">1</property>
                     <child>
                       <object class="GtkBox">
-                        <property name="visible">True</property>
-                        <property name="can_focus">False</property>
+                        <property name="visible">1</property>
                         <property name="spacing">6</property>
                         <child>
                           <object class="GtkSearchEntry" id="LogSearchEntry">
-                            <property name="visible">True</property>
-                            <property name="can_focus">True</property>
-                            <property name="max_width_chars">75</property>
+                            <property name="visible">1</property>
+                            <property name="can-focus">1</property>
+                            <property name="max-width-chars">75</property>
                           </object>
-                          <packing>
-                            <property name="expand">False</property>
-                            <property name="fill">True</property>
-                            <property name="position">0</property>
-                          </packing>
                         </child>
                       </object>
                     </child>
                   </object>
-                  <packing>
-                    <property name="expand">False</property>
-                    <property name="fill">True</property>
-                    <property name="position">0</property>
-                  </packing>
                 </child>
                 <child>
                   <object class="GtkScrolledWindow" id="RoomLogWindow">
-                    <property name="visible">True</property>
-                    <property name="can_focus">True</property>
-                    <property name="hscrollbar_policy">automatic</property>
-                    <property name="vscrollbar_policy">automatic</property>
+                    <property name="visible">1</property>
+                    <property name="can-focus">1</property>
                     <child>
                       <object class="GtkTextView" id="RoomLog">
-                        <property name="visible">True</property>
-                        <property name="can_focus">True</property>
-                        <property name="editable">False</property>
-                        <property name="cursor_visible">False</property>
-                        <property name="pixels_above_lines">1</property>
-                        <property name="pixels_below_lines">1</property>
-                        <property name="left_margin">10</property>
-                        <property name="right_margin">10</property>
-                        <property name="top_margin">5</property>
-                        <property name="bottom_margin">5</property>
+                        <property name="visible">1</property>
+                        <property name="can-focus">1</property>
+                        <property name="editable">0</property>
+                        <property name="cursor-visible">0</property>
+                        <property name="pixels-above-lines">1</property>
+                        <property name="pixels-below-lines">1</property>
+                        <property name="left-margin">10</property>
+                        <property name="right-margin">10</property>
+                        <property name="top-margin">5</property>
+                        <property name="bottom-margin">5</property>
                       </object>
                     </child>
                   </object>
-                  <packing>
-                    <property name="expand">True</property>
-                    <property name="fill">True</property>
-                    <property name="position">1</property>
-                  </packing>
                 </child>
               </object>
               <packing>
-                <property name="resize">False</property>
-                <property name="shrink">True</property>
+                <property name="resize">0</property>
               </packing>
             </child>
             <child>
               <object class="GtkBox">
-                <property name="visible">True</property>
-                <property name="can_focus">False</property>
+                <property name="visible">1</property>
                 <property name="orientation">vertical</property>
                 <child>
                   <object class="GtkSearchBar" id="ChatSearchBar">
-                    <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <property name="show_close_button">True</property>
+                    <property name="visible">1</property>
+                    <property name="show-close-button">1</property>
                     <child>
                       <object class="GtkBox">
-                        <property name="visible">True</property>
-                        <property name="can_focus">False</property>
+                        <property name="visible">1</property>
                         <property name="spacing">6</property>
                         <child>
                           <object class="GtkSearchEntry" id="ChatSearchEntry">
-                            <property name="visible">True</property>
-                            <property name="can_focus">True</property>
-                            <property name="max_width_chars">75</property>
+                            <property name="visible">1</property>
+                            <property name="can-focus">1</property>
+                            <property name="max-width-chars">75</property>
                           </object>
-                          <packing>
-                            <property name="expand">False</property>
-                            <property name="fill">True</property>
-                            <property name="position">0</property>
-                          </packing>
                         </child>
                       </object>
                     </child>
                   </object>
-                  <packing>
-                    <property name="expand">False</property>
-                    <property name="fill">True</property>
-                    <property name="position">0</property>
-                  </packing>
                 </child>
                 <child>
                   <object class="GtkScrolledWindow" id="ChatScrollWindow">
-                    <property name="visible">True</property>
-                    <property name="can_focus">True</property>
-                    <property name="hscrollbar_policy">automatic</property>
-                    <property name="vscrollbar_policy">automatic</property>
+                    <property name="visible">1</property>
+                    <property name="can-focus">1</property>
+                    <property name="vexpand">1</property>
                     <child>
                       <object class="GtkTextView" id="ChatScroll">
-                        <property name="visible">True</property>
-                        <property name="can_focus">True</property>
-                        <property name="editable">False</property>
-                        <property name="wrap_mode">word-char</property>
-                        <property name="cursor_visible">False</property>
-                        <property name="pixels_above_lines">1</property>
-                        <property name="pixels_below_lines">1</property>
-                        <property name="left_margin">10</property>
-                        <property name="right_margin">10</property>
-                        <property name="top_margin">5</property>
-                        <property name="bottom_margin">5</property>
+                        <property name="visible">1</property>
+                        <property name="can-focus">1</property>
+                        <property name="editable">0</property>
+                        <property name="wrap-mode">word-char</property>
+                        <property name="cursor-visible">0</property>
+                        <property name="pixels-above-lines">1</property>
+                        <property name="pixels-below-lines">1</property>
+                        <property name="left-margin">10</property>
+                        <property name="right-margin">10</property>
+                        <property name="top-margin">5</property>
+                        <property name="bottom-margin">5</property>
                       </object>
                     </child>
                   </object>
-                  <packing>
-                    <property name="expand">True</property>
-                    <property name="fill">True</property>
-                    <property name="position">1</property>
-                  </packing>
                 </child>
                 <child>
                   <object class="GtkBox" id="ChatEntryBox">
-                    <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <property name="border_width">8</property>
+                    <property name="visible">1</property>
+                    <property name="border-width">8</property>
                     <property name="spacing">6</property>
                     <child>
                       <object class="GtkEntry" id="ChatEntry">
-                        <property name="visible">True</property>
-                        <property name="can_focus">True</property>
-                        <property name="has_focus">True</property>
-                        <property name="primary_icon_activatable">False</property>
-                        <property name="secondary_icon_activatable">False</property>
-                        <property name="primary_icon_sensitive">True</property>
-                        <property name="secondary_icon_sensitive">True</property>
+                        <property name="visible">1</property>
+                        <property name="can-focus">1</property>
+                        <property name="has-focus">1</property>
+                        <property name="hexpand">1</property>
                         <signal name="activate" handler="on_enter" swapped="no"/>
                         <signal name="key-press-event" handler="on_key_press" swapped="no"/>
                       </object>
-                      <packing>
-                        <property name="expand">True</property>
-                        <property name="fill">True</property>
-                        <property name="position">0</property>
-                      </packing>
                     </child>
                     <child>
                       <object class="GtkCheckButton" id="Log">
                         <property name="label" translatable="yes">Log</property>
-                        <property name="visible">True</property>
-                        <property name="can_focus">True</property>
-                        <property name="receives_default">False</property>
-                        <property name="use_underline">True</property>
-                        <property name="draw_indicator">True</property>
+                        <property name="visible">1</property>
+                        <property name="can-focus">1</property>
+                        <property name="use-underline">1</property>
+                        <property name="draw-indicator">1</property>
                         <signal name="toggled" handler="on_log_toggled" swapped="no"/>
                       </object>
-                      <packing>
-                        <property name="expand">False</property>
-                        <property name="fill">False</property>
-                        <property name="position">1</property>
-                      </packing>
                     </child>
                     <child>
                       <object class="GtkToggleButton" id="Speech">
-                        <property name="visible">True</property>
-                        <property name="can_focus">True</property>
-                        <property name="receives_default">True</property>
-                        <property name="tooltip_text" translatable="yes">Toggle Text-To-Speech</property>
+                        <property name="visible">1</property>
+                        <property name="can-focus">1</property>
+                        <property name="receives-default">1</property>
+                        <property name="tooltip-text" translatable="yes">Toggle Text-To-Speech</property>
                         <property name="image">speech</property>
-                        <property name="always_show_image">True</property>
-                        <property name="active">True</property>
+                        <property name="always-show-image">1</property>
+                        <property name="active">1</property>
                         <child>
                           <object class="GtkImage" id="speech">
-                            <property name="can_focus">False</property>
-                            <property name="icon_name">multimedia-volume-control-symbolic</property>
+                            <property name="icon-name">multimedia-volume-control-symbolic</property>
                           </object>
                         </child>
                       </object>
-                      <packing>
-                        <property name="expand">False</property>
-                        <property name="fill">False</property>
-                        <property name="position">2</property>
-                      </packing>
                     </child>
                     <child>
                       <object class="GtkButton" id="ShowRoomWall">
-                        <property name="visible">True</property>
-                        <property name="can_focus">True</property>
-                        <property name="receives_default">True</property>
-                        <property name="tooltip_text" translatable="yes">Room wall</property>
+                        <property name="visible">1</property>
+                        <property name="can-focus">1</property>
+                        <property name="receives-default">1</property>
+                        <property name="tooltip-text" translatable="yes">Room wall</property>
                         <property name="image">list</property>
-                        <property name="always_show_image">True</property>
+                        <property name="always-show-image">1</property>
                         <signal name="clicked" handler="on_show_room_wall" swapped="no"/>
                         <child>
                           <object class="GtkImage" id="list">
-                            <property name="can_focus">False</property>
-                            <property name="icon_name">view-list-symbolic</property>
+                            <property name="icon-name">view-list-symbolic</property>
                           </object>
                         </child>
                       </object>
-                      <packing>
-                        <property name="expand">False</property>
-                        <property name="fill">False</property>
-                        <property name="position">3</property>
-                      </packing>
                     </child>
                     <child>
                       <object class="GtkButton" id="ShowChatHelp">
-                        <property name="visible">True</property>
-                        <property name="can_focus">True</property>
-                        <property name="receives_default">True</property>
-                        <property name="tooltip_text" translatable="yes">Chat room command help</property>
+                        <property name="visible">1</property>
+                        <property name="can-focus">1</property>
+                        <property name="receives-default">1</property>
+                        <property name="tooltip-text" translatable="yes">Chat room command help</property>
                         <property name="image">help</property>
-                        <property name="always_show_image">True</property>
+                        <property name="always-show-image">1</property>
                         <signal name="clicked" handler="on_show_chat_help" swapped="no"/>
                         <child>
                           <object class="GtkImage" id="help">
-                            <property name="can_focus">False</property>
-                            <property name="icon_name">dialog-question-symbolic</property>
+                            <property name="icon-name">dialog-question-symbolic</property>
                           </object>
                         </child>
                       </object>
-                      <packing>
-                        <property name="expand">False</property>
-                        <property name="fill">False</property>
-                        <property name="position">4</property>
-                      </packing>
                     </child>
                   </object>
-                  <packing>
-                    <property name="expand">False</property>
-                    <property name="fill">False</property>
-                    <property name="position">2</property>
-                  </packing>
                 </child>
               </object>
               <packing>
-                <property name="resize">True</property>
-                <property name="shrink">False</property>
+                <property name="shrink">0</property>
               </packing>
             </child>
           </object>
           <packing>
-            <property name="resize">True</property>
-            <property name="shrink">True</property>
+            <property name="resize">1</property>
           </packing>
         </child>
         <child>
           <object class="GtkBox" id="vbox5">
-            <property name="visible">True</property>
-            <property name="can_focus">False</property>
+            <property name="visible">1</property>
             <property name="orientation">vertical</property>
             <child>
               <object class="GtkBox">
-                <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="border_width">6</property>
+                <property name="visible">1</property>
+                <property name="border-width">6</property>
                 <property name="spacing">10</property>
                 <child>
                   <object class="GtkBox">
-                    <property name="visible">True</property>
-                    <property name="can_focus">False</property>
+                    <property name="visible">1</property>
                     <property name="spacing">6</property>
+                    <property name="margin-start">5</property>
+                    <property name="margin-end">5</property>
                     <child>
                       <object class="GtkLabel">
-                        <property name="visible">True</property>
-                        <property name="can_focus">False</property>
+                        <property name="visible">1</property>
                         <property name="label" translatable="yes">User List</property>
                       </object>
-                      <packing>
-                        <property name="expand">False</property>
-                        <property name="fill">True</property>
-                        <property name="position">0</property>
-                      </packing>
                     </child>
                     <child>
                       <object class="GtkButton">
-                        <property name="visible">True</property>
-                        <property name="sensitive">False</property>
-                        <property name="can-focus">False</property>
-                        <property name="receives-default">False</property>
+                        <property name="visible">1</property>
+                        <property name="sensitive">0</property>
                         <child>
                           <object class="GtkBox">
                             <property name="width-request">24</property>
-                            <property name="visible">True</property>
-                            <property name="can-focus">False</property>
+                            <property name="visible">1</property>
                             <property name="spacing">5</property>
-                            <property name="homogeneous">True</property>
+                            <property name="homogeneous">1</property>
                             <child>
                               <object class="GtkLabel" id="LabelPeople">
-                                <property name="visible">True</property>
-                                <property name="can-focus">False</property>
+                                <property name="visible">1</property>
                                 <property name="label">&lt;b&gt;0&lt;/b&gt;</property>
-                                <property name="use_markup">True</property>
+                                <property name="use-markup">1</property>
+                                <property name="margin-start">5</property>
+                                <property name="margin-end">5</property>
                               </object>
-                              <packing>
-                                <property name="expand">False</property>
-                                <property name="fill">True</property>
-                                <property name="padding">5</property>
-                                <property name="position">0</property>
-                              </packing>
                             </child>
                           </object>
                         </child>
@@ -333,77 +237,46 @@
                           <class name="circular"/>
                         </style>
                       </object>
-                      <packing>
-                        <property name="expand">False</property>
-                        <property name="fill">False</property>
-                        <property name="position">1</property>
-                      </packing>
                     </child>
                   </object>
-                  <packing>
-                    <property name="expand">False</property>
-                    <property name="fill">False</property>
-                    <property name="padding">5</property>
-                    <property name="position">0</property>
-                  </packing>
                 </child>
                 <child>
                   <object class="GtkCheckButton" id="AutoJoin">
                     <property name="label" translatable="yes">Auto-join Room</property>
-                    <property name="visible">True</property>
-                    <property name="can_focus">True</property>
-                    <property name="receives_default">False</property>
-                    <property name="use_underline">True</property>
-                    <property name="draw_indicator">True</property>
+                    <property name="visible">1</property>
+                    <property name="can-focus">1</property>
+                    <property name="use-underline">1</property>
+                    <property name="draw-indicator">1</property>
                     <signal name="toggled" handler="on_autojoin" swapped="no"/>
                   </object>
                   <packing>
-                    <property name="expand">False</property>
-                    <property name="fill">False</property>
-                    <property name="pack_type">end</property>
-                    <property name="position">1</property>
+                    <property name="pack-type">end</property>
                   </packing>
                 </child>
               </object>
-              <packing>
-                <property name="expand">False</property>
-                <property name="fill">False</property>
-              </packing>
             </child>
             <child>
               <object class="GtkScrolledWindow">
-                <property name="width_request">340</property>
-                <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <property name="hscrollbar_policy">automatic</property>
-                <property name="vscrollbar_policy">automatic</property>
+                <property name="width-request">340</property>
+                <property name="visible">1</property>
+                <property name="can-focus">1</property>
+                <property name="vexpand">1</property>
                 <child>
                   <object class="GtkTreeView" id="UserList">
-                    <property name="visible">True</property>
-                    <property name="can_focus">True</property>
-                    <property name="has_tooltip">True</property>
+                    <property name="visible">1</property>
+                    <property name="can-focus">1</property>
+                    <property name="has-tooltip">1</property>
                     <signal name="query-tooltip" handler="on_tooltip" swapped="no"/>
                   </object>
                 </child>
               </object>
-              <packing>
-                <property name="expand">True</property>
-                <property name="fill">True</property>
-                <property name="position">1</property>
-              </packing>
             </child>
           </object>
           <packing>
-            <property name="resize">False</property>
-            <property name="shrink">True</property>
+            <property name="resize">0</property>
           </packing>
         </child>
       </object>
-      <packing>
-        <property name="expand">True</property>
-        <property name="fill">True</property>
-        <property name="position">1</property>
-      </packing>
     </child>
   </object>
 </interface>

--- a/pynicotine/gtkgui/ui/chatrooms.ui
+++ b/pynicotine/gtkgui/ui/chatrooms.ui
@@ -40,6 +40,7 @@
                   <object class="GtkScrolledWindow" id="RoomLogWindow">
                     <property name="visible">1</property>
                     <property name="can-focus">1</property>
+                    <property name="vexpand">1</property>
                     <child>
                       <object class="GtkTextView" id="RoomLog">
                         <property name="visible">1</property>

--- a/pynicotine/gtkgui/ui/chatrooms.ui
+++ b/pynicotine/gtkgui/ui/chatrooms.ui
@@ -247,11 +247,10 @@
                     <property name="can-focus">1</property>
                     <property name="use-underline">1</property>
                     <property name="draw-indicator">1</property>
+                    <property name="halign">end</property>
+                    <property name="hexpand">True</property>
                     <signal name="toggled" handler="on_autojoin" swapped="no"/>
                   </object>
-                  <packing>
-                    <property name="pack-type">end</property>
-                  </packing>
                 </child>
               </object>
             </child>

--- a/pynicotine/gtkgui/ui/chatrooms.ui
+++ b/pynicotine/gtkgui/ui/chatrooms.ui
@@ -109,7 +109,10 @@
                 <child>
                   <object class="GtkBox" id="ChatEntryBox">
                     <property name="visible">1</property>
-                    <property name="margin">8</property>
+                    <property name="margin-start">8</property>
+                    <property name="margin-end">8</property>
+                    <property name="margin-top">8</property>
+                    <property name="margin-bottom">8</property>
                     <property name="spacing">6</property>
                     <child>
                       <object class="GtkEntry" id="ChatEntry">
@@ -136,14 +139,16 @@
                         <property name="can-focus">1</property>
                         <property name="receives-default">1</property>
                         <property name="tooltip-text" translatable="yes">Toggle Text-To-Speech</property>
-                        <property name="image">speech</property>
-                        <property name="always-show-image">1</property>
                         <property name="active">1</property>
                         <child>
-                          <object class="GtkImage" id="speech">
+                          <object class="GtkImage">
+                            <property name="visible">1</property>
                             <property name="icon-name">multimedia-volume-control-symbolic</property>
                           </object>
                         </child>
+                        <style>
+                          <class name="image-button"/>
+                        </style>
                       </object>
                     </child>
                     <child>
@@ -152,14 +157,16 @@
                         <property name="can-focus">1</property>
                         <property name="receives-default">1</property>
                         <property name="tooltip-text" translatable="yes">Room wall</property>
-                        <property name="image">list</property>
-                        <property name="always-show-image">1</property>
                         <signal name="clicked" handler="on_show_room_wall" swapped="no"/>
                         <child>
-                          <object class="GtkImage" id="list">
+                          <object class="GtkImage">
+                            <property name="visible">1</property>
                             <property name="icon-name">view-list-symbolic</property>
                           </object>
                         </child>
+                        <style>
+                          <class name="image-button"/>
+                        </style>
                       </object>
                     </child>
                     <child>
@@ -168,14 +175,16 @@
                         <property name="can-focus">1</property>
                         <property name="receives-default">1</property>
                         <property name="tooltip-text" translatable="yes">Chat room command help</property>
-                        <property name="image">help</property>
-                        <property name="always-show-image">1</property>
                         <signal name="clicked" handler="on_show_chat_help" swapped="no"/>
                         <child>
-                          <object class="GtkImage" id="help">
+                          <object class="GtkImage">
+                            <property name="visible">1</property>
                             <property name="icon-name">dialog-question-symbolic</property>
                           </object>
                         </child>
+                        <style>
+                          <class name="image-button"/>
+                        </style>
                       </object>
                     </child>
                   </object>
@@ -197,7 +206,10 @@
             <child>
               <object class="GtkBox">
                 <property name="visible">1</property>
-                <property name="margin">6</property>
+                <property name="margin-start">6</property>
+                <property name="margin-end">6</property>
+                <property name="margin-top">6</property>
+                <property name="margin-bottom">6</property>
                 <property name="spacing">10</property>
                 <child>
                   <object class="GtkBox">
@@ -246,7 +258,7 @@
                     <property name="can-focus">1</property>
                     <property name="use-underline">1</property>
                     <property name="halign">end</property>
-                    <property name="hexpand">True</property>
+                    <property name="hexpand">1</property>
                     <signal name="toggled" handler="on_autojoin" swapped="no"/>
                   </object>
                 </child>

--- a/pynicotine/gtkgui/ui/chatrooms.ui
+++ b/pynicotine/gtkgui/ui/chatrooms.ui
@@ -127,7 +127,6 @@
                         <property name="visible">1</property>
                         <property name="can-focus">1</property>
                         <property name="use-underline">1</property>
-                        <property name="draw-indicator">1</property>
                         <signal name="toggled" handler="on_log_toggled" swapped="no"/>
                       </object>
                     </child>
@@ -246,7 +245,6 @@
                     <property name="visible">1</property>
                     <property name="can-focus">1</property>
                     <property name="use-underline">1</property>
-                    <property name="draw-indicator">1</property>
                     <property name="halign">end</property>
                     <property name="hexpand">True</property>
                     <signal name="toggled" handler="on_autojoin" swapped="no"/>

--- a/pynicotine/gtkgui/ui/chatrooms.ui
+++ b/pynicotine/gtkgui/ui/chatrooms.ui
@@ -109,7 +109,7 @@
                 <child>
                   <object class="GtkBox" id="ChatEntryBox">
                     <property name="visible">1</property>
-                    <property name="border-width">8</property>
+                    <property name="margin">8</property>
                     <property name="spacing">6</property>
                     <child>
                       <object class="GtkEntry" id="ChatEntry">
@@ -198,7 +198,7 @@
             <child>
               <object class="GtkBox">
                 <property name="visible">1</property>
-                <property name="border-width">6</property>
+                <property name="margin">6</property>
                 <property name="spacing">10</property>
                 <child>
                   <object class="GtkBox">

--- a/pynicotine/gtkgui/ui/fastconfigure.ui
+++ b/pynicotine/gtkgui/ui/fastconfigure.ui
@@ -2,12 +2,11 @@
 <interface>
   <requires lib="gtk+" version="3.18"/>
   <object class="GtkAssistant" id="FastConfigureDialog">
-    <property name="can_focus">False</property>
-    <property name="modal">True</property>
-    <property name="window_position">center-on-parent</property>
-    <property name="default_width">900</property>
-    <property name="default_height">450</property>
-    <property name="type_hint">dialog</property>
+    <property name="modal">1</property>
+    <property name="window-position">center-on-parent</property>
+    <property name="default-width">900</property>
+    <property name="default-height">450</property>
+    <property name="type-hint">dialog</property>
     <property name="gravity">center</property>
     <signal name="apply" handler="on_apply" swapped="no"/>
     <signal name="cancel" handler="on_cancel" swapped="no"/>
@@ -15,133 +14,99 @@
     <signal name="prepare" handler="on_prepare" swapped="no"/>
     <child>
       <object class="GtkBox" id="welcomepage">
-        <property name="visible">True</property>
-        <property name="can_focus">False</property>
+        <property name="visible">1</property>
         <property name="halign">center</property>
         <property name="valign">center</property>
-        <property name="margin_start">5</property>
-        <property name="margin_end">5</property>
-        <property name="margin_top">5</property>
-        <property name="margin_bottom">5</property>
+        <property name="margin-start">5</property>
+        <property name="margin-end">5</property>
+        <property name="margin-top">5</property>
+        <property name="margin-bottom">5</property>
         <property name="orientation">vertical</property>
         <property name="spacing">20</property>
         <child>
           <object class="GtkLabel">
-            <property name="visible">True</property>
-            <property name="can_focus">False</property>
+            <property name="visible">1</property>
             <property name="halign">center</property>
             <property name="label" translatable="yes">&lt;b&gt;Welcome to Nicotine+!&lt;/b&gt;</property>
-            <property name="use_markup">True</property>
+            <property name="use-markup">1</property>
           </object>
-          <packing>
-            <property name="expand">False</property>
-            <property name="fill">True</property>
-            <property name="position">0</property>
-          </packing>
         </child>
         <child>
           <object class="GtkLabel">
-            <property name="visible">True</property>
-            <property name="can_focus">False</property>
+            <property name="visible">1</property>
             <property name="halign">center</property>
             <property name="valign">center</property>
             <property name="label" translatable="yes">Nicotine+ is a graphical client for the Soulseek peer-to-peer file sharing network.</property>
             <property name="justify">center</property>
-            <property name="wrap">True</property>
-            <property name="width_chars">60</property>
-            <property name="max_width_chars">60</property>
+            <property name="wrap">1</property>
+            <property name="width-chars">60</property>
+            <property name="max-width-chars">60</property>
           </object>
-          <packing>
-            <property name="expand">False</property>
-            <property name="fill">True</property>
-            <property name="position">1</property>
-          </packing>
         </child>
         <child>
           <object class="GtkLabel">
-            <property name="visible">True</property>
-            <property name="can_focus">False</property>
+            <property name="visible">1</property>
             <property name="halign">center</property>
             <property name="valign">center</property>
-            <property name="label" translatable="yes">Press "Next" to start configuring Nicotine+.</property>
+            <property name="label" translatable="yes">Press &quot;Next&quot; to start configuring Nicotine+.</property>
             <property name="justify">center</property>
-            <property name="wrap">True</property>
-            <property name="width_chars">60</property>
-            <property name="max_width_chars">60</property>
+            <property name="wrap">1</property>
+            <property name="width-chars">60</property>
+            <property name="max-width-chars">60</property>
           </object>
-          <packing>
-            <property name="expand">False</property>
-            <property name="fill">True</property>
-            <property name="position">2</property>
-          </packing>
         </child>
       </object>
       <packing>
-        <property name="page_type">intro</property>
-        <property name="has_padding">True</property>
+        <property name="page-type">intro</property>
       </packing>
     </child>
     <child>
       <object class="GtkBox" id="userpasspage">
-        <property name="visible">True</property>
-        <property name="can_focus">False</property>
+        <property name="visible">1</property>
         <property name="halign">center</property>
         <property name="valign">center</property>
-        <property name="margin_start">5</property>
-        <property name="margin_end">5</property>
-        <property name="margin_top">5</property>
-        <property name="margin_bottom">5</property>
+        <property name="margin-start">5</property>
+        <property name="margin-end">5</property>
+        <property name="margin-top">5</property>
+        <property name="margin-bottom">5</property>
         <property name="orientation">vertical</property>
         <property name="spacing">30</property>
         <child>
           <object class="GtkLabel">
-            <property name="visible">True</property>
-            <property name="can_focus">False</property>
+            <property name="visible">1</property>
             <property name="label" translatable="yes">To create a new user, fill in the username and password you want. If you already have a Soulseek account, fill in your chosen details.
 
-Please keep in mind that more common usernames may be taken. If you're unable to connect, you can change your username in the preferences later.</property>
+Please keep in mind that more common usernames may be taken. If you&apos;re unable to connect, you can change your username in the preferences later.</property>
             <property name="justify">center</property>
-            <property name="wrap">True</property>
-            <property name="width_chars">60</property>
-            <property name="max_width_chars">60</property>
+            <property name="wrap">1</property>
+            <property name="width-chars">60</property>
+            <property name="max-width-chars">60</property>
           </object>
-          <packing>
-            <property name="expand">True</property>
-            <property name="fill">True</property>
-            <property name="position">0</property>
-          </packing>
         </child>
         <child>
           <object class="GtkBox">
-            <property name="visible">True</property>
-            <property name="can_focus">False</property>
+            <property name="visible">1</property>
             <property name="spacing">10</property>
             <child>
               <object class="GtkBox">
-                <property name="visible">True</property>
-                <property name="can_focus">False</property>
+                <property name="visible">1</property>
                 <property name="orientation">vertical</property>
                 <property name="spacing">10</property>
+                <property name="hexpand">1</property>
                 <child>
                   <object class="GtkLabel">
-                    <property name="visible">True</property>
-                    <property name="can_focus">False</property>
+                    <property name="visible">1</property>
                     <property name="halign">start</property>
                     <property name="label" translatable="yes">Username</property>
                   </object>
-                  <packing>
-                    <property name="expand">True</property>
-                    <property name="fill">True</property>
-                    <property name="position">0</property>
-                  </packing>
                 </child>
                 <child>
                   <object class="GtkEntry" id="username">
-                    <property name="visible">True</property>
-                    <property name="can_focus">True</property>
-                    <property name="invisible_char">●</property>
-                    <property name="primary_icon_activatable">False</property>
-                    <property name="secondary_icon_activatable">False</property>
+                    <property name="visible">1</property>
+                    <property name="can-focus">1</property>
+                    <property name="invisible-char">●</property>
+                    <property name="primary-icon-activatable">0</property>
+                    <property name="secondary-icon-activatable">0</property>
                     <signal name="backspace" handler="on_entry_changed" swapped="no"/>
                     <signal name="changed" handler="on_entry_paste" swapped="no"/>
                     <signal name="cut-clipboard" handler="on_entry_changed" swapped="no"/>
@@ -150,46 +115,30 @@ Please keep in mind that more common usernames may be taken. If you're unable to
                     <signal name="key-press-event" handler="on_entry_changed" swapped="no"/>
                     <signal name="paste-clipboard" handler="on_entry_changed" swapped="no"/>
                   </object>
-                  <packing>
-                    <property name="expand">True</property>
-                    <property name="fill">True</property>
-                    <property name="position">1</property>
-                  </packing>
                 </child>
               </object>
-              <packing>
-                <property name="expand">True</property>
-                <property name="fill">True</property>
-                <property name="position">0</property>
-              </packing>
             </child>
             <child>
               <object class="GtkBox">
-                <property name="visible">True</property>
-                <property name="can_focus">False</property>
+                <property name="visible">1</property>
                 <property name="orientation">vertical</property>
                 <property name="spacing">10</property>
+                <property name="hexpand">1</property>
                 <child>
                   <object class="GtkLabel">
-                    <property name="visible">True</property>
-                    <property name="can_focus">False</property>
+                    <property name="visible">1</property>
                     <property name="halign">start</property>
                     <property name="label" translatable="yes">Password</property>
                   </object>
-                  <packing>
-                    <property name="expand">True</property>
-                    <property name="fill">True</property>
-                    <property name="position">0</property>
-                  </packing>
                 </child>
                 <child>
                   <object class="GtkEntry" id="password">
-                    <property name="visible">True</property>
-                    <property name="can_focus">True</property>
-                    <property name="visibility">False</property>
-                    <property name="invisible_char">●</property>
-                    <property name="primary_icon_activatable">False</property>
-                    <property name="secondary_icon_activatable">False</property>
+                    <property name="visible">1</property>
+                    <property name="can-focus">1</property>
+                    <property name="visibility">0</property>
+                    <property name="invisible-char">●</property>
+                    <property name="primary-icon-activatable">0</property>
+                    <property name="secondary-icon-activatable">0</property>
                     <signal name="backspace" handler="on_entry_changed" swapped="no"/>
                     <signal name="changed" handler="on_entry_paste" swapped="no"/>
                     <signal name="cut-clipboard" handler="on_entry_changed" swapped="no"/>
@@ -198,343 +147,216 @@ Please keep in mind that more common usernames may be taken. If you're unable to
                     <signal name="key-press-event" handler="on_entry_changed" swapped="no"/>
                     <signal name="paste-clipboard" handler="on_entry_changed" swapped="no"/>
                   </object>
-                  <packing>
-                    <property name="expand">True</property>
-                    <property name="fill">True</property>
-                    <property name="position">1</property>
-                  </packing>
                 </child>
               </object>
-              <packing>
-                <property name="expand">True</property>
-                <property name="fill">True</property>
-                <property name="position">1</property>
-              </packing>
             </child>
           </object>
-          <packing>
-            <property name="expand">True</property>
-            <property name="fill">True</property>
-            <property name="position">1</property>
-          </packing>
         </child>
       </object>
-      <packing>
-        <property name="has_padding">True</property>
-      </packing>
     </child>
     <child>
       <object class="GtkBox" id="portpage">
-        <property name="visible">True</property>
-        <property name="can_focus">False</property>
+        <property name="visible">1</property>
         <property name="halign">center</property>
         <property name="valign">center</property>
-        <property name="margin_start">5</property>
-        <property name="margin_end">5</property>
-        <property name="margin_top">5</property>
-        <property name="margin_bottom">5</property>
+        <property name="margin-start">5</property>
+        <property name="margin-end">5</property>
+        <property name="margin-top">5</property>
+        <property name="margin-bottom">5</property>
         <property name="orientation">vertical</property>
         <property name="spacing">20</property>
         <child>
           <object class="GtkBox" id="portselection">
-            <property name="visible">True</property>
-            <property name="can_focus">False</property>
+            <property name="visible">1</property>
             <property name="halign">center</property>
             <property name="orientation">vertical</property>
             <property name="spacing">20</property>
             <child>
               <object class="GtkLabel">
-                <property name="visible">True</property>
-                <property name="can_focus">False</property>
+                <property name="visible">1</property>
                 <property name="label" translatable="yes">Nicotine+ uses peer-to-peer networking to connect to other users. An open listening port is crucial to allow users to connect to you without trouble.</property>
                 <property name="justify">center</property>
-                <property name="wrap">True</property>
-                <property name="width_chars">60</property>
-                <property name="max_width_chars">60</property>
+                <property name="wrap">1</property>
+                <property name="width-chars">60</property>
+                <property name="max-width-chars">60</property>
               </object>
-              <packing>
-                <property name="expand">True</property>
-                <property name="fill">True</property>
-                <property name="position">0</property>
-              </packing>
             </child>
             <child>
               <object class="GtkLabel">
-                <property name="visible">True</property>
-                <property name="can_focus">False</property>
+                <property name="visible">1</property>
                 <property name="label" translatable="yes">The default listening port should work fine in most cases. If you need to use a different port, you can change it in the preferences later.</property>
                 <property name="justify">center</property>
-                <property name="wrap">True</property>
-                <property name="width_chars">60</property>
-                <property name="max_width_chars">60</property>
+                <property name="wrap">1</property>
+                <property name="width-chars">60</property>
+                <property name="max-width-chars">60</property>
               </object>
-              <packing>
-                <property name="expand">True</property>
-                <property name="fill">True</property>
-                <property name="position">1</property>
-              </packing>
             </child>
             <child>
               <object class="GtkLabel">
-                <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="label" translatable="yes">Nicotine+ will still work to some degree if your port is closed. However, do keep in mind that you won't be able to connect to users whose port is also closed.</property>
+                <property name="visible">1</property>
+                <property name="label" translatable="yes">Nicotine+ will still work to some degree if your port is closed. However, do keep in mind that you won&apos;t be able to connect to users whose port is also closed.</property>
                 <property name="justify">center</property>
-                <property name="wrap">True</property>
-                <property name="width_chars">60</property>
-                <property name="max_width_chars">60</property>
+                <property name="wrap">1</property>
+                <property name="width-chars">60</property>
+                <property name="max-width-chars">60</property>
               </object>
-              <packing>
-                <property name="expand">True</property>
-                <property name="fill">True</property>
-                <property name="position">2</property>
-              </packing>
             </child>
             <child>
               <object class="GtkButton" id="checkmyport">
                 <property name="label" translatable="yes">Check my port status</property>
-                <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <property name="receives_default">True</property>
+                <property name="visible">1</property>
+                <property name="can-focus">1</property>
+                <property name="receives-default">1</property>
                 <property name="halign">center</property>
                 <signal name="clicked" handler="on_button_pressed" swapped="no"/>
               </object>
-              <packing>
-                <property name="expand">True</property>
-                <property name="fill">True</property>
-                <property name="position">3</property>
-              </packing>
             </child>
           </object>
-          <packing>
-            <property name="expand">True</property>
-            <property name="fill">True</property>
-            <property name="position">0</property>
-          </packing>
         </child>
       </object>
-      <packing>
-        <property name="has_padding">True</property>
-      </packing>
     </child>
     <child>
       <object class="GtkBox" id="sharepage">
-        <property name="visible">True</property>
-        <property name="can_focus">False</property>
+        <property name="visible">1</property>
         <property name="valign">center</property>
-        <property name="margin_start">5</property>
-        <property name="margin_end">5</property>
-        <property name="margin_top">5</property>
-        <property name="margin_bottom">5</property>
+        <property name="margin-start">5</property>
+        <property name="margin-end">5</property>
+        <property name="margin-top">5</property>
+        <property name="margin-bottom">5</property>
         <property name="orientation">vertical</property>
         <property name="spacing">10</property>
         <child>
           <object class="GtkLabel">
-            <property name="visible">True</property>
-            <property name="can_focus">False</property>
+            <property name="visible">1</property>
             <property name="halign">center</property>
             <property name="label" translatable="yes">Download files to the following directory:</property>
           </object>
-          <packing>
-            <property name="expand">True</property>
-            <property name="fill">False</property>
-            <property name="position">0</property>
-          </packing>
         </child>
         <child>
           <object class="GtkFileChooserButton" id="downloaddir">
-            <property name="visible">True</property>
-            <property name="can_focus">False</property>
+            <property name="visible">1</property>
             <property name="halign">center</property>
-            <property name="margin_bottom">15</property>
+            <property name="margin-bottom">15</property>
             <property name="action">select-folder</property>
           </object>
-          <packing>
-            <property name="expand">False</property>
-            <property name="fill">False</property>
-            <property name="position">1</property>
-          </packing>
         </child>
         <child>
           <object class="GtkLabel">
-            <property name="visible">True</property>
-            <property name="can_focus">False</property>
+            <property name="visible">1</property>
             <property name="halign">center</property>
             <property name="label" translatable="yes">Share the following directories:</property>
-            <property name="width_chars">0</property>
+            <property name="width-chars">0</property>
           </object>
-          <packing>
-            <property name="expand">True</property>
-            <property name="fill">False</property>
-            <property name="position">2</property>
-          </packing>
         </child>
         <child>
           <object class="GtkBox">
-            <property name="visible">True</property>
-            <property name="can_focus">False</property>
+            <property name="visible">1</property>
             <property name="orientation">vertical</property>
             <property name="spacing">15</property>
             <child>
               <object class="GtkScrolledWindow">
-                <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <property name="height_request">150</property>
-                <property name="shadow_type">in</property>
+                <property name="visible">1</property>
+                <property name="can-focus">1</property>
+                <property name="height-request">150</property>
+                <property name="shadow-type">in</property>
                 <child>
                   <object class="GtkTreeView" id="shareddirectoriestree">
-                    <property name="visible">True</property>
-                    <property name="can_focus">True</property>
-                    <property name="rubber_banding">True</property>
+                    <property name="visible">1</property>
+                    <property name="can-focus">1</property>
+                    <property name="rubber-banding">1</property>
                     <child internal-child="selection">
                       <object class="GtkTreeSelection"/>
                     </child>
                   </object>
                 </child>
               </object>
-              <packing>
-                <property name="expand">True</property>
-                <property name="fill">True</property>
-                <property name="position">0</property>
-              </packing>
             </child>
             <child>
               <object class="GtkBox">
-                <property name="visible">True</property>
-                <property name="can_focus">False</property>
+                <property name="visible">1</property>
                 <property name="halign">center</property>
                 <property name="spacing">10</property>
                 <child>
                   <object class="GtkButton" id="addshare">
                     <property name="label" translatable="yes">Add</property>
-                    <property name="visible">True</property>
-                    <property name="can_focus">True</property>
-                    <property name="receives_default">True</property>
+                    <property name="visible">1</property>
+                    <property name="can-focus">1</property>
+                    <property name="receives-default">1</property>
                     <signal name="clicked" handler="on_button_pressed" swapped="no"/>
                   </object>
-                  <packing>
-                    <property name="expand">False</property>
-                    <property name="fill">False</property>
-                    <property name="position">0</property>
-                  </packing>
                 </child>
                 <child>
                   <object class="GtkButton" id="removeshares">
                     <property name="label" translatable="yes">Remove</property>
-                    <property name="visible">True</property>
-                    <property name="can_focus">True</property>
-                    <property name="receives_default">True</property>
+                    <property name="visible">1</property>
+                    <property name="can-focus">1</property>
+                    <property name="receives-default">1</property>
                     <signal name="clicked" handler="on_button_pressed" swapped="no"/>
                   </object>
-                  <packing>
-                    <property name="expand">False</property>
-                    <property name="fill">False</property>
-                    <property name="position">1</property>
-                  </packing>
                 </child>
               </object>
-              <packing>
-                <property name="expand">False</property>
-                <property name="fill">False</property>
-                <property name="position">1</property>
-              </packing>
             </child>
             <child>
               <object class="GtkCheckButton" id="onlysharewithfriends">
                 <property name="label" translatable="yes">Only share files with friends</property>
-                <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <property name="receives_default">False</property>
+                <property name="visible">1</property>
+                <property name="can-focus">1</property>
                 <property name="halign">center</property>
-                <property name="draw_indicator">True</property>
+                <property name="draw-indicator">1</property>
               </object>
-              <packing>
-                <property name="expand">False</property>
-                <property name="fill">False</property>
-                <property name="position">2</property>
-              </packing>
             </child>
           </object>
-          <packing>
-            <property name="expand">True</property>
-            <property name="fill">True</property>
-            <property name="position">3</property>
-          </packing>
         </child>
       </object>
-      <packing>
-        <property name="has_padding">True</property>
-      </packing>
     </child>
     <child>
       <object class="GtkBox" id="summarypage">
-        <property name="visible">True</property>
-        <property name="can_focus">False</property>
+        <property name="visible">1</property>
         <property name="halign">center</property>
         <property name="valign">center</property>
-        <property name="margin_start">5</property>
-        <property name="margin_end">5</property>
-        <property name="margin_top">5</property>
-        <property name="margin_bottom">5</property>
+        <property name="margin-start">5</property>
+        <property name="margin-end">5</property>
+        <property name="margin-top">5</property>
+        <property name="margin-bottom">5</property>
         <property name="orientation">vertical</property>
         <property name="spacing">20</property>
         <child>
           <object class="GtkLabel">
-            <property name="visible">True</property>
-            <property name="can_focus">False</property>
+            <property name="visible">1</property>
             <property name="halign">center</property>
             <property name="label" translatable="yes">&lt;b&gt;You are now ready to use Nicotine+!&lt;/b&gt;</property>
-            <property name="use_markup">True</property>
+            <property name="use-markup">1</property>
           </object>
-          <packing>
-            <property name="expand">False</property>
-            <property name="fill">False</property>
-            <property name="position">0</property>
-          </packing>
         </child>
         <child>
           <object class="GtkLabel">
-            <property name="visible">True</property>
-            <property name="can_focus">False</property>
+            <property name="visible">1</property>
             <property name="halign">start</property>
             <property name="label" translatable="yes">Transfer speeds depend on the users you are downloading from. Some users will be fast while others will be slow.</property>
             <property name="justify">fill</property>
-            <property name="wrap">True</property>
-            <property name="width_chars">60</property>
-            <property name="max_width_chars">60</property>
+            <property name="wrap">1</property>
+            <property name="width-chars">60</property>
+            <property name="max-width-chars">60</property>
           </object>
-          <packing>
-            <property name="expand">False</property>
-            <property name="fill">False</property>
-            <property name="position">1</property>
-          </packing>
         </child>
         <child>
           <object class="GtkLabel" id="labelnoshare">
-            <property name="visible">True</property>
-            <property name="can_focus">False</property>
+            <property name="visible">1</property>
             <property name="halign">start</property>
             <property name="label" translatable="yes">You do not publicly share any files. Sharing files is crucial for the health of the Soulseek network, and many people will ban you if you download from them without sharing anything yourself.</property>
             <property name="justify">fill</property>
-            <property name="wrap">True</property>
-            <property name="width_chars">60</property>
-            <property name="max_width_chars">60</property>
+            <property name="wrap">1</property>
+            <property name="width-chars">60</property>
+            <property name="max-width-chars">60</property>
           </object>
-          <packing>
-            <property name="expand">False</property>
-            <property name="fill">False</property>
-            <property name="position">2</property>
-          </packing>
         </child>
       </object>
       <packing>
-        <property name="page_type">confirm</property>
-        <property name="has_padding">True</property>
+        <property name="page-type">confirm</property>
       </packing>
     </child>
     <child internal-child="action_area">
       <object class="GtkBox">
-        <property name="can_focus">False</property>
       </object>
     </child>
   </object>

--- a/pynicotine/gtkgui/ui/fastconfigure.ui
+++ b/pynicotine/gtkgui/ui/fastconfigure.ui
@@ -302,7 +302,6 @@ Please keep in mind that more common usernames may be taken. If you&apos;re unab
                 <property name="visible">1</property>
                 <property name="can-focus">1</property>
                 <property name="halign">center</property>
-                <property name="draw-indicator">1</property>
               </object>
             </child>
           </object>

--- a/pynicotine/gtkgui/ui/fileproperties.ui
+++ b/pynicotine/gtkgui/ui/fileproperties.ui
@@ -369,6 +369,8 @@
             <child>
               <object class="GtkBox" id="navigation_buttons">
                 <property name="visible">1</property>
+                <property name="halign">end</property>
+                <property name="hexpand">True</property>
                 <child>
                   <object class="GtkButton" id="previous">
                     <property name="visible">1</property>
@@ -403,9 +405,6 @@
                   <class name="linked"/>
                 </style>
               </object>
-              <packing>
-                <property name="pack-type">end</property>
-              </packing>
             </child>
           </object>
         </child>

--- a/pynicotine/gtkgui/ui/fileproperties.ui
+++ b/pynicotine/gtkgui/ui/fileproperties.ui
@@ -8,9 +8,9 @@
     <property name="window-position">center-on-parent</property>
     <child internal-child="vbox">
       <object class="GtkBox">
-        <property name="border-width">18</property>
         <property name="visible">1</property>
         <property name="orientation">vertical</property>
+        <property name="margin">18</property>
         <child>
           <object class="GtkGrid">
             <property name="visible">1</property>

--- a/pynicotine/gtkgui/ui/fileproperties.ui
+++ b/pynicotine/gtkgui/ui/fileproperties.ui
@@ -10,7 +10,10 @@
       <object class="GtkBox">
         <property name="visible">1</property>
         <property name="orientation">vertical</property>
-        <property name="margin">18</property>
+        <property name="margin-start">18</property>
+        <property name="margin-end">18</property>
+        <property name="margin-top">18</property>
+        <property name="margin-bottom">18</property>
         <child>
           <object class="GtkGrid">
             <property name="visible">1</property>
@@ -356,14 +359,16 @@
                 <property name="visible">1</property>
                 <property name="can-focus">1</property>
                 <property name="tooltip-text" translatable="yes">Download file</property>
-                <property name="image">DownloadImage</property>
-                <property name="always-show-image">1</property>
                 <signal name="clicked" handler="on_download_item" swapped="no"/>
                 <child>
-                  <object class="GtkImage" id="DownloadImage">
+                  <object class="GtkImage">
+                    <property name="visible">1</property>
                     <property name="icon-name">document-save-symbolic</property>
                   </object>
                 </child>
+                <style>
+                  <class name="image-button"/>
+                </style>
               </object>
             </child>
             <child>
@@ -376,14 +381,16 @@
                     <property name="visible">1</property>
                     <property name="can-focus">1</property>
                     <property name="tooltip-text" translatable="yes">Previous file</property>
-                    <property name="image">PreviousImage</property>
-                    <property name="always-show-image">1</property>
                     <signal name="clicked" handler="on_previous" swapped="no"/>
                     <child>
-                      <object class="GtkImage" id="PreviousImage">
+                      <object class="GtkImage">
+                        <property name="visible">1</property>
                         <property name="icon-name">go-previous-symbolic</property>
                       </object>
                     </child>
+                    <style>
+                      <class name="image-button"/>
+                    </style>
                   </object>
                 </child>
                 <child>
@@ -391,14 +398,16 @@
                     <property name="visible">1</property>
                     <property name="can-focus">1</property>
                     <property name="tooltip-text" translatable="yes">Next file</property>
-                    <property name="image">NextImage</property>
-                    <property name="always-show-image">1</property>
                     <signal name="clicked" handler="on_next" swapped="no"/>
                     <child>
-                      <object class="GtkImage" id="NextImage">
+                      <object class="GtkImage">
+                        <property name="visible">1</property>
                         <property name="icon-name">go-next-symbolic</property>
                       </object>
                     </child>
+                    <style>
+                      <class name="image-button"/>
+                    </style>
                   </object>
                 </child>
                 <style>

--- a/pynicotine/gtkgui/ui/fileproperties.ui
+++ b/pynicotine/gtkgui/ui/fileproperties.ui
@@ -2,445 +2,409 @@
 <interface>
   <requires lib="gtk+" version="3.18"/>
   <object class="GtkDialog" id="FilePropertiesDialog">
-    <property name="can_focus">False</property>
     <property name="title" translatable="yes">File Properties</property>
-    <property name="modal">True</property>
+    <property name="modal">1</property>
     <property name="default-width">600</property>
-    <property name="window_position">center-on-parent</property>
+    <property name="window-position">center-on-parent</property>
     <child internal-child="vbox">
       <object class="GtkBox">
-        <property name="border_width">18</property>
-        <property name="visible">True</property>
-        <property name="can_focus">False</property>
+        <property name="border-width">18</property>
+        <property name="visible">1</property>
         <property name="orientation">vertical</property>
         <child>
           <object class="GtkGrid">
-            <property name="visible">True</property>
-            <property name="can_focus">False</property>
-            <property name="row_spacing">10</property>
-            <property name="column_spacing">6</property>
+            <property name="visible">1</property>
+            <property name="row-spacing">10</property>
+            <property name="column-spacing">6</property>
             <child>
               <object class="GtkLabel" id="filename_label">
-                <property name="visible">True</property>
-                <property name="can_focus">True</property>
+                <property name="visible">1</property>
+                <property name="can-focus">1</property>
                 <property name="label" translatable="yes">File Name</property>
-                <property name="selectable">True</property>
+                <property name="selectable">1</property>
                 <property name="xalign">1</property>
                 <style>
                   <class name="dim-label"/>
                 </style>
               </object>
               <packing>
-                <property name="left_attach">0</property>
-                <property name="top_attach">0</property>
+                <property name="left-attach">0</property>
+                <property name="top-attach">0</property>
               </packing>
             </child>
             <child>
               <object class="GtkLabel" id="filename_value">
-                <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <property name="hexpand">True</property>
-                <property name="selectable">True</property>
+                <property name="visible">1</property>
+                <property name="can-focus">1</property>
+                <property name="hexpand">1</property>
+                <property name="selectable">1</property>
                 <property name="ellipsize">end</property>
-                <property name="max_width_chars">48</property>
+                <property name="max-width-chars">48</property>
                 <property name="xalign">0</property>
               </object>
               <packing>
-                <property name="left_attach">1</property>
-                <property name="top_attach">0</property>
+                <property name="left-attach">1</property>
+                <property name="top-attach">0</property>
               </packing>
             </child>
             <child>
               <object class="GtkLabel" id="folder_label">
-                <property name="visible">True</property>
-                <property name="can_focus">True</property>
+                <property name="visible">1</property>
+                <property name="can-focus">1</property>
                 <property name="label" translatable="yes">Folder</property>
-                <property name="selectable">True</property>
+                <property name="selectable">1</property>
                 <property name="xalign">1</property>
                 <style>
                   <class name="dim-label"/>
                 </style>
               </object>
               <packing>
-                <property name="left_attach">0</property>
-                <property name="top_attach">1</property>
+                <property name="left-attach">0</property>
+                <property name="top-attach">1</property>
               </packing>
             </child>
             <child>
               <object class="GtkLabel" id="folder_value">
-                <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <property name="hexpand">True</property>
-                <property name="selectable">True</property>
+                <property name="visible">1</property>
+                <property name="can-focus">1</property>
+                <property name="hexpand">1</property>
+                <property name="selectable">1</property>
                 <property name="ellipsize">end</property>
-                <property name="max_width_chars">48</property>
+                <property name="max-width-chars">48</property>
                 <property name="xalign">0</property>
               </object>
               <packing>
-                <property name="left_attach">1</property>
-                <property name="top_attach">1</property>
+                <property name="left-attach">1</property>
+                <property name="top-attach">1</property>
               </packing>
             </child>
             <child>
               <object class="GtkLabel" id="filesize_label">
-                <property name="visible">True</property>
-                <property name="can_focus">True</property>
+                <property name="visible">1</property>
+                <property name="can-focus">1</property>
                 <property name="label" translatable="yes">File Size</property>
-                <property name="selectable">True</property>
+                <property name="selectable">1</property>
                 <property name="xalign">1</property>
                 <style>
                   <class name="dim-label"/>
                 </style>
               </object>
               <packing>
-                <property name="left_attach">0</property>
-                <property name="top_attach">2</property>
+                <property name="left-attach">0</property>
+                <property name="top-attach">2</property>
               </packing>
             </child>
             <child>
               <object class="GtkLabel" id="filesize_value">
-                <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <property name="hexpand">True</property>
-                <property name="selectable">True</property>
+                <property name="visible">1</property>
+                <property name="can-focus">1</property>
+                <property name="hexpand">1</property>
+                <property name="selectable">1</property>
                 <property name="ellipsize">end</property>
-                <property name="max_width_chars">48</property>
+                <property name="max-width-chars">48</property>
                 <property name="xalign">0</property>
               </object>
               <packing>
-                <property name="left_attach">1</property>
-                <property name="top_attach">2</property>
+                <property name="left-attach">1</property>
+                <property name="top-attach">2</property>
               </packing>
             </child>
             <child>
               <object class="GtkLabel" id="empty_1">
-                <property name="visible">True</property>
-                <property name="can_focus">False</property>
+                <property name="visible">1</property>
               </object>
               <packing>
-                <property name="left_attach">0</property>
-                <property name="top_attach">3</property>
+                <property name="left-attach">0</property>
+                <property name="top-attach">3</property>
               </packing>
             </child>
             <child>
               <object class="GtkLabel" id="length_label">
-                <property name="visible">True</property>
-                <property name="can_focus">True</property>
+                <property name="visible">1</property>
+                <property name="can-focus">1</property>
                 <property name="label" translatable="yes">Length</property>
-                <property name="selectable">True</property>
+                <property name="selectable">1</property>
                 <property name="xalign">1</property>
                 <style>
                   <class name="dim-label"/>
                 </style>
               </object>
               <packing>
-                <property name="left_attach">0</property>
-                <property name="top_attach">4</property>
+                <property name="left-attach">0</property>
+                <property name="top-attach">4</property>
               </packing>
             </child>
             <child>
               <object class="GtkLabel" id="length_value">
-                <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <property name="hexpand">True</property>
-                <property name="selectable">True</property>
+                <property name="visible">1</property>
+                <property name="can-focus">1</property>
+                <property name="hexpand">1</property>
+                <property name="selectable">1</property>
                 <property name="ellipsize">end</property>
-                <property name="max_width_chars">48</property>
+                <property name="max-width-chars">48</property>
                 <property name="xalign">0</property>
               </object>
               <packing>
-                <property name="left_attach">1</property>
-                <property name="top_attach">4</property>
+                <property name="left-attach">1</property>
+                <property name="top-attach">4</property>
               </packing>
             </child>
             <child>
               <object class="GtkLabel" id="bitrate_label">
-                <property name="visible">True</property>
-                <property name="can_focus">True</property>
+                <property name="visible">1</property>
+                <property name="can-focus">1</property>
                 <property name="label" translatable="yes">Bitrate</property>
-                <property name="selectable">True</property>
+                <property name="selectable">1</property>
                 <property name="xalign">1</property>
                 <style>
                   <class name="dim-label"/>
                 </style>
               </object>
               <packing>
-                <property name="left_attach">0</property>
-                <property name="top_attach">5</property>
+                <property name="left-attach">0</property>
+                <property name="top-attach">5</property>
               </packing>
             </child>
             <child>
               <object class="GtkLabel" id="bitrate_value">
-                <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <property name="hexpand">True</property>
-                <property name="selectable">True</property>
+                <property name="visible">1</property>
+                <property name="can-focus">1</property>
+                <property name="hexpand">1</property>
+                <property name="selectable">1</property>
                 <property name="ellipsize">end</property>
-                <property name="max_width_chars">48</property>
+                <property name="max-width-chars">48</property>
                 <property name="xalign">0</property>
               </object>
               <packing>
-                <property name="left_attach">1</property>
-                <property name="top_attach">5</property>
+                <property name="left-attach">1</property>
+                <property name="top-attach">5</property>
               </packing>
             </child>
             <child>
               <object class="GtkLabel">
-                <property name="visible">True</property>
-                <property name="can_focus">False</property>
+                <property name="visible">1</property>
               </object>
               <packing>
-                <property name="left_attach">0</property>
-                <property name="top_attach">6</property>
+                <property name="left-attach">0</property>
+                <property name="top-attach">6</property>
               </packing>
             </child>
             <child>
               <object class="GtkLabel" id="username_label">
-                <property name="visible">True</property>
-                <property name="can_focus">True</property>
+                <property name="visible">1</property>
+                <property name="can-focus">1</property>
                 <property name="label" translatable="yes">Username</property>
-                <property name="selectable">True</property>
+                <property name="selectable">1</property>
                 <property name="xalign">1</property>
                 <style>
                   <class name="dim-label"/>
                 </style>
               </object>
               <packing>
-                <property name="left_attach">0</property>
-                <property name="top_attach">7</property>
+                <property name="left-attach">0</property>
+                <property name="top-attach">7</property>
               </packing>
             </child>
             <child>
               <object class="GtkLabel" id="username_value">
-                <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <property name="hexpand">True</property>
-                <property name="selectable">True</property>
+                <property name="visible">1</property>
+                <property name="can-focus">1</property>
+                <property name="hexpand">1</property>
+                <property name="selectable">1</property>
                 <property name="ellipsize">end</property>
-                <property name="max_width_chars">48</property>
+                <property name="max-width-chars">48</property>
                 <property name="xalign">0</property>
               </object>
               <packing>
-                <property name="left_attach">1</property>
-                <property name="top_attach">7</property>
+                <property name="left-attach">1</property>
+                <property name="top-attach">7</property>
               </packing>
             </child>
             <child>
               <object class="GtkLabel" id="immediate_label">
-                <property name="visible">True</property>
-                <property name="can_focus">True</property>
+                <property name="visible">1</property>
+                <property name="can-focus">1</property>
                 <property name="label" translatable="yes">Immediate Download</property>
-                <property name="selectable">True</property>
+                <property name="selectable">1</property>
                 <property name="xalign">1</property>
                 <style>
                   <class name="dim-label"/>
                 </style>
               </object>
               <packing>
-                <property name="left_attach">0</property>
-                <property name="top_attach">8</property>
+                <property name="left-attach">0</property>
+                <property name="top-attach">8</property>
               </packing>
             </child>
             <child>
               <object class="GtkLabel" id="immediate_value">
-                <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <property name="hexpand">True</property>
-                <property name="selectable">True</property>
+                <property name="visible">1</property>
+                <property name="can-focus">1</property>
+                <property name="hexpand">1</property>
+                <property name="selectable">1</property>
                 <property name="ellipsize">end</property>
-                <property name="max_width_chars">48</property>
+                <property name="max-width-chars">48</property>
                 <property name="xalign">0</property>
               </object>
               <packing>
-                <property name="left_attach">1</property>
-                <property name="top_attach">8</property>
+                <property name="left-attach">1</property>
+                <property name="top-attach">8</property>
               </packing>
             </child>
             <child>
               <object class="GtkLabel" id="queue_label">
-                <property name="visible">True</property>
-                <property name="can_focus">True</property>
+                <property name="visible">1</property>
+                <property name="can-focus">1</property>
                 <property name="label" translatable="yes">In Queue</property>
-                <property name="selectable">True</property>
+                <property name="selectable">1</property>
                 <property name="xalign">1</property>
                 <style>
                   <class name="dim-label"/>
                 </style>
               </object>
               <packing>
-                <property name="left_attach">0</property>
-                <property name="top_attach">9</property>
+                <property name="left-attach">0</property>
+                <property name="top-attach">9</property>
               </packing>
             </child>
             <child>
               <object class="GtkLabel" id="queue_value">
-                <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <property name="hexpand">True</property>
-                <property name="selectable">True</property>
+                <property name="visible">1</property>
+                <property name="can-focus">1</property>
+                <property name="hexpand">1</property>
+                <property name="selectable">1</property>
                 <property name="ellipsize">end</property>
-                <property name="max_width_chars">48</property>
+                <property name="max-width-chars">48</property>
                 <property name="xalign">0</property>
               </object>
               <packing>
-                <property name="left_attach">1</property>
-                <property name="top_attach">9</property>
+                <property name="left-attach">1</property>
+                <property name="top-attach">9</property>
               </packing>
             </child>
             <child>
               <object class="GtkLabel" id="speed_label">
-                <property name="visible">True</property>
-                <property name="can_focus">True</property>
+                <property name="visible">1</property>
+                <property name="can-focus">1</property>
                 <property name="label" translatable="yes">Last Speed</property>
-                <property name="selectable">True</property>
+                <property name="selectable">1</property>
                 <property name="xalign">1</property>
                 <style>
                   <class name="dim-label"/>
                 </style>
               </object>
               <packing>
-                <property name="left_attach">0</property>
-                <property name="top_attach">10</property>
+                <property name="left-attach">0</property>
+                <property name="top-attach">10</property>
               </packing>
             </child>
             <child>
               <object class="GtkLabel" id="speed_value">
-                <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <property name="hexpand">True</property>
-                <property name="selectable">True</property>
+                <property name="visible">1</property>
+                <property name="can-focus">1</property>
+                <property name="hexpand">1</property>
+                <property name="selectable">1</property>
                 <property name="ellipsize">end</property>
-                <property name="max_width_chars">48</property>
+                <property name="max-width-chars">48</property>
                 <property name="xalign">0</property>
               </object>
               <packing>
-                <property name="left_attach">1</property>
-                <property name="top_attach">10</property>
+                <property name="left-attach">1</property>
+                <property name="top-attach">10</property>
               </packing>
             </child>
             <child>
               <object class="GtkLabel" id="country_label">
-                <property name="visible">True</property>
-                <property name="can_focus">True</property>
+                <property name="visible">1</property>
+                <property name="can-focus">1</property>
                 <property name="label" translatable="yes">Country</property>
-                <property name="selectable">True</property>
+                <property name="selectable">1</property>
                 <property name="xalign">1</property>
                 <style>
                   <class name="dim-label"/>
                 </style>
               </object>
               <packing>
-                <property name="left_attach">0</property>
-                <property name="top_attach">11</property>
+                <property name="left-attach">0</property>
+                <property name="top-attach">11</property>
               </packing>
             </child>
             <child>
               <object class="GtkLabel" id="country_value">
-                <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <property name="hexpand">True</property>
-                <property name="selectable">True</property>
+                <property name="visible">1</property>
+                <property name="can-focus">1</property>
+                <property name="hexpand">1</property>
+                <property name="selectable">1</property>
                 <property name="ellipsize">end</property>
-                <property name="max_width_chars">48</property>
+                <property name="max-width-chars">48</property>
                 <property name="xalign">0</property>
               </object>
               <packing>
-                <property name="left_attach">1</property>
-                <property name="top_attach">11</property>
+                <property name="left-attach">1</property>
+                <property name="top-attach">11</property>
               </packing>
             </child>
           </object>
-          <packing>
-            <property name="expand">True</property>
-            <property name="fill">True</property>
-            <property name="position">0</property>
-          </packing>
         </child>
         <child>
           <object class="GtkBox">
-            <property name="visible">True</property>
-            <property name="can_focus">False</property>
-            <property name="margin_top">18</property>
+            <property name="visible">1</property>
+            <property name="margin-top">18</property>
             <property name="spacing">5</property>
             <child>
               <object class="GtkButton" id="download">
-                <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <property name="receives_default">False</property>
-                <property name="tooltip_text" translatable="yes">Download file</property>
+                <property name="visible">1</property>
+                <property name="can-focus">1</property>
+                <property name="tooltip-text" translatable="yes">Download file</property>
                 <property name="image">DownloadImage</property>
-                <property name="always_show_image">True</property>
+                <property name="always-show-image">1</property>
                 <signal name="clicked" handler="on_download_item" swapped="no"/>
                 <child>
                   <object class="GtkImage" id="DownloadImage">
-                    <property name="can_focus">False</property>
-                    <property name="icon_name">document-save-symbolic</property>
+                    <property name="icon-name">document-save-symbolic</property>
                   </object>
                 </child>
               </object>
-              <packing>
-                <property name="expand">False</property>
-                <property name="fill">False</property>
-                <property name="position">0</property>
-              </packing>
             </child>
             <child>
               <object class="GtkBox" id="navigation_buttons">
-                <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="halign">end</property>
+                <property name="visible">1</property>
                 <child>
                   <object class="GtkButton" id="previous">
-                    <property name="visible">True</property>
-                    <property name="can_focus">True</property>
-                    <property name="receives_default">False</property>
-                    <property name="tooltip_text" translatable="yes">Previous file</property>
+                    <property name="visible">1</property>
+                    <property name="can-focus">1</property>
+                    <property name="tooltip-text" translatable="yes">Previous file</property>
                     <property name="image">PreviousImage</property>
-                    <property name="always_show_image">True</property>
+                    <property name="always-show-image">1</property>
                     <signal name="clicked" handler="on_previous" swapped="no"/>
                     <child>
                       <object class="GtkImage" id="PreviousImage">
-                        <property name="can_focus">False</property>
-                        <property name="icon_name">go-previous-symbolic</property>
+                        <property name="icon-name">go-previous-symbolic</property>
                       </object>
                     </child>
                   </object>
-                  <packing>
-                    <property name="expand">False</property>
-                    <property name="fill">True</property>
-                    <property name="position">0</property>
-                  </packing>
                 </child>
                 <child>
                   <object class="GtkButton" id="next">
-                    <property name="visible">True</property>
-                    <property name="can_focus">True</property>
-                    <property name="receives_default">False</property>
-                    <property name="tooltip_text" translatable="yes">Next file</property>
+                    <property name="visible">1</property>
+                    <property name="can-focus">1</property>
+                    <property name="tooltip-text" translatable="yes">Next file</property>
                     <property name="image">NextImage</property>
-                    <property name="always_show_image">True</property>
+                    <property name="always-show-image">1</property>
                     <signal name="clicked" handler="on_next" swapped="no"/>
                     <child>
                       <object class="GtkImage" id="NextImage">
-                        <property name="can_focus">False</property>
-                        <property name="icon_name">go-next-symbolic</property>
+                        <property name="icon-name">go-next-symbolic</property>
                       </object>
                     </child>
                   </object>
-                  <packing>
-                    <property name="expand">False</property>
-                    <property name="fill">True</property>
-                    <property name="position">1</property>
-                  </packing>
                 </child>
                 <style>
                   <class name="linked"/>
                 </style>
               </object>
               <packing>
-                <property name="expand">True</property>
-                <property name="fill">True</property>
-                <property name="position">1</property>
+                <property name="pack-type">end</property>
               </packing>
             </child>
           </object>

--- a/pynicotine/gtkgui/ui/interests.ui
+++ b/pynicotine/gtkgui/ui/interests.ui
@@ -161,9 +161,36 @@
                           <object class="GtkLabel">
                             <property name="visible">1</property>
                             <property name="halign">start</property>
+                            <property name="hexpand">1</property>
                             <property name="margin-start">5</property>
                             <property name="label" translatable="yes">&lt;b&gt;Recommendations&lt;/b&gt;</property>
                             <property name="use-markup">1</property>
+                          </object>
+                        </child>
+                        <child>
+                          <object class="GtkButton" id="GlobalRecommendationsButton">
+                            <property name="visible">1</property>
+                            <property name="can-focus">1</property>
+                            <signal name="clicked" handler="on_global_recommendations_clicked" swapped="no"/>
+                            <child>
+                              <object class="GtkBox">
+                                <property name="visible">1</property>
+                                <property name="spacing">6</property>
+                                <child>
+                                  <object class="GtkImage">
+                                    <property name="visible">1</property>
+                                    <property name="icon-name">view-refresh-symbolic</property>
+                                  </object>
+                                </child>
+                                <child>
+                                  <object class="GtkLabel">
+                                    <property name="visible">1</property>
+                                    <property name="label" translatable="yes">Global</property>
+                                    <property name="use-underline">1</property>
+                                  </object>
+                                </child>
+                              </object>
+                            </child>
                           </object>
                         </child>
                         <child>
@@ -191,38 +218,6 @@
                               </object>
                             </child>
                           </object>
-                          <packing>
-                            <property name="pack-type">end</property>
-                          </packing>
-                        </child>
-                        <child>
-                          <object class="GtkButton" id="GlobalRecommendationsButton">
-                            <property name="visible">1</property>
-                            <property name="can-focus">1</property>
-                            <signal name="clicked" handler="on_global_recommendations_clicked" swapped="no"/>
-                            <child>
-                              <object class="GtkBox">
-                                <property name="visible">1</property>
-                                <property name="spacing">6</property>
-                                <child>
-                                  <object class="GtkImage">
-                                    <property name="visible">1</property>
-                                    <property name="icon-name">view-refresh-symbolic</property>
-                                  </object>
-                                </child>
-                                <child>
-                                  <object class="GtkLabel">
-                                    <property name="visible">1</property>
-                                    <property name="label" translatable="yes">Global</property>
-                                    <property name="use-underline">1</property>
-                                  </object>
-                                </child>
-                              </object>
-                            </child>
-                          </object>
-                          <packing>
-                            <property name="pack-type">end</property>
-                          </packing>
                         </child>
                       </object>
                     </child>
@@ -298,6 +293,7 @@
                       <object class="GtkLabel">
                         <property name="visible">1</property>
                         <property name="halign">start</property>
+                        <property name="hexpand">1</property>
                         <property name="margin-start">5</property>
                         <property name="label" translatable="yes">&lt;b&gt;Similar Users&lt;/b&gt;</property>
                         <property name="use-markup">1</property>
@@ -328,9 +324,6 @@
                           </object>
                         </child>
                       </object>
-                      <packing>
-                        <property name="pack-type">end</property>
-                      </packing>
                     </child>
                   </object>
                 </child>

--- a/pynicotine/gtkgui/ui/interests.ui
+++ b/pynicotine/gtkgui/ui/interests.ui
@@ -345,6 +345,7 @@
                   <object class="GtkScrolledWindow">
                     <property name="visible">1</property>
                     <property name="can-focus">1</property>
+                    <property name="vexpand">1</property>
                     <child>
                       <object class="GtkTreeView" id="RecommendationUsersList">
                         <property name="visible">1</property>

--- a/pynicotine/gtkgui/ui/interests.ui
+++ b/pynicotine/gtkgui/ui/interests.ui
@@ -2,506 +2,361 @@
 <interface>
   <requires lib="gtk+" version="3.18"/>
   <object class="GtkBox" id="Main">
-    <property name="visible">True</property>
-    <property name="can_focus">False</property>
+    <property name="visible">1</property>
     <property name="spacing">6</property>
     <child>
       <object class="GtkPaned">
-        <property name="visible">True</property>
-        <property name="can_focus">True</property>
+        <property name="visible">1</property>
+        <property name="can-focus">1</property>
+        <property name="hexpand">1</property>
         <child>
           <object class="GtkBox">
-            <property name="width_request">240</property>
-            <property name="visible">True</property>
-            <property name="can_focus">False</property>
+            <property name="width-request">240</property>
+            <property name="visible">1</property>
             <property name="orientation">vertical</property>
             <child>
               <object class="GtkLabel">
-                <property name="visible">True</property>
-                <property name="can_focus">False</property>
+                <property name="visible">1</property>
                 <property name="halign">start</property>
-                <property name="margin_start">10</property>
+                <property name="margin-start">10</property>
+                <property name="margin-end">10</property>
+                <property name="margin-top">13</property>
+                <property name="margin-bottom">13</property>
                 <property name="label" translatable="yes">&lt;b&gt;Your Interests&lt;/b&gt;</property>
-                <property name="use_markup">True</property>
+                <property name="use-markup">1</property>
               </object>
-              <packing>
-                <property name="expand">False</property>
-                <property name="fill">False</property>
-                <property name="padding">13</property>
-                <property name="position">0</property>
-              </packing>
             </child>
             <child>
               <object class="GtkBox">
-                <property name="visible">True</property>
-                <property name="can_focus">False</property>
+                <property name="visible">1</property>
                 <property name="spacing">6</property>
                 <property name="orientation">vertical</property>
+                <property name="vexpand">1</property>
                 <child>
                   <object class="GtkScrolledWindow">
-                    <property name="visible">True</property>
-                    <property name="can_focus">True</property>
+                    <property name="visible">1</property>
+                    <property name="can-focus">1</property>
+                    <property name="vexpand">1</property>
                     <child>
                       <object class="GtkTreeView" id="LikesList">
-                        <property name="visible">True</property>
-                        <property name="can_focus">True</property>
-                        <property name="enable_search">False</property>
+                        <property name="visible">1</property>
+                        <property name="can-focus">1</property>
+                        <property name="enable-search">0</property>
                         <child internal-child="selection">
                           <object class="GtkTreeSelection"/>
                         </child>
                       </object>
                     </child>
                   </object>
-                  <packing>
-                    <property name="expand">True</property>
-                    <property name="fill">True</property>
-                    <property name="position">0</property>
-                  </packing>
                 </child>
                 <child>
                   <object class="GtkBox">
-                    <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <property name="border_width">6</property>
+                    <property name="visible">1</property>
+                    <property name="border-width">6</property>
                     <property name="spacing">6</property>
                     <child>
                       <object class="GtkEntry" id="AddLikeEntry">
-                        <property name="visible">True</property>
-                        <property name="can_focus">True</property>
+                        <property name="visible">1</property>
+                        <property name="can-focus">1</property>
+                        <property name="hexpand">1</property>
                         <signal name="activate" handler="on_add_thing_i_like" swapped="no"/>
                       </object>
-                      <packing>
-                        <property name="expand">True</property>
-                        <property name="fill">True</property>
-                        <property name="position">0</property>
-                      </packing>
                     </child>
                     <child>
                       <object class="GtkButton">
-                        <property name="visible">True</property>
-                        <property name="can_focus">True</property>
-                        <property name="receives_default">False</property>
+                        <property name="visible">1</property>
+                        <property name="can-focus">1</property>
                         <property name="image">add1</property>
-                        <property name="always_show_image">True</property>
+                        <property name="always-show-image">1</property>
                         <signal name="clicked" handler="on_add_thing_i_like" swapped="no"/>
                         <child>
                           <object class="GtkImage" id="add1">
-                            <property name="can_focus">False</property>
-                            <property name="icon_name">list-add-symbolic</property>
+                            <property name="icon-name">list-add-symbolic</property>
                           </object>
                         </child>
                       </object>
-                      <packing>
-                        <property name="expand">False</property>
-                        <property name="fill">False</property>
-                        <property name="position">1</property>
-                      </packing>
                     </child>
                   </object>
-                  <packing>
-                    <property name="expand">False</property>
-                    <property name="fill">True</property>
-                    <property name="position">1</property>
-                  </packing>
                 </child>
               </object>
-              <packing>
-                <property name="expand">True</property>
-                <property name="fill">True</property>
-                <property name="position">1</property>
-              </packing>
             </child>
             <child>
               <object class="GtkBox">
-                <property name="visible">True</property>
-                <property name="can_focus">False</property>
+                <property name="visible">1</property>
                 <property name="spacing">6</property>
                 <property name="orientation">vertical</property>
+                <property name="vexpand">1</property>
                 <child>
                   <object class="GtkScrolledWindow">
-                    <property name="visible">True</property>
-                    <property name="can_focus">True</property>
+                    <property name="visible">1</property>
+                    <property name="can-focus">1</property>
+                    <property name="vexpand">1</property>
                     <child>
                       <object class="GtkTreeView" id="DislikesList">
-                        <property name="visible">True</property>
-                        <property name="can_focus">True</property>
-                        <property name="enable_search">False</property>
+                        <property name="visible">1</property>
+                        <property name="can-focus">1</property>
+                        <property name="enable-search">0</property>
                         <child internal-child="selection">
                           <object class="GtkTreeSelection"/>
                         </child>
                       </object>
                     </child>
                   </object>
-                  <packing>
-                    <property name="expand">True</property>
-                    <property name="fill">True</property>
-                    <property name="position">0</property>
-                  </packing>
                 </child>
                 <child>
                   <object class="GtkBox">
-                    <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <property name="border_width">6</property>
+                    <property name="visible">1</property>
+                    <property name="border-width">6</property>
                     <property name="spacing">6</property>
                     <child>
                       <object class="GtkEntry" id="AddDislikeEntry">
-                        <property name="visible">True</property>
-                        <property name="can_focus">True</property>
+                        <property name="visible">1</property>
+                        <property name="can-focus">1</property>
+                        <property name="hexpand">1</property>
                         <signal name="activate" handler="on_add_thing_i_dislike" swapped="no"/>
                       </object>
-                      <packing>
-                        <property name="expand">True</property>
-                        <property name="fill">True</property>
-                        <property name="position">0</property>
-                      </packing>
                     </child>
                     <child>
                       <object class="GtkButton">
-                        <property name="visible">True</property>
-                        <property name="can_focus">True</property>
-                        <property name="receives_default">False</property>
+                        <property name="visible">1</property>
+                        <property name="can-focus">1</property>
                         <property name="image">add2</property>
-                        <property name="always_show_image">True</property>
+                        <property name="always-show-image">1</property>
                         <signal name="clicked" handler="on_add_thing_i_dislike" swapped="no"/>
                         <child>
                           <object class="GtkImage" id="add2">
-                            <property name="can_focus">False</property>
-                            <property name="icon_name">list-add-symbolic</property>
+                            <property name="icon-name">list-add-symbolic</property>
                           </object>
                         </child>
                       </object>
-                      <packing>
-                        <property name="expand">False</property>
-                        <property name="fill">False</property>
-                        <property name="position">1</property>
-                      </packing>
                     </child>
                   </object>
-                  <packing>
-                    <property name="expand">False</property>
-                    <property name="fill">True</property>
-                    <property name="position">1</property>
-                  </packing>
                 </child>
               </object>
-              <packing>
-                <property name="expand">True</property>
-                <property name="fill">True</property>
-                <property name="position">2</property>
-              </packing>
             </child>
           </object>
           <packing>
-            <property name="resize">False</property>
-            <property name="shrink">True</property>
+            <property name="resize">0</property>
           </packing>
         </child>
         <child>
           <object class="GtkPaned">
-            <property name="visible">True</property>
-            <property name="can_focus">True</property>
+            <property name="visible">1</property>
+            <property name="can-focus">1</property>
             <child>
               <object class="GtkBox" id="RecommendationsVbox">
-                <property name="visible">True</property>
-                <property name="can_focus">False</property>
+                <property name="visible">1</property>
                 <property name="orientation">vertical</property>
                 <child>
                   <object class="GtkBox">
-                    <property name="visible">True</property>
-                    <property name="can_focus">False</property>
+                    <property name="visible">1</property>
                     <property name="orientation">vertical</property>
                     <child>
                       <object class="GtkBox">
-                        <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="border_width">6</property>
-                        <property name="margin_bottom">6</property>
+                        <property name="visible">1</property>
+                        <property name="border-width">6</property>
+                        <property name="margin-bottom">6</property>
                         <property name="spacing">6</property>
                         <child>
                           <object class="GtkLabel">
-                            <property name="visible">True</property>
-                            <property name="can_focus">False</property>
+                            <property name="visible">1</property>
                             <property name="halign">start</property>
+                            <property name="margin-start">5</property>
                             <property name="label" translatable="yes">&lt;b&gt;Recommendations&lt;/b&gt;</property>
-                            <property name="use_markup">True</property>
+                            <property name="use-markup">1</property>
                           </object>
-                          <packing>
-                            <property name="expand">False</property>
-                            <property name="fill">False</property>
-                            <property name="padding">5</property>
-                            <property name="position">0</property>
-                          </packing>
                         </child>
                         <child>
                           <object class="GtkButton" id="RecommendationsButton">
-                            <property name="visible">True</property>
-                            <property name="can_focus">True</property>
-                            <property name="receives_default">False</property>
+                            <property name="visible">1</property>
+                            <property name="can-focus">1</property>
                             <signal name="clicked" handler="on_recommendations_clicked" swapped="no"/>
                             <child>
                               <object class="GtkBox">
-                                <property name="visible">True</property>
-                                <property name="can_focus">False</property>
+                                <property name="visible">1</property>
                                 <property name="spacing">6</property>
                                 <child>
                                   <object class="GtkImage">
-                                    <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
-                                    <property name="icon_name">view-refresh-symbolic</property>
+                                    <property name="visible">1</property>
+                                    <property name="icon-name">view-refresh-symbolic</property>
                                   </object>
                                 </child>
                                 <child>
                                   <object class="GtkLabel">
-                                    <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
+                                    <property name="visible">1</property>
                                     <property name="label" translatable="yes">Personal</property>
-                                    <property name="use_underline">True</property>
+                                    <property name="use-underline">1</property>
                                   </object>
                                 </child>
                               </object>
                             </child>
                           </object>
                           <packing>
-                            <property name="expand">False</property>
-                            <property name="fill">False</property>
-                            <property name="pack_type">end</property>
-                            <property name="position">1</property>
+                            <property name="pack-type">end</property>
                           </packing>
                         </child>
                         <child>
                           <object class="GtkButton" id="GlobalRecommendationsButton">
-                            <property name="visible">True</property>
-                            <property name="can_focus">True</property>
-                            <property name="receives_default">False</property>
+                            <property name="visible">1</property>
+                            <property name="can-focus">1</property>
                             <signal name="clicked" handler="on_global_recommendations_clicked" swapped="no"/>
                             <child>
                               <object class="GtkBox">
-                                <property name="visible">True</property>
-                                <property name="can_focus">False</property>
+                                <property name="visible">1</property>
                                 <property name="spacing">6</property>
                                 <child>
                                   <object class="GtkImage">
-                                    <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
-                                    <property name="icon_name">view-refresh-symbolic</property>
+                                    <property name="visible">1</property>
+                                    <property name="icon-name">view-refresh-symbolic</property>
                                   </object>
                                 </child>
                                 <child>
                                   <object class="GtkLabel">
-                                    <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
+                                    <property name="visible">1</property>
                                     <property name="label" translatable="yes">Global</property>
-                                    <property name="use_underline">True</property>
+                                    <property name="use-underline">1</property>
                                   </object>
                                 </child>
                               </object>
                             </child>
                           </object>
                           <packing>
-                            <property name="expand">False</property>
-                            <property name="fill">False</property>
-                            <property name="pack_type">end</property>
-                            <property name="position">2</property>
+                            <property name="pack-type">end</property>
                           </packing>
                         </child>
                       </object>
-                      <packing>
-                        <property name="expand">False</property>
-                        <property name="fill">True</property>
-                        <property name="position">0</property>
-                      </packing>
                     </child>
                     <child>
                       <object class="GtkScrolledWindow">
-                        <property name="visible">True</property>
-                        <property name="can_focus">True</property>
+                        <property name="visible">1</property>
+                        <property name="can-focus">1</property>
+                        <property name="vexpand">1</property>
                         <child>
                           <object class="GtkTreeView" id="RecommendationsList">
-                            <property name="visible">True</property>
-                            <property name="can_focus">True</property>
+                            <property name="visible">1</property>
+                            <property name="can-focus">1</property>
                             <child internal-child="selection">
                               <object class="GtkTreeSelection"/>
                             </child>
                           </object>
                         </child>
                       </object>
-                      <packing>
-                        <property name="expand">True</property>
-                        <property name="fill">True</property>
-                        <property name="position">1</property>
-                      </packing>
                     </child>
                   </object>
-                  <packing>
-                    <property name="expand">True</property>
-                    <property name="fill">True</property>
-                    <property name="position">1</property>
-                  </packing>
                 </child>
                 <child>
                   <object class="GtkBox">
-                    <property name="visible">True</property>
-                    <property name="can_focus">False</property>
+                    <property name="visible">1</property>
                     <property name="orientation">vertical</property>
                     <child>
                       <object class="GtkLabel" id="UnrecommendationsLabel">
-                        <property name="visible">True</property>
-                        <property name="can_focus">False</property>
+                        <property name="visible">1</property>
                         <property name="halign">start</property>
-                        <property name="margin_start">10</property>
+                        <property name="margin-start">10</property>
+                        <property name="margin-end">10</property>
+                        <property name="margin-top">13</property>
+                        <property name="margin-bottom">13</property>
                         <property name="label" translatable="yes">&lt;b&gt;Unrecommendations&lt;/b&gt;</property>
-                        <property name="use_markup">True</property>
+                        <property name="use-markup">1</property>
                       </object>
-                      <packing>
-                        <property name="expand">False</property>
-                        <property name="fill">False</property>
-                        <property name="padding">13</property>
-                        <property name="position">0</property>
-                      </packing>
                     </child>
                     <child>
                       <object class="GtkScrolledWindow">
-                        <property name="visible">True</property>
-                        <property name="can_focus">True</property>
+                        <property name="visible">1</property>
+                        <property name="can-focus">1</property>
+                        <property name="vexpand">1</property>
                         <child>
                           <object class="GtkTreeView" id="UnrecommendationsList">
-                            <property name="visible">True</property>
-                            <property name="can_focus">True</property>
+                            <property name="visible">1</property>
+                            <property name="can-focus">1</property>
                             <child internal-child="selection">
                               <object class="GtkTreeSelection"/>
                             </child>
                           </object>
                         </child>
                       </object>
-                      <packing>
-                        <property name="expand">True</property>
-                        <property name="fill">True</property>
-                        <property name="position">1</property>
-                      </packing>
                     </child>
                   </object>
-                  <packing>
-                    <property name="expand">True</property>
-                    <property name="fill">True</property>
-                    <property name="position">2</property>
-                  </packing>
                 </child>
               </object>
               <packing>
-                <property name="resize">True</property>
-                <property name="shrink">True</property>
+                <property name="resize">1</property>
               </packing>
             </child>
             <child>
               <object class="GtkBox">
-                <property name="width_request">280</property>
-                <property name="visible">True</property>
-                <property name="can_focus">False</property>
+                <property name="width-request">280</property>
+                <property name="visible">1</property>
                 <property name="orientation">vertical</property>
                 <child>
                   <object class="GtkBox">
-                    <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <property name="border_width">6</property>
-                    <property name="margin_bottom">6</property>
+                    <property name="visible">1</property>
+                    <property name="border-width">6</property>
+                    <property name="margin-bottom">6</property>
                     <property name="spacing">6</property>
                     <child>
                       <object class="GtkLabel">
-                        <property name="visible">True</property>
-                        <property name="can_focus">False</property>
+                        <property name="visible">1</property>
                         <property name="halign">start</property>
+                        <property name="margin-start">5</property>
                         <property name="label" translatable="yes">&lt;b&gt;Similar Users&lt;/b&gt;</property>
-                        <property name="use_markup">True</property>
+                        <property name="use-markup">1</property>
                       </object>
-                      <packing>
-                        <property name="expand">False</property>
-                        <property name="fill">False</property>
-                        <property name="padding">5</property>
-                        <property name="position">0</property>
-                      </packing>
                     </child>
                     <child>
                       <object class="GtkButton" id="SimilarUsersButton">
-                        <property name="visible">True</property>
-                        <property name="can_focus">True</property>
-                        <property name="receives_default">False</property>
+                        <property name="visible">1</property>
+                        <property name="can-focus">1</property>
                         <signal name="clicked" handler="on_similar_users_clicked" swapped="no"/>
                         <child>
                           <object class="GtkBox">
-                            <property name="visible">True</property>
-                            <property name="can_focus">False</property>
+                            <property name="visible">1</property>
                             <property name="spacing">6</property>
                             <child>
                               <object class="GtkImage">
-                                <property name="visible">True</property>
-                                <property name="can_focus">False</property>
-                                <property name="icon_name">view-refresh-symbolic</property>
+                                <property name="visible">1</property>
+                                <property name="icon-name">view-refresh-symbolic</property>
                               </object>
                             </child>
                             <child>
                               <object class="GtkLabel">
-                                <property name="visible">True</property>
-                                <property name="can_focus">False</property>
+                                <property name="visible">1</property>
                                 <property name="label" translatable="yes">Show Similar Users</property>
-                                <property name="use_underline">True</property>
+                                <property name="use-underline">1</property>
                               </object>
                             </child>
                           </object>
                         </child>
                       </object>
                       <packing>
-                        <property name="expand">False</property>
-                        <property name="fill">False</property>
-                        <property name="pack_type">end</property>
-                        <property name="position">1</property>
+                        <property name="pack-type">end</property>
                       </packing>
                     </child>
                   </object>
-                  <packing>
-                    <property name="expand">False</property>
-                    <property name="fill">True</property>
-                    <property name="position">0</property>
-                  </packing>
                 </child>
                 <child>
                   <object class="GtkScrolledWindow">
-                    <property name="visible">True</property>
-                    <property name="can_focus">True</property>
+                    <property name="visible">1</property>
+                    <property name="can-focus">1</property>
                     <child>
                       <object class="GtkTreeView" id="RecommendationUsersList">
-                        <property name="visible">True</property>
-                        <property name="can_focus">True</property>
+                        <property name="visible">1</property>
+                        <property name="can-focus">1</property>
                         <child internal-child="selection">
                           <object class="GtkTreeSelection"/>
                         </child>
                       </object>
                     </child>
                   </object>
-                  <packing>
-                    <property name="expand">True</property>
-                    <property name="fill">True</property>
-                    <property name="position">1</property>
-                  </packing>
                 </child>
               </object>
               <packing>
-                <property name="resize">False</property>
-                <property name="shrink">True</property>
+                <property name="resize">0</property>
               </packing>
             </child>
           </object>
-          <packing>
-            <property name="resize">True</property>
-            <property name="shrink">True</property>
-          </packing>
         </child>
       </object>
-      <packing>
-        <property name="expand">True</property>
-        <property name="fill">True</property>
-        <property name="position">0</property>
-      </packing>
     </child>
   </object>
 </interface>

--- a/pynicotine/gtkgui/ui/interests.ui
+++ b/pynicotine/gtkgui/ui/interests.ui
@@ -52,7 +52,10 @@
                 <child>
                   <object class="GtkBox">
                     <property name="visible">1</property>
-                    <property name="margin">6</property>
+                    <property name="margin-start">6</property>
+                    <property name="margin-end">6</property>
+                    <property name="margin-top">6</property>
+                    <property name="margin-bottom">6</property>
                     <property name="spacing">6</property>
                     <child>
                       <object class="GtkEntry" id="AddLikeEntry">
@@ -66,14 +69,16 @@
                       <object class="GtkButton">
                         <property name="visible">1</property>
                         <property name="can-focus">1</property>
-                        <property name="image">add1</property>
-                        <property name="always-show-image">1</property>
                         <signal name="clicked" handler="on_add_thing_i_like" swapped="no"/>
                         <child>
-                          <object class="GtkImage" id="add1">
+                          <object class="GtkImage">
+                            <property name="visible">1</property>
                             <property name="icon-name">list-add-symbolic</property>
                           </object>
                         </child>
+                        <style>
+                          <class name="image-button"/>
+                        </style>
                       </object>
                     </child>
                   </object>
@@ -106,7 +111,10 @@
                 <child>
                   <object class="GtkBox">
                     <property name="visible">1</property>
-                    <property name="margin">6</property>
+                    <property name="margin-start">6</property>
+                    <property name="margin-end">6</property>
+                    <property name="margin-top">6</property>
+                    <property name="margin-bottom">6</property>
                     <property name="spacing">6</property>
                     <child>
                       <object class="GtkEntry" id="AddDislikeEntry">
@@ -120,14 +128,16 @@
                       <object class="GtkButton">
                         <property name="visible">1</property>
                         <property name="can-focus">1</property>
-                        <property name="image">add2</property>
-                        <property name="always-show-image">1</property>
                         <signal name="clicked" handler="on_add_thing_i_dislike" swapped="no"/>
                         <child>
-                          <object class="GtkImage" id="add2">
+                          <object class="GtkImage">
+                            <property name="visible">1</property>
                             <property name="icon-name">list-add-symbolic</property>
                           </object>
                         </child>
+                        <style>
+                          <class name="image-button"/>
+                        </style>
                       </object>
                     </child>
                   </object>
@@ -154,7 +164,10 @@
                     <child>
                       <object class="GtkBox">
                         <property name="visible">1</property>
-                        <property name="margin">6</property>
+                        <property name="margin-start">6</property>
+                        <property name="margin-end">6</property>
+                        <property name="margin-top">6</property>
+                        <property name="margin-bottom">6</property>
                         <property name="spacing">6</property>
                         <child>
                           <object class="GtkLabel">
@@ -285,7 +298,10 @@
                 <child>
                   <object class="GtkBox">
                     <property name="visible">1</property>
-                    <property name="margin">6</property>
+                    <property name="margin-start">6</property>
+                    <property name="margin-end">6</property>
+                    <property name="margin-top">6</property>
+                    <property name="margin-bottom">6</property>
                     <property name="spacing">6</property>
                     <child>
                       <object class="GtkLabel">

--- a/pynicotine/gtkgui/ui/interests.ui
+++ b/pynicotine/gtkgui/ui/interests.ui
@@ -52,7 +52,7 @@
                 <child>
                   <object class="GtkBox">
                     <property name="visible">1</property>
-                    <property name="border-width">6</property>
+                    <property name="margin">6</property>
                     <property name="spacing">6</property>
                     <child>
                       <object class="GtkEntry" id="AddLikeEntry">
@@ -106,7 +106,7 @@
                 <child>
                   <object class="GtkBox">
                     <property name="visible">1</property>
-                    <property name="border-width">6</property>
+                    <property name="margin">6</property>
                     <property name="spacing">6</property>
                     <child>
                       <object class="GtkEntry" id="AddDislikeEntry">
@@ -154,8 +154,7 @@
                     <child>
                       <object class="GtkBox">
                         <property name="visible">1</property>
-                        <property name="border-width">6</property>
-                        <property name="margin-bottom">6</property>
+                        <property name="margin">6</property>
                         <property name="spacing">6</property>
                         <child>
                           <object class="GtkLabel">
@@ -286,8 +285,7 @@
                 <child>
                   <object class="GtkBox">
                     <property name="visible">1</property>
-                    <property name="border-width">6</property>
-                    <property name="margin-bottom">6</property>
+                    <property name="margin">6</property>
                     <property name="spacing">6</property>
                     <child>
                       <object class="GtkLabel">

--- a/pynicotine/gtkgui/ui/mainwindow.ui
+++ b/pynicotine/gtkgui/ui/mainwindow.ui
@@ -2,164 +2,125 @@
 <interface>
   <requires lib="gtk+" version="3.18"/>
   <object class="GtkApplicationWindow" id="MainWindow">
-    <property name="can_focus">False</property>
     <property name="title" translatable="yes">Nicotine+</property>
-    <property name="window_position">center</property>
     <child>
       <object class="GtkBox">
-        <property name="visible">True</property>
-        <property name="can_focus">False</property>
+        <property name="visible">1</property>
         <property name="orientation">vertical</property>
         <child>
           <object class="GtkPaned" id="vpaned1">
-            <property name="visible">True</property>
-            <property name="can_focus">True</property>
+            <property name="visible">1</property>
+            <property name="can-focus">1</property>
             <property name="orientation">vertical</property>
+            <property name="vexpand">1</property>
             <child>
               <object class="GtkPaned">
-                <property name="visible">True</property>
-                <property name="can_focus">True</property>
+                <property name="visible">1</property>
+                <property name="can-focus">1</property>
                 <child>
                   <object class="GtkNotebook" id="MainNotebook">
-                    <property name="visible">True</property>
-                    <property name="can_focus">True</property>
-                    <property name="show_border">False</property>
-                    <property name="scrollable">True</property>
+                    <property name="visible">1</property>
+                    <property name="can-focus">1</property>
+                    <property name="show-border">0</property>
+                    <property name="scrollable">1</property>
                     <signal name="switch-page" handler="on_switch_page" swapped="no"/>
-
                     <!-- Chat Rooms -->
-
                     <child>
                       <object class="GtkPaned" id="chathbox">
-                        <property name="visible">True</property>
-                        <property name="can_focus">True</property>
+                        <property name="visible">1</property>
+                        <property name="can-focus">1</property>
                         <child>
                           <object class="GtkNotebook" id="ChatNotebookRaw">
-                            <property name="visible">True</property>
-                            <property name="can_focus">True</property>
-                            <property name="show_border">False</property>
-                            <property name="scrollable">True</property>
+                            <property name="visible">1</property>
+                            <property name="can-focus">1</property>
+                            <property name="show-border">0</property>
+                            <property name="scrollable">1</property>
                           </object>
                           <packing>
-                            <property name="resize">True</property>
-                            <property name="shrink">True</property>
+                            <property name="resize">1</property>
                           </packing>
                         </child>
                         <child>
                           <object class="GtkPaned" id="vpaned3">
-                            <property name="visible">True</property>
-                            <property name="can_focus">True</property>
+                            <property name="visible">1</property>
+                            <property name="can-focus">1</property>
                             <property name="orientation">vertical</property>
-                            <child>
-                              <placeholder/>
-                            </child>
                           </object>
                           <packing>
-                            <property name="resize">False</property>
-                            <property name="shrink">True</property>
+                            <property name="resize">0</property>
                           </packing>
                         </child>
                       </object>
                     </child>
                     <child type="tab">
                       <object class="GtkEventBox" id="ChatTabLabel">
-                        <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="visible_window">False</property>
-                        <child>
-                          <placeholder/>
-                        </child>
+                        <property name="visible">1</property>
+                        <property name="visible-window">0</property>
                       </object>
                       <packing>
-                        <property name="tab_fill">False</property>
+                        <property name="tab-fill">0</property>
                       </packing>
                     </child>
-
                     <!-- Private Chat -->
-
                     <child>
                       <object class="GtkBox" id="privatevbox">
-                        <property name="visible">True</property>
-                        <property name="can_focus">False</property>
+                        <property name="visible">1</property>
                         <property name="orientation">vertical</property>
                         <child>
                           <object class="GtkBox">
-                            <property name="visible">True</property>
-                            <property name="can_focus">False</property>
-                            <property name="border_width">6</property>
+                            <property name="visible">1</property>
+                            <property name="border-width">6</property>
                             <property name="spacing">6</property>
                             <child>
                               <object class="GtkLabel">
-                                <property name="visible">True</property>
-                                <property name="can_focus">False</property>
+                                <property name="visible">1</property>
                                 <property name="label" translatable="yes">User:</property>
+                                <property name="margin-start">5</property>
+                                <property name="margin-end">5</property>
                               </object>
-                              <packing>
-                                <property name="expand">False</property>
-                                <property name="fill">True</property>
-                                <property name="padding">5</property>
-                                <property name="position">0</property>
-                              </packing>
                             </child>
                             <child>
                               <object class="GtkComboBox" id="UserPrivateCombo">
-                                <property name="visible">True</property>
-                                <property name="can_focus">False</property>
-                                <property name="has_entry">True</property>
+                                <property name="visible">1</property>
+                                <property name="has-entry">1</property>
                               </object>
-                              <packing>
-                                <property name="expand">False</property>
-                                <property name="fill">False</property>
-                                <property name="position">1</property>
-                              </packing>
                             </child>
                             <child>
                               <object class="GtkButton" id="sPrivateChatButton">
-                                <property name="visible">True</property>
-                                <property name="can_focus">True</property>
-                                <property name="receives_default">False</property>
+                                <property name="visible">1</property>
+                                <property name="can-focus">1</property>
                                 <child>
                                   <object class="GtkBox">
-                                    <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
+                                    <property name="visible">1</property>
                                     <property name="spacing">5</property>
                                     <child>
                                       <object class="GtkImage">
-                                        <property name="visible">True</property>
-                                        <property name="can_focus">False</property>
-                                        <property name="icon_name">mail-send-symbolic</property>
+                                        <property name="visible">1</property>
+                                        <property name="icon-name">mail-send-symbolic</property>
                                       </object>
                                     </child>
                                     <child>
                                       <object class="GtkLabel">
-                                        <property name="visible">True</property>
-                                        <property name="can_focus">False</property>
+                                        <property name="visible">1</property>
                                         <property name="label" translatable="yes">Start Messaging</property>
-                                        <property name="use_underline">True</property>
+                                        <property name="use-underline">1</property>
                                       </object>
                                     </child>
                                   </object>
                                 </child>
                               </object>
-                              <packing>
-                                <property name="expand">False</property>
-                                <property name="fill">False</property>
-                                <property name="position">2</property>
-                              </packing>
                             </child>
                             <child>
                               <object class="GtkButton" id="configureLog">
-                                <property name="visible">True</property>
-                                <property name="can_focus">True</property>
-                                <property name="receives_default">False</property>
-                                <property name="tooltip_text" translatable="yes">Configure logging</property>
+                                <property name="visible">1</property>
+                                <property name="can-focus">1</property>
+                                <property name="tooltip-text" translatable="yes">Configure logging</property>
                                 <property name="image">ConfigureLogImage</property>
-                                <property name="always_show_image">True</property>
+                                <property name="always-show-image">1</property>
                                 <signal name="clicked" handler="on_settings_logging" swapped="no"/>
                                 <child>
                                   <object class="GtkImage" id="ConfigureLogImage">
-                                    <property name="can_focus">False</property>
-                                    <property name="icon_name">applications-system-symbolic</property>
+                                    <property name="icon-name">applications-system-symbolic</property>
                                   </object>
                                 </child>
                                 <style>
@@ -167,108 +128,69 @@
                                 </style>
                               </object>
                               <packing>
-                                <property name="expand">False</property>
-                                <property name="fill">False</property>
-                                <property name="pack_type">end</property>
-                                <property name="position">3</property>
+                                <property name="pack-type">end</property>
                               </packing>
                             </child>
                           </object>
-                          <packing>
-                            <property name="expand">False</property>
-                            <property name="fill">True</property>
-                            <property name="position">0</property>
-                          </packing>
                         </child>
                         <child>
                           <object class="GtkNotebook" id="PrivatechatNotebookRaw">
-                            <property name="visible">True</property>
-                            <property name="can_focus">True</property>
-                            <property name="show_border">True</property>
-                            <property name="scrollable">True</property>
+                            <property name="visible">1</property>
+                            <property name="can-focus">1</property>
+                            <property name="scrollable">1</property>
                           </object>
-                          <packing>
-                            <property name="expand">True</property>
-                            <property name="fill">True</property>
-                            <property name="position">1</property>
-                          </packing>
                         </child>
                       </object>
-                      <packing>
-                        <property name="position">1</property>
-                      </packing>
                     </child>
                     <child type="tab">
                       <object class="GtkEventBox" id="PrivateChatTabLabel">
-                        <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="visible_window">False</property>
-                        <child>
-                          <placeholder/>
-                        </child>
+                        <property name="visible">1</property>
+                        <property name="visible-window">0</property>
                       </object>
                       <packing>
-                        <property name="position">1</property>
-                        <property name="tab_fill">False</property>
+                        <property name="tab-fill">0</property>
                       </packing>
                     </child>
-
                     <!-- Downloads -->
-
                     <child>
                       <object class="GtkBox" id="downloadsvbox">
-                        <property name="visible">True</property>
-                        <property name="can_focus">False</property>
+                        <property name="visible">1</property>
                         <property name="orientation">vertical</property>
                         <child>
                           <object class="GtkBox">
-                            <property name="visible">True</property>
-                            <property name="can_focus">False</property>
-                            <property name="border_width">6</property>
+                            <property name="visible">1</property>
+                            <property name="border-width">6</property>
                             <property name="spacing">6</property>
                             <child>
                               <object class="GtkBox">
-                                <property name="visible">True</property>
-                                <property name="can_focus">False</property>
+                                <property name="visible">1</property>
                                 <property name="spacing">6</property>
+                                <property name="margin-start">5</property>
+                                <property name="margin-end">5</property>
                                 <child>
                                   <object class="GtkLabel">
-                                    <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
+                                    <property name="visible">1</property>
                                     <property name="label" translatable="yes">Users</property>
                                   </object>
-                                  <packing>
-                                    <property name="expand">False</property>
-                                    <property name="fill">True</property>
-                                    <property name="position">0</property>
-                                  </packing>
                                 </child>
                                 <child>
                                   <object class="GtkButton">
-                                    <property name="visible">True</property>
-                                    <property name="sensitive">False</property>
-                                    <property name="can-focus">False</property>
-                                    <property name="receives-default">False</property>
+                                    <property name="visible">1</property>
+                                    <property name="sensitive">0</property>
                                     <child>
                                       <object class="GtkBox">
                                         <property name="width-request">24</property>
-                                        <property name="visible">True</property>
-                                        <property name="can-focus">False</property>
+                                        <property name="visible">1</property>
                                         <property name="spacing">5</property>
-                                        <property name="homogeneous">True</property>
+                                        <property name="homogeneous">1</property>
                                         <child>
                                           <object class="GtkLabel" id="DownloadUsers">
-                                            <property name="visible">True</property>
-                                            <property name="can-focus">False</property>
+                                            <property name="visible">1</property>
                                             <property name="label">&lt;b&gt;0&lt;/b&gt;</property>
-                                            <property name="use_markup">True</property>
+                                            <property name="use-markup">1</property>
+                                            <property name="margin-start">5</property>
+                                            <property name="margin-end">5</property>
                                           </object>
-                                          <packing>
-                                            <property name="expand">False</property>
-                                            <property name="fill">True</property>
-                                            <property name="padding">5</property>
-                                            <property name="position">0</property>
-                                          </packing>
                                         </child>
                                       </object>
                                     </child>
@@ -276,63 +198,40 @@
                                       <class name="circular"/>
                                     </style>
                                   </object>
-                                  <packing>
-                                    <property name="expand">False</property>
-                                    <property name="fill">False</property>
-                                    <property name="position">1</property>
-                                  </packing>
                                 </child>
                               </object>
-                              <packing>
-                                <property name="expand">False</property>
-                                <property name="fill">False</property>
-                                <property name="padding">5</property>
-                                <property name="position">0</property>
-                              </packing>
                             </child>
                             <child>
                               <object class="GtkBox">
-                                <property name="visible">True</property>
-                                <property name="can_focus">False</property>
+                                <property name="visible">1</property>
+                                <property name="hexpand">1</property>
                                 <property name="spacing">6</property>
+                                <property name="margin-start">5</property>
+                                <property name="margin-end">5</property>
                                 <child>
                                   <object class="GtkLabel">
-                                    <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
+                                    <property name="visible">1</property>
                                     <property name="label" translatable="yes">Files</property>
                                   </object>
-                                  <packing>
-                                    <property name="expand">False</property>
-                                    <property name="fill">True</property>
-                                    <property name="position">0</property>
-                                  </packing>
                                 </child>
                                 <child>
                                   <object class="GtkButton">
-                                    <property name="visible">True</property>
-                                    <property name="sensitive">False</property>
-                                    <property name="can-focus">False</property>
-                                    <property name="receives-default">False</property>
+                                    <property name="visible">1</property>
+                                    <property name="sensitive">0</property>
                                     <child>
                                       <object class="GtkBox">
                                         <property name="width-request">24</property>
-                                        <property name="visible">True</property>
-                                        <property name="can-focus">False</property>
+                                        <property name="visible">1</property>
                                         <property name="spacing">5</property>
-                                        <property name="homogeneous">True</property>
+                                        <property name="homogeneous">1</property>
                                         <child>
                                           <object class="GtkLabel" id="DownloadFiles">
-                                            <property name="visible">True</property>
-                                            <property name="can-focus">False</property>
+                                            <property name="visible">1</property>
                                             <property name="label">&lt;b&gt;0&lt;/b&gt;</property>
-                                            <property name="use_markup">True</property>
+                                            <property name="use-markup">1</property>
+                                            <property name="margin-start">5</property>
+                                            <property name="margin-end">5</property>
                                           </object>
-                                          <packing>
-                                            <property name="expand">False</property>
-                                            <property name="fill">True</property>
-                                            <property name="padding">5</property>
-                                            <property name="position">0</property>
-                                          </packing>
                                         </child>
                                       </object>
                                     </child>
@@ -340,392 +239,270 @@
                                       <class name="circular"/>
                                     </style>
                                   </object>
-                                  <packing>
-                                    <property name="expand">False</property>
-                                    <property name="fill">False</property>
-                                    <property name="position">1</property>
-                                  </packing>
                                 </child>
                               </object>
-                              <packing>
-                                <property name="expand">False</property>
-                                <property name="fill">False</property>
-                                <property name="padding">3</property>
-                                <property name="position">1</property>
-                              </packing>
                             </child>
                             <child>
                               <object class="GtkLabel">
-                                <property name="visible">True</property>
-                                <property name="can_focus">False</property>
+                                <property name="visible">1</property>
                               </object>
-                              <packing>
-                                <property name="expand">True</property>
-                                <property name="fill">True</property>
-                                <property name="position">2</property>
-                              </packing>
                             </child>
                             <child>
                               <object class="GtkCheckButton" id="ToggleAutoclearDownloads">
                                 <property name="label" translatable="yes">Autoclear finished / filtered</property>
-                                <property name="visible">True</property>
-                                <property name="can_focus">True</property>
-                                <property name="receives_default">False</property>
-                                <property name="draw_indicator">True</property>
+                                <property name="visible">1</property>
+                                <property name="can-focus">1</property>
+                                <property name="draw-indicator">1</property>
                               </object>
-                              <packing>
-                                <property name="expand">False</property>
-                                <property name="fill">False</property>
-                                <property name="position">3</property>
-                              </packing>
                             </child>
                             <child>
                               <object class="GtkToggleButton" id="ExpandDownloads">
-                                <property name="visible">True</property>
-                                <property name="can_focus">True</property>
-                                <property name="receives_default">False</property>
-                                <property name="tooltip_text" translatable="yes">Expand / Collapse all</property>
+                                <property name="visible">1</property>
+                                <property name="can-focus">1</property>
+                                <property name="tooltip-text" translatable="yes">Expand / Collapse all</property>
                                 <property name="image">ExpandDownloadsImage</property>
-                                <property name="always_show_image">True</property>
+                                <property name="always-show-image">1</property>
                                 <child>
                                   <object class="GtkImage" id="ExpandDownloadsImage">
-                                    <property name="can_focus">False</property>
-                                    <property name="icon_name">list-remove-symbolic</property>
+                                    <property name="icon-name">list-remove-symbolic</property>
                                   </object>
                                 </child>
                               </object>
-                              <packing>
-                                <property name="expand">False</property>
-                                <property name="fill">True</property>
-                                <property name="position">4</property>
-                              </packing>
                             </child>
                             <child>
                               <object class="GtkComboBox" id="ToggleTreeDownloads">
-                                <property name="visible">True</property>
-                                <property name="can_focus">False</property>
-                                <property name="tooltip_text" translatable="yes">File grouping mode</property>
+                                <property name="visible">1</property>
+                                <property name="tooltip-text" translatable="yes">File grouping mode</property>
                               </object>
-                              <packing>
-                                <property name="expand">False</property>
-                                <property name="fill">False</property>
-                                <property name="position">5</property>
-                              </packing>
                             </child>
                             <child>
                               <object class="GtkButton" id="configureTransfers1">
-                                <property name="visible">True</property>
-                                <property name="can_focus">True</property>
-                                <property name="receives_default">False</property>
-                                <property name="tooltip_text" translatable="yes">Configure downloads</property>
+                                <property name="visible">1</property>
+                                <property name="can-focus">1</property>
+                                <property name="tooltip-text" translatable="yes">Configure downloads</property>
                                 <property name="image">ConfigureTransfersImage</property>
-                                <property name="always_show_image">True</property>
+                                <property name="always-show-image">1</property>
                                 <signal name="clicked" handler="on_settings_downloads" swapped="no"/>
                                 <child>
                                   <object class="GtkImage" id="ConfigureTransfersImage">
-                                    <property name="can_focus">False</property>
-                                    <property name="icon_name">applications-system-symbolic</property>
+                                    <property name="icon-name">applications-system-symbolic</property>
                                   </object>
                                 </child>
                                 <style>
                                   <class name="circular"/>
                                 </style>
                               </object>
-                              <packing>
-                                <property name="expand">False</property>
-                                <property name="fill">False</property>
-                                <property name="position">6</property>
-                              </packing>
                             </child>
                           </object>
-                          <packing>
-                            <property name="expand">False</property>
-                            <property name="fill">False</property>
-                            <property name="position">0</property>
-                          </packing>
                         </child>
                         <child>
                           <object class="GtkScrolledWindow">
-                            <property name="visible">True</property>
-                            <property name="can_focus">True</property>
+                            <property name="visible">1</property>
+                            <property name="can-focus">1</property>
+                            <property name="vexpand">1</property>
                             <child>
                               <object class="GtkTreeView" id="DownloadList">
-                                <property name="visible">True</property>
-                                <property name="can_focus">True</property>
+                                <property name="visible">1</property>
+                                <property name="can-focus">1</property>
                                 <child internal-child="selection">
                                   <object class="GtkTreeSelection"/>
                                 </child>
                               </object>
                             </child>
                           </object>
-                          <packing>
-                            <property name="expand">True</property>
-                            <property name="fill">True</property>
-                            <property name="position">1</property>
-                          </packing>
                         </child>
                         <child>
                           <object class="GtkBox" id="DownloadButtons">
-                            <property name="visible">True</property>
-                            <property name="can_focus">False</property>
-                            <property name="border_width">6</property>
+                            <property name="visible">1</property>
+                            <property name="border-width">6</property>
                             <property name="spacing">6</property>
                             <child>
                               <object class="GtkButton" id="clearFinishedAbortedButton">
-                                <property name="visible">True</property>
-                                <property name="can_focus">True</property>
-                                <property name="receives_default">False</property>
+                                <property name="visible">1</property>
+                                <property name="can-focus">1</property>
                                 <child>
                                   <object class="GtkBox">
-                                    <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
+                                    <property name="visible">1</property>
                                     <property name="spacing">5</property>
                                     <child>
                                       <object class="GtkImage">
-                                        <property name="visible">True</property>
-                                        <property name="can_focus">False</property>
-                                        <property name="icon_name">edit-clear-symbolic</property>
+                                        <property name="visible">1</property>
+                                        <property name="icon-name">edit-clear-symbolic</property>
                                       </object>
                                     </child>
                                     <child>
                                       <object class="GtkLabel">
-                                        <property name="visible">True</property>
-                                        <property name="can_focus">False</property>
+                                        <property name="visible">1</property>
                                         <property name="label" translatable="yes">Clear Finished / Aborted</property>
-                                        <property name="use_underline">True</property>
+                                        <property name="use-underline">1</property>
                                       </object>
                                     </child>
                                   </object>
                                 </child>
                               </object>
-                              <packing>
-                                <property name="expand">False</property>
-                                <property name="fill">False</property>
-                                <property name="position">0</property>
-                              </packing>
                             </child>
                             <child>
                               <object class="GtkButton" id="clearQueuedButton">
-                                <property name="visible">True</property>
-                                <property name="can_focus">True</property>
-                                <property name="receives_default">False</property>
+                                <property name="visible">1</property>
+                                <property name="can-focus">1</property>
                                 <child>
                                   <object class="GtkBox">
-                                    <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
+                                    <property name="visible">1</property>
                                     <property name="spacing">5</property>
                                     <child>
                                       <object class="GtkImage">
-                                        <property name="visible">True</property>
-                                        <property name="can_focus">False</property>
-                                        <property name="icon_name">edit-clear-symbolic</property>
+                                        <property name="visible">1</property>
+                                        <property name="icon-name">edit-clear-symbolic</property>
                                       </object>
                                     </child>
                                     <child>
                                       <object class="GtkLabel">
-                                        <property name="visible">True</property>
-                                        <property name="can_focus">False</property>
+                                        <property name="visible">1</property>
                                         <property name="label" translatable="yes">Clear Queued</property>
-                                        <property name="use_underline">True</property>
+                                        <property name="use-underline">1</property>
                                       </object>
                                     </child>
                                   </object>
                                 </child>
                               </object>
-                              <packing>
-                                <property name="expand">False</property>
-                                <property name="fill">False</property>
-                                <property name="position">1</property>
-                              </packing>
                             </child>
                             <child>
                               <object class="GtkButton" id="deleteTransferButton">
-                                <property name="visible">True</property>
-                                <property name="can_focus">True</property>
-                                <property name="receives_default">False</property>
+                                <property name="visible">1</property>
+                                <property name="can-focus">1</property>
                                 <child>
                                   <object class="GtkBox">
-                                    <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
+                                    <property name="visible">1</property>
                                     <property name="spacing">5</property>
                                     <child>
                                       <object class="GtkImage">
-                                        <property name="visible">True</property>
-                                        <property name="can_focus">False</property>
-                                        <property name="icon_name">edit-delete-symbolic</property>
+                                        <property name="visible">1</property>
+                                        <property name="icon-name">edit-delete-symbolic</property>
                                       </object>
                                     </child>
                                     <child>
                                       <object class="GtkLabel">
-                                        <property name="visible">True</property>
-                                        <property name="can_focus">False</property>
+                                        <property name="visible">1</property>
                                         <property name="label" translatable="yes">Clear</property>
-                                        <property name="use_underline">True</property>
+                                        <property name="use-underline">1</property>
                                       </object>
                                     </child>
                                   </object>
                                 </child>
                               </object>
                               <packing>
-                                <property name="expand">False</property>
-                                <property name="fill">False</property>
-                                <property name="pack_type">end</property>
-                                <property name="position">2</property>
+                                <property name="pack-type">end</property>
                               </packing>
                             </child>
                             <child>
                               <object class="GtkButton" id="abortTransferButton">
-                                <property name="visible">True</property>
-                                <property name="can_focus">True</property>
-                                <property name="receives_default">False</property>
+                                <property name="visible">1</property>
+                                <property name="can-focus">1</property>
                                 <child>
                                   <object class="GtkBox">
-                                    <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
+                                    <property name="visible">1</property>
                                     <property name="spacing">5</property>
                                     <child>
                                       <object class="GtkImage">
-                                        <property name="visible">True</property>
-                                        <property name="can_focus">False</property>
-                                        <property name="icon_name">system-shutdown-symbolic</property>
+                                        <property name="visible">1</property>
+                                        <property name="icon-name">system-shutdown-symbolic</property>
                                       </object>
                                     </child>
                                     <child>
                                       <object class="GtkLabel">
-                                        <property name="visible">True</property>
-                                        <property name="can_focus">False</property>
+                                        <property name="visible">1</property>
                                         <property name="label" translatable="yes">Abort</property>
-                                        <property name="use_underline">True</property>
+                                        <property name="use-underline">1</property>
                                       </object>
                                     </child>
                                   </object>
                                 </child>
                               </object>
                               <packing>
-                                <property name="expand">False</property>
-                                <property name="fill">False</property>
-                                <property name="pack_type">end</property>
-                                <property name="position">3</property>
+                                <property name="pack-type">end</property>
                               </packing>
                             </child>
                             <child>
                               <object class="GtkButton" id="retryTransferButton">
-                                <property name="visible">True</property>
-                                <property name="can_focus">True</property>
-                                <property name="receives_default">False</property>
+                                <property name="visible">1</property>
+                                <property name="can-focus">1</property>
                                 <child>
                                   <object class="GtkBox">
-                                    <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
+                                    <property name="visible">1</property>
                                     <property name="spacing">5</property>
                                     <child>
                                       <object class="GtkImage">
-                                        <property name="visible">True</property>
-                                        <property name="can_focus">False</property>
-                                        <property name="icon_name">edit-redo-symbolic</property>
+                                        <property name="visible">1</property>
+                                        <property name="icon-name">edit-redo-symbolic</property>
                                       </object>
                                     </child>
                                     <child>
                                       <object class="GtkLabel">
-                                        <property name="visible">True</property>
-                                        <property name="can_focus">False</property>
+                                        <property name="visible">1</property>
                                         <property name="label" translatable="yes">Retry</property>
-                                        <property name="use_underline">True</property>
+                                        <property name="use-underline">1</property>
                                       </object>
                                     </child>
                                   </object>
                                 </child>
                               </object>
                               <packing>
-                                <property name="expand">False</property>
-                                <property name="fill">False</property>
-                                <property name="pack_type">end</property>
-                                <property name="position">4</property>
+                                <property name="pack-type">end</property>
                               </packing>
                             </child>
                           </object>
-                          <packing>
-                            <property name="expand">False</property>
-                            <property name="fill">True</property>
-                            <property name="position">2</property>
-                          </packing>
                         </child>
                       </object>
-                      <packing>
-                        <property name="position">2</property>
-                      </packing>
                     </child>
                     <child type="tab">
                       <object class="GtkEventBox" id="DownloadsTabLabel">
-                        <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="visible_window">False</property>
-                        <child>
-                          <placeholder/>
-                        </child>
+                        <property name="visible">1</property>
+                        <property name="visible-window">0</property>
                       </object>
                       <packing>
-                        <property name="position">2</property>
-                        <property name="tab_fill">False</property>
+                        <property name="tab-fill">0</property>
                       </packing>
                     </child>
-
                     <!-- Uploads -->
-
                     <child>
                       <object class="GtkBox" id="uploadsvbox">
-                        <property name="visible">True</property>
-                        <property name="can_focus">False</property>
+                        <property name="visible">1</property>
                         <property name="orientation">vertical</property>
                         <child>
                           <object class="GtkBox">
-                            <property name="visible">True</property>
-                            <property name="can_focus">False</property>
-                            <property name="border_width">6</property>
+                            <property name="visible">1</property>
+                            <property name="border-width">6</property>
                             <property name="spacing">6</property>
                             <child>
                               <object class="GtkBox">
-                                <property name="visible">True</property>
-                                <property name="can_focus">False</property>
+                                <property name="visible">1</property>
                                 <property name="spacing">6</property>
+                                <property name="margin-start">5</property>
+                                <property name="margin-end">5</property>
                                 <child>
                                   <object class="GtkLabel">
-                                    <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
+                                    <property name="visible">1</property>
                                     <property name="label" translatable="yes">Users</property>
                                   </object>
-                                  <packing>
-                                    <property name="expand">False</property>
-                                    <property name="fill">True</property>
-                                    <property name="position">0</property>
-                                  </packing>
                                 </child>
                                 <child>
                                   <object class="GtkButton">
-                                    <property name="visible">True</property>
-                                    <property name="sensitive">False</property>
-                                    <property name="can-focus">False</property>
-                                    <property name="receives-default">False</property>
+                                    <property name="visible">1</property>
+                                    <property name="sensitive">0</property>
                                     <child>
                                       <object class="GtkBox">
                                         <property name="width-request">24</property>
-                                        <property name="visible">True</property>
-                                        <property name="can-focus">False</property>
+                                        <property name="visible">1</property>
                                         <property name="spacing">5</property>
-                                        <property name="homogeneous">True</property>
+                                        <property name="homogeneous">1</property>
                                         <child>
                                           <object class="GtkLabel" id="UploadUsers">
-                                            <property name="visible">True</property>
-                                            <property name="can-focus">False</property>
+                                            <property name="visible">1</property>
                                             <property name="label">&lt;b&gt;0&lt;/b&gt;</property>
-                                            <property name="use_markup">True</property>
+                                            <property name="use-markup">1</property>
+                                            <property name="margin-start">5</property>
+                                            <property name="margin-end">5</property>
                                           </object>
-                                          <packing>
-                                            <property name="expand">False</property>
-                                            <property name="fill">True</property>
-                                            <property name="padding">5</property>
-                                            <property name="position">0</property>
-                                          </packing>
                                         </child>
                                       </object>
                                     </child>
@@ -733,63 +510,40 @@
                                       <class name="circular"/>
                                     </style>
                                   </object>
-                                  <packing>
-                                    <property name="expand">False</property>
-                                    <property name="fill">False</property>
-                                    <property name="position">1</property>
-                                  </packing>
                                 </child>
                               </object>
-                              <packing>
-                                <property name="expand">False</property>
-                                <property name="fill">False</property>
-                                <property name="padding">5</property>
-                                <property name="position">0</property>
-                              </packing>
                             </child>
                             <child>
                               <object class="GtkBox">
-                                <property name="visible">True</property>
-                                <property name="can_focus">False</property>
+                                <property name="visible">1</property>
+                                <property name="hexpand">1</property>
                                 <property name="spacing">6</property>
+                                <property name="margin-start">5</property>
+                                <property name="margin-end">5</property>
                                 <child>
                                   <object class="GtkLabel">
-                                    <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
+                                    <property name="visible">1</property>
                                     <property name="label" translatable="yes">Files</property>
                                   </object>
-                                  <packing>
-                                    <property name="expand">False</property>
-                                    <property name="fill">True</property>
-                                    <property name="position">0</property>
-                                  </packing>
                                 </child>
                                 <child>
                                   <object class="GtkButton">
-                                    <property name="visible">True</property>
-                                    <property name="sensitive">False</property>
-                                    <property name="can-focus">False</property>
-                                    <property name="receives-default">False</property>
+                                    <property name="visible">1</property>
+                                    <property name="sensitive">0</property>
                                     <child>
                                       <object class="GtkBox">
                                         <property name="width-request">24</property>
-                                        <property name="visible">True</property>
-                                        <property name="can-focus">False</property>
+                                        <property name="visible">1</property>
                                         <property name="spacing">5</property>
-                                        <property name="homogeneous">True</property>
+                                        <property name="homogeneous">1</property>
                                         <child>
                                           <object class="GtkLabel" id="UploadFiles">
-                                            <property name="visible">True</property>
-                                            <property name="can-focus">False</property>
+                                            <property name="visible">1</property>
                                             <property name="label">&lt;b&gt;0&lt;/b&gt;</property>
-                                            <property name="use_markup">True</property>
+                                            <property name="use-markup">1</property>
+                                            <property name="margin-start">5</property>
+                                            <property name="margin-end">5</property>
                                           </object>
-                                          <packing>
-                                            <property name="expand">False</property>
-                                            <property name="fill">True</property>
-                                            <property name="padding">5</property>
-                                            <property name="position">0</property>
-                                          </packing>
                                         </child>
                                       </object>
                                     </child>
@@ -797,492 +551,339 @@
                                       <class name="circular"/>
                                     </style>
                                   </object>
-                                  <packing>
-                                    <property name="expand">False</property>
-                                    <property name="fill">False</property>
-                                    <property name="position">1</property>
-                                  </packing>
                                 </child>
                               </object>
-                              <packing>
-                                <property name="expand">True</property>
-                                <property name="fill">True</property>
-                                <property name="padding">3</property>
-                                <property name="position">1</property>
-                              </packing>
                             </child>
                             <child>
                               <object class="GtkCheckButton" id="ToggleAutoclearUploads">
                                 <property name="label" translatable="yes">Autoclear finished / aborted</property>
-                                <property name="visible">True</property>
-                                <property name="can_focus">True</property>
-                                <property name="receives_default">False</property>
-                                <property name="draw_indicator">True</property>
+                                <property name="visible">1</property>
+                                <property name="can-focus">1</property>
+                                <property name="draw-indicator">1</property>
                               </object>
-                              <packing>
-                                <property name="expand">False</property>
-                                <property name="fill">False</property>
-                                <property name="position">2</property>
-                              </packing>
                             </child>
                             <child>
                               <object class="GtkToggleButton" id="ExpandUploads">
-                                <property name="visible">True</property>
-                                <property name="can_focus">True</property>
-                                <property name="receives_default">False</property>
-                                <property name="tooltip_text" translatable="yes">Expand / Collapse all</property>
-                                <property name="active">True</property>
+                                <property name="visible">1</property>
+                                <property name="can-focus">1</property>
+                                <property name="tooltip-text" translatable="yes">Expand / Collapse all</property>
+                                <property name="active">1</property>
                                 <property name="image">ExpandUploadsImage</property>
-                                <property name="always_show_image">True</property>
+                                <property name="always-show-image">1</property>
                                 <child>
                                   <object class="GtkImage" id="ExpandUploadsImage">
-                                    <property name="can_focus">False</property>
-                                    <property name="icon_name">list-remove-symbolic</property>
+                                    <property name="icon-name">list-remove-symbolic</property>
                                   </object>
                                 </child>
                               </object>
-                              <packing>
-                                <property name="expand">False</property>
-                                <property name="fill">True</property>
-                                <property name="position">3</property>
-                              </packing>
                             </child>
                             <child>
                               <object class="GtkComboBox" id="ToggleTreeUploads">
-                                <property name="visible">True</property>
-                                <property name="can_focus">False</property>
-                                <property name="tooltip_text" translatable="yes">File grouping mode</property>
+                                <property name="visible">1</property>
+                                <property name="tooltip-text" translatable="yes">File grouping mode</property>
                               </object>
-                              <packing>
-                                <property name="expand">False</property>
-                                <property name="fill">False</property>
-                                <property name="position">4</property>
-                              </packing>
                             </child>
                             <child>
                               <object class="GtkButton" id="configureTransfers2">
-                                <property name="visible">True</property>
-                                <property name="can_focus">True</property>
-                                <property name="receives_default">False</property>
-                                <property name="tooltip_text" translatable="yes">Configure uploads</property>
+                                <property name="visible">1</property>
+                                <property name="can-focus">1</property>
+                                <property name="tooltip-text" translatable="yes">Configure uploads</property>
                                 <property name="image">ConfigureTransfers2Image</property>
-                                <property name="always_show_image">True</property>
+                                <property name="always-show-image">1</property>
                                 <signal name="clicked" handler="on_settings_uploads" swapped="no"/>
                                 <child>
                                   <object class="GtkImage" id="ConfigureTransfers2Image">
-                                    <property name="can_focus">False</property>
-                                    <property name="icon_name">applications-system-symbolic</property>
+                                    <property name="icon-name">applications-system-symbolic</property>
                                   </object>
                                 </child>
                                 <style>
                                   <class name="circular"/>
                                 </style>
                               </object>
-                              <packing>
-                                <property name="expand">False</property>
-                                <property name="fill">False</property>
-                                <property name="position">5</property>
-                              </packing>
                             </child>
                           </object>
-                          <packing>
-                            <property name="expand">False</property>
-                            <property name="fill">False</property>
-                            <property name="position">0</property>
-                          </packing>
                         </child>
                         <child>
                           <object class="GtkScrolledWindow">
-                            <property name="visible">True</property>
-                            <property name="can_focus">True</property>
+                            <property name="visible">1</property>
+                            <property name="can-focus">1</property>
+                            <property name="vexpand">1</property>
                             <child>
                               <object class="GtkTreeView" id="UploadList">
-                                <property name="visible">True</property>
-                                <property name="can_focus">True</property>
+                                <property name="visible">1</property>
+                                <property name="can-focus">1</property>
                                 <child internal-child="selection">
                                   <object class="GtkTreeSelection"/>
                                 </child>
                               </object>
                             </child>
                           </object>
-                          <packing>
-                            <property name="expand">True</property>
-                            <property name="fill">True</property>
-                            <property name="position">1</property>
-                          </packing>
                         </child>
                         <child>
                           <object class="GtkBox" id="UploadButtons">
-                            <property name="visible">True</property>
-                            <property name="can_focus">False</property>
-                            <property name="border_width">6</property>
+                            <property name="visible">1</property>
+                            <property name="border-width">6</property>
                             <property name="spacing">6</property>
                             <child>
                               <object class="GtkButton" id="clearUploadFinishedErredButton">
-                                <property name="visible">True</property>
-                                <property name="can_focus">True</property>
-                                <property name="receives_default">False</property>
+                                <property name="visible">1</property>
+                                <property name="can-focus">1</property>
                                 <child>
                                   <object class="GtkBox">
-                                    <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
+                                    <property name="visible">1</property>
                                     <property name="spacing">6</property>
                                     <child>
                                       <object class="GtkImage">
-                                        <property name="visible">True</property>
-                                        <property name="can_focus">False</property>
-                                        <property name="icon_name">edit-clear-symbolic</property>
+                                        <property name="visible">1</property>
+                                        <property name="icon-name">edit-clear-symbolic</property>
                                       </object>
                                     </child>
                                     <child>
                                       <object class="GtkLabel">
-                                        <property name="visible">True</property>
-                                        <property name="can_focus">False</property>
+                                        <property name="visible">1</property>
                                         <property name="label" translatable="yes">Clear Finished / Failed</property>
-                                        <property name="use_underline">True</property>
+                                        <property name="use-underline">1</property>
                                       </object>
                                     </child>
                                   </object>
                                 </child>
                               </object>
-                              <packing>
-                                <property name="expand">False</property>
-                                <property name="fill">False</property>
-                                <property name="position">0</property>
-                              </packing>
                             </child>
                             <child>
                               <object class="GtkButton" id="clearUploadQueueButton">
-                                <property name="visible">True</property>
-                                <property name="can_focus">True</property>
-                                <property name="receives_default">False</property>
+                                <property name="visible">1</property>
+                                <property name="can-focus">1</property>
                                 <child>
                                   <object class="GtkBox">
-                                    <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
+                                    <property name="visible">1</property>
                                     <property name="spacing">5</property>
                                     <child>
                                       <object class="GtkImage">
-                                        <property name="visible">True</property>
-                                        <property name="can_focus">False</property>
-                                        <property name="icon_name">edit-clear-symbolic</property>
+                                        <property name="visible">1</property>
+                                        <property name="icon-name">edit-clear-symbolic</property>
                                       </object>
                                     </child>
                                     <child>
                                       <object class="GtkLabel">
-                                        <property name="visible">True</property>
-                                        <property name="can_focus">False</property>
+                                        <property name="visible">1</property>
                                         <property name="label" translatable="yes">Clear Queued</property>
-                                        <property name="use_underline">True</property>
+                                        <property name="use-underline">1</property>
                                       </object>
                                     </child>
                                   </object>
                                 </child>
                               </object>
-                              <packing>
-                                <property name="expand">False</property>
-                                <property name="fill">False</property>
-                                <property name="position">1</property>
-                              </packing>
                             </child>
                             <child>
                               <object class="GtkButton" id="banUploadButton">
-                                <property name="visible">True</property>
-                                <property name="can_focus">True</property>
-                                <property name="receives_default">False</property>
+                                <property name="visible">1</property>
+                                <property name="can-focus">1</property>
                                 <child>
                                   <object class="GtkBox">
-                                    <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
+                                    <property name="visible">1</property>
                                     <property name="spacing">5</property>
                                     <child>
                                       <object class="GtkImage">
-                                        <property name="visible">True</property>
-                                        <property name="can_focus">False</property>
-                                        <property name="icon_name">action-unavailable-symbolic</property>
+                                        <property name="visible">1</property>
+                                        <property name="icon-name">action-unavailable-symbolic</property>
                                       </object>
                                     </child>
                                     <child>
                                       <object class="GtkLabel">
-                                        <property name="visible">True</property>
-                                        <property name="can_focus">False</property>
+                                        <property name="visible">1</property>
                                         <property name="label" translatable="yes">Ban User(s)</property>
-                                        <property name="use_underline">True</property>
+                                        <property name="use-underline">1</property>
                                       </object>
                                     </child>
                                   </object>
                                 </child>
                               </object>
                               <packing>
-                                <property name="expand">False</property>
-                                <property name="fill">False</property>
-                                <property name="pack_type">end</property>
-                                <property name="position">2</property>
+                                <property name="pack-type">end</property>
                               </packing>
                             </child>
                             <child>
                               <object class="GtkButton" id="abortUserUploadButton">
-                                <property name="visible">True</property>
-                                <property name="can_focus">True</property>
-                                <property name="receives_default">False</property>
+                                <property name="visible">1</property>
+                                <property name="can-focus">1</property>
                                 <child>
                                   <object class="GtkBox">
-                                    <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
+                                    <property name="visible">1</property>
                                     <property name="spacing">5</property>
                                     <child>
                                       <object class="GtkImage">
-                                        <property name="visible">True</property>
-                                        <property name="can_focus">False</property>
-                                        <property name="icon_name">system-shutdown-symbolic</property>
+                                        <property name="visible">1</property>
+                                        <property name="icon-name">system-shutdown-symbolic</property>
                                       </object>
                                     </child>
                                     <child>
                                       <object class="GtkLabel">
-                                        <property name="visible">True</property>
-                                        <property name="can_focus">False</property>
-                                        <property name="label" translatable="yes">Abort User's Uploads</property>
-                                        <property name="use_underline">True</property>
+                                        <property name="visible">1</property>
+                                        <property name="label" translatable="yes">Abort User&apos;s Uploads</property>
+                                        <property name="use-underline">1</property>
                                       </object>
                                     </child>
                                   </object>
                                 </child>
                               </object>
                               <packing>
-                                <property name="expand">False</property>
-                                <property name="fill">False</property>
-                                <property name="pack_type">end</property>
-                                <property name="position">3</property>
+                                <property name="pack-type">end</property>
                               </packing>
                             </child>
                             <child>
                               <object class="GtkButton" id="abortUploadButton">
-                                <property name="visible">True</property>
-                                <property name="can_focus">True</property>
-                                <property name="receives_default">False</property>
+                                <property name="visible">1</property>
+                                <property name="can-focus">1</property>
                                 <child>
                                   <object class="GtkBox">
-                                    <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
+                                    <property name="visible">1</property>
                                     <property name="spacing">5</property>
                                     <child>
                                       <object class="GtkImage">
-                                        <property name="visible">True</property>
-                                        <property name="can_focus">False</property>
-                                        <property name="icon_name">system-shutdown-symbolic</property>
+                                        <property name="visible">1</property>
+                                        <property name="icon-name">system-shutdown-symbolic</property>
                                       </object>
                                     </child>
                                     <child>
                                       <object class="GtkLabel">
-                                        <property name="visible">True</property>
-                                        <property name="can_focus">False</property>
+                                        <property name="visible">1</property>
                                         <property name="label" translatable="yes">Abort</property>
-                                        <property name="use_underline">True</property>
+                                        <property name="use-underline">1</property>
                                       </object>
                                     </child>
                                   </object>
                                 </child>
                               </object>
                               <packing>
-                                <property name="expand">False</property>
-                                <property name="fill">False</property>
-                                <property name="pack_type">end</property>
-                                <property name="position">4</property>
+                                <property name="pack-type">end</property>
                               </packing>
                             </child>
                           </object>
-                          <packing>
-                            <property name="expand">False</property>
-                            <property name="fill">True</property>
-                            <property name="position">2</property>
-                          </packing>
                         </child>
                       </object>
-                      <packing>
-                        <property name="position">3</property>
-                      </packing>
                     </child>
                     <child type="tab">
                       <object class="GtkEventBox" id="UploadsTabLabel">
-                        <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="visible_window">False</property>
-                        <child>
-                          <placeholder/>
-                        </child>
+                        <property name="visible">1</property>
+                        <property name="visible-window">0</property>
                       </object>
                       <packing>
-                        <property name="position">3</property>
-                        <property name="tab_fill">False</property>
+                        <property name="tab-fill">0</property>
                       </packing>
                     </child>
-
                     <!-- Search -->
-
                     <child>
                       <object class="GtkBox" id="searchvbox">
-                        <property name="visible">True</property>
-                        <property name="can_focus">False</property>
+                        <property name="visible">1</property>
                         <property name="orientation">vertical</property>
                         <child>
                           <object class="GtkBox">
-                            <property name="visible">True</property>
-                            <property name="can_focus">False</property>
-                            <property name="border_width">6</property>
+                            <property name="visible">1</property>
+                            <property name="border-width">6</property>
                             <property name="spacing">6</property>
                             <child>
                               <object class="GtkComboBox" id="SearchMethod">
-                                <property name="visible">True</property>
-                                <property name="can_focus">False</property>
-                                <property name="tooltip_text" translatable="yes">Search scope</property>
+                                <property name="visible">1</property>
+                                <property name="tooltip-text" translatable="yes">Search scope</property>
                               </object>
-                              <packing>
-                                <property name="expand">False</property>
-                                <property name="fill">False</property>
-                                <property name="position">0</property>
-                              </packing>
                             </child>
                             <child>
                               <object class="GtkComboBox" id="RoomSearchCombo">
-                                <property name="visible">True</property>
-                                <property name="can_focus">False</property>
-                                <property name="has_entry">True</property>
+                                <property name="visible">1</property>
+                                <property name="has-entry">1</property>
                               </object>
-                              <packing>
-                                <property name="expand">False</property>
-                                <property name="fill">False</property>
-                                <property name="position">1</property>
-                              </packing>
                             </child>
                             <child>
                               <object class="GtkComboBox" id="UserSearchCombo">
-                                <property name="visible">True</property>
-                                <property name="can_focus">False</property>
-                                <property name="has_entry">True</property>
+                                <property name="visible">1</property>
+                                <property name="has-entry">1</property>
                               </object>
-                              <packing>
-                                <property name="expand">False</property>
-                                <property name="fill">False</property>
-                                <property name="position">2</property>
-                              </packing>
                             </child>
                             <child>
                               <object class="GtkComboBox" id="SearchEntryCombo">
-                                <property name="visible">True</property>
-                                <property name="can_focus">False</property>
-                                <property name="tooltip_text" translatable="yes">Search patterns: with a word = term, without a word = -term</property>
-                                <property name="has_entry">True</property>
+                                <property name="visible">1</property>
+                                <property name="hexpand">1</property>
+                                <property name="tooltip-text" translatable="yes">Search patterns: with a word = term, without a word = -term</property>
+                                <property name="has-entry">1</property>
                               </object>
-                              <packing>
-                                <property name="expand">True</property>
-                                <property name="fill">True</property>
-                                <property name="position">3</property>
-                              </packing>
                             </child>
                             <child>
                               <object class="GtkButton" id="ClearSearchHistory">
-                                <property name="visible">True</property>
-                                <property name="can_focus">True</property>
-                                <property name="receives_default">False</property>
-                                <property name="tooltip_text" translatable="yes">Clear all searches attempts</property>
+                                <property name="visible">1</property>
+                                <property name="can-focus">1</property>
+                                <property name="tooltip-text" translatable="yes">Clear all searches attempts</property>
                                 <property name="image">ClearSearchHistoryImage</property>
-                                <property name="always_show_image">True</property>
+                                <property name="always-show-image">1</property>
                                 <signal name="clicked" handler="on_clear_search_history" swapped="no"/>
                                 <child>
                                   <object class="GtkImage" id="ClearSearchHistoryImage">
-                                    <property name="can_focus">False</property>
-                                    <property name="icon_name">edit-clear-symbolic</property>
+                                    <property name="icon-name">edit-clear-symbolic</property>
                                   </object>
                                 </child>
                               </object>
-                              <packing>
-                                <property name="expand">False</property>
-                                <property name="fill">False</property>
-                                <property name="position">4</property>
-                              </packing>
                             </child>
                             <child>
                               <object class="GtkButton" id="SearchButton">
-                                <property name="visible">True</property>
-                                <property name="can_focus">True</property>
-                                <property name="receives_default">False</property>
+                                <property name="visible">1</property>
+                                <property name="can-focus">1</property>
                                 <signal name="clicked" handler="on_search" swapped="no"/>
                                 <child>
                                   <object class="GtkBox">
-                                    <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
+                                    <property name="visible">1</property>
                                     <property name="spacing">5</property>
                                     <child>
                                       <object class="GtkImage">
-                                        <property name="visible">True</property>
-                                        <property name="can_focus">False</property>
-                                        <property name="icon_name">system-search-symbolic</property>
+                                        <property name="visible">1</property>
+                                        <property name="icon-name">system-search-symbolic</property>
                                       </object>
                                     </child>
                                     <child>
                                       <object class="GtkLabel">
-                                        <property name="visible">True</property>
-                                        <property name="can_focus">False</property>
+                                        <property name="visible">1</property>
                                         <property name="label" translatable="yes">Search</property>
-                                        <property name="use_underline">True</property>
+                                        <property name="use-underline">1</property>
                                       </object>
                                     </child>
                                   </object>
                                 </child>
                               </object>
-                              <packing>
-                                <property name="expand">False</property>
-                                <property name="fill">False</property>
-                                <property name="position">5</property>
-                              </packing>
                             </child>
                             <child>
                               <object class="GtkButton" id="WishList">
-                                <property name="visible">True</property>
-                                <property name="can_focus">True</property>
-                                <property name="receives_default">False</property>
+                                <property name="visible">1</property>
+                                <property name="can-focus">1</property>
                                 <child>
                                   <object class="GtkBox">
-                                    <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
+                                    <property name="visible">1</property>
                                     <property name="spacing">5</property>
                                     <child>
                                       <object class="GtkImage">
-                                        <property name="visible">True</property>
-                                        <property name="can_focus">False</property>
-                                        <property name="icon_name">text-editor-symbolic</property>
+                                        <property name="visible">1</property>
+                                        <property name="icon-name">text-editor-symbolic</property>
                                       </object>
                                     </child>
                                     <child>
                                       <object class="GtkLabel">
-                                        <property name="visible">True</property>
-                                        <property name="can_focus">False</property>
+                                        <property name="visible">1</property>
                                         <property name="label" translatable="yes">Wishlist</property>
-                                        <property name="use_underline">True</property>
+                                        <property name="use-underline">1</property>
                                       </object>
                                     </child>
                                   </object>
                                 </child>
                               </object>
-                              <packing>
-                                <property name="expand">False</property>
-                                <property name="fill">False</property>
-                                <property name="position">6</property>
-                              </packing>
                             </child>
                             <child>
                               <object class="GtkButton" id="configureSearches">
-                                <property name="visible">True</property>
-                                <property name="can_focus">True</property>
-                                <property name="receives_default">False</property>
-                                <property name="tooltip_text" translatable="yes">Configure searches</property>
+                                <property name="visible">1</property>
+                                <property name="can-focus">1</property>
+                                <property name="tooltip-text" translatable="yes">Configure searches</property>
                                 <property name="image">ConfigureSearchesImage</property>
-                                <property name="always_show_image">True</property>
+                                <property name="always-show-image">1</property>
                                 <signal name="clicked" handler="on_settings_searches" swapped="no"/>
                                 <child>
                                   <object class="GtkImage" id="ConfigureSearchesImage">
-                                    <property name="can_focus">False</property>
-                                    <property name="icon_name">applications-system-symbolic</property>
+                                    <property name="icon-name">applications-system-symbolic</property>
                                   </object>
                                 </child>
                                 <style>
@@ -1290,137 +891,89 @@
                                 </style>
                               </object>
                               <packing>
-                                <property name="expand">False</property>
-                                <property name="fill">False</property>
-                                <property name="pack_type">end</property>
-                                <property name="position">7</property>
+                                <property name="pack-type">end</property>
                               </packing>
                             </child>
                           </object>
-                          <packing>
-                            <property name="expand">False</property>
-                            <property name="fill">True</property>
-                            <property name="position">0</property>
-                          </packing>
                         </child>
                         <child>
                           <object class="GtkNotebook" id="SearchNotebookRaw">
-                            <property name="visible">True</property>
-                            <property name="can_focus">True</property>
-                            <property name="show_border">True</property>
-                            <property name="scrollable">True</property>
+                            <property name="visible">1</property>
+                            <property name="can-focus">1</property>
+                            <property name="scrollable">1</property>
                           </object>
-                          <packing>
-                            <property name="expand">True</property>
-                            <property name="fill">True</property>
-                            <property name="position">1</property>
-                          </packing>
                         </child>
                       </object>
-                      <packing>
-                        <property name="position">4</property>
-                      </packing>
                     </child>
                     <child type="tab">
                       <object class="GtkEventBox" id="SearchTabLabel">
-                        <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="visible_window">False</property>
-                        <child>
-                          <placeholder/>
-                        </child>
+                        <property name="visible">1</property>
+                        <property name="visible-window">0</property>
                       </object>
                       <packing>
-                        <property name="position">4</property>
-                        <property name="tab_fill">False</property>
+                        <property name="tab-fill">0</property>
                       </packing>
                     </child>
-
                     <!-- User Info -->
-
                     <child>
                       <object class="GtkBox" id="userinfovbox">
-                        <property name="visible">True</property>
-                        <property name="can_focus">False</property>
+                        <property name="visible">1</property>
                         <property name="orientation">vertical</property>
                         <child>
                           <object class="GtkBox">
-                            <property name="visible">True</property>
-                            <property name="can_focus">False</property>
-                            <property name="border_width">6</property>
+                            <property name="visible">1</property>
+                            <property name="border-width">6</property>
                             <property name="spacing">6</property>
                             <child>
                               <object class="GtkLabel">
-                                <property name="visible">True</property>
-                                <property name="can_focus">False</property>
+                                <property name="visible">1</property>
                                 <property name="label" translatable="yes">User:</property>
+                                <property name="margin-start">5</property>
+                                <property name="margin-end">5</property>
                               </object>
-                              <packing>
-                                <property name="expand">False</property>
-                                <property name="fill">True</property>
-                                <property name="padding">5</property>
-                                <property name="position">0</property>
-                              </packing>
                             </child>
                             <child>
                               <object class="GtkComboBox" id="UserInfoCombo">
-                                <property name="visible">True</property>
-                                <property name="can_focus">False</property>
-                                <property name="has_entry">True</property>
+                                <property name="visible">1</property>
+                                <property name="has-entry">1</property>
                               </object>
-                              <packing>
-                                <property name="expand">False</property>
-                                <property name="fill">True</property>
-                                <property name="position">1</property>
-                              </packing>
                             </child>
                             <child>
                               <object class="GtkButton" id="sUserinfoButton">
-                                <property name="visible">True</property>
-                                <property name="can_focus">True</property>
-                                <property name="receives_default">False</property>
+                                <property name="visible">1</property>
+                                <property name="can-focus">1</property>
                                 <child>
                                   <object class="GtkBox">
-                                    <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
+                                    <property name="visible">1</property>
                                     <property name="spacing">5</property>
                                     <child>
                                       <object class="GtkImage">
-                                        <property name="visible">True</property>
-                                        <property name="can_focus">False</property>
-                                        <property name="icon_name">avatar-default-symbolic</property>
+                                        <property name="visible">1</property>
+                                        <property name="icon-name">avatar-default-symbolic</property>
                                       </object>
                                     </child>
                                     <child>
                                       <object class="GtkLabel">
-                                        <property name="visible">True</property>
-                                        <property name="can_focus">False</property>
+                                        <property name="visible">1</property>
                                         <property name="label" translatable="yes">Show Info</property>
-                                        <property name="use_underline">True</property>
+                                        <property name="use-underline">1</property>
                                       </object>
                                     </child>
                                   </object>
                                 </child>
                               </object>
-                              <packing>
-                                <property name="expand">False</property>
-                                <property name="fill">False</property>
-                                <property name="position">2</property>
-                              </packing>
                             </child>
                             <child>
                               <object class="GtkButton" id="configureUserinfo">
-                                <property name="visible">True</property>
-                                <property name="can_focus">True</property>
-                                <property name="receives_default">False</property>
-                                <property name="tooltip_text" translatable="yes">Configure user info</property>
+                                <property name="visible">1</property>
+                                <property name="can-focus">1</property>
+                                <property name="tooltip-text" translatable="yes">Configure user info</property>
                                 <property name="image">ConfigureUserinfoImage</property>
-                                <property name="always_show_image">True</property>
+                                <property name="always-show-image">1</property>
                                 <signal name="clicked" handler="on_settings_userinfo" swapped="no"/>
                                 <child>
                                   <object class="GtkImage" id="ConfigureUserinfoImage">
-                                    <property name="can_focus">False</property>
-                                    <property name="icon_name">applications-system-symbolic</property>
+                                    <property name="icon-name">applications-system-symbolic</property>
                                   </object>
                                 </child>
                                 <style>
@@ -1428,172 +981,115 @@
                                 </style>
                               </object>
                               <packing>
-                                <property name="expand">False</property>
-                                <property name="fill">False</property>
-                                <property name="pack_type">end</property>
-                                <property name="position">3</property>
+                                <property name="pack-type">end</property>
                               </packing>
                             </child>
                           </object>
-                          <packing>
-                            <property name="expand">False</property>
-                            <property name="fill">True</property>
-                            <property name="position">0</property>
-                          </packing>
                         </child>
                         <child>
                           <object class="GtkNotebook" id="UserInfoNotebookRaw">
-                            <property name="visible">True</property>
-                            <property name="can_focus">True</property>
-                            <property name="show_border">True</property>
-                            <property name="scrollable">True</property>
+                            <property name="visible">1</property>
+                            <property name="can-focus">1</property>
+                            <property name="scrollable">1</property>
                           </object>
-                          <packing>
-                            <property name="expand">True</property>
-                            <property name="fill">True</property>
-                            <property name="position">1</property>
-                          </packing>
                         </child>
                       </object>
-                      <packing>
-                        <property name="position">5</property>
-                      </packing>
                     </child>
                     <child type="tab">
                       <object class="GtkEventBox" id="UserInfoTabLabel">
-                        <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="visible_window">False</property>
-                        <child>
-                          <placeholder/>
-                        </child>
+                        <property name="visible">1</property>
+                        <property name="visible-window">0</property>
                       </object>
                       <packing>
-                        <property name="position">5</property>
-                        <property name="tab_fill">False</property>
+                        <property name="tab-fill">0</property>
                       </packing>
                     </child>
-
                     <!-- User Browse -->
-
                     <child>
                       <object class="GtkBox" id="userbrowsevbox">
-                        <property name="visible">True</property>
-                        <property name="can_focus">False</property>
+                        <property name="visible">1</property>
                         <property name="orientation">vertical</property>
                         <child>
                           <object class="GtkBox">
-                            <property name="visible">True</property>
-                            <property name="can_focus">False</property>
-                            <property name="border_width">6</property>
+                            <property name="visible">1</property>
+                            <property name="border-width">6</property>
                             <property name="spacing">6</property>
                             <child>
                               <object class="GtkLabel">
-                                <property name="visible">True</property>
-                                <property name="can_focus">False</property>
+                                <property name="visible">1</property>
                                 <property name="label" translatable="yes">User:</property>
+                                <property name="margin-start">5</property>
+                                <property name="margin-end">5</property>
                               </object>
-                              <packing>
-                                <property name="expand">False</property>
-                                <property name="fill">True</property>
-                                <property name="padding">5</property>
-                                <property name="position">0</property>
-                              </packing>
                             </child>
                             <child>
                               <object class="GtkComboBox" id="UserBrowseCombo">
-                                <property name="visible">True</property>
-                                <property name="can_focus">False</property>
-                                <property name="has_entry">True</property>
+                                <property name="visible">1</property>
+                                <property name="has-entry">1</property>
                               </object>
-                              <packing>
-                                <property name="expand">False</property>
-                                <property name="fill">True</property>
-                                <property name="position">1</property>
-                              </packing>
                             </child>
                             <child>
                               <object class="GtkButton" id="sSharesButton">
-                                <property name="visible">True</property>
-                                <property name="can_focus">True</property>
-                                <property name="receives_default">False</property>
-                                 <child>
+                                <property name="visible">1</property>
+                                <property name="can-focus">1</property>
+                                <child>
                                   <object class="GtkBox">
-                                    <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
+                                    <property name="visible">1</property>
                                     <property name="spacing">5</property>
                                     <child>
                                       <object class="GtkImage">
-                                        <property name="visible">True</property>
-                                        <property name="can_focus">False</property>
-                                        <property name="icon_name">system-file-manager-symbolic</property>
+                                        <property name="visible">1</property>
+                                        <property name="icon-name">system-file-manager-symbolic</property>
                                       </object>
                                     </child>
                                     <child>
                                       <object class="GtkLabel">
-                                        <property name="visible">True</property>
-                                        <property name="can_focus">False</property>
+                                        <property name="visible">1</property>
                                         <property name="label" translatable="yes">Browse Shares</property>
-                                        <property name="use_underline">True</property>
+                                        <property name="use-underline">1</property>
                                       </object>
                                     </child>
                                   </object>
                                 </child>
                               </object>
-                              <packing>
-                                <property name="expand">False</property>
-                                <property name="fill">False</property>
-                                <property name="position">2</property>
-                              </packing>
                             </child>
                             <child>
                               <object class="GtkButton" id="LoadFromDisk">
-                                <property name="visible">True</property>
-                                <property name="can_focus">True</property>
-                                <property name="receives_default">False</property>
+                                <property name="visible">1</property>
+                                <property name="can-focus">1</property>
                                 <signal name="clicked" handler="on_load_from_disk" swapped="no"/>
                                 <child>
                                   <object class="GtkBox">
-                                    <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
+                                    <property name="visible">1</property>
                                     <property name="spacing">5</property>
                                     <child>
                                       <object class="GtkImage">
-                                        <property name="visible">True</property>
-                                        <property name="can_focus">False</property>
-                                        <property name="icon_name">folder-symbolic</property>
+                                        <property name="visible">1</property>
+                                        <property name="icon-name">folder-symbolic</property>
                                       </object>
                                     </child>
                                     <child>
                                       <object class="GtkLabel">
-                                        <property name="visible">True</property>
-                                        <property name="can_focus">False</property>
+                                        <property name="visible">1</property>
                                         <property name="label" translatable="yes">Load from Disk</property>
-                                        <property name="use_underline">True</property>
+                                        <property name="use-underline">1</property>
                                       </object>
                                     </child>
                                   </object>
                                 </child>
                               </object>
-                              <packing>
-                                <property name="expand">False</property>
-                                <property name="fill">False</property>
-                                <property name="position">3</property>
-                              </packing>
                             </child>
                             <child>
                               <object class="GtkButton" id="configureShares">
-                                <property name="visible">True</property>
-                                <property name="can_focus">True</property>
-                                <property name="receives_default">False</property>
-                                <property name="tooltip_text" translatable="yes">Configure shares</property>
+                                <property name="visible">1</property>
+                                <property name="can-focus">1</property>
+                                <property name="tooltip-text" translatable="yes">Configure shares</property>
                                 <property name="image">ConfigureSharesImage</property>
-                                <property name="always_show_image">True</property>
+                                <property name="always-show-image">1</property>
                                 <signal name="clicked" handler="on_configure_shares" swapped="no"/>
                                 <child>
                                   <object class="GtkImage" id="ConfigureSharesImage">
-                                    <property name="can_focus">False</property>
-                                    <property name="icon_name">applications-system-symbolic</property>
+                                    <property name="icon-name">applications-system-symbolic</property>
                                   </object>
                                 </child>
                                 <style>
@@ -1601,437 +1097,275 @@
                                 </style>
                               </object>
                               <packing>
-                                <property name="expand">False</property>
-                                <property name="fill">False</property>
-                                <property name="pack_type">end</property>
-                                <property name="position">4</property>
+                                <property name="pack-type">end</property>
                               </packing>
                             </child>
                           </object>
-                          <packing>
-                            <property name="expand">False</property>
-                            <property name="fill">True</property>
-                            <property name="position">0</property>
-                          </packing>
                         </child>
                         <child>
                           <object class="GtkNotebook" id="UserBrowseNotebookRaw">
-                            <property name="visible">True</property>
-                            <property name="can_focus">True</property>
-                            <property name="show_border">True</property>
-                            <property name="scrollable">True</property>
+                            <property name="visible">1</property>
+                            <property name="can-focus">1</property>
+                            <property name="scrollable">1</property>
                           </object>
-                          <packing>
-                            <property name="expand">True</property>
-                            <property name="fill">True</property>
-                            <property name="position">1</property>
-                          </packing>
                         </child>
                       </object>
-                      <packing>
-                        <property name="position">6</property>
-                      </packing>
                     </child>
                     <child type="tab">
                       <object class="GtkEventBox" id="UserBrowseTabLabel">
-                        <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="visible_window">False</property>
-                        <child>
-                          <placeholder/>
-                        </child>
+                        <property name="visible">1</property>
+                        <property name="visible-window">0</property>
                       </object>
                       <packing>
-                        <property name="position">6</property>
-                        <property name="tab_fill">False</property>
+                        <property name="tab-fill">0</property>
                       </packing>
                     </child>
-
                     <!-- Interests -->
-
                     <child>
                       <object class="GtkBox" id="interestsvbox">
-                        <property name="visible">True</property>
-                        <property name="can_focus">False</property>
+                        <property name="visible">1</property>
                         <property name="spacing">6</property>
                         <property name="orientation">vertical</property>
-                        <child>
-                          <placeholder/>
-                        </child>
                       </object>
-                      <packing>
-                        <property name="position">7</property>
-                      </packing>
                     </child>
                     <child type="tab">
                       <object class="GtkEventBox" id="InterestsTabLabel">
-                        <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="visible_window">False</property>
-                        <child>
-                          <placeholder/>
-                        </child>
+                        <property name="visible">1</property>
+                        <property name="visible-window">0</property>
                       </object>
                       <packing>
-                        <property name="position">7</property>
-                        <property name="tab_fill">False</property>
+                        <property name="tab-fill">0</property>
                       </packing>
                     </child>
                   </object>
                   <packing>
-                    <property name="resize">True</property>
-                    <property name="shrink">False</property>
+                    <property name="shrink">0</property>
                   </packing>
                 </child>
-
                 <!-- Buddy list always visible placeholder -->
-
                 <child>
                   <object class="GtkPaned" id="vpanedm">
-                    <property name="visible">True</property>
-                    <property name="can_focus">True</property>
+                    <property name="visible">1</property>
+                    <property name="can-focus">1</property>
                     <property name="orientation">vertical</property>
-                    <child>
-                      <placeholder/>
-                    </child>
-                    <child>
-                      <placeholder/>
-                    </child>
                   </object>
-                  <packing>
-                    <property name="resize">True</property>
-                    <property name="shrink">True</property>
-                  </packing>
                 </child>
               </object>
               <packing>
-                <property name="resize">True</property>
-                <property name="shrink">False</property>
+                <property name="resize">1</property>
+                <property name="shrink">0</property>
               </packing>
             </child>
-
             <!-- Log Window -->
-
             <child>
               <object class="GtkBox" id="debugLogBox">
-                <property name="visible">True</property>
-                <property name="can_focus">False</property>
+                <property name="visible">1</property>
                 <property name="orientation">vertical</property>
                 <child>
                   <object class="GtkBox" id="debugButtonsBox">
-                    <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <property name="border_width">5</property>
+                    <property name="visible">1</property>
+                    <property name="border-width">5</property>
                     <property name="spacing">5</property>
                     <child>
                       <object class="GtkLabel" id="debugLabel">
-                        <property name="visible">True</property>
-                        <property name="can_focus">False</property>
+                        <property name="visible">1</property>
                         <property name="label" translatable="yes">Debug output:</property>
                         <property name="xalign">0</property>
+                        <property name="margin-start">5</property>
+                        <property name="margin-end">5</property>
                       </object>
-                      <packing>
-                        <property name="expand">False</property>
-                        <property name="fill">True</property>
-                        <property name="padding">5</property>
-                        <property name="position">0</property>
-                      </packing>
                     </child>
                     <child>
                       <object class="GtkCheckButton" id="debugWarnings">
                         <property name="label" translatable="yes">Warnings</property>
-                        <property name="visible">True</property>
-                        <property name="can_focus">True</property>
-                        <property name="receives_default">False</property>
-                        <property name="draw_indicator">True</property>
+                        <property name="visible">1</property>
+                        <property name="can-focus">1</property>
+                        <property name="draw-indicator">1</property>
                         <signal name="toggled" handler="on_debug_warnings" swapped="no"/>
                       </object>
-                      <packing>
-                        <property name="expand">False</property>
-                        <property name="fill">True</property>
-                        <property name="position">1</property>
-                      </packing>
                     </child>
                     <child>
                       <object class="GtkCheckButton" id="debugSearches">
                         <property name="label" translatable="yes">Search results</property>
-                        <property name="visible">True</property>
-                        <property name="can_focus">True</property>
-                        <property name="receives_default">False</property>
-                        <property name="draw_indicator">True</property>
+                        <property name="visible">1</property>
+                        <property name="can-focus">1</property>
+                        <property name="draw-indicator">1</property>
                         <signal name="toggled" handler="on_debug_searches" swapped="no"/>
                       </object>
-                      <packing>
-                        <property name="expand">False</property>
-                        <property name="fill">True</property>
-                        <property name="position">2</property>
-                      </packing>
                     </child>
                     <child>
                       <object class="GtkCheckButton" id="debugConnections">
                         <property name="label" translatable="yes">Connections</property>
-                        <property name="visible">True</property>
-                        <property name="can_focus">True</property>
-                        <property name="receives_default">False</property>
-                        <property name="draw_indicator">True</property>
+                        <property name="visible">1</property>
+                        <property name="can-focus">1</property>
+                        <property name="draw-indicator">1</property>
                         <signal name="toggled" handler="on_debug_connections" swapped="no"/>
                       </object>
-                      <packing>
-                        <property name="expand">False</property>
-                        <property name="fill">True</property>
-                        <property name="position">3</property>
-                      </packing>
                     </child>
                     <child>
                       <object class="GtkCheckButton" id="debugMessages">
                         <property name="label" translatable="yes">Messages</property>
-                        <property name="visible">True</property>
-                        <property name="can_focus">True</property>
-                        <property name="receives_default">False</property>
-                        <property name="draw_indicator">True</property>
+                        <property name="visible">1</property>
+                        <property name="can-focus">1</property>
+                        <property name="draw-indicator">1</property>
                         <signal name="toggled" handler="on_debug_messages" swapped="no"/>
                       </object>
-                      <packing>
-                        <property name="expand">False</property>
-                        <property name="fill">True</property>
-                        <property name="position">4</property>
-                      </packing>
                     </child>
                     <child>
                       <object class="GtkCheckButton" id="debugTransfers">
                         <property name="label" translatable="yes">Transfers</property>
-                        <property name="visible">True</property>
-                        <property name="can_focus">True</property>
-                        <property name="receives_default">False</property>
-                        <property name="draw_indicator">True</property>
+                        <property name="visible">1</property>
+                        <property name="can-focus">1</property>
+                        <property name="draw-indicator">1</property>
                         <signal name="toggled" handler="on_debug_transfers" swapped="no"/>
                       </object>
-                      <packing>
-                        <property name="expand">False</property>
-                        <property name="fill">True</property>
-                        <property name="position">5</property>
-                      </packing>
                     </child>
                     <child>
                       <object class="GtkCheckButton" id="debugStatistics">
                         <property name="label" translatable="yes">Statistics</property>
-                        <property name="visible">True</property>
-                        <property name="can_focus">True</property>
-                        <property name="receives_default">False</property>
-                        <property name="draw_indicator">True</property>
+                        <property name="visible">1</property>
+                        <property name="can-focus">1</property>
+                        <property name="draw-indicator">1</property>
                         <signal name="toggled" handler="on_debug_statistics" swapped="no"/>
                       </object>
-                      <packing>
-                        <property name="expand">False</property>
-                        <property name="fill">True</property>
-                        <property name="position">6</property>
-                      </packing>
                     </child>
                   </object>
-                  <packing>
-                    <property name="expand">False</property>
-                    <property name="fill">True</property>
-                    <property name="position">0</property>
-                  </packing>
                 </child>
                 <child>
                   <object class="GtkSearchBar" id="LogSearchBar">
-                    <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <property name="show_close_button">True</property>
+                    <property name="visible">1</property>
+                    <property name="show-close-button">1</property>
                     <child>
                       <object class="GtkBox">
-                        <property name="visible">True</property>
-                        <property name="can_focus">False</property>
+                        <property name="visible">1</property>
                         <property name="spacing">5</property>
                         <child>
                           <object class="GtkSearchEntry" id="LogSearchEntry">
-                            <property name="visible">True</property>
-                            <property name="can_focus">True</property>
-                            <property name="max_width_chars">75</property>
-                            <property name="primary_icon_name">edit-find-symbolic</property>
-                            <property name="primary_icon_activatable">False</property>
-                            <property name="primary_icon_sensitive">False</property>
+                            <property name="visible">1</property>
+                            <property name="can-focus">1</property>
+                            <property name="max-width-chars">75</property>
                           </object>
-                          <packing>
-                            <property name="expand">False</property>
-                            <property name="fill">True</property>
-                            <property name="position">0</property>
-                          </packing>
                         </child>
                       </object>
                     </child>
                   </object>
-                  <packing>
-                    <property name="expand">False</property>
-                    <property name="fill">True</property>
-                    <property name="position">1</property>
-                  </packing>
                 </child>
                 <child>
                   <object class="GtkScrolledWindow" id="LogScrolledWindow">
-                    <property name="visible">True</property>
-                    <property name="can_focus">True</property>
-                    <property name="min_content_height">90</property>
-                    <property name="hscrollbar_policy">automatic</property>
-                    <property name="vscrollbar_policy">automatic</property>
+                    <property name="visible">1</property>
+                    <property name="can-focus">1</property>
+                    <property name="min-content-height">90</property>
+                    <property name="vexpand">1</property>
                     <child>
                       <object class="GtkTextView" id="LogWindow">
-                        <property name="visible">True</property>
-                        <property name="can_focus">True</property>
-                        <property name="editable">False</property>
-                        <property name="cursor_visible">False</property>
-                        <property name="pixels_above_lines">1</property>
-                        <property name="pixels_below_lines">1</property>
-                        <property name="left_margin">10</property>
-                        <property name="right_margin">10</property>
-                        <property name="top_margin">5</property>
-                        <property name="bottom_margin">5</property>
+                        <property name="visible">1</property>
+                        <property name="can-focus">1</property>
+                        <property name="editable">0</property>
+                        <property name="cursor-visible">0</property>
+                        <property name="pixels-above-lines">1</property>
+                        <property name="pixels-below-lines">1</property>
+                        <property name="left-margin">10</property>
+                        <property name="right-margin">10</property>
+                        <property name="top-margin">5</property>
+                        <property name="bottom-margin">5</property>
                         <signal name="button-press-event" handler="on_popup_log_menu" swapped="no"/>
                       </object>
                     </child>
                   </object>
-                  <packing>
-                    <property name="expand">True</property>
-                    <property name="fill">True</property>
-                    <property name="position">2</property>
-                  </packing>
                 </child>
               </object>
               <packing>
-                <property name="resize">False</property>
-                <property name="shrink">False</property>
+                <property name="resize">0</property>
+                <property name="shrink">0</property>
               </packing>
             </child>
           </object>
-          <packing>
-            <property name="expand">True</property>
-            <property name="fill">True</property>
-            <property name="position">1</property>
-          </packing>
         </child>
-
         <!-- Status Bar -->
-
         <child>
           <object class="GtkBox">
-            <property name="visible">True</property>
-            <property name="can_focus">False</property>
+            <property name="visible">1</property>
             <child>
               <object class="GtkStatusbar" id="UpStatus">
-                <property name="width_request">200</property>
-                <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="margin_top">3</property>
-                <property name="margin_bottom">3</property>
+                <property name="width-request">200</property>
+                <property name="visible">1</property>
+                <property name="margin-top">3</property>
+                <property name="margin-bottom">3</property>
               </object>
               <packing>
-                <property name="expand">False</property>
-                <property name="fill">True</property>
-                <property name="pack_type">end</property>
-                <property name="position">0</property>
+                <property name="pack-type">end</property>
               </packing>
             </child>
             <child>
               <object class="GtkStatusbar" id="DownStatus">
-                <property name="width_request">200</property>
-                <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="margin_top">3</property>
-                <property name="margin_bottom">3</property>
+                <property name="width-request">200</property>
+                <property name="visible">1</property>
+                <property name="margin-top">3</property>
+                <property name="margin-bottom">3</property>
               </object>
               <packing>
-                <property name="expand">False</property>
-                <property name="fill">True</property>
-                <property name="pack_type">end</property>
-                <property name="position">1</property>
+                <property name="pack-type">end</property>
               </packing>
             </child>
             <child>
               <object class="GtkStatusbar" id="SocketStatus">
-                <property name="width_request">150</property>
-                <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="margin_top">3</property>
-                <property name="margin_bottom">3</property>
+                <property name="width-request">150</property>
+                <property name="visible">1</property>
+                <property name="margin-top">3</property>
+                <property name="margin-bottom">3</property>
               </object>
               <packing>
-                <property name="expand">False</property>
-                <property name="fill">True</property>
-                <property name="pack_type">end</property>
-                <property name="position">2</property>
+                <property name="pack-type">end</property>
               </packing>
             </child>
             <child>
               <object class="GtkStatusbar" id="UserStatus">
-                <property name="width_request">80</property>
-                <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="margin_top">3</property>
-                <property name="margin_bottom">3</property>
+                <property name="width-request">80</property>
+                <property name="visible">1</property>
+                <property name="margin-top">3</property>
+                <property name="margin-bottom">3</property>
               </object>
               <packing>
-                <property name="expand">False</property>
-                <property name="fill">True</property>
-                <property name="pack_type">end</property>
-                <property name="position">3</property>
+                <property name="pack-type">end</property>
               </packing>
             </child>
             <child>
               <object class="GtkProgressBar" id="BuddySharesProgress">
-                <property name="can_focus">False</property>
                 <property name="valign">center</property>
-                <property name="pulse_step">0.10000000149</property>
+                <property name="pulse-step">0.10000000149</property>
                 <property name="text" translatable="yes">Scanning Buddy Shares</property>
-                <property name="show_text">True</property>
+                <property name="show-text">1</property>
               </object>
               <packing>
-                <property name="expand">False</property>
-                <property name="fill">False</property>
-                <property name="pack_type">end</property>
-                <property name="position">4</property>
+                <property name="pack-type">end</property>
               </packing>
             </child>
             <child>
               <object class="GtkProgressBar" id="SharesProgress">
-                <property name="can_focus">False</property>
                 <property name="valign">center</property>
-                <property name="pulse_step">0.10000000149</property>
+                <property name="pulse-step">0.10000000149</property>
                 <property name="text" translatable="yes">Scanning Shares</property>
-                <property name="show_text">True</property>
+                <property name="show-text">1</property>
               </object>
               <packing>
-                <property name="expand">False</property>
-                <property name="fill">False</property>
-                <property name="pack_type">end</property>
-                <property name="position">5</property>
+                <property name="pack-type">end</property>
               </packing>
             </child>
             <child>
               <object class="GtkStatusbar" id="Statusbar">
-                <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="margin_top">3</property>
-                <property name="margin_bottom">3</property>
+                <property name="visible">1</property>
+                <property name="margin-top">3</property>
+                <property name="margin-bottom">3</property>
               </object>
               <packing>
-                <property name="expand">True</property>
-                <property name="fill">True</property>
-                <property name="pack_type">end</property>
-                <property name="position">6</property>
+                <property name="pack-type">end</property>
               </packing>
             </child>
           </object>
-          <packing>
-            <property name="expand">False</property>
-            <property name="fill">False</property>
-            <property name="position">2</property>
-          </packing>
         </child>
       </object>
     </child>
     <child type="titlebar">
-      <placeholder/>
     </child>
   </object>
 </interface>

--- a/pynicotine/gtkgui/ui/mainwindow.ui
+++ b/pynicotine/gtkgui/ui/mainwindow.ui
@@ -69,7 +69,10 @@
                         <child>
                           <object class="GtkBox">
                             <property name="visible">1</property>
-                            <property name="margin">6</property>
+                            <property name="margin-start">6</property>
+                            <property name="margin-end">6</property>
+                            <property name="margin-top">6</property>
+                            <property name="margin-bottom">6</property>
                             <property name="spacing">6</property>
                             <child>
                               <object class="GtkLabel">
@@ -115,18 +118,18 @@
                                 <property name="visible">1</property>
                                 <property name="can-focus">1</property>
                                 <property name="tooltip-text" translatable="yes">Configure logging</property>
-                                <property name="image">ConfigureLogImage</property>
-                                <property name="always-show-image">1</property>
                                 <property name="halign">end</property>
                                 <property name="hexpand">True</property>
                                 <signal name="clicked" handler="on_settings_logging" swapped="no"/>
                                 <child>
-                                  <object class="GtkImage" id="ConfigureLogImage">
+                                  <object class="GtkImage">
+                                    <property name="visible">1</property>
                                     <property name="icon-name">applications-system-symbolic</property>
                                   </object>
                                 </child>
                                 <style>
                                   <class name="circular"/>
+                                  <class name="image-button"/>
                                 </style>
                               </object>
                             </child>
@@ -158,7 +161,10 @@
                         <child>
                           <object class="GtkBox">
                             <property name="visible">1</property>
-                            <property name="margin">6</property>
+                            <property name="margin-start">6</property>
+                            <property name="margin-end">6</property>
+                            <property name="margin-top">6</property>
+                            <property name="margin-bottom">6</property>
                             <property name="spacing">6</property>
                             <child>
                               <object class="GtkBox">
@@ -258,13 +264,15 @@
                                 <property name="visible">1</property>
                                 <property name="can-focus">1</property>
                                 <property name="tooltip-text" translatable="yes">Expand / Collapse all</property>
-                                <property name="image">ExpandDownloadsImage</property>
-                                <property name="always-show-image">1</property>
                                 <child>
                                   <object class="GtkImage" id="ExpandDownloadsImage">
+                                    <property name="visible">1</property>
                                     <property name="icon-name">list-remove-symbolic</property>
                                   </object>
                                 </child>
+                                <style>
+                                  <class name="image-button"/>
+                                </style>
                               </object>
                             </child>
                             <child>
@@ -278,16 +286,16 @@
                                 <property name="visible">1</property>
                                 <property name="can-focus">1</property>
                                 <property name="tooltip-text" translatable="yes">Configure downloads</property>
-                                <property name="image">ConfigureTransfersImage</property>
-                                <property name="always-show-image">1</property>
                                 <signal name="clicked" handler="on_settings_downloads" swapped="no"/>
                                 <child>
-                                  <object class="GtkImage" id="ConfigureTransfersImage">
+                                  <object class="GtkImage">
+                                    <property name="visible">1</property>
                                     <property name="icon-name">applications-system-symbolic</property>
                                   </object>
                                 </child>
                                 <style>
                                   <class name="circular"/>
+                                  <class name="image-button"/>
                                 </style>
                               </object>
                             </child>
@@ -312,7 +320,10 @@
                         <child>
                           <object class="GtkBox" id="DownloadButtons">
                             <property name="visible">1</property>
-                            <property name="margin">6</property>
+                            <property name="margin-start">6</property>
+                            <property name="margin-end">6</property>
+                            <property name="margin-top">6</property>
+                            <property name="margin-bottom">6</property>
                             <property name="spacing">6</property>
                             <child>
                               <object class="GtkBox">
@@ -467,7 +478,10 @@
                         <child>
                           <object class="GtkBox">
                             <property name="visible">1</property>
-                            <property name="margin">6</property>
+                            <property name="margin-start">6</property>
+                            <property name="margin-end">6</property>
+                            <property name="margin-top">6</property>
+                            <property name="margin-bottom">6</property>
                             <property name="spacing">6</property>
                             <child>
                               <object class="GtkBox">
@@ -563,13 +577,15 @@
                                 <property name="can-focus">1</property>
                                 <property name="tooltip-text" translatable="yes">Expand / Collapse all</property>
                                 <property name="active">1</property>
-                                <property name="image">ExpandUploadsImage</property>
-                                <property name="always-show-image">1</property>
                                 <child>
                                   <object class="GtkImage" id="ExpandUploadsImage">
+                                    <property name="visible">1</property>
                                     <property name="icon-name">list-remove-symbolic</property>
                                   </object>
                                 </child>
+                                <style>
+                                  <class name="image-button"/>
+                                </style>
                               </object>
                             </child>
                             <child>
@@ -583,16 +599,16 @@
                                 <property name="visible">1</property>
                                 <property name="can-focus">1</property>
                                 <property name="tooltip-text" translatable="yes">Configure uploads</property>
-                                <property name="image">ConfigureTransfers2Image</property>
-                                <property name="always-show-image">1</property>
                                 <signal name="clicked" handler="on_settings_uploads" swapped="no"/>
                                 <child>
-                                  <object class="GtkImage" id="ConfigureTransfers2Image">
+                                  <object class="GtkImage">
+                                    <property name="visible">1</property>
                                     <property name="icon-name">applications-system-symbolic</property>
                                   </object>
                                 </child>
                                 <style>
                                   <class name="circular"/>
+                                  <class name="image-button"/>
                                 </style>
                               </object>
                             </child>
@@ -617,7 +633,10 @@
                         <child>
                           <object class="GtkBox" id="UploadButtons">
                             <property name="visible">1</property>
-                            <property name="margin">6</property>
+                            <property name="margin-start">6</property>
+                            <property name="margin-end">6</property>
+                            <property name="margin-top">6</property>
+                            <property name="margin-bottom">6</property>
                             <property name="spacing">6</property>
                             <child>
                               <object class="GtkBox">
@@ -772,7 +791,10 @@
                         <child>
                           <object class="GtkBox">
                             <property name="visible">1</property>
-                            <property name="margin">6</property>
+                            <property name="margin-start">6</property>
+                            <property name="margin-end">6</property>
+                            <property name="margin-top">6</property>
+                            <property name="margin-bottom">6</property>
                             <property name="spacing">6</property>
                             <child>
                               <object class="GtkComboBox" id="SearchMethod">
@@ -805,11 +827,10 @@
                                 <property name="visible">1</property>
                                 <property name="can-focus">1</property>
                                 <property name="tooltip-text" translatable="yes">Clear all searches attempts</property>
-                                <property name="image">ClearSearchHistoryImage</property>
-                                <property name="always-show-image">1</property>
                                 <signal name="clicked" handler="on_clear_search_history" swapped="no"/>
                                 <child>
-                                  <object class="GtkImage" id="ClearSearchHistoryImage">
+                                  <object class="GtkImage">
+                                    <property name="visible">1</property>
                                     <property name="icon-name">edit-clear-symbolic</property>
                                   </object>
                                 </child>
@@ -871,16 +892,16 @@
                                 <property name="visible">1</property>
                                 <property name="can-focus">1</property>
                                 <property name="tooltip-text" translatable="yes">Configure searches</property>
-                                <property name="image">ConfigureSearchesImage</property>
-                                <property name="always-show-image">1</property>
                                 <signal name="clicked" handler="on_settings_searches" swapped="no"/>
                                 <child>
-                                  <object class="GtkImage" id="ConfigureSearchesImage">
+                                  <object class="GtkImage">
+                                    <property name="visible">1</property>
                                     <property name="icon-name">applications-system-symbolic</property>
                                   </object>
                                 </child>
                                 <style>
                                   <class name="circular"/>
+                                  <class name="image-button"/>
                                 </style>
                               </object>
                             </child>
@@ -912,7 +933,10 @@
                         <child>
                           <object class="GtkBox">
                             <property name="visible">1</property>
-                            <property name="margin">6</property>
+                            <property name="margin-start">6</property>
+                            <property name="margin-end">6</property>
+                            <property name="margin-top">6</property>
+                            <property name="margin-bottom">6</property>
                             <property name="spacing">6</property>
                             <child>
                               <object class="GtkLabel">
@@ -958,18 +982,18 @@
                                 <property name="visible">1</property>
                                 <property name="can-focus">1</property>
                                 <property name="tooltip-text" translatable="yes">Configure user info</property>
-                                <property name="image">ConfigureUserinfoImage</property>
-                                <property name="always-show-image">1</property>
                                 <property name="halign">end</property>
                                 <property name="hexpand">True</property>
                                 <signal name="clicked" handler="on_settings_userinfo" swapped="no"/>
                                 <child>
-                                  <object class="GtkImage" id="ConfigureUserinfoImage">
+                                  <object class="GtkImage">
+                                    <property name="visible">1</property>
                                     <property name="icon-name">applications-system-symbolic</property>
                                   </object>
                                 </child>
                                 <style>
                                   <class name="circular"/>
+                                  <class name="image-button"/>
                                 </style>
                               </object>
                             </child>
@@ -1001,7 +1025,10 @@
                         <child>
                           <object class="GtkBox">
                             <property name="visible">1</property>
-                            <property name="margin">6</property>
+                            <property name="margin-start">6</property>
+                            <property name="margin-end">6</property>
+                            <property name="margin-top">6</property>
+                            <property name="margin-bottom">6</property>
                             <property name="spacing">6</property>
                             <child>
                               <object class="GtkLabel">
@@ -1073,18 +1100,18 @@
                                 <property name="visible">1</property>
                                 <property name="can-focus">1</property>
                                 <property name="tooltip-text" translatable="yes">Configure shares</property>
-                                <property name="image">ConfigureSharesImage</property>
-                                <property name="always-show-image">1</property>
                                 <property name="halign">end</property>
                                 <property name="hexpand">True</property>
                                 <signal name="clicked" handler="on_configure_shares" swapped="no"/>
                                 <child>
-                                  <object class="GtkImage" id="ConfigureSharesImage">
+                                  <object class="GtkImage">
+                                    <property name="visible">1</property>
                                     <property name="icon-name">applications-system-symbolic</property>
                                   </object>
                                 </child>
                                 <style>
                                   <class name="circular"/>
+                                  <class name="image-button"/>
                                 </style>
                               </object>
                             </child>
@@ -1152,7 +1179,10 @@
                 <child>
                   <object class="GtkBox" id="debugButtonsBox">
                     <property name="visible">1</property>
-                    <property name="margin">5</property>
+                    <property name="margin-start">6</property>
+                    <property name="margin-end">6</property>
+                    <property name="margin-top">6</property>
+                    <property name="margin-bottom">6</property>
                     <property name="spacing">5</property>
                     <child>
                       <object class="GtkLabel" id="debugLabel">

--- a/pynicotine/gtkgui/ui/mainwindow.ui
+++ b/pynicotine/gtkgui/ui/mainwindow.ui
@@ -69,7 +69,7 @@
                         <child>
                           <object class="GtkBox">
                             <property name="visible">1</property>
-                            <property name="border-width">6</property>
+                            <property name="margin">6</property>
                             <property name="spacing">6</property>
                             <child>
                               <object class="GtkLabel">
@@ -158,7 +158,7 @@
                         <child>
                           <object class="GtkBox">
                             <property name="visible">1</property>
-                            <property name="border-width">6</property>
+                            <property name="margin">6</property>
                             <property name="spacing">6</property>
                             <child>
                               <object class="GtkBox">
@@ -313,7 +313,7 @@
                         <child>
                           <object class="GtkBox" id="DownloadButtons">
                             <property name="visible">1</property>
-                            <property name="border-width">6</property>
+                            <property name="margin">6</property>
                             <property name="spacing">6</property>
                             <child>
                               <object class="GtkBox">
@@ -468,7 +468,7 @@
                         <child>
                           <object class="GtkBox">
                             <property name="visible">1</property>
-                            <property name="border-width">6</property>
+                            <property name="margin">6</property>
                             <property name="spacing">6</property>
                             <child>
                               <object class="GtkBox">
@@ -619,7 +619,7 @@
                         <child>
                           <object class="GtkBox" id="UploadButtons">
                             <property name="visible">1</property>
-                            <property name="border-width">6</property>
+                            <property name="margin">6</property>
                             <property name="spacing">6</property>
                             <child>
                               <object class="GtkBox">
@@ -774,7 +774,7 @@
                         <child>
                           <object class="GtkBox">
                             <property name="visible">1</property>
-                            <property name="border-width">6</property>
+                            <property name="margin">6</property>
                             <property name="spacing">6</property>
                             <child>
                               <object class="GtkComboBox" id="SearchMethod">
@@ -914,7 +914,7 @@
                         <child>
                           <object class="GtkBox">
                             <property name="visible">1</property>
-                            <property name="border-width">6</property>
+                            <property name="margin">6</property>
                             <property name="spacing">6</property>
                             <child>
                               <object class="GtkLabel">
@@ -1003,7 +1003,7 @@
                         <child>
                           <object class="GtkBox">
                             <property name="visible">1</property>
-                            <property name="border-width">6</property>
+                            <property name="margin">6</property>
                             <property name="spacing">6</property>
                             <child>
                               <object class="GtkLabel">
@@ -1154,7 +1154,7 @@
                 <child>
                   <object class="GtkBox" id="debugButtonsBox">
                     <property name="visible">1</property>
-                    <property name="border-width">5</property>
+                    <property name="margin">5</property>
                     <property name="spacing">5</property>
                     <child>
                       <object class="GtkLabel" id="debugLabel">

--- a/pynicotine/gtkgui/ui/mainwindow.ui
+++ b/pynicotine/gtkgui/ui/mainwindow.ui
@@ -1156,6 +1156,10 @@
                     <property name="can-focus">1</property>
                     <property name="orientation">vertical</property>
                   </object>
+                  <packing>
+                    <property name="resize">0</property>
+                    <property name="shrink">1</property>
+                  </packing>
                 </child>
               </object>
               <packing>

--- a/pynicotine/gtkgui/ui/mainwindow.ui
+++ b/pynicotine/gtkgui/ui/mainwindow.ui
@@ -53,9 +53,8 @@
                       </object>
                     </child>
                     <child type="tab">
-                      <object class="GtkEventBox" id="ChatTabLabel">
+                      <object class="GtkBox" id="ChatTabLabel">
                         <property name="visible">1</property>
-                        <property name="visible-window">0</property>
                       </object>
                       <packing>
                         <property name="tab-fill">0</property>
@@ -145,9 +144,8 @@
                       </object>
                     </child>
                     <child type="tab">
-                      <object class="GtkEventBox" id="PrivateChatTabLabel">
+                      <object class="GtkBox" id="PrivateChatTabLabel">
                         <property name="visible">1</property>
-                        <property name="visible-window">0</property>
                       </object>
                       <packing>
                         <property name="tab-fill">0</property>
@@ -462,9 +460,8 @@
                       </object>
                     </child>
                     <child type="tab">
-                      <object class="GtkEventBox" id="DownloadsTabLabel">
+                      <object class="GtkBox" id="DownloadsTabLabel">
                         <property name="visible">1</property>
-                        <property name="visible-window">0</property>
                       </object>
                       <packing>
                         <property name="tab-fill">0</property>
@@ -775,9 +772,8 @@
                       </object>
                     </child>
                     <child type="tab">
-                      <object class="GtkEventBox" id="UploadsTabLabel">
+                      <object class="GtkBox" id="UploadsTabLabel">
                         <property name="visible">1</property>
-                        <property name="visible-window">0</property>
                       </object>
                       <packing>
                         <property name="tab-fill">0</property>
@@ -917,9 +913,8 @@
                       </object>
                     </child>
                     <child type="tab">
-                      <object class="GtkEventBox" id="SearchTabLabel">
+                      <object class="GtkBox" id="SearchTabLabel">
                         <property name="visible">1</property>
-                        <property name="visible-window">0</property>
                       </object>
                       <packing>
                         <property name="tab-fill">0</property>
@@ -1009,9 +1004,8 @@
                       </object>
                     </child>
                     <child type="tab">
-                      <object class="GtkEventBox" id="UserInfoTabLabel">
+                      <object class="GtkBox" id="UserInfoTabLabel">
                         <property name="visible">1</property>
-                        <property name="visible-window">0</property>
                       </object>
                       <packing>
                         <property name="tab-fill">0</property>
@@ -1127,9 +1121,8 @@
                       </object>
                     </child>
                     <child type="tab">
-                      <object class="GtkEventBox" id="UserBrowseTabLabel">
+                      <object class="GtkBox" id="UserBrowseTabLabel">
                         <property name="visible">1</property>
-                        <property name="visible-window">0</property>
                       </object>
                       <packing>
                         <property name="tab-fill">0</property>
@@ -1144,9 +1137,8 @@
                       </object>
                     </child>
                     <child type="tab">
-                      <object class="GtkEventBox" id="InterestsTabLabel">
+                      <object class="GtkBox" id="InterestsTabLabel">
                         <property name="visible">1</property>
-                        <property name="visible-window">0</property>
                       </object>
                       <packing>
                         <property name="tab-fill">0</property>

--- a/pynicotine/gtkgui/ui/mainwindow.ui
+++ b/pynicotine/gtkgui/ui/mainwindow.ui
@@ -117,6 +117,8 @@
                                 <property name="tooltip-text" translatable="yes">Configure logging</property>
                                 <property name="image">ConfigureLogImage</property>
                                 <property name="always-show-image">1</property>
+                                <property name="halign">end</property>
+                                <property name="hexpand">True</property>
                                 <signal name="clicked" handler="on_settings_logging" swapped="no"/>
                                 <child>
                                   <object class="GtkImage" id="ConfigureLogImage">
@@ -127,9 +129,6 @@
                                   <class name="circular"/>
                                 </style>
                               </object>
-                              <packing>
-                                <property name="pack-type">end</property>
-                              </packing>
                             </child>
                           </object>
                         </child>
@@ -317,7 +316,64 @@
                             <property name="border-width">6</property>
                             <property name="spacing">6</property>
                             <child>
-                              <object class="GtkButton" id="clearFinishedAbortedButton">
+                              <object class="GtkBox">
+                                <property name="visible">1</property>
+                                <property name="hexpand">1</property>
+                                <property name="spacing">6</property>
+                                <child>
+                                  <object class="GtkButton" id="clearFinishedAbortedButton">
+                                    <property name="visible">1</property>
+                                    <property name="can-focus">1</property>
+                                    <child>
+                                      <object class="GtkBox">
+                                        <property name="visible">1</property>
+                                        <property name="spacing">5</property>
+                                        <child>
+                                          <object class="GtkImage">
+                                            <property name="visible">1</property>
+                                            <property name="icon-name">edit-clear-symbolic</property>
+                                          </object>
+                                        </child>
+                                        <child>
+                                          <object class="GtkLabel">
+                                            <property name="visible">1</property>
+                                            <property name="label" translatable="yes">Clear Finished / Aborted</property>
+                                            <property name="use-underline">1</property>
+                                          </object>
+                                        </child>
+                                      </object>
+                                    </child>
+                                  </object>
+                                </child>
+                                <child>
+                                  <object class="GtkButton" id="clearQueuedButton">
+                                    <property name="visible">1</property>
+                                    <property name="can-focus">1</property>
+                                    <child>
+                                      <object class="GtkBox">
+                                        <property name="visible">1</property>
+                                        <property name="spacing">5</property>
+                                        <child>
+                                          <object class="GtkImage">
+                                            <property name="visible">1</property>
+                                            <property name="icon-name">edit-clear-symbolic</property>
+                                          </object>
+                                        </child>
+                                        <child>
+                                          <object class="GtkLabel">
+                                            <property name="visible">1</property>
+                                            <property name="label" translatable="yes">Clear Queued</property>
+                                            <property name="use-underline">1</property>
+                                          </object>
+                                        </child>
+                                      </object>
+                                    </child>
+                                  </object>
+                                </child>
+                              </object>
+                            </child>
+                            <child>
+                              <object class="GtkButton" id="retryTransferButton">
                                 <property name="visible">1</property>
                                 <property name="can-focus">1</property>
                                 <child>
@@ -327,13 +383,13 @@
                                     <child>
                                       <object class="GtkImage">
                                         <property name="visible">1</property>
-                                        <property name="icon-name">edit-clear-symbolic</property>
+                                        <property name="icon-name">edit-redo-symbolic</property>
                                       </object>
                                     </child>
                                     <child>
                                       <object class="GtkLabel">
                                         <property name="visible">1</property>
-                                        <property name="label" translatable="yes">Clear Finished / Aborted</property>
+                                        <property name="label" translatable="yes">Retry</property>
                                         <property name="use-underline">1</property>
                                       </object>
                                     </child>
@@ -342,7 +398,7 @@
                               </object>
                             </child>
                             <child>
-                              <object class="GtkButton" id="clearQueuedButton">
+                              <object class="GtkButton" id="abortTransferButton">
                                 <property name="visible">1</property>
                                 <property name="can-focus">1</property>
                                 <child>
@@ -352,13 +408,13 @@
                                     <child>
                                       <object class="GtkImage">
                                         <property name="visible">1</property>
-                                        <property name="icon-name">edit-clear-symbolic</property>
+                                        <property name="icon-name">system-shutdown-symbolic</property>
                                       </object>
                                     </child>
                                     <child>
                                       <object class="GtkLabel">
                                         <property name="visible">1</property>
-                                        <property name="label" translatable="yes">Clear Queued</property>
+                                        <property name="label" translatable="yes">Abort</property>
                                         <property name="use-underline">1</property>
                                       </object>
                                     </child>
@@ -390,65 +446,6 @@
                                   </object>
                                 </child>
                               </object>
-                              <packing>
-                                <property name="pack-type">end</property>
-                              </packing>
-                            </child>
-                            <child>
-                              <object class="GtkButton" id="abortTransferButton">
-                                <property name="visible">1</property>
-                                <property name="can-focus">1</property>
-                                <child>
-                                  <object class="GtkBox">
-                                    <property name="visible">1</property>
-                                    <property name="spacing">5</property>
-                                    <child>
-                                      <object class="GtkImage">
-                                        <property name="visible">1</property>
-                                        <property name="icon-name">system-shutdown-symbolic</property>
-                                      </object>
-                                    </child>
-                                    <child>
-                                      <object class="GtkLabel">
-                                        <property name="visible">1</property>
-                                        <property name="label" translatable="yes">Abort</property>
-                                        <property name="use-underline">1</property>
-                                      </object>
-                                    </child>
-                                  </object>
-                                </child>
-                              </object>
-                              <packing>
-                                <property name="pack-type">end</property>
-                              </packing>
-                            </child>
-                            <child>
-                              <object class="GtkButton" id="retryTransferButton">
-                                <property name="visible">1</property>
-                                <property name="can-focus">1</property>
-                                <child>
-                                  <object class="GtkBox">
-                                    <property name="visible">1</property>
-                                    <property name="spacing">5</property>
-                                    <child>
-                                      <object class="GtkImage">
-                                        <property name="visible">1</property>
-                                        <property name="icon-name">edit-redo-symbolic</property>
-                                      </object>
-                                    </child>
-                                    <child>
-                                      <object class="GtkLabel">
-                                        <property name="visible">1</property>
-                                        <property name="label" translatable="yes">Retry</property>
-                                        <property name="use-underline">1</property>
-                                      </object>
-                                    </child>
-                                  </object>
-                                </child>
-                              </object>
-                              <packing>
-                                <property name="pack-type">end</property>
-                              </packing>
                             </child>
                           </object>
                         </child>
@@ -625,24 +622,56 @@
                             <property name="border-width">6</property>
                             <property name="spacing">6</property>
                             <child>
-                              <object class="GtkButton" id="clearUploadFinishedErredButton">
+                              <object class="GtkBox">
                                 <property name="visible">1</property>
-                                <property name="can-focus">1</property>
+                                <property name="hexpand">1</property>
+                                <property name="spacing">6</property>
                                 <child>
-                                  <object class="GtkBox">
+                                  <object class="GtkButton" id="clearUploadFinishedErredButton">
                                     <property name="visible">1</property>
-                                    <property name="spacing">6</property>
+                                    <property name="can-focus">1</property>
                                     <child>
-                                      <object class="GtkImage">
+                                      <object class="GtkBox">
                                         <property name="visible">1</property>
-                                        <property name="icon-name">edit-clear-symbolic</property>
+                                        <property name="spacing">6</property>
+                                        <child>
+                                          <object class="GtkImage">
+                                            <property name="visible">1</property>
+                                            <property name="icon-name">edit-clear-symbolic</property>
+                                          </object>
+                                        </child>
+                                        <child>
+                                          <object class="GtkLabel">
+                                            <property name="visible">1</property>
+                                            <property name="label" translatable="yes">Clear Finished / Failed</property>
+                                            <property name="use-underline">1</property>
+                                          </object>
+                                        </child>
                                       </object>
                                     </child>
+                                  </object>
+                                </child>
+                                <child>
+                                  <object class="GtkButton" id="clearUploadQueueButton">
+                                    <property name="visible">1</property>
+                                    <property name="can-focus">1</property>
                                     <child>
-                                      <object class="GtkLabel">
+                                      <object class="GtkBox">
                                         <property name="visible">1</property>
-                                        <property name="label" translatable="yes">Clear Finished / Failed</property>
-                                        <property name="use-underline">1</property>
+                                        <property name="spacing">5</property>
+                                        <child>
+                                          <object class="GtkImage">
+                                            <property name="visible">1</property>
+                                            <property name="icon-name">edit-clear-symbolic</property>
+                                          </object>
+                                        </child>
+                                        <child>
+                                          <object class="GtkLabel">
+                                            <property name="visible">1</property>
+                                            <property name="label" translatable="yes">Clear Queued</property>
+                                            <property name="use-underline">1</property>
+                                          </object>
+                                        </child>
                                       </object>
                                     </child>
                                   </object>
@@ -650,7 +679,7 @@
                               </object>
                             </child>
                             <child>
-                              <object class="GtkButton" id="clearUploadQueueButton">
+                              <object class="GtkButton" id="abortUploadButton">
                                 <property name="visible">1</property>
                                 <property name="can-focus">1</property>
                                 <child>
@@ -660,13 +689,38 @@
                                     <child>
                                       <object class="GtkImage">
                                         <property name="visible">1</property>
-                                        <property name="icon-name">edit-clear-symbolic</property>
+                                        <property name="icon-name">system-shutdown-symbolic</property>
                                       </object>
                                     </child>
                                     <child>
                                       <object class="GtkLabel">
                                         <property name="visible">1</property>
-                                        <property name="label" translatable="yes">Clear Queued</property>
+                                        <property name="label" translatable="yes">Abort</property>
+                                        <property name="use-underline">1</property>
+                                      </object>
+                                    </child>
+                                  </object>
+                                </child>
+                              </object>
+                            </child>
+                            <child>
+                              <object class="GtkButton" id="abortUserUploadButton">
+                                <property name="visible">1</property>
+                                <property name="can-focus">1</property>
+                                <child>
+                                  <object class="GtkBox">
+                                    <property name="visible">1</property>
+                                    <property name="spacing">5</property>
+                                    <child>
+                                      <object class="GtkImage">
+                                        <property name="visible">1</property>
+                                        <property name="icon-name">system-shutdown-symbolic</property>
+                                      </object>
+                                    </child>
+                                    <child>
+                                      <object class="GtkLabel">
+                                        <property name="visible">1</property>
+                                        <property name="label" translatable="yes">Abort User&apos;s Uploads</property>
                                         <property name="use-underline">1</property>
                                       </object>
                                     </child>
@@ -698,65 +752,6 @@
                                   </object>
                                 </child>
                               </object>
-                              <packing>
-                                <property name="pack-type">end</property>
-                              </packing>
-                            </child>
-                            <child>
-                              <object class="GtkButton" id="abortUserUploadButton">
-                                <property name="visible">1</property>
-                                <property name="can-focus">1</property>
-                                <child>
-                                  <object class="GtkBox">
-                                    <property name="visible">1</property>
-                                    <property name="spacing">5</property>
-                                    <child>
-                                      <object class="GtkImage">
-                                        <property name="visible">1</property>
-                                        <property name="icon-name">system-shutdown-symbolic</property>
-                                      </object>
-                                    </child>
-                                    <child>
-                                      <object class="GtkLabel">
-                                        <property name="visible">1</property>
-                                        <property name="label" translatable="yes">Abort User&apos;s Uploads</property>
-                                        <property name="use-underline">1</property>
-                                      </object>
-                                    </child>
-                                  </object>
-                                </child>
-                              </object>
-                              <packing>
-                                <property name="pack-type">end</property>
-                              </packing>
-                            </child>
-                            <child>
-                              <object class="GtkButton" id="abortUploadButton">
-                                <property name="visible">1</property>
-                                <property name="can-focus">1</property>
-                                <child>
-                                  <object class="GtkBox">
-                                    <property name="visible">1</property>
-                                    <property name="spacing">5</property>
-                                    <child>
-                                      <object class="GtkImage">
-                                        <property name="visible">1</property>
-                                        <property name="icon-name">system-shutdown-symbolic</property>
-                                      </object>
-                                    </child>
-                                    <child>
-                                      <object class="GtkLabel">
-                                        <property name="visible">1</property>
-                                        <property name="label" translatable="yes">Abort</property>
-                                        <property name="use-underline">1</property>
-                                      </object>
-                                    </child>
-                                  </object>
-                                </child>
-                              </object>
-                              <packing>
-                                <property name="pack-type">end</property>
-                              </packing>
                             </child>
                           </object>
                         </child>
@@ -890,9 +885,6 @@
                                   <class name="circular"/>
                                 </style>
                               </object>
-                              <packing>
-                                <property name="pack-type">end</property>
-                              </packing>
                             </child>
                           </object>
                         </child>
@@ -970,6 +962,8 @@
                                 <property name="tooltip-text" translatable="yes">Configure user info</property>
                                 <property name="image">ConfigureUserinfoImage</property>
                                 <property name="always-show-image">1</property>
+                                <property name="halign">end</property>
+                                <property name="hexpand">True</property>
                                 <signal name="clicked" handler="on_settings_userinfo" swapped="no"/>
                                 <child>
                                   <object class="GtkImage" id="ConfigureUserinfoImage">
@@ -980,9 +974,6 @@
                                   <class name="circular"/>
                                 </style>
                               </object>
-                              <packing>
-                                <property name="pack-type">end</property>
-                              </packing>
                             </child>
                           </object>
                         </child>
@@ -1086,6 +1077,8 @@
                                 <property name="tooltip-text" translatable="yes">Configure shares</property>
                                 <property name="image">ConfigureSharesImage</property>
                                 <property name="always-show-image">1</property>
+                                <property name="halign">end</property>
+                                <property name="hexpand">True</property>
                                 <signal name="clicked" handler="on_configure_shares" swapped="no"/>
                                 <child>
                                   <object class="GtkImage" id="ConfigureSharesImage">
@@ -1096,9 +1089,6 @@
                                   <class name="circular"/>
                                 </style>
                               </object>
-                              <packing>
-                                <property name="pack-type">end</property>
-                              </packing>
                             </child>
                           </object>
                         </child>
@@ -1286,59 +1276,12 @@
           <object class="GtkBox">
             <property name="visible">1</property>
             <child>
-              <object class="GtkStatusbar" id="UpStatus">
-                <property name="width-request">200</property>
+              <object class="GtkStatusbar" id="Statusbar">
                 <property name="visible">1</property>
+                <property name="hexpand">1</property>
                 <property name="margin-top">3</property>
                 <property name="margin-bottom">3</property>
               </object>
-              <packing>
-                <property name="pack-type">end</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkStatusbar" id="DownStatus">
-                <property name="width-request">200</property>
-                <property name="visible">1</property>
-                <property name="margin-top">3</property>
-                <property name="margin-bottom">3</property>
-              </object>
-              <packing>
-                <property name="pack-type">end</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkStatusbar" id="SocketStatus">
-                <property name="width-request">150</property>
-                <property name="visible">1</property>
-                <property name="margin-top">3</property>
-                <property name="margin-bottom">3</property>
-              </object>
-              <packing>
-                <property name="pack-type">end</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkStatusbar" id="UserStatus">
-                <property name="width-request">80</property>
-                <property name="visible">1</property>
-                <property name="margin-top">3</property>
-                <property name="margin-bottom">3</property>
-              </object>
-              <packing>
-                <property name="pack-type">end</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkProgressBar" id="BuddySharesProgress">
-                <property name="valign">center</property>
-                <property name="pulse-step">0.10000000149</property>
-                <property name="text" translatable="yes">Scanning Buddy Shares</property>
-                <property name="show-text">1</property>
-              </object>
-              <packing>
-                <property name="pack-type">end</property>
-              </packing>
             </child>
             <child>
               <object class="GtkProgressBar" id="SharesProgress">
@@ -1347,19 +1290,46 @@
                 <property name="text" translatable="yes">Scanning Shares</property>
                 <property name="show-text">1</property>
               </object>
-              <packing>
-                <property name="pack-type">end</property>
-              </packing>
             </child>
             <child>
-              <object class="GtkStatusbar" id="Statusbar">
+              <object class="GtkProgressBar" id="BuddySharesProgress">
+                <property name="valign">center</property>
+                <property name="pulse-step">0.10000000149</property>
+                <property name="text" translatable="yes">Scanning Buddy Shares</property>
+                <property name="show-text">1</property>
+              </object>
+            </child>
+            <child>
+              <object class="GtkStatusbar" id="UserStatus">
+                <property name="width-request">80</property>
                 <property name="visible">1</property>
                 <property name="margin-top">3</property>
                 <property name="margin-bottom">3</property>
               </object>
-              <packing>
-                <property name="pack-type">end</property>
-              </packing>
+            </child>
+            <child>
+              <object class="GtkStatusbar" id="SocketStatus">
+                <property name="width-request">150</property>
+                <property name="visible">1</property>
+                <property name="margin-top">3</property>
+                <property name="margin-bottom">3</property>
+              </object>
+            </child>
+            <child>
+              <object class="GtkStatusbar" id="DownStatus">
+                <property name="width-request">200</property>
+                <property name="visible">1</property>
+                <property name="margin-top">3</property>
+                <property name="margin-bottom">3</property>
+              </object>
+            </child>
+            <child>
+              <object class="GtkStatusbar" id="UpStatus">
+                <property name="width-request">200</property>
+                <property name="visible">1</property>
+                <property name="margin-top">3</property>
+                <property name="margin-bottom">3</property>
+              </object>
             </child>
           </object>
         </child>

--- a/pynicotine/gtkgui/ui/mainwindow.ui
+++ b/pynicotine/gtkgui/ui/mainwindow.ui
@@ -251,7 +251,6 @@
                                 <property name="label" translatable="yes">Autoclear finished / filtered</property>
                                 <property name="visible">1</property>
                                 <property name="can-focus">1</property>
-                                <property name="draw-indicator">1</property>
                               </object>
                             </child>
                             <child>
@@ -556,7 +555,6 @@
                                 <property name="label" translatable="yes">Autoclear finished / aborted</property>
                                 <property name="visible">1</property>
                                 <property name="can-focus">1</property>
-                                <property name="draw-indicator">1</property>
                               </object>
                             </child>
                             <child>
@@ -1170,7 +1168,6 @@
                         <property name="label" translatable="yes">Warnings</property>
                         <property name="visible">1</property>
                         <property name="can-focus">1</property>
-                        <property name="draw-indicator">1</property>
                         <signal name="toggled" handler="on_debug_warnings" swapped="no"/>
                       </object>
                     </child>
@@ -1179,7 +1176,6 @@
                         <property name="label" translatable="yes">Search results</property>
                         <property name="visible">1</property>
                         <property name="can-focus">1</property>
-                        <property name="draw-indicator">1</property>
                         <signal name="toggled" handler="on_debug_searches" swapped="no"/>
                       </object>
                     </child>
@@ -1188,7 +1184,6 @@
                         <property name="label" translatable="yes">Connections</property>
                         <property name="visible">1</property>
                         <property name="can-focus">1</property>
-                        <property name="draw-indicator">1</property>
                         <signal name="toggled" handler="on_debug_connections" swapped="no"/>
                       </object>
                     </child>
@@ -1197,7 +1192,6 @@
                         <property name="label" translatable="yes">Messages</property>
                         <property name="visible">1</property>
                         <property name="can-focus">1</property>
-                        <property name="draw-indicator">1</property>
                         <signal name="toggled" handler="on_debug_messages" swapped="no"/>
                       </object>
                     </child>
@@ -1206,7 +1200,6 @@
                         <property name="label" translatable="yes">Transfers</property>
                         <property name="visible">1</property>
                         <property name="can-focus">1</property>
-                        <property name="draw-indicator">1</property>
                         <signal name="toggled" handler="on_debug_transfers" swapped="no"/>
                       </object>
                     </child>
@@ -1215,7 +1208,6 @@
                         <property name="label" translatable="yes">Statistics</property>
                         <property name="visible">1</property>
                         <property name="can-focus">1</property>
-                        <property name="draw-indicator">1</property>
                         <signal name="toggled" handler="on_debug_statistics" swapped="no"/>
                       </object>
                     </child>

--- a/pynicotine/gtkgui/ui/privatechat.ui
+++ b/pynicotine/gtkgui/ui/privatechat.ui
@@ -68,7 +68,6 @@
             <property name="visible">1</property>
             <property name="can-focus">1</property>
             <property name="tooltip-text" translatable="yes">Send the private message directly to the user (not supported on most clients)</property>
-            <property name="draw-indicator">1</property>
           </object>
         </child>
         <child>
@@ -77,7 +76,6 @@
             <property name="visible">1</property>
             <property name="can-focus">1</property>
             <property name="use-underline">1</property>
-            <property name="draw-indicator">1</property>
           </object>
         </child>
         <child>

--- a/pynicotine/gtkgui/ui/privatechat.ui
+++ b/pynicotine/gtkgui/ui/privatechat.ui
@@ -51,7 +51,7 @@
     <child>
       <object class="GtkBox">
         <property name="visible">1</property>
-        <property name="border-width">8</property>
+        <property name="margin">8</property>
         <property name="spacing">6</property>
         <child>
           <object class="GtkEntry" id="ChatLine">

--- a/pynicotine/gtkgui/ui/privatechat.ui
+++ b/pynicotine/gtkgui/ui/privatechat.ui
@@ -2,152 +2,101 @@
 <interface>
   <requires lib="gtk+" version="3.18"/>
   <object class="GtkBox" id="Main">
-    <property name="visible">True</property>
-    <property name="can_focus">False</property>
+    <property name="visible">1</property>
     <property name="orientation">vertical</property>
     <child>
       <object class="GtkSearchBar" id="SearchBar">
-        <property name="visible">True</property>
-        <property name="can_focus">False</property>
-        <property name="show_close_button">True</property>
+        <property name="visible">1</property>
+        <property name="show-close-button">1</property>
         <child>
           <object class="GtkBox">
-            <property name="visible">True</property>
-            <property name="can_focus">False</property>
+            <property name="visible">1</property>
             <property name="spacing">6</property>
             <child>
               <object class="GtkSearchEntry" id="SearchEntry">
-                <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <property name="max_width_chars">75</property>
-                <property name="primary_icon_name">edit-find-symbolic</property>
-                <property name="primary_icon_activatable">False</property>
-                <property name="primary_icon_sensitive">False</property>
+                <property name="visible">1</property>
+                <property name="can-focus">1</property>
+                <property name="max-width-chars">75</property>
+                <property name="primary-icon-name">edit-find-symbolic</property>
+                <property name="primary-icon-activatable">0</property>
+                <property name="primary-icon-sensitive">0</property>
               </object>
-              <packing>
-                <property name="expand">False</property>
-                <property name="fill">True</property>
-                <property name="position">0</property>
-              </packing>
             </child>
           </object>
         </child>
       </object>
-      <packing>
-        <property name="expand">False</property>
-        <property name="fill">True</property>
-        <property name="position">0</property>
-      </packing>
     </child>
     <child>
       <object class="GtkScrolledWindow">
-        <property name="visible">True</property>
-        <property name="can_focus">True</property>
-        <property name="hscrollbar_policy">automatic</property>
-        <property name="vscrollbar_policy">automatic</property>
+        <property name="visible">1</property>
+        <property name="can-focus">1</property>
+        <property name="vexpand">1</property>
         <child>
           <object class="GtkTextView" id="ChatScroll">
-            <property name="visible">True</property>
-            <property name="can_focus">True</property>
-            <property name="editable">False</property>
-            <property name="wrap_mode">word-char</property>
-            <property name="cursor_visible">False</property>
-            <property name="pixels_above_lines">1</property>
-            <property name="pixels_below_lines">1</property>
-            <property name="left_margin">10</property>
-            <property name="right_margin">10</property>
-            <property name="top_margin">5</property>
-            <property name="bottom_margin">5</property>
+            <property name="visible">1</property>
+            <property name="can-focus">1</property>
+            <property name="editable">0</property>
+            <property name="wrap-mode">word-char</property>
+            <property name="cursor-visible">0</property>
+            <property name="pixels-above-lines">1</property>
+            <property name="pixels-below-lines">1</property>
+            <property name="left-margin">10</property>
+            <property name="right-margin">10</property>
+            <property name="top-margin">5</property>
+            <property name="bottom-margin">5</property>
           </object>
         </child>
       </object>
-      <packing>
-        <property name="expand">True</property>
-        <property name="fill">True</property>
-        <property name="position">1</property>
-      </packing>
     </child>
     <child>
       <object class="GtkBox">
-        <property name="visible">True</property>
-        <property name="can_focus">False</property>
-        <property name="border_width">8</property>
+        <property name="visible">1</property>
+        <property name="border-width">8</property>
         <property name="spacing">6</property>
         <child>
           <object class="GtkEntry" id="ChatLine">
-            <property name="visible">True</property>
-            <property name="can_focus">True</property>
-            <property name="primary_icon_activatable">False</property>
-            <property name="secondary_icon_activatable">False</property>
-            <property name="primary_icon_sensitive">True</property>
-            <property name="secondary_icon_sensitive">True</property>
+            <property name="visible">1</property>
+            <property name="can-focus">1</property>
+            <property name="hexpand">1</property>
             <signal name="activate" handler="on_enter" swapped="no"/>
             <signal name="key-press-event" handler="on_key_press" swapped="no"/>
           </object>
-          <packing>
-            <property name="expand">True</property>
-            <property name="fill">True</property>
-            <property name="position">0</property>
-          </packing>
         </child>
         <child>
           <object class="GtkCheckButton" id="PeerPrivateMessages">
             <property name="label" translatable="yes">Direct Message</property>
-            <property name="visible">True</property>
-            <property name="can_focus">True</property>
-            <property name="receives_default">False</property>
-            <property name="tooltip_text" translatable="yes">Send the private message directly to the user (not supported on most clients)</property>
-            <property name="draw_indicator">True</property>
+            <property name="visible">1</property>
+            <property name="can-focus">1</property>
+            <property name="tooltip-text" translatable="yes">Send the private message directly to the user (not supported on most clients)</property>
+            <property name="draw-indicator">1</property>
           </object>
-          <packing>
-            <property name="expand">False</property>
-            <property name="fill">False</property>
-            <property name="position">2</property>
-          </packing>
         </child>
         <child>
           <object class="GtkCheckButton" id="Log">
             <property name="label" translatable="yes">Log</property>
-            <property name="visible">True</property>
-            <property name="can_focus">True</property>
-            <property name="receives_default">False</property>
-            <property name="use_underline">True</property>
-            <property name="draw_indicator">True</property>
+            <property name="visible">1</property>
+            <property name="can-focus">1</property>
+            <property name="use-underline">1</property>
+            <property name="draw-indicator">1</property>
           </object>
-          <packing>
-            <property name="expand">False</property>
-            <property name="fill">False</property>
-            <property name="position">3</property>
-          </packing>
         </child>
         <child>
           <object class="GtkButton" id="ShowChatHelp">
-            <property name="visible">True</property>
-            <property name="can_focus">True</property>
-            <property name="receives_default">True</property>
-            <property name="tooltip_text" translatable="yes">Private chat command help</property>
+            <property name="visible">1</property>
+            <property name="can-focus">1</property>
+            <property name="receives-default">1</property>
+            <property name="tooltip-text" translatable="yes">Private chat command help</property>
             <property name="image">help</property>
-            <property name="always_show_image">True</property>
+            <property name="always-show-image">1</property>
             <signal name="clicked" handler="on_show_chat_help" swapped="no"/>
             <child>
               <object class="GtkImage" id="help">
-                <property name="can_focus">False</property>
-                <property name="icon_name">dialog-question-symbolic</property>
+                <property name="icon-name">dialog-question-symbolic</property>
               </object>
             </child>
           </object>
-          <packing>
-            <property name="expand">False</property>
-            <property name="fill">False</property>
-            <property name="position">4</property>
-          </packing>
         </child>
       </object>
-      <packing>
-        <property name="expand">False</property>
-        <property name="fill">True</property>
-        <property name="position">2</property>
-      </packing>
     </child>
   </object>
 </interface>

--- a/pynicotine/gtkgui/ui/privatechat.ui
+++ b/pynicotine/gtkgui/ui/privatechat.ui
@@ -17,9 +17,6 @@
                 <property name="visible">1</property>
                 <property name="can-focus">1</property>
                 <property name="max-width-chars">75</property>
-                <property name="primary-icon-name">edit-find-symbolic</property>
-                <property name="primary-icon-activatable">0</property>
-                <property name="primary-icon-sensitive">0</property>
               </object>
             </child>
           </object>
@@ -51,7 +48,10 @@
     <child>
       <object class="GtkBox">
         <property name="visible">1</property>
-        <property name="margin">8</property>
+        <property name="margin-start">8</property>
+        <property name="margin-end">8</property>
+        <property name="margin-top">8</property>
+        <property name="margin-bottom">8</property>
         <property name="spacing">6</property>
         <child>
           <object class="GtkEntry" id="ChatLine">
@@ -84,14 +84,16 @@
             <property name="can-focus">1</property>
             <property name="receives-default">1</property>
             <property name="tooltip-text" translatable="yes">Private chat command help</property>
-            <property name="image">help</property>
-            <property name="always-show-image">1</property>
             <signal name="clicked" handler="on_show_chat_help" swapped="no"/>
             <child>
-              <object class="GtkImage" id="help">
+              <object class="GtkImage">
+                <property name="visible">1</property>
                 <property name="icon-name">dialog-question-symbolic</property>
               </object>
             </child>
+            <style>
+              <class name="image-button"/>
+            </style>
           </object>
         </child>
       </object>

--- a/pynicotine/gtkgui/ui/roomlist.ui
+++ b/pynicotine/gtkgui/ui/roomlist.ui
@@ -71,7 +71,6 @@
             <property name="visible">1</property>
             <property name="can-focus">1</property>
             <property name="use-underline">1</property>
-            <property name="draw-indicator">1</property>
           </object>
         </child>
       </object>

--- a/pynicotine/gtkgui/ui/roomlist.ui
+++ b/pynicotine/gtkgui/ui/roomlist.ui
@@ -2,120 +2,79 @@
 <interface>
   <requires lib="gtk+" version="3.18"/>
   <object class="GtkBox" id="vbox2">
-    <property name="visible">True</property>
-    <property name="can_focus">False</property>
+    <property name="visible">1</property>
     <property name="orientation">vertical</property>
     <child>
       <object class="GtkBox">
-        <property name="visible">True</property>
-        <property name="can_focus">False</property>
-        <property name="border_width">6</property>
+        <property name="visible">1</property>
+        <property name="border-width">6</property>
         <property name="spacing">6</property>
         <child>
           <object class="GtkLabel" id="ChatroomsLabel">
-            <property name="visible">True</property>
-            <property name="can_focus">False</property>
+            <property name="visible">1</property>
             <property name="halign">start</property>
             <property name="label" translatable="yes">Chat Rooms</property>
-            <property name="use_markup">True</property>
-            <property name="margin_start">5</property>
-            <property name="margin_end">10</property>
+            <property name="use-markup">1</property>
+            <property name="margin-start">5</property>
+            <property name="margin-end">10</property>
           </object>
-          <packing>
-            <property name="expand">False</property>
-            <property name="fill">True</property>
-            <property name="position">0</property>
-          </packing>
         </child>
         <child>
           <object class="GtkSearchEntry" id="SearchRooms">
-            <property name="visible">True</property>
-            <property name="can_focus">True</property>
+            <property name="visible">1</property>
+            <property name="can-focus">1</property>
+            <property name="hexpand">1</property>
             <signal name="activate" handler="on_search_room" swapped="no"/>
           </object>
-          <packing>
-            <property name="expand">True</property>
-            <property name="fill">True</property>
-            <property name="position">1</property>
-          </packing>
         </child>
         <child>
           <object class="GtkButton" id="RefreshButton">
-            <property name="visible">True</property>
-            <property name="can_focus">True</property>
-            <property name="receives_default">False</property>
-            <property name="tooltip_text" translatable="yes">Refresh room list</property>
+            <property name="visible">1</property>
+            <property name="can-focus">1</property>
+            <property name="tooltip-text" translatable="yes">Refresh room list</property>
             <property name="image">refresh</property>
-            <property name="always_show_image">True</property>
+            <property name="always-show-image">1</property>
             <signal name="clicked" handler="on_refresh" swapped="no"/>
             <child>
               <object class="GtkImage" id="refresh">
-                <property name="can_focus">False</property>
-                <property name="icon_name">view-refresh-symbolic</property>
+                <property name="icon-name">view-refresh-symbolic</property>
               </object>
             </child>
             <style>
               <class name="circular"/>
             </style>
           </object>
-          <packing>
-            <property name="expand">False</property>
-            <property name="fill">False</property>
-            <property name="position">2</property>
-          </packing>
         </child>
       </object>
-      <packing>
-        <property name="expand">False</property>
-        <property name="fill">False</property>
-      </packing>
     </child>
     <child>
       <object class="GtkScrolledWindow">
-        <property name="visible">True</property>
-        <property name="can_focus">True</property>
-        <property name="hscrollbar_policy">automatic</property>
-        <property name="vscrollbar_policy">automatic</property>
+        <property name="visible">1</property>
+        <property name="can-focus">1</property>
+        <property name="vexpand">1</property>
         <child>
           <object class="GtkTreeView" id="RoomsList">
-            <property name="visible">True</property>
-            <property name="can_focus">True</property>
+            <property name="visible">1</property>
+            <property name="can-focus">1</property>
           </object>
         </child>
       </object>
-      <packing>
-        <property name="expand">True</property>
-        <property name="fill">True</property>
-        <property name="position">1</property>
-      </packing>
     </child>
     <child>
       <object class="GtkBox">
-        <property name="visible">True</property>
-        <property name="can_focus">False</property>
-        <property name="border_width">8</property>
+        <property name="visible">1</property>
+        <property name="border-width">8</property>
         <property name="orientation">vertical</property>
         <child>
           <object class="GtkCheckButton" id="AcceptPrivateRoom">
             <property name="label" translatable="yes">Accept private room invitations</property>
-            <property name="visible">True</property>
-            <property name="can_focus">True</property>
-            <property name="receives_default">False</property>
-            <property name="use_underline">True</property>
-            <property name="draw_indicator">True</property>
+            <property name="visible">1</property>
+            <property name="can-focus">1</property>
+            <property name="use-underline">1</property>
+            <property name="draw-indicator">1</property>
           </object>
-          <packing>
-            <property name="expand">False</property>
-            <property name="fill">False</property>
-            <property name="position">0</property>
-          </packing>
         </child>
       </object>
-      <packing>
-        <property name="expand">False</property>
-        <property name="fill">True</property>
-        <property name="position">2</property>
-      </packing>
     </child>
   </object>
 </interface>

--- a/pynicotine/gtkgui/ui/roomlist.ui
+++ b/pynicotine/gtkgui/ui/roomlist.ui
@@ -7,7 +7,7 @@
     <child>
       <object class="GtkBox">
         <property name="visible">1</property>
-        <property name="border-width">6</property>
+        <property name="margin">6</property>
         <property name="spacing">6</property>
         <child>
           <object class="GtkLabel" id="ChatroomsLabel">
@@ -63,7 +63,7 @@
     <child>
       <object class="GtkBox">
         <property name="visible">1</property>
-        <property name="border-width">8</property>
+        <property name="margin">8</property>
         <property name="orientation">vertical</property>
         <child>
           <object class="GtkCheckButton" id="AcceptPrivateRoom">

--- a/pynicotine/gtkgui/ui/roomlist.ui
+++ b/pynicotine/gtkgui/ui/roomlist.ui
@@ -7,7 +7,10 @@
     <child>
       <object class="GtkBox">
         <property name="visible">1</property>
-        <property name="margin">6</property>
+        <property name="margin-start">6</property>
+        <property name="margin-end">6</property>
+        <property name="margin-top">6</property>
+        <property name="margin-bottom">6</property>
         <property name="spacing">6</property>
         <child>
           <object class="GtkLabel" id="ChatroomsLabel">
@@ -32,16 +35,16 @@
             <property name="visible">1</property>
             <property name="can-focus">1</property>
             <property name="tooltip-text" translatable="yes">Refresh room list</property>
-            <property name="image">refresh</property>
-            <property name="always-show-image">1</property>
             <signal name="clicked" handler="on_refresh" swapped="no"/>
             <child>
-              <object class="GtkImage" id="refresh">
+              <object class="GtkImage">
+                <property name="visible">1</property>
                 <property name="icon-name">view-refresh-symbolic</property>
               </object>
             </child>
             <style>
               <class name="circular"/>
+              <class name="image-button"/>
             </style>
           </object>
         </child>
@@ -63,7 +66,10 @@
     <child>
       <object class="GtkBox">
         <property name="visible">1</property>
-        <property name="margin">8</property>
+        <property name="margin-start">8</property>
+        <property name="margin-end">8</property>
+        <property name="margin-top">8</property>
+        <property name="margin-bottom">8</property>
         <property name="orientation">vertical</property>
         <child>
           <object class="GtkCheckButton" id="AcceptPrivateRoom">

--- a/pynicotine/gtkgui/ui/roomwall.ui
+++ b/pynicotine/gtkgui/ui/roomwall.ui
@@ -2,123 +2,91 @@
 <interface>
   <requires lib="gtk+" version="3.18"/>
   <object class="GtkDialog" id="RoomWallDialog">
-    <property name="can_focus">False</property>
     <property name="title" translatable="yes">Room Wall</property>
-    <property name="modal">True</property>
-    <property name="window_position">center-on-parent</property>
-    <property name="default_width">900</property>
-    <property name="default_height">600</property>
+    <property name="modal">1</property>
+    <property name="window-position">center-on-parent</property>
+    <property name="default-width">900</property>
+    <property name="default-height">600</property>
     <child internal-child="vbox">
       <object class="GtkBox">
-        <property name="visible">True</property>
-        <property name="can_focus">False</property>
+        <property name="visible">1</property>
         <property name="orientation">vertical</property>
         <child>
           <object class="GtkLabel">
-            <property name="visible">True</property>
-            <property name="can_focus">False</property>
+            <property name="visible">1</property>
             <property name="halign">start</property>
             <property name="xpad">13</property>
             <property name="ypad">10</property>
             <property name="label" translatable="yes">The room wall feature allows users in a room to specify a unique message to display to others.</property>
             <property name="justify">fill</property>
-            <property name="wrap">True</property>
+            <property name="wrap">1</property>
           </object>
-          <packing>
-            <property name="expand">False</property>
-            <property name="fill">False</property>
-            <property name="position">0</property>
-          </packing>
         </child>
         <child>
           <object class="GtkScrolledWindow" id="RoomWallListWindow">
-            <property name="visible">True</property>
-            <property name="can_focus">True</property>
-            <property name="hscrollbar_policy">automatic</property>
-            <property name="vscrollbar_policy">automatic</property>
-            <property name="margin_start">10</property>
-            <property name="margin_end">10</property>
-            <property name="shadow_type">in</property>
+            <property name="visible">1</property>
+            <property name="can-focus">1</property>
+            <property name="vexpand">1</property>
+            <property name="margin-start">10</property>
+            <property name="margin-end">10</property>
+            <property name="shadow-type">in</property>
             <child>
               <object class="GtkTextView" id="RoomWallList">
-                <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <property name="editable">False</property>
-                <property name="wrap_mode">word-char</property>
-                <property name="cursor_visible">False</property>
-                <property name="pixels_above_lines">4</property>
-                <property name="pixels_below_lines">4</property>
-                <property name="left_margin">10</property>
-                <property name="right_margin">10</property>
-                <property name="top_margin">5</property>
-                <property name="bottom_margin">5</property>
+                <property name="visible">1</property>
+                <property name="can-focus">1</property>
+                <property name="editable">0</property>
+                <property name="wrap-mode">word-char</property>
+                <property name="cursor-visible">0</property>
+                <property name="pixels-above-lines">4</property>
+                <property name="pixels-below-lines">4</property>
+                <property name="left-margin">10</property>
+                <property name="right-margin">10</property>
+                <property name="top-margin">5</property>
+                <property name="bottom-margin">5</property>
               </object>
             </child>
           </object>
-          <packing>
-            <property name="expand">True</property>
-            <property name="fill">True</property>
-            <property name="position">1</property>
-          </packing>
         </child>
         <child>
           <object class="GtkBox">
-            <property name="visible">True</property>
-            <property name="can_focus">False</property>
-            <property name="border_width">10</property>
+            <property name="visible">1</property>
+            <property name="border-width">10</property>
             <property name="spacing">10</property>
             <child>
               <object class="GtkEntry" id="RoomWallEntry">
-                <property name="visible">True</property>
-                <property name="can_focus">True</property>
+                <property name="visible">1</property>
+                <property name="can-focus">1</property>
+                <property name="hexpand">1</property>
                 <signal name="activate" handler="on_set_room_wall_message" swapped="no"/>
               </object>
-              <packing>
-                <property name="expand">True</property>
-                <property name="fill">True</property>
-                <property name="position">0</property>
-              </packing>
             </child>
             <child>
               <object class="GtkButton">
-                <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <property name="receives_default">False</property>
+                <property name="visible">1</property>
+                <property name="can-focus">1</property>
                 <signal name="clicked" handler="on_set_room_wall_message" swapped="no"/>
                 <child>
                   <object class="GtkBox">
-                    <property name="visible">True</property>
-                    <property name="can_focus">False</property>
+                    <property name="visible">1</property>
                     <property name="spacing">5</property>
                     <child>
                       <object class="GtkImage">
-                        <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="icon_name">list-add-symbolic</property>
+                        <property name="visible">1</property>
+                        <property name="icon-name">list-add-symbolic</property>
                       </object>
                     </child>
                     <child>
                       <object class="GtkLabel">
-                        <property name="visible">True</property>
-                        <property name="can_focus">False</property>
+                        <property name="visible">1</property>
                         <property name="label" translatable="yes">Set Message</property>
-                        <property name="use_underline">True</property>
+                        <property name="use-underline">1</property>
                       </object>
                     </child>
                   </object>
                 </child>
               </object>
-              <packing>
-                <property name="expand">False</property>
-                <property name="fill">False</property>
-                <property name="position">1</property>
-              </packing>
             </child>
           </object>
-          <packing>
-            <property name="expand">False</property>
-            <property name="fill">True</property>
-          </packing>
         </child>
       </object>
     </child>

--- a/pynicotine/gtkgui/ui/roomwall.ui
+++ b/pynicotine/gtkgui/ui/roomwall.ui
@@ -50,7 +50,7 @@
         <child>
           <object class="GtkBox">
             <property name="visible">1</property>
-            <property name="border-width">10</property>
+            <property name="margin">10</property>
             <property name="spacing">10</property>
             <child>
               <object class="GtkEntry" id="RoomWallEntry">

--- a/pynicotine/gtkgui/ui/roomwall.ui
+++ b/pynicotine/gtkgui/ui/roomwall.ui
@@ -15,8 +15,10 @@
           <object class="GtkLabel">
             <property name="visible">1</property>
             <property name="halign">start</property>
-            <property name="xpad">13</property>
-            <property name="ypad">10</property>
+            <property name="margin-start">10</property>
+            <property name="margin-end">10</property>
+            <property name="margin-top">13</property>
+            <property name="margin-bottom">13</property>
             <property name="label" translatable="yes">The room wall feature allows users in a room to specify a unique message to display to others.</property>
             <property name="justify">fill</property>
             <property name="wrap">1</property>
@@ -50,7 +52,10 @@
         <child>
           <object class="GtkBox">
             <property name="visible">1</property>
-            <property name="margin">10</property>
+            <property name="margin-start">10</property>
+            <property name="margin-end">10</property>
+            <property name="margin-top">10</property>
+            <property name="margin-bottom">10</property>
             <property name="spacing">10</property>
             <child>
               <object class="GtkEntry" id="RoomWallEntry">

--- a/pynicotine/gtkgui/ui/search.ui
+++ b/pynicotine/gtkgui/ui/search.ui
@@ -8,7 +8,7 @@
       <object class="GtkBox">
         <property name="visible">1</property>
         <property name="spacing">6</property>
-        <property name="border-width">7</property>
+        <property name="margin">7</property>
         <child>
           <object class="GtkBox">
             <property name="visible">1</property>

--- a/pynicotine/gtkgui/ui/search.ui
+++ b/pynicotine/gtkgui/ui/search.ui
@@ -8,7 +8,10 @@
       <object class="GtkBox">
         <property name="visible">1</property>
         <property name="spacing">6</property>
-        <property name="margin">7</property>
+        <property name="margin-start">7</property>
+        <property name="margin-end">7</property>
+        <property name="margin-top">7</property>
+        <property name="margin-bottom">7</property>
         <child>
           <object class="GtkBox">
             <property name="visible">1</property>
@@ -75,13 +78,15 @@
             <property name="receives-default">1</property>
             <property name="tooltip-text" translatable="yes">Expand / Collapse all</property>
             <property name="active">1</property>
-            <property name="image">expand</property>
-            <property name="always-show-image">1</property>
             <child>
               <object class="GtkImage" id="expand">
+                <property name="visible">1</property>
                 <property name="icon-name">list-remove-symbolic</property>
               </object>
             </child>
+            <style>
+              <class name="image-button"/>
+            </style>
           </object>
         </child>
         <child>
@@ -287,16 +292,16 @@
                     <property name="can-focus">1</property>
                     <property name="receives-default">1</property>
                     <property name="tooltip-text" translatable="yes">Search filter help</property>
-                    <property name="image">help</property>
-                    <property name="always-show-image">1</property>
                     <signal name="clicked" handler="on_about_filters" swapped="no"/>
                     <child>
-                      <object class="GtkImage" id="help">
+                      <object class="GtkImage">
+                        <property name="visible">1</property>
                         <property name="icon-name">dialog-question-symbolic</property>
                       </object>
                     </child>
                     <style>
                       <class name="circular"/>
+                      <class name="image-button"/>
                     </style>
                   </object>
                 </child>

--- a/pynicotine/gtkgui/ui/search.ui
+++ b/pynicotine/gtkgui/ui/search.ui
@@ -2,58 +2,44 @@
 <interface>
   <requires lib="gtk+" version="3.18"/>
   <object class="GtkBox" id="Main">
-    <property name="visible">True</property>
-    <property name="can_focus">False</property>
+    <property name="visible">1</property>
     <property name="orientation">vertical</property>
     <child>
       <object class="GtkBox">
-        <property name="visible">True</property>
-        <property name="can_focus">False</property>
+        <property name="visible">1</property>
         <property name="spacing">6</property>
-        <property name="border_width">7</property>
+        <property name="border-width">7</property>
         <child>
           <object class="GtkBox">
-            <property name="visible">True</property>
-            <property name="can_focus">False</property>
+            <property name="visible">1</property>
+            <property name="hexpand">1</property>
             <property name="spacing">6</property>
+            <property name="margin-start">5</property>
+            <property name="margin-end">5</property>
             <child>
               <object class="GtkLabel">
-                <property name="visible">True</property>
-                <property name="can_focus">False</property>
+                <property name="visible">1</property>
                 <property name="label" translatable="yes">Results</property>
               </object>
-              <packing>
-                <property name="expand">False</property>
-                <property name="fill">True</property>
-                <property name="position">0</property>
-              </packing>
             </child>
             <child>
               <object class="GtkButton">
-                <property name="visible">True</property>
-                <property name="sensitive">False</property>
-                <property name="can-focus">False</property>
-                <property name="receives-default">False</property>
+                <property name="visible">1</property>
+                <property name="sensitive">0</property>
                 <child>
                   <object class="GtkBox">
                     <property name="width-request">24</property>
-                    <property name="visible">True</property>
-                    <property name="can-focus">False</property>
+                    <property name="visible">1</property>
                     <property name="spacing">5</property>
-                    <property name="homogeneous">True</property>
+                    <property name="homogeneous">1</property>
                     <child>
                       <object class="GtkLabel" id="Counter">
-                        <property name="visible">True</property>
-                        <property name="can-focus">False</property>
+                        <property name="visible">1</property>
                         <property name="label">&lt;b&gt;0&lt;/b&gt;</property>
-                        <property name="use_markup">True</property>
+                        <property name="use-markup">1</property>
+                        <property name="margin-start">5</property>
+                        <property name="margin-end">5</property>
                       </object>
-                      <packing>
-                        <property name="expand">False</property>
-                        <property name="fill">True</property>
-                        <property name="padding">5</property>
-                        <property name="position">0</property>
-                      </packing>
                     </child>
                   </object>
                 </child>
@@ -61,175 +47,112 @@
                   <class name="circular"/>
                 </style>
               </object>
-              <packing>
-                <property name="expand">False</property>
-                <property name="fill">False</property>
-                <property name="position">1</property>
-              </packing>
             </child>
           </object>
-          <packing>
-            <property name="expand">True</property>
-            <property name="fill">True</property>
-            <property name="padding">5</property>
-            <property name="position">0</property>
-          </packing>
         </child>
         <child>
           <object class="GtkCheckButton" id="filtersCheck">
             <property name="label" translatable="yes">Filter results</property>
-            <property name="visible">True</property>
-            <property name="can_focus">True</property>
-            <property name="receives_default">False</property>
-            <property name="use_underline">True</property>
-            <property name="draw_indicator">True</property>
+            <property name="visible">1</property>
+            <property name="can-focus">1</property>
+            <property name="use-underline">1</property>
+            <property name="draw-indicator">1</property>
             <signal name="toggled" handler="on_toggle_filters" swapped="no"/>
           </object>
-          <packing>
-            <property name="expand">False</property>
-            <property name="fill">True</property>
-            <property name="position">1</property>
-          </packing>
         </child>
         <child>
           <object class="GtkCheckButton" id="RememberCheckButton">
             <property name="label" translatable="yes">Add wish</property>
-            <property name="visible">True</property>
-            <property name="can_focus">True</property>
-            <property name="receives_default">False</property>
-            <property name="tooltip_text" translatable="yes">This search term will be requested at regular intervals</property>
-            <property name="use_underline">True</property>
-            <property name="draw_indicator">True</property>
+            <property name="visible">1</property>
+            <property name="can-focus">1</property>
+            <property name="tooltip-text" translatable="yes">This search term will be requested at regular intervals</property>
+            <property name="use-underline">1</property>
+            <property name="draw-indicator">1</property>
             <signal name="toggled" handler="on_toggle_remember" swapped="no"/>
           </object>
-          <packing>
-            <property name="expand">False</property>
-            <property name="fill">False</property>
-            <property name="position">2</property>
-          </packing>
         </child>
         <child>
           <object class="GtkToggleButton" id="ExpandButton">
-            <property name="can_focus">True</property>
-            <property name="receives_default">True</property>
-            <property name="tooltip_text" translatable="yes">Expand / Collapse all</property>
-            <property name="active">True</property>
+            <property name="can-focus">1</property>
+            <property name="receives-default">1</property>
+            <property name="tooltip-text" translatable="yes">Expand / Collapse all</property>
+            <property name="active">1</property>
             <property name="image">expand</property>
-            <property name="always_show_image">True</property>
+            <property name="always-show-image">1</property>
             <child>
               <object class="GtkImage" id="expand">
-                <property name="can_focus">False</property>
-                <property name="icon_name">list-remove-symbolic</property>
+                <property name="icon-name">list-remove-symbolic</property>
               </object>
             </child>
           </object>
-          <packing>
-            <property name="expand">False</property>
-            <property name="fill">True</property>
-            <property name="position">3</property>
-          </packing>
         </child>
         <child>
           <object class="GtkButton" id="IgnoreButton">
-            <property name="visible">True</property>
-            <property name="can_focus">True</property>
-            <property name="receives_default">False</property>
-            <property name="tooltip_text" translatable="yes">Stop new search results from being displayed</property>
+            <property name="visible">1</property>
+            <property name="can-focus">1</property>
+            <property name="tooltip-text" translatable="yes">Stop new search results from being displayed</property>
             <signal name="clicked" handler="on_ignore" swapped="no"/>
             <child>
               <object class="GtkBox">
-                <property name="visible">True</property>
-                <property name="can_focus">False</property>
+                <property name="visible">1</property>
                 <property name="spacing">5</property>
                 <child>
                   <object class="GtkImage">
-                    <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <property name="icon_name">dialog-error-symbolic</property>
+                    <property name="visible">1</property>
+                    <property name="icon-name">dialog-error-symbolic</property>
                   </object>
                 </child>
                 <child>
                   <object class="GtkLabel">
-                    <property name="visible">True</property>
-                    <property name="can_focus">False</property>
+                    <property name="visible">1</property>
                     <property name="label" translatable="yes">Ignore</property>
-                    <property name="use_underline">True</property>
+                    <property name="use-underline">1</property>
                   </object>
                 </child>
               </object>
             </child>
           </object>
-          <packing>
-            <property name="expand">False</property>
-            <property name="fill">False</property>
-            <property name="position">4</property>
-          </packing>
         </child>
         <child>
           <object class="GtkComboBox" id="ResultGrouping">
-            <property name="visible">True</property>
-            <property name="can_focus">False</property>
-            <property name="tooltip_text" translatable="yes">Result grouping mode</property>
+            <property name="visible">1</property>
+            <property name="tooltip-text" translatable="yes">Result grouping mode</property>
           </object>
-          <packing>
-            <property name="expand">False</property>
-            <property name="fill">False</property>
-            <property name="position">5</property>
-          </packing>
         </child>
       </object>
-      <packing>
-        <property name="expand">False</property>
-        <property name="fill">True</property>
-        <property name="position">0</property>
-      </packing>
     </child>
     <child>
       <object class="GtkFlowBox" id="FiltersContainer">
-        <property name="can_focus">False</property>
-        <property name="column_spacing">10</property>
-        <property name="margin_start">5</property>
-        <property name="margin_end">5</property>
-        <property name="max_children_per_line">5</property>
+        <property name="column-spacing">10</property>
+        <property name="margin-start">5</property>
+        <property name="margin-end">5</property>
+        <property name="max-children-per-line">5</property>
         <child>
           <object class="GtkFlowBoxChild">
-            <property name="visible">True</property>
-            <property name="can_focus">False</property>
+            <property name="visible">1</property>
             <child>
               <object class="GtkBox">
-                <property name="visible">True</property>
-                <property name="can_focus">False</property>
+                <property name="visible">1</property>
                 <property name="spacing">10</property>
                 <child>
                   <object class="GtkLabel">
-                    <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <property name="margin_start">5</property>
+                    <property name="visible">1</property>
+                    <property name="margin-start">5</property>
                     <property name="label" translatable="yes">Include:</property>
                   </object>
-                  <packing>
-                    <property name="expand">False</property>
-                    <property name="fill">False</property>
-                    <property name="position">0</property>
-                  </packing>
                 </child>
                 <child>
                   <object class="GtkComboBox" id="FilterIn">
-                    <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <property name="has_entry">True</property>
+                    <property name="visible">1</property>
+                    <property name="has-entry">1</property>
+                    <property name="hexpand">1</property>
                     <child internal-child="entry">
                       <object class="GtkEntry">
-                        <property name="can_focus">True</property>
-                        <property name="width_chars">10</property>
+                        <property name="can-focus">1</property>
+                        <property name="width-chars">10</property>
                       </object>
                     </child>
                   </object>
-                  <packing>
-                    <property name="expand">True</property>
-                    <property name="fill">True</property>
-                    <property name="position">1</property>
-                  </packing>
                 </child>
               </object>
             </child>
@@ -237,42 +160,29 @@
         </child>
         <child>
           <object class="GtkFlowBoxChild">
-            <property name="visible">True</property>
-            <property name="can_focus">False</property>
+            <property name="visible">1</property>
             <child>
               <object class="GtkBox">
-                <property name="visible">True</property>
-                <property name="can_focus">False</property>
+                <property name="visible">1</property>
                 <property name="spacing">10</property>
                 <child>
                   <object class="GtkLabel">
-                    <property name="visible">True</property>
-                    <property name="can_focus">False</property>
+                    <property name="visible">1</property>
                     <property name="label" translatable="yes">Exclude:</property>
                   </object>
-                  <packing>
-                    <property name="expand">False</property>
-                    <property name="fill">False</property>
-                    <property name="position">0</property>
-                  </packing>
                 </child>
                 <child>
                   <object class="GtkComboBox" id="FilterOut">
-                    <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <property name="has_entry">True</property>
+                    <property name="visible">1</property>
+                    <property name="has-entry">1</property>
+                    <property name="hexpand">1</property>
                     <child internal-child="entry">
                       <object class="GtkEntry">
-                        <property name="can_focus">True</property>
-                        <property name="width_chars">10</property>
+                        <property name="can-focus">1</property>
+                        <property name="width-chars">10</property>
                       </object>
                     </child>
                   </object>
-                  <packing>
-                    <property name="expand">True</property>
-                    <property name="fill">True</property>
-                    <property name="position">1</property>
-                  </packing>
                 </child>
               </object>
             </child>
@@ -280,42 +190,29 @@
         </child>
         <child>
           <object class="GtkFlowBoxChild">
-            <property name="visible">True</property>
-            <property name="can_focus">False</property>
+            <property name="visible">1</property>
             <child>
               <object class="GtkBox">
-                <property name="visible">True</property>
-                <property name="can_focus">False</property>
+                <property name="visible">1</property>
                 <property name="spacing">10</property>
                 <child>
                   <object class="GtkLabel">
-                    <property name="visible">True</property>
-                    <property name="can_focus">False</property>
+                    <property name="visible">1</property>
                     <property name="label" translatable="yes">Size:</property>
                   </object>
-                  <packing>
-                    <property name="expand">False</property>
-                    <property name="fill">False</property>
-                    <property name="position">0</property>
-                  </packing>
                 </child>
                 <child>
                   <object class="GtkComboBox" id="FilterSize">
-                    <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <property name="has_entry">True</property>
+                    <property name="visible">1</property>
+                    <property name="has-entry">1</property>
+                    <property name="hexpand">1</property>
                     <child internal-child="entry">
                       <object class="GtkEntry">
-                        <property name="can_focus">True</property>
-                        <property name="width_chars">5</property>
+                        <property name="can-focus">1</property>
+                        <property name="width-chars">5</property>
                       </object>
                     </child>
                   </object>
-                  <packing>
-                    <property name="expand">True</property>
-                    <property name="fill">True</property>
-                    <property name="position">1</property>
-                  </packing>
                 </child>
               </object>
             </child>
@@ -323,42 +220,29 @@
         </child>
         <child>
           <object class="GtkFlowBoxChild">
-            <property name="visible">True</property>
-            <property name="can_focus">False</property>
+            <property name="visible">1</property>
             <child>
               <object class="GtkBox">
-                <property name="visible">True</property>
-                <property name="can_focus">False</property>
+                <property name="visible">1</property>
                 <property name="spacing">10</property>
                 <child>
                   <object class="GtkLabel">
-                    <property name="visible">True</property>
-                    <property name="can_focus">False</property>
+                    <property name="visible">1</property>
                     <property name="label" translatable="yes">Bitrate:</property>
                   </object>
-                  <packing>
-                    <property name="expand">False</property>
-                    <property name="fill">False</property>
-                    <property name="position">0</property>
-                  </packing>
                 </child>
                 <child>
                   <object class="GtkComboBox" id="FilterBitrate">
-                    <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <property name="has_entry">True</property>
+                    <property name="visible">1</property>
+                    <property name="has-entry">1</property>
+                    <property name="hexpand">1</property>
                     <child internal-child="entry">
                       <object class="GtkEntry">
-                        <property name="can_focus">True</property>
-                        <property name="width_chars">5</property>
+                        <property name="can-focus">1</property>
+                        <property name="width-chars">5</property>
                       </object>
                     </child>
                   </object>
-                  <packing>
-                    <property name="expand">True</property>
-                    <property name="fill">True</property>
-                    <property name="position">1</property>
-                  </packing>
                 </child>
               </object>
             </child>
@@ -366,117 +250,80 @@
         </child>
         <child>
           <object class="GtkFlowBoxChild">
-            <property name="visible">True</property>
-            <property name="can_focus">False</property>
+            <property name="visible">1</property>
             <child>
               <object class="GtkBox">
-                <property name="visible">True</property>
-                <property name="can_focus">False</property>
+                <property name="visible">1</property>
                 <property name="spacing">10</property>
                 <child>
                   <object class="GtkLabel">
-                    <property name="visible">True</property>
-                    <property name="can_focus">False</property>
+                    <property name="visible">1</property>
                     <property name="label" translatable="yes">Country:</property>
                   </object>
-                  <packing>
-                    <property name="expand">False</property>
-                    <property name="fill">False</property>
-                    <property name="position">0</property>
-                  </packing>
                 </child>
                 <child>
                   <object class="GtkComboBox" id="FilterCountry">
-                    <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <property name="has_entry">True</property>
+                    <property name="visible">1</property>
+                    <property name="has-entry">1</property>
+                    <property name="hexpand">1</property>
                     <child internal-child="entry">
                       <object class="GtkEntry">
-                        <property name="can_focus">True</property>
-                        <property name="width_chars">5</property>
+                        <property name="can-focus">1</property>
+                        <property name="width-chars">5</property>
                       </object>
                     </child>
                   </object>
-                  <packing>
-                    <property name="expand">True</property>
-                    <property name="fill">True</property>
-                    <property name="position">1</property>
-                  </packing>
                 </child>
                 <child>
                   <object class="GtkCheckButton" id="FilterFreeSlot">
                     <property name="label" translatable="yes">Free slot</property>
-                    <property name="visible">True</property>
-                    <property name="can_focus">True</property>
-                    <property name="receives_default">False</property>
-                    <property name="use_underline">True</property>
-                    <property name="draw_indicator">True</property>
+                    <property name="visible">1</property>
+                    <property name="can-focus">1</property>
+                    <property name="use-underline">1</property>
+                    <property name="draw-indicator">1</property>
                     <signal name="toggled" handler="on_refilter" swapped="no"/>
                   </object>
-                  <packing>
-                    <property name="expand">False</property>
-                    <property name="fill">False</property>
-                    <property name="position">2</property>
-                  </packing>
                 </child>
                 <child>
                   <object class="GtkButton" id="ShowChatHelp">
-                    <property name="visible">True</property>
-                    <property name="can_focus">True</property>
-                    <property name="receives_default">True</property>
-                    <property name="tooltip_text" translatable="yes">Search filter help</property>
+                    <property name="visible">1</property>
+                    <property name="can-focus">1</property>
+                    <property name="receives-default">1</property>
+                    <property name="tooltip-text" translatable="yes">Search filter help</property>
                     <property name="image">help</property>
-                    <property name="always_show_image">True</property>
+                    <property name="always-show-image">1</property>
                     <signal name="clicked" handler="on_about_filters" swapped="no"/>
                     <child>
                       <object class="GtkImage" id="help">
-                        <property name="can_focus">False</property>
-                        <property name="icon_name">dialog-question-symbolic</property>
+                        <property name="icon-name">dialog-question-symbolic</property>
                       </object>
                     </child>
                     <style>
                       <class name="circular"/>
                     </style>
                   </object>
-                  <packing>
-                    <property name="expand">False</property>
-                    <property name="fill">False</property>
-                    <property name="position">3</property>
-                  </packing>
                 </child>
               </object>
             </child>
           </object>
         </child>
       </object>
-      <packing>
-        <property name="expand">False</property>
-        <property name="fill">True</property>
-        <property name="padding">3</property>
-        <property name="position">1</property>
-      </packing>
     </child>
     <child>
       <object class="GtkScrolledWindow">
-        <property name="visible">True</property>
-        <property name="can_focus">True</property>
-        <property name="hscrollbar_policy">automatic</property>
-        <property name="vscrollbar_policy">automatic</property>
+        <property name="visible">1</property>
+        <property name="can-focus">1</property>
+        <property name="vexpand">1</property>
         <child>
           <object class="GtkTreeView" id="ResultsList">
-            <property name="visible">True</property>
-            <property name="can_focus">True</property>
-            <property name="has_tooltip">True</property>
-            <property name="enable_search">False</property>
+            <property name="visible">1</property>
+            <property name="can-focus">1</property>
+            <property name="has-tooltip">1</property>
+            <property name="enable-search">0</property>
             <signal name="query-tooltip" handler="on_tooltip" swapped="no"/>
           </object>
         </child>
       </object>
-      <packing>
-        <property name="expand">True</property>
-        <property name="fill">True</property>
-        <property name="position">2</property>
-      </packing>
     </child>
   </object>
 </interface>

--- a/pynicotine/gtkgui/ui/search.ui
+++ b/pynicotine/gtkgui/ui/search.ui
@@ -56,7 +56,6 @@
             <property name="visible">1</property>
             <property name="can-focus">1</property>
             <property name="use-underline">1</property>
-            <property name="draw-indicator">1</property>
             <signal name="toggled" handler="on_toggle_filters" swapped="no"/>
           </object>
         </child>
@@ -67,7 +66,6 @@
             <property name="can-focus">1</property>
             <property name="tooltip-text" translatable="yes">This search term will be requested at regular intervals</property>
             <property name="use-underline">1</property>
-            <property name="draw-indicator">1</property>
             <signal name="toggled" handler="on_toggle_remember" swapped="no"/>
           </object>
         </child>
@@ -280,7 +278,6 @@
                     <property name="visible">1</property>
                     <property name="can-focus">1</property>
                     <property name="use-underline">1</property>
-                    <property name="draw-indicator">1</property>
                     <signal name="toggled" handler="on_refilter" swapped="no"/>
                   </object>
                 </child>

--- a/pynicotine/gtkgui/ui/settings/settingswindow.ui
+++ b/pynicotine/gtkgui/ui/settings/settingswindow.ui
@@ -2,8 +2,6 @@
 <interface>
   <requires lib="gtk+" version="3.18"/>
   <object class="GtkDialog" id="SettingsWindow">
-    <property name="border_width">10</property>
-    <property name="can_focus">False</property>
     <property name="title" translatable="yes">Preferences</property>
     <property name="window_position">center</property>
     <property name="default_width">1200</property>
@@ -13,6 +11,7 @@
         <property name="visible">True</property>
         <property name="can_focus">False</property>
         <property name="orientation">vertical</property>
+        <property name="margin">10</property>
         <child>
           <object class="GtkPaned">
             <property name="visible">True</property>
@@ -48,7 +47,7 @@
                 <property name="margin_start">10</property>
                 <child>
                   <object class="GtkViewport" id="viewport1">
-                    <property name="border_width">5</property>
+                    <property name="margin">5</property>
                     <property name="width_request">600</property>
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>

--- a/pynicotine/gtkgui/ui/settings/settingswindow.ui
+++ b/pynicotine/gtkgui/ui/settings/settingswindow.ui
@@ -11,7 +11,10 @@
         <property name="visible">True</property>
         <property name="can_focus">False</property>
         <property name="orientation">vertical</property>
-        <property name="margin">10</property>
+        <property name="margin-start">10</property>
+        <property name="margin-end">10</property>
+        <property name="margin-top">10</property>
+        <property name="margin-bottom">10</property>
         <child>
           <object class="GtkPaned">
             <property name="visible">True</property>

--- a/pynicotine/gtkgui/ui/userbrowse.ui
+++ b/pynicotine/gtkgui/ui/userbrowse.ui
@@ -15,7 +15,10 @@
             <child>
               <object class="GtkBox">
                 <property name="visible">1</property>
-                <property name="margin">6</property>
+                <property name="margin-start">6</property>
+                <property name="margin-end">6</property>
+                <property name="margin-top">6</property>
+                <property name="margin-bottom">6</property>
                 <property name="spacing">6</property>
                 <child>
                   <object class="GtkBox">
@@ -120,11 +123,10 @@
                     <property name="visible">1</property>
                     <property name="can-focus">1</property>
                     <property name="tooltip-text" translatable="yes">Refresh files</property>
-                    <property name="image">refresh</property>
-                    <property name="always-show-image">1</property>
                     <signal name="clicked" handler="on_refresh" swapped="no"/>
                     <child>
-                      <object class="GtkImage" id="refresh">
+                      <object class="GtkImage">
+                        <property name="visible">1</property>
                         <property name="icon-name">view-refresh-symbolic</property>
                       </object>
                     </child>
@@ -135,11 +137,10 @@
                     <property name="visible">1</property>
                     <property name="can-focus">1</property>
                     <property name="tooltip-text" translatable="yes">Expand / Collapse all</property>
-                    <property name="image">expand</property>
-                    <property name="always-show-image">1</property>
                     <signal name="clicked" handler="on_expand" swapped="no"/>
                     <child>
-                      <object class="GtkImage" id="expand">
+                      <object class="GtkImage">
+                        <property name="visible">1</property>
                         <property name="icon-name">list-add-symbolic</property>
                       </object>
                     </child>

--- a/pynicotine/gtkgui/ui/userbrowse.ui
+++ b/pynicotine/gtkgui/ui/userbrowse.ui
@@ -2,59 +2,50 @@
 <interface>
   <requires lib="gtk+" version="3.18"/>
   <object class="GtkBox" id="Main">
-    <property name="visible">True</property>
-    <property name="can_focus">False</property>
+    <property name="visible">1</property>
     <property name="orientation">vertical</property>
     <child>
       <object class="GtkPaned">
-        <property name="visible">True</property>
-        <property name="can_focus">True</property>
+        <property name="visible">1</property>
+        <property name="can-focus">1</property>
         <child>
           <object class="GtkBox">
-            <property name="visible">True</property>
-            <property name="can_focus">False</property>
+            <property name="visible">1</property>
             <property name="orientation">vertical</property>
             <child>
               <object class="GtkBox">
-                <property name="visible">True</property>
-                <property name="can_focus">False</property>
+                <property name="visible">1</property>
+                <property name="margin">6</property>
                 <property name="spacing">6</property>
-                <property name="border_width">6</property>
                 <child>
                   <object class="GtkBox">
-                    <property name="visible">True</property>
-                    <property name="can_focus">False</property>
+                    <property name="visible">1</property>
                     <property name="spacing">6</property>
-                    <property name="margin_start">10</property>
-                    <property name="margin_end">5</property>
+                    <property name="margin-start">10</property>
+                    <property name="margin-end">5</property>
                     <child>
                       <object class="GtkLabel">
-                        <property name="visible">True</property>
-                        <property name="can_focus">False</property>
+                        <property name="visible">1</property>
                         <property name="label" translatable="yes">Folders</property>
                       </object>
                     </child>
                     <child>
                       <object class="GtkButton">
-                        <property name="visible">True</property>
-                        <property name="sensitive">False</property>
-                        <property name="can-focus">False</property>
-                        <property name="receives-default">False</property>
+                        <property name="visible">1</property>
+                        <property name="sensitive">0</property>
                         <child>
                           <object class="GtkBox">
                             <property name="width-request">24</property>
-                            <property name="visible">True</property>
-                            <property name="can-focus">False</property>
+                            <property name="visible">1</property>
                             <property name="spacing">5</property>
-                            <property name="homogeneous">True</property>
+                            <property name="homogeneous">1</property>
                             <child>
                               <object class="GtkLabel" id="NumDirectories">
-                                <property name="visible">True</property>
-                                <property name="can-focus">False</property>
+                                <property name="visible">1</property>
                                 <property name="label">&lt;b&gt;0&lt;/b&gt;</property>
-                                <property name="use_markup">True</property>
-                                <property name="margin_start">5</property>
-                                <property name="margin_end">5</property>
+                                <property name="use-markup">1</property>
+                                <property name="margin-start">5</property>
+                                <property name="margin-end">5</property>
                               </object>
                             </child>
                           </object>
@@ -68,39 +59,33 @@
                 </child>
                 <child>
                   <object class="GtkBox">
-                    <property name="visible">True</property>
-                    <property name="can_focus">False</property>
+                    <property name="visible">1</property>
                     <property name="spacing">6</property>
-                    <property name="margin_start">5</property>
-                    <property name="margin_end">5</property>
+                    <property name="margin-start">5</property>
+                    <property name="margin-end">5</property>
                     <child>
                       <object class="GtkLabel">
-                        <property name="visible">True</property>
-                        <property name="can_focus">False</property>
+                        <property name="visible">1</property>
                         <property name="label" translatable="yes">Shared</property>
                       </object>
                     </child>
                     <child>
                       <object class="GtkButton">
-                        <property name="visible">True</property>
-                        <property name="sensitive">False</property>
-                        <property name="can-focus">False</property>
-                        <property name="receives-default">False</property>
+                        <property name="visible">1</property>
+                        <property name="sensitive">0</property>
                         <child>
                           <object class="GtkBox">
                             <property name="width-request">24</property>
-                            <property name="visible">True</property>
-                            <property name="can-focus">False</property>
+                            <property name="visible">1</property>
                             <property name="spacing">5</property>
-                            <property name="homogeneous">True</property>
+                            <property name="homogeneous">1</property>
                             <child>
                               <object class="GtkLabel" id="AmountShared">
-                                <property name="visible">True</property>
-                                <property name="can-focus">False</property>
+                                <property name="visible">1</property>
                                 <property name="label">&lt;b&gt;0 B&lt;/b&gt;</property>
-                                <property name="use_markup">True</property>
-                                <property name="margin_start">5</property>
-                                <property name="margin_end">5</property>
+                                <property name="use-markup">1</property>
+                                <property name="margin-start">5</property>
+                                <property name="margin-end">5</property>
                               </object>
                             </child>
                           </object>
@@ -116,51 +101,46 @@
             </child>
             <child>
               <object class="GtkBox">
-                <property name="visible">True</property>
-                <property name="can_focus">False</property>
+                <property name="visible">1</property>
                 <property name="spacing">6</property>
-                <property name="margin_start">11</property>
-                <property name="margin_end">11</property>
-                <property name="margin_bottom">5</property>
+                <property name="margin-start">11</property>
+                <property name="margin-end">11</property>
+                <property name="margin-bottom">5</property>
                 <child>
                   <object class="GtkSearchEntry" id="SearchEntry">
-                    <property name="visible">True</property>
-                    <property name="can_focus">True</property>
-                    <property name="hexpand">True</property>
-                    <property name="tooltip_text" translatable="yes">Search files and folders (exact match)</property>
+                    <property name="visible">1</property>
+                    <property name="can-focus">1</property>
+                    <property name="hexpand">1</property>
+                    <property name="tooltip-text" translatable="yes">Search files and folders (exact match)</property>
                     <signal name="activate" handler="on_search" swapped="no"/>
                   </object>
                 </child>
                 <child>
                   <object class="GtkButton" id="RefreshButton">
-                    <property name="visible">True</property>
-                    <property name="can_focus">True</property>
-                    <property name="receives_default">False</property>
-                    <property name="tooltip_text" translatable="yes">Refresh files</property>
+                    <property name="visible">1</property>
+                    <property name="can-focus">1</property>
+                    <property name="tooltip-text" translatable="yes">Refresh files</property>
                     <property name="image">refresh</property>
-                    <property name="always_show_image">True</property>
+                    <property name="always-show-image">1</property>
                     <signal name="clicked" handler="on_refresh" swapped="no"/>
                     <child>
                       <object class="GtkImage" id="refresh">
-                        <property name="can_focus">False</property>
-                        <property name="icon_name">view-refresh-symbolic</property>
+                        <property name="icon-name">view-refresh-symbolic</property>
                       </object>
                     </child>
                   </object>
                 </child>
                 <child>
                   <object class="GtkToggleButton" id="ExpandButton">
-                    <property name="visible">True</property>
-                    <property name="can_focus">True</property>
-                    <property name="receives_default">False</property>
-                    <property name="tooltip_text" translatable="yes">Expand / Collapse all</property>
+                    <property name="visible">1</property>
+                    <property name="can-focus">1</property>
+                    <property name="tooltip-text" translatable="yes">Expand / Collapse all</property>
                     <property name="image">expand</property>
-                    <property name="always_show_image">True</property>
+                    <property name="always-show-image">1</property>
                     <signal name="clicked" handler="on_expand" swapped="no"/>
                     <child>
                       <object class="GtkImage" id="expand">
-                        <property name="can_focus">False</property>
-                        <property name="icon_name">list-add-symbolic</property>
+                        <property name="icon-name">list-add-symbolic</property>
                       </object>
                     </child>
                   </object>
@@ -169,16 +149,16 @@
             </child>
             <child>
               <object class="GtkScrolledWindow">
-                <property name="width_request">350</property>
-                <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <property name="vexpand">True</property>
+                <property name="width-request">350</property>
+                <property name="visible">1</property>
+                <property name="can-focus">1</property>
+                <property name="vexpand">1</property>
                 <child>
                   <object class="GtkTreeView" id="FolderTreeView">
-                    <property name="visible">True</property>
-                    <property name="sensitive">False</property>
-                    <property name="can_focus">True</property>
-                    <property name="headers_visible">False</property>
+                    <property name="visible">1</property>
+                    <property name="sensitive">0</property>
+                    <property name="can-focus">1</property>
+                    <property name="headers-visible">0</property>
                   </object>
                 </child>
               </object>
@@ -186,39 +166,33 @@
             <child>
               <object class="GtkProgressBar" id="progressbar1">
                 <property name="valign">center</property>
-                <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="pulse_step">0.10000000149</property>
-                <property name="margin_start">5</property>
-                <property name="margin_end">5</property>
-                <property name="margin_top">5</property>
-                <property name="margin_bottom">5</property>
+                <property name="visible">1</property>
+                <property name="pulse-step">0.10000000149</property>
+                <property name="margin-start">5</property>
+                <property name="margin-end">5</property>
+                <property name="margin-top">5</property>
+                <property name="margin-bottom">5</property>
               </object>
             </child>
           </object>
           <packing>
-            <property name="resize">False</property>
-            <property name="shrink">True</property>
+            <property name="resize">0</property>
           </packing>
         </child>
         <child>
           <object class="GtkBox">
-            <property name="visible">True</property>
-            <property name="can_focus">False</property>
+            <property name="visible">1</property>
             <property name="orientation">vertical</property>
             <child>
               <object class="GtkInfoBar" id="InfoBar">
-                <property name="visible">True</property>
-                <property name="can-focus">False</property>
+                <property name="visible">1</property>
                 <child internal-child="content_area">
                   <object class="GtkBox">
-                    <property name="can-focus">False</property>
                     <property name="spacing">16</property>
                     <child>
                       <object class="GtkLabel">
-                        <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="wrap">True</property>
+                        <property name="visible">1</property>
+                        <property name="wrap">1</property>
                       </object>
                     </child>
                   </object>
@@ -227,23 +201,19 @@
             </child>
             <child>
               <object class="GtkScrolledWindow">
-                <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <property name="vexpand">True</property>
+                <property name="visible">1</property>
+                <property name="can-focus">1</property>
+                <property name="vexpand">1</property>
                 <child>
                   <object class="GtkTreeView" id="FileTreeView">
-                    <property name="visible">True</property>
-                    <property name="sensitive">False</property>
-                    <property name="can_focus">True</property>
+                    <property name="visible">1</property>
+                    <property name="sensitive">0</property>
+                    <property name="can-focus">1</property>
                   </object>
                 </child>
               </object>
             </child>
           </object>
-          <packing>
-            <property name="resize">True</property>
-            <property name="shrink">True</property>
-          </packing>
         </child>
       </object>
     </child>

--- a/pynicotine/gtkgui/ui/userbrowse.ui
+++ b/pynicotine/gtkgui/ui/userbrowse.ui
@@ -18,24 +18,21 @@
               <object class="GtkBox">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
-                <property name="spacing">3</property>
-                <property name="border_width">2</property>
+                <property name="spacing">6</property>
+                <property name="border_width">6</property>
                 <child>
                   <object class="GtkBox">
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
                     <property name="spacing">6</property>
+                    <property name="margin_start">10</property>
+                    <property name="margin_end">5</property>
                     <child>
                       <object class="GtkLabel">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
                         <property name="label" translatable="yes">Folders</property>
                       </object>
-                      <packing>
-                        <property name="expand">False</property>
-                        <property name="fill">True</property>
-                        <property name="position">0</property>
-                      </packing>
                     </child>
                     <child>
                       <object class="GtkButton">
@@ -56,13 +53,9 @@
                                 <property name="can-focus">False</property>
                                 <property name="label">&lt;b&gt;0&lt;/b&gt;</property>
                                 <property name="use_markup">True</property>
+                                <property name="margin_start">5</property>
+                                <property name="margin_end">5</property>
                               </object>
-                              <packing>
-                                <property name="expand">False</property>
-                                <property name="fill">True</property>
-                                <property name="padding">5</property>
-                                <property name="position">0</property>
-                              </packing>
                             </child>
                           </object>
                         </child>
@@ -70,36 +63,22 @@
                           <class name="circular"/>
                         </style>
                       </object>
-                      <packing>
-                        <property name="expand">False</property>
-                        <property name="fill">False</property>
-                        <property name="position">1</property>
-                      </packing>
                     </child>
                   </object>
-                  <packing>
-                    <property name="expand">False</property>
-                    <property name="fill">False</property>
-                    <property name="padding">10</property>
-                    <property name="position">0</property>
-                  </packing>
                 </child>
                 <child>
                   <object class="GtkBox">
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
                     <property name="spacing">6</property>
+                    <property name="margin_start">5</property>
+                    <property name="margin_end">5</property>
                     <child>
                       <object class="GtkLabel">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
                         <property name="label" translatable="yes">Shared</property>
                       </object>
-                      <packing>
-                        <property name="expand">False</property>
-                        <property name="fill">True</property>
-                        <property name="position">0</property>
-                      </packing>
                     </child>
                     <child>
                       <object class="GtkButton">
@@ -120,13 +99,9 @@
                                 <property name="can-focus">False</property>
                                 <property name="label">&lt;b&gt;0 B&lt;/b&gt;</property>
                                 <property name="use_markup">True</property>
+                                <property name="margin_start">5</property>
+                                <property name="margin_end">5</property>
                               </object>
-                              <packing>
-                                <property name="expand">False</property>
-                                <property name="fill">True</property>
-                                <property name="padding">5</property>
-                                <property name="position">0</property>
-                              </packing>
                             </child>
                           </object>
                         </child>
@@ -134,26 +109,10 @@
                           <class name="circular"/>
                         </style>
                       </object>
-                      <packing>
-                        <property name="expand">False</property>
-                        <property name="fill">False</property>
-                        <property name="position">1</property>
-                      </packing>
                     </child>
                   </object>
-                  <packing>
-                    <property name="expand">True</property>
-                    <property name="fill">True</property>
-                    <property name="position">1</property>
-                  </packing>
                 </child>
               </object>
-              <packing>
-                <property name="expand">False</property>
-                <property name="fill">False</property>
-                <property name="position">0</property>
-                <property name="padding">5</property>
-              </packing>
             </child>
             <child>
               <object class="GtkBox">
@@ -167,14 +126,10 @@
                   <object class="GtkSearchEntry" id="SearchEntry">
                     <property name="visible">True</property>
                     <property name="can_focus">True</property>
+                    <property name="hexpand">True</property>
                     <property name="tooltip_text" translatable="yes">Search files and folders (exact match)</property>
                     <signal name="activate" handler="on_search" swapped="no"/>
                   </object>
-                  <packing>
-                    <property name="expand">True</property>
-                    <property name="fill">True</property>
-                    <property name="position">0</property>
-                  </packing>
                 </child>
                 <child>
                   <object class="GtkButton" id="RefreshButton">
@@ -192,11 +147,6 @@
                       </object>
                     </child>
                   </object>
-                  <packing>
-                    <property name="expand">False</property>
-                    <property name="fill">False</property>
-                    <property name="position">1</property>
-                  </packing>
                 </child>
                 <child>
                   <object class="GtkToggleButton" id="ExpandButton">
@@ -214,26 +164,15 @@
                       </object>
                     </child>
                   </object>
-                  <packing>
-                    <property name="expand">False</property>
-                    <property name="fill">False</property>
-                    <property name="position">2</property>
-                  </packing>
                 </child>
               </object>
-              <packing>
-                <property name="expand">False</property>
-                <property name="fill">False</property>
-                <property name="position">1</property>
-              </packing>
             </child>
             <child>
               <object class="GtkScrolledWindow">
                 <property name="width_request">350</property>
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
-                <property name="hscrollbar_policy">automatic</property>
-                <property name="vscrollbar_policy">automatic</property>
+                <property name="vexpand">True</property>
                 <child>
                   <object class="GtkTreeView" id="FolderTreeView">
                     <property name="visible">True</property>
@@ -243,11 +182,6 @@
                   </object>
                 </child>
               </object>
-              <packing>
-                <property name="expand">True</property>
-                <property name="fill">True</property>
-                <property name="position">2</property>
-              </packing>
             </child>
             <child>
               <object class="GtkProgressBar" id="progressbar1">
@@ -257,13 +191,9 @@
                 <property name="pulse_step">0.10000000149</property>
                 <property name="margin_start">5</property>
                 <property name="margin_end">5</property>
+                <property name="margin_top">5</property>
+                <property name="margin_bottom">5</property>
               </object>
-              <packing>
-                <property name="expand">False</property>
-                <property name="fill">True</property>
-                <property name="padding">5</property>
-                <property name="position">3</property>
-              </packing>
             </child>
           </object>
           <packing>
@@ -292,11 +222,6 @@
                       </object>
                     </child>
                   </object>
-                  <packing>
-                    <property name="expand">False</property>
-                    <property name="fill">False</property>
-                    <property name="position">0</property>
-                  </packing>
                 </child>
               </object>
             </child>
@@ -304,8 +229,7 @@
               <object class="GtkScrolledWindow">
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
-                <property name="hscrollbar_policy">automatic</property>
-                <property name="vscrollbar_policy">automatic</property>
+                <property name="vexpand">True</property>
                 <child>
                   <object class="GtkTreeView" id="FileTreeView">
                     <property name="visible">True</property>
@@ -314,11 +238,6 @@
                   </object>
                 </child>
               </object>
-              <packing>
-                <property name="expand">True</property>
-                <property name="fill">True</property>
-                <property name="position">1</property>
-              </packing>
             </child>
           </object>
           <packing>
@@ -327,11 +246,6 @@
           </packing>
         </child>
       </object>
-      <packing>
-        <property name="expand">True</property>
-        <property name="fill">True</property>
-        <property name="position">1</property>
-      </packing>
     </child>
   </object>
 </interface>

--- a/pynicotine/gtkgui/ui/userinfo.ui
+++ b/pynicotine/gtkgui/ui/userinfo.ui
@@ -174,9 +174,6 @@
                         <property name="margin-top">6</property>
                         <property name="pulse-step">0.10000000149</property>
                       </object>
-                      <packing>
-                        <property name="pack-type">end</property>
-                      </packing>
                     </child>
                   </object>
                 </child>

--- a/pynicotine/gtkgui/ui/userinfo.ui
+++ b/pynicotine/gtkgui/ui/userinfo.ui
@@ -87,7 +87,7 @@
                 <child>
                   <object class="GtkBox">
                     <property name="visible">1</property>
-                    <property name="border-width">10</property>
+                    <property name="margin">10</property>
                     <property name="spacing">6</property>
                     <property name="orientation">vertical</property>
                     <child>
@@ -294,7 +294,7 @@
         <child>
           <object class="GtkBox">
             <property name="visible">1</property>
-            <property name="border-width">10</property>
+            <property name="margin">10</property>
             <property name="spacing">6</property>
             <property name="orientation">vertical</property>
             <child>

--- a/pynicotine/gtkgui/ui/userinfo.ui
+++ b/pynicotine/gtkgui/ui/userinfo.ui
@@ -2,420 +2,284 @@
 <interface>
   <requires lib="gtk+" version="3.18"/>
   <object class="GtkBox" id="Main">
-    <property name="visible">True</property>
-    <property name="can_focus">False</property>
+    <property name="visible">1</property>
     <property name="orientation">vertical</property>
     <child>
       <object class="GtkInfoBar" id="InfoBar">
-        <property name="visible">True</property>
-        <property name="can-focus">False</property>
+        <property name="visible">1</property>
         <child internal-child="content_area">
           <object class="GtkBox">
-            <property name="can-focus">False</property>
             <property name="spacing">16</property>
             <child>
               <object class="GtkLabel">
-                <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="wrap">True</property>
+                <property name="visible">1</property>
+                <property name="wrap">1</property>
               </object>
             </child>
           </object>
-          <packing>
-            <property name="expand">False</property>
-            <property name="fill">False</property>
-            <property name="position">0</property>
-          </packing>
         </child>
       </object>
     </child>
     <child>
       <object class="GtkBox">
-        <property name="visible">True</property>
-        <property name="can_focus">False</property>
+        <property name="visible">1</property>
+        <property name="vexpand">1</property>
         <child>
           <object class="GtkPaned">
-            <property name="visible">True</property>
-            <property name="can_focus">True</property>
+            <property name="visible">1</property>
+            <property name="can-focus">1</property>
+            <property name="hexpand">1</property>
             <child>
               <object class="GtkBox" id="InfoVbox">
-                <property name="visible">True</property>
-                <property name="can_focus">False</property>
+                <property name="visible">1</property>
                 <property name="spacing">6</property>
                 <property name="orientation">vertical</property>
                 <child>
                   <object class="GtkBox">
-                    <property name="visible">True</property>
-                    <property name="can_focus">False</property>
+                    <property name="visible">1</property>
                     <property name="spacing">2</property>
                     <property name="orientation">vertical</property>
                     <child>
                       <object class="GtkLabel">
-                        <property name="visible">True</property>
-                        <property name="can_focus">False</property>
+                        <property name="visible">1</property>
                         <property name="halign">start</property>
-                        <property name="margin_start">10</property>
-                        <property name="margin_end">10</property>
+                        <property name="margin-start">10</property>
+                        <property name="margin-end">10</property>
+                        <property name="margin-top">10</property>
+                        <property name="margin-bottom">10</property>
                         <property name="label" translatable="yes">&lt;b&gt;Self Description&lt;/b&gt;</property>
-                        <property name="use_markup">True</property>
+                        <property name="use-markup">1</property>
                       </object>
-                      <packing>
-                        <property name="expand">False</property>
-                        <property name="fill">False</property>
-                        <property name="position">0</property>
-                        <property name="padding">10</property>
-                      </packing>
                     </child>
                     <child>
                       <object class="GtkScrolledWindow">
-                        <property name="visible">True</property>
-                        <property name="can_focus">True</property>
+                        <property name="visible">1</property>
+                        <property name="can-focus">1</property>
+                        <property name="vexpand">1</property>
                         <child>
                           <object class="GtkTextView" id="descr">
-                            <property name="visible">True</property>
-                            <property name="can_focus">True</property>
-                            <property name="editable">False</property>
-                            <property name="wrap_mode">word</property>
-                            <property name="cursor_visible">False</property>
-                            <property name="pixels_above_lines">1</property>
-                            <property name="pixels_below_lines">1</property>
-                            <property name="left_margin">10</property>
-                            <property name="right_margin">10</property>
-                            <property name="bottom_margin">5</property>
+                            <property name="visible">1</property>
+                            <property name="can-focus">1</property>
+                            <property name="editable">0</property>
+                            <property name="wrap-mode">word</property>
+                            <property name="cursor-visible">0</property>
+                            <property name="pixels-above-lines">1</property>
+                            <property name="pixels-below-lines">1</property>
+                            <property name="left-margin">10</property>
+                            <property name="right-margin">10</property>
+                            <property name="bottom-margin">5</property>
                           </object>
                         </child>
                       </object>
-                      <packing>
-                        <property name="expand">True</property>
-                        <property name="fill">True</property>
-                        <property name="padding">3</property>
-                        <property name="position">1</property>
-                      </packing>
                     </child>
                   </object>
-                  <packing>
-                    <property name="expand">True</property>
-                    <property name="fill">True</property>
-                    <property name="position">0</property>
-                  </packing>
                 </child>
                 <child>
                   <object class="GtkLabel">
-                    <property name="visible">True</property>
-                    <property name="can_focus">False</property>
+                    <property name="visible">1</property>
                     <property name="halign">start</property>
-                    <property name="margin_start">10</property>
-                    <property name="margin_end">10</property>
+                    <property name="margin-start">10</property>
+                    <property name="margin-end">10</property>
                     <property name="label" translatable="yes">&lt;b&gt;Information&lt;/b&gt;</property>
-                    <property name="use_markup">True</property>
+                    <property name="use-markup">1</property>
                   </object>
-                  <packing>
-                    <property name="expand">False</property>
-                    <property name="fill">False</property>
-                    <property name="position">1</property>
-                  </packing>
                 </child>
                 <child>
                   <object class="GtkBox">
-                    <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <property name="border_width">10</property>
+                    <property name="visible">1</property>
+                    <property name="border-width">10</property>
                     <property name="spacing">6</property>
                     <property name="orientation">vertical</property>
                     <child>
                       <object class="GtkLabel" id="uploads">
-                        <property name="visible">True</property>
-                        <property name="can_focus">False</property>
+                        <property name="visible">1</property>
                         <property name="label" translatable="yes">Total uploads allowed: unknown</property>
                         <property name="xalign">0</property>
                       </object>
-                      <packing>
-                        <property name="expand">False</property>
-                        <property name="fill">False</property>
-                        <property name="position">1</property>
-                      </packing>
                     </child>
                     <child>
                       <object class="GtkLabel" id="slotsavail">
-                        <property name="visible">True</property>
-                        <property name="can_focus">False</property>
+                        <property name="visible">1</property>
                         <property name="label" translatable="yes">Slots free: unknown</property>
                         <property name="xalign">0</property>
                       </object>
-                      <packing>
-                        <property name="expand">False</property>
-                        <property name="fill">False</property>
-                        <property name="position">2</property>
-                      </packing>
                     </child>
                     <child>
                       <object class="GtkBox">
-                        <property name="visible">True</property>
-                        <property name="can_focus">False</property>
+                        <property name="visible">1</property>
                         <property name="spacing">6</property>
                         <child>
                           <object class="GtkLabel" id="queuesize">
-                            <property name="visible">True</property>
-                            <property name="can_focus">False</property>
+                            <property name="visible">1</property>
                             <property name="label" translatable="yes">Queue size: unknown</property>
                             <property name="xalign">0</property>
                           </object>
-                          <packing>
-                            <property name="expand">False</property>
-                            <property name="fill">False</property>
-                            <property name="position">0</property>
-                          </packing>
                         </child>
                       </object>
-                      <packing>
-                        <property name="expand">False</property>
-                        <property name="fill">False</property>
-                        <property name="position">3</property>
-                      </packing>
                     </child>
                     <child>
                       <object class="GtkBox">
-                        <property name="visible">True</property>
-                        <property name="can_focus">False</property>
+                        <property name="visible">1</property>
                         <property name="spacing">6</property>
                         <child>
                           <object class="GtkLabel" id="speed">
-                            <property name="visible">True</property>
-                            <property name="can_focus">False</property>
+                            <property name="visible">1</property>
                             <property name="label" translatable="yes">Speed: unknown</property>
                             <property name="xalign">0</property>
                           </object>
-                          <packing>
-                            <property name="expand">False</property>
-                            <property name="fill">False</property>
-                            <property name="position">0</property>
-                          </packing>
                         </child>
                       </object>
-                      <packing>
-                        <property name="expand">False</property>
-                        <property name="fill">False</property>
-                        <property name="position">4</property>
-                      </packing>
                     </child>
                     <child>
                       <object class="GtkBox">
-                        <property name="visible">True</property>
-                        <property name="can_focus">False</property>
+                        <property name="visible">1</property>
                         <property name="spacing">6</property>
                         <child>
                           <object class="GtkLabel" id="filesshared">
-                            <property name="visible">True</property>
-                            <property name="can_focus">False</property>
+                            <property name="visible">1</property>
                             <property name="label" translatable="yes">Files: unknown</property>
                             <property name="xalign">0</property>
                           </object>
-                          <packing>
-                            <property name="expand">False</property>
-                            <property name="fill">False</property>
-                            <property name="position">0</property>
-                          </packing>
                         </child>
                         <child>
                           <object class="GtkLabel" id="dirsshared">
-                            <property name="visible">True</property>
-                            <property name="can_focus">False</property>
+                            <property name="visible">1</property>
                             <property name="label" translatable="yes">Directories: unknown</property>
                             <property name="xalign">0</property>
                           </object>
-                          <packing>
-                            <property name="expand">False</property>
-                            <property name="fill">False</property>
-                            <property name="position">1</property>
-                          </packing>
                         </child>
                       </object>
-                      <packing>
-                        <property name="expand">False</property>
-                        <property name="fill">False</property>
-                        <property name="position">5</property>
-                      </packing>
                     </child>
                     <child>
                       <object class="GtkBox">
-                        <property name="visible">True</property>
-                        <property name="can_focus">False</property>
+                        <property name="visible">1</property>
                         <property name="spacing">6</property>
                         <child>
                           <object class="GtkLabel">
-                            <property name="visible">True</property>
-                            <property name="can_focus">False</property>
+                            <property name="visible">1</property>
                             <property name="label" translatable="yes">Accepts Uploads from:</property>
                           </object>
-                          <packing>
-                            <property name="expand">False</property>
-                            <property name="fill">False</property>
-                            <property name="position">0</property>
-                          </packing>
                         </child>
                         <child>
                           <object class="GtkLabel" id="AcceptUploads">
-                            <property name="visible">True</property>
-                            <property name="can_focus">False</property>
+                            <property name="visible">1</property>
                             <property name="label" translatable="yes">unknown</property>
                           </object>
-                          <packing>
-                            <property name="expand">False</property>
-                            <property name="fill">False</property>
-                            <property name="position">1</property>
-                          </packing>
                         </child>
                       </object>
-                      <packing>
-                        <property name="expand">False</property>
-                        <property name="fill">True</property>
-                        <property name="position">6</property>
-                      </packing>
                     </child>
                     <child>
                       <object class="GtkProgressBar" id="progressbar">
-                        <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="margin_top">6</property>
-                        <property name="pulse_step">0.10000000149</property>
+                        <property name="visible">1</property>
+                        <property name="margin-top">6</property>
+                        <property name="pulse-step">0.10000000149</property>
                       </object>
                       <packing>
-                        <property name="expand">False</property>
-                        <property name="fill">False</property>
-                        <property name="pack_type">end</property>
-                        <property name="position">6</property>
+                        <property name="pack-type">end</property>
                       </packing>
                     </child>
                   </object>
-                  <packing>
-                    <property name="expand">False</property>
-                    <property name="fill">False</property>
-                    <property name="position">2</property>
-                  </packing>
                 </child>
               </object>
               <packing>
-                <property name="resize">False</property>
-                <property name="shrink">True</property>
+                <property name="resize">0</property>
               </packing>
             </child>
             <child>
               <object class="GtkPaned">
-                <property name="visible">True</property>
-                <property name="can_focus">True</property>
+                <property name="visible">1</property>
+                <property name="can-focus">1</property>
                 <child>
                   <object class="GtkBox">
-                    <property name="width_request">300</property>
-                    <property name="visible">True</property>
-                    <property name="can_focus">False</property>
+                    <property name="width-request">300</property>
+                    <property name="visible">1</property>
                     <property name="spacing">6</property>
                     <property name="orientation">vertical</property>
                     <child>
                       <object class="GtkLabel">
-                        <property name="visible">True</property>
-                        <property name="can_focus">False</property>
+                        <property name="visible">1</property>
                         <property name="halign">start</property>
-                        <property name="margin_start">10</property>
-                        <property name="margin_end">10</property>
+                        <property name="margin-start">10</property>
+                        <property name="margin-end">10</property>
+                        <property name="margin-top">10</property>
+                        <property name="margin-bottom">10</property>
                         <property name="label" translatable="yes">&lt;b&gt;Interests&lt;/b&gt;</property>
-                        <property name="use_markup">True</property>
+                        <property name="use-markup">1</property>
                       </object>
-                      <packing>
-                        <property name="expand">False</property>
-                        <property name="fill">False</property>
-                        <property name="position">0</property>
-                        <property name="padding">10</property>
-                      </packing>
                     </child>
                     <child>
                       <object class="GtkScrolledWindow">
-                        <property name="visible">True</property>
-                        <property name="can_focus">True</property>
+                        <property name="visible">1</property>
+                        <property name="can-focus">1</property>
+                        <property name="vexpand">1</property>
                         <child>
                           <object class="GtkTreeView" id="Likes">
-                            <property name="visible">True</property>
-                            <property name="can_focus">True</property>
+                            <property name="visible">1</property>
+                            <property name="can-focus">1</property>
                             <child internal-child="selection">
                               <object class="GtkTreeSelection"/>
                             </child>
                           </object>
                         </child>
                       </object>
-                      <packing>
-                        <property name="expand">True</property>
-                        <property name="fill">True</property>
-                        <property name="position">1</property>
-                      </packing>
                     </child>
                     <child>
                       <object class="GtkScrolledWindow">
-                        <property name="visible">True</property>
-                        <property name="can_focus">True</property>
+                        <property name="visible">1</property>
+                        <property name="can-focus">1</property>
+                        <property name="vexpand">1</property>
                         <child>
                           <object class="GtkTreeView" id="Hates">
-                            <property name="visible">True</property>
-                            <property name="can_focus">True</property>
+                            <property name="visible">1</property>
+                            <property name="can-focus">1</property>
                             <child internal-child="selection">
                               <object class="GtkTreeSelection"/>
                             </child>
                           </object>
                         </child>
                       </object>
-                      <packing>
-                        <property name="expand">True</property>
-                        <property name="fill">True</property>
-                        <property name="position">2</property>
-                      </packing>
                     </child>
                   </object>
                   <packing>
-                    <property name="resize">False</property>
-                    <property name="shrink">True</property>
+                    <property name="resize">0</property>
                   </packing>
                 </child>
                 <child>
                   <object class="GtkBox">
-                    <property name="visible">True</property>
-                    <property name="can_focus">False</property>
+                    <property name="visible">1</property>
                     <property name="orientation">vertical</property>
+                    <property name="hexpand">1</property>
                     <property name="spacing">6</property>
                     <child>
                       <object class="GtkLabel">
-                        <property name="visible">True</property>
-                        <property name="can_focus">False</property>
+                        <property name="visible">1</property>
                         <property name="halign">start</property>
-                        <property name="margin_start">10</property>
-                        <property name="margin_end">10</property>
+                        <property name="margin-start">10</property>
+                        <property name="margin-end">10</property>
+                        <property name="margin-top">10</property>
+                        <property name="margin-bottom">10</property>
                         <property name="label" translatable="yes">&lt;b&gt;Picture&lt;/b&gt;</property>
-                        <property name="use_markup">True</property>
+                        <property name="use-markup">1</property>
                       </object>
-                      <packing>
-                        <property name="expand">False</property>
-                        <property name="fill">True</property>
-                        <property name="position">0</property>
-                        <property name="padding">10</property>
-                      </packing>
                     </child>
                     <child>
                       <object class="GtkScrolledWindow">
-                        <property name="visible">True</property>
-                        <property name="can_focus">True</property>
+                        <property name="visible">1</property>
+                        <property name="can-focus">1</property>
+                        <property name="vexpand">1</property>
                         <signal name="scroll-event" handler="on_scroll_event" swapped="no"/>
                         <child>
                           <object class="GtkViewport">
-                            <property name="visible">True</property>
-                            <property name="can_focus">False</property>
-                            <property name="shadow_type">none</property>
+                            <property name="visible">1</property>
+                            <property name="shadow-type">none</property>
                             <child>
                               <object class="GtkEventBox">
-                                <property name="visible">True</property>
-                                <property name="can_focus">False</property>
+                                <property name="visible">1</property>
                                 <signal name="button-press-event" handler="on_image_click" swapped="no"/>
                                 <child>
                                   <object class="GtkImage" id="image">
-                                    <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
-                                    <property name="icon_name">action-unavailable-symbolic</property>
+                                    <property name="visible">1</property>
+                                    <property name="icon-name">action-unavailable-symbolic</property>
                                   </object>
                                 </child>
                               </object>
@@ -423,343 +287,237 @@
                           </object>
                         </child>
                       </object>
-                      <packing>
-                        <property name="expand">True</property>
-                        <property name="fill">True</property>
-                        <property name="position">1</property>
-                      </packing>
                     </child>
                   </object>
-                  <packing>
-                    <property name="resize">True</property>
-                    <property name="shrink">True</property>
-                  </packing>
                 </child>
               </object>
-              <packing>
-                <property name="resize">True</property>
-                <property name="shrink">True</property>
-              </packing>
             </child>
           </object>
-          <packing>
-            <property name="expand">True</property>
-            <property name="fill">True</property>
-            <property name="position">0</property>
-          </packing>
         </child>
         <child>
           <object class="GtkBox">
-            <property name="visible">True</property>
-            <property name="can_focus">False</property>
-            <property name="border_width">10</property>
+            <property name="visible">1</property>
+            <property name="border-width">10</property>
             <property name="spacing">6</property>
             <property name="orientation">vertical</property>
             <child>
               <object class="GtkButton">
-                <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <property name="receives_default">False</property>
+                <property name="visible">1</property>
+                <property name="can-focus">1</property>
                 <signal name="clicked" handler="on_send_message" swapped="no"/>
                 <child>
                   <object class="GtkBox">
-                    <property name="visible">True</property>
-                    <property name="can_focus">False</property>
+                    <property name="visible">1</property>
                     <property name="spacing">5</property>
                     <child>
                       <object class="GtkImage">
-                        <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="icon_name">user-available-symbolic</property>
+                        <property name="visible">1</property>
+                        <property name="icon-name">user-available-symbolic</property>
                       </object>
                     </child>
                     <child>
                       <object class="GtkLabel">
-                        <property name="visible">True</property>
-                        <property name="can_focus">False</property>
+                        <property name="visible">1</property>
                         <property name="label" translatable="yes">Send Message</property>
-                        <property name="use_underline">True</property>
+                        <property name="use-underline">1</property>
                       </object>
                     </child>
                   </object>
                 </child>
               </object>
-              <packing>
-                <property name="expand">False</property>
-                <property name="fill">False</property>
-                <property name="position">0</property>
-              </packing>
             </child>
             <child>
               <object class="GtkButton">
-                <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <property name="receives_default">False</property>
+                <property name="visible">1</property>
+                <property name="can-focus">1</property>
                 <signal name="clicked" handler="on_browse_user" swapped="no"/>
                 <child>
                   <object class="GtkBox">
-                    <property name="visible">True</property>
-                    <property name="can_focus">False</property>
+                    <property name="visible">1</property>
                     <property name="spacing">5</property>
                     <child>
                       <object class="GtkImage">
-                        <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="icon_name">system-file-manager-symbolic</property>
+                        <property name="visible">1</property>
+                        <property name="icon-name">system-file-manager-symbolic</property>
                       </object>
                     </child>
                     <child>
                       <object class="GtkLabel">
-                        <property name="visible">True</property>
-                        <property name="can_focus">False</property>
+                        <property name="visible">1</property>
                         <property name="label" translatable="yes">Browse Files</property>
-                        <property name="use_underline">True</property>
+                        <property name="use-underline">1</property>
                       </object>
                     </child>
                   </object>
                 </child>
               </object>
-              <packing>
-                <property name="expand">False</property>
-                <property name="fill">False</property>
-                <property name="position">1</property>
-              </packing>
             </child>
             <child>
               <object class="GtkButton">
-                <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <property name="receives_default">False</property>
+                <property name="visible">1</property>
+                <property name="can-focus">1</property>
                 <signal name="clicked" handler="on_show_ip_address" swapped="no"/>
                 <child>
                   <object class="GtkBox">
-                    <property name="visible">True</property>
-                    <property name="can_focus">False</property>
+                    <property name="visible">1</property>
                     <property name="spacing">5</property>
                     <child>
                       <object class="GtkImage">
-                        <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="icon_name">network-wired-symbolic</property>
+                        <property name="visible">1</property>
+                        <property name="icon-name">network-wired-symbolic</property>
                       </object>
                     </child>
                     <child>
                       <object class="GtkLabel">
-                        <property name="visible">True</property>
-                        <property name="can_focus">False</property>
+                        <property name="visible">1</property>
                         <property name="label" translatable="yes">Show IP Address</property>
-                        <property name="use_underline">True</property>
+                        <property name="use-underline">1</property>
                       </object>
                     </child>
                   </object>
                 </child>
               </object>
-              <packing>
-                <property name="expand">False</property>
-                <property name="fill">False</property>
-                <property name="position">2</property>
-              </packing>
             </child>
             <child>
               <object class="GtkButton" id="AddToList">
-                <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <property name="receives_default">False</property>
+                <property name="visible">1</property>
+                <property name="can-focus">1</property>
                 <signal name="clicked" handler="on_add_to_list" swapped="no"/>
                 <child>
                   <object class="GtkBox">
-                    <property name="visible">True</property>
-                    <property name="can_focus">False</property>
+                    <property name="visible">1</property>
                     <property name="spacing">5</property>
                     <child>
                       <object class="GtkImage">
-                        <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="icon_name">list-add-symbolic</property>
+                        <property name="visible">1</property>
+                        <property name="icon-name">list-add-symbolic</property>
                       </object>
                     </child>
                     <child>
                       <object class="GtkLabel">
-                        <property name="visible">True</property>
-                        <property name="can_focus">False</property>
+                        <property name="visible">1</property>
                         <property name="label" translatable="yes">Add to Buddy List</property>
-                        <property name="use_underline">True</property>
+                        <property name="use-underline">1</property>
                       </object>
                     </child>
                   </object>
                 </child>
               </object>
-              <packing>
-                <property name="expand">False</property>
-                <property name="fill">False</property>
-                <property name="position">3</property>
-              </packing>
             </child>
             <child>
               <object class="GtkButton" id="BanUser">
-                <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <property name="receives_default">False</property>
+                <property name="visible">1</property>
+                <property name="can-focus">1</property>
                 <signal name="clicked" handler="on_ban_user" swapped="no"/>
                 <child>
                   <object class="GtkBox">
-                    <property name="visible">True</property>
-                    <property name="can_focus">False</property>
+                    <property name="visible">1</property>
                     <property name="spacing">5</property>
                     <child>
                       <object class="GtkImage">
-                        <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="icon_name">action-unavailable-symbolic</property>
+                        <property name="visible">1</property>
+                        <property name="icon-name">action-unavailable-symbolic</property>
                       </object>
                     </child>
                     <child>
                       <object class="GtkLabel">
-                        <property name="visible">True</property>
-                        <property name="can_focus">False</property>
+                        <property name="visible">1</property>
                         <property name="label" translatable="yes">Ban User</property>
-                        <property name="use_underline">True</property>
+                        <property name="use-underline">1</property>
                       </object>
                     </child>
                   </object>
                 </child>
               </object>
-              <packing>
-                <property name="expand">False</property>
-                <property name="fill">False</property>
-                <property name="position">4</property>
-              </packing>
             </child>
             <child>
               <object class="GtkButton" id="IgnoreUser">
-                <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <property name="receives_default">False</property>
+                <property name="visible">1</property>
+                <property name="can-focus">1</property>
                 <signal name="clicked" handler="on_ignore_user" swapped="no"/>
                 <child>
                   <object class="GtkBox">
-                    <property name="visible">True</property>
-                    <property name="can_focus">False</property>
+                    <property name="visible">1</property>
                     <property name="spacing">5</property>
                     <child>
                       <object class="GtkImage">
-                        <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="icon_name">dialog-error-symbolic</property>
+                        <property name="visible">1</property>
+                        <property name="icon-name">dialog-error-symbolic</property>
                       </object>
                     </child>
                     <child>
                       <object class="GtkLabel">
-                        <property name="visible">True</property>
-                        <property name="can_focus">False</property>
+                        <property name="visible">1</property>
                         <property name="label" translatable="yes">Ignore User</property>
-                        <property name="use_underline">True</property>
+                        <property name="use-underline">1</property>
                       </object>
                     </child>
                   </object>
                 </child>
               </object>
-              <packing>
-                <property name="expand">False</property>
-                <property name="fill">False</property>
-                <property name="position">5</property>
-              </packing>
             </child>
             <child>
               <object class="GtkButton" id="SavePicture">
-                <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <property name="receives_default">False</property>
-                <property name="sensitive">False</property>
+                <property name="visible">1</property>
+                <property name="can-focus">1</property>
+                <property name="sensitive">0</property>
                 <signal name="clicked" handler="on_save_picture" swapped="no"/>
                 <child>
                   <object class="GtkBox">
-                    <property name="visible">True</property>
-                    <property name="can_focus">False</property>
+                    <property name="visible">1</property>
                     <property name="spacing">5</property>
                     <child>
                       <object class="GtkImage">
-                        <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="icon_name">document-save-symbolic</property>
+                        <property name="visible">1</property>
+                        <property name="icon-name">document-save-symbolic</property>
                       </object>
                     </child>
                     <child>
                       <object class="GtkLabel">
-                        <property name="visible">True</property>
-                        <property name="can_focus">False</property>
+                        <property name="visible">1</property>
                         <property name="label" translatable="yes">Save Picture</property>
-                        <property name="use_underline">True</property>
+                        <property name="use-underline">1</property>
                       </object>
                     </child>
                   </object>
                 </child>
               </object>
-              <packing>
-                <property name="expand">False</property>
-                <property name="fill">False</property>
-                <property name="position">6</property>
-              </packing>
             </child>
             <child>
               <object class="GtkLabel" id="Filler">
-                <property name="visible">True</property>
-                <property name="can_focus">False</property>
+                <property name="visible">1</property>
+                <property name="vexpand">1</property>
               </object>
-              <packing>
-                <property name="expand">True</property>
-                <property name="fill">True</property>
-                <property name="position">7</property>
-              </packing>
             </child>
             <child>
               <object class="GtkButton" id="RefreshUserinfo">
-                <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <property name="receives_default">False</property>
+                <property name="visible">1</property>
+                <property name="can-focus">1</property>
                 <signal name="clicked" handler="on_refresh" swapped="no"/>
                 <child>
                   <object class="GtkBox">
-                    <property name="visible">True</property>
-                    <property name="can_focus">False</property>
+                    <property name="visible">1</property>
                     <property name="spacing">5</property>
                     <child>
                       <object class="GtkImage">
-                        <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="icon_name">view-refresh-symbolic</property>
+                        <property name="visible">1</property>
+                        <property name="icon-name">view-refresh-symbolic</property>
                       </object>
                     </child>
                     <child>
                       <object class="GtkLabel">
-                        <property name="visible">True</property>
-                        <property name="can_focus">False</property>
+                        <property name="visible">1</property>
                         <property name="label" translatable="yes">Refresh Info</property>
-                        <property name="use_underline">True</property>
+                        <property name="use-underline">1</property>
                       </object>
                     </child>
                   </object>
                 </child>
               </object>
-              <packing>
-                <property name="expand">False</property>
-                <property name="fill">False</property>
-                <property name="position">8</property>
-              </packing>
             </child>
           </object>
-          <packing>
-            <property name="expand">False</property>
-            <property name="fill">True</property>
-            <property name="position">1</property>
-          </packing>
         </child>
       </object>
-      <packing>
-        <property name="expand">True</property>
-        <property name="fill">True</property>
-            <property name="position">1</property>
-      </packing>
     </child>
   </object>
 </interface>

--- a/pynicotine/gtkgui/ui/userinfo.ui
+++ b/pynicotine/gtkgui/ui/userinfo.ui
@@ -87,7 +87,10 @@
                 <child>
                   <object class="GtkBox">
                     <property name="visible">1</property>
-                    <property name="margin">10</property>
+                    <property name="margin-start">10</property>
+                    <property name="margin-end">10</property>
+                    <property name="margin-top">10</property>
+                    <property name="margin-bottom">10</property>
                     <property name="spacing">6</property>
                     <property name="orientation">vertical</property>
                     <child>
@@ -294,7 +297,10 @@
         <child>
           <object class="GtkBox">
             <property name="visible">1</property>
-            <property name="margin">10</property>
+            <property name="margin-start">10</property>
+            <property name="margin-end">10</property>
+            <property name="margin-top">10</property>
+            <property name="margin-bottom">10</property>
             <property name="spacing">6</property>
             <property name="orientation">vertical</property>
             <child>

--- a/pynicotine/gtkgui/ui/wishlist.ui
+++ b/pynicotine/gtkgui/ui/wishlist.ui
@@ -15,8 +15,10 @@
           <object class="GtkLabel">
             <property name="visible">1</property>
             <property name="halign">start</property>
-            <property name="xpad">13</property>
-            <property name="ypad">10</property>
+            <property name="margin-start">10</property>
+            <property name="margin-end">10</property>
+            <property name="margin-top">13</property>
+            <property name="margin-bottom">13</property>
             <property name="label" translatable="yes">The search wishlist can be useful when you are looking for rare content. Search terms in the wishlist are automatically requested at regular intervals.</property>
             <property name="justify">fill</property>
             <property name="wrap">1</property>
@@ -40,7 +42,10 @@
         <child>
           <object class="GtkBox">
             <property name="visible">1</property>
-            <property name="margin">10</property>
+            <property name="margin-start">10</property>
+            <property name="margin-end">10</property>
+            <property name="margin-top">10</property>
+            <property name="margin-bottom">10</property>
             <property name="spacing">10</property>
             <child>
               <object class="GtkBox">

--- a/pynicotine/gtkgui/ui/wishlist.ui
+++ b/pynicotine/gtkgui/ui/wishlist.ui
@@ -2,184 +2,139 @@
 <interface>
   <requires lib="gtk+" version="3.18"/>
   <object class="GtkDialog" id="WishListDialog">
-    <property name="can_focus">False</property>
     <property name="title" translatable="yes">Search Wishlist</property>
-    <property name="modal">True</property>
-    <property name="window_position">center-on-parent</property>
-    <property name="default_width">600</property>
-    <property name="default_height">600</property>
+    <property name="modal">1</property>
+    <property name="window-position">center-on-parent</property>
+    <property name="default-width">600</property>
+    <property name="default-height">600</property>
     <child internal-child="vbox">
       <object class="GtkBox">
-        <property name="visible">True</property>
-        <property name="can_focus">False</property>
+        <property name="visible">1</property>
         <property name="orientation">vertical</property>
         <child>
           <object class="GtkLabel">
-            <property name="visible">True</property>
-            <property name="can_focus">False</property>
+            <property name="visible">1</property>
             <property name="halign">start</property>
             <property name="xpad">13</property>
             <property name="ypad">10</property>
             <property name="label" translatable="yes">The search wishlist can be useful when you are looking for rare content. Search terms in the wishlist are automatically requested at regular intervals.</property>
             <property name="justify">fill</property>
-            <property name="wrap">True</property>
+            <property name="wrap">1</property>
           </object>
-          <packing>
-            <property name="expand">False</property>
-            <property name="fill">False</property>
-            <property name="position">0</property>
-          </packing>
         </child>
         <child>
           <object class="GtkScrolledWindow">
-            <property name="visible">True</property>
-            <property name="can_focus">False</property>
-            <property name="margin_start">10</property>
-            <property name="margin_end">10</property>
-            <property name="shadow_type">in</property>
+            <property name="visible">1</property>
+            <property name="margin-start">10</property>
+            <property name="margin-end">10</property>
+            <property name="shadow-type">in</property>
+            <property name="vexpand">1</property>
             <child>
               <object class="GtkTreeView" id="WishlistView">
-                <property name="visible">True</property>
-                <property name="can_focus">True</property>
+                <property name="visible">1</property>
+                <property name="can-focus">1</property>
               </object>
             </child>
           </object>
-          <packing>
-            <property name="expand">True</property>
-            <property name="fill">True</property>
-          </packing>
         </child>
         <child>
           <object class="GtkBox">
-            <property name="visible">True</property>
-            <property name="can_focus">False</property>
-            <property name="border_width">10</property>
+            <property name="visible">1</property>
+            <property name="border-width">10</property>
             <property name="spacing">10</property>
             <child>
               <object class="GtkEntry" id="AddWishEntry">
-                <property name="visible">True</property>
-                <property name="can_focus">True</property>
+                <property name="visible">1</property>
+                <property name="can-focus">1</property>
                 <signal name="activate" handler="on_add_wish" swapped="no"/>
               </object>
-              <packing>
-                <property name="expand">True</property>
-                <property name="fill">True</property>
-                <property name="position">0</property>
-              </packing>
             </child>
             <child>
               <object class="GtkButton">
-                <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <property name="receives_default">False</property>
-                <property name="margin_end">30</property>
+                <property name="visible">1</property>
+                <property name="can-focus">1</property>
+                <property name="margin-end">30</property>
                 <signal name="clicked" handler="on_add_wish" swapped="no"/>
                 <child>
                   <object class="GtkBox">
-                    <property name="visible">True</property>
-                    <property name="can_focus">False</property>
+                    <property name="visible">1</property>
                     <property name="spacing">5</property>
                     <child>
                       <object class="GtkImage">
-                        <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="icon_name">list-add-symbolic</property>
+                        <property name="visible">1</property>
+                        <property name="icon-name">list-add-symbolic</property>
                       </object>
                     </child>
                     <child>
                       <object class="GtkLabel">
-                        <property name="visible">True</property>
-                        <property name="can_focus">False</property>
+                        <property name="visible">1</property>
                         <property name="label" translatable="yes">Add...</property>
-                        <property name="use_underline">True</property>
+                        <property name="use-underline">1</property>
                       </object>
                     </child>
                   </object>
                 </child>
               </object>
-              <packing>
-                <property name="expand">False</property>
-                <property name="fill">False</property>
-                <property name="position">1</property>
-              </packing>
             </child>
             <child>
               <object class="GtkButton">
-                <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <property name="receives_default">False</property>
+                <property name="visible">1</property>
+                <property name="can-focus">1</property>
                 <signal name="clicked" handler="on_remove_wish" swapped="no"/>
                 <child>
                   <object class="GtkBox">
-                    <property name="visible">True</property>
-                    <property name="can_focus">False</property>
+                    <property name="visible">1</property>
                     <property name="spacing">5</property>
                     <child>
                       <object class="GtkImage">
-                        <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="icon_name">edit-clear-symbolic</property>
+                        <property name="visible">1</property>
+                        <property name="icon-name">edit-clear-symbolic</property>
                       </object>
                     </child>
                     <child>
                       <object class="GtkLabel">
-                        <property name="visible">True</property>
-                        <property name="can_focus">False</property>
+                        <property name="visible">1</property>
                         <property name="label" translatable="yes">Remove</property>
-                        <property name="use_underline">True</property>
+                        <property name="use-underline">1</property>
                       </object>
                     </child>
                   </object>
                 </child>
               </object>
               <packing>
-                <property name="expand">False</property>
-                <property name="fill">False</property>
-                <property name="position">2</property>
-                <property name="pack_type">end</property>
+                <property name="pack-type">end</property>
               </packing>
             </child>
             <child>
               <object class="GtkButton">
-                <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <property name="receives_default">False</property>
+                <property name="visible">1</property>
+                <property name="can-focus">1</property>
                 <signal name="clicked" handler="on_select_all_wishes" swapped="no"/>
                 <child>
                   <object class="GtkBox">
-                    <property name="visible">True</property>
-                    <property name="can_focus">False</property>
+                    <property name="visible">1</property>
                     <property name="spacing">5</property>
                     <child>
                       <object class="GtkImage">
-                        <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="icon_name">object-select-symbolic</property>
+                        <property name="visible">1</property>
+                        <property name="icon-name">object-select-symbolic</property>
                       </object>
                     </child>
                     <child>
                       <object class="GtkLabel">
-                        <property name="visible">True</property>
-                        <property name="can_focus">False</property>
+                        <property name="visible">1</property>
                         <property name="label" translatable="yes">Select All</property>
-                        <property name="use_underline">True</property>
+                        <property name="use-underline">1</property>
                       </object>
                     </child>
                   </object>
                 </child>
               </object>
               <packing>
-                <property name="expand">False</property>
-                <property name="fill">False</property>
-                <property name="position">3</property>
-                <property name="pack_type">end</property>
+                <property name="pack-type">end</property>
               </packing>
             </child>
           </object>
-          <packing>
-            <property name="expand">False</property>
-            <property name="fill">True</property>
-          </packing>
         </child>
       </object>
     </child>

--- a/pynicotine/gtkgui/ui/wishlist.ui
+++ b/pynicotine/gtkgui/ui/wishlist.ui
@@ -43,18 +43,51 @@
             <property name="border-width">10</property>
             <property name="spacing">10</property>
             <child>
-              <object class="GtkEntry" id="AddWishEntry">
+              <object class="GtkBox">
                 <property name="visible">1</property>
-                <property name="can-focus">1</property>
-                <signal name="activate" handler="on_add_wish" swapped="no"/>
+                <property name="hexpand">1</property>
+                <property name="spacing">10</property>
+                <child>
+                  <object class="GtkEntry" id="AddWishEntry">
+                    <property name="visible">1</property>
+                    <property name="can-focus">1</property>
+                    <signal name="activate" handler="on_add_wish" swapped="no"/>
+                  </object>
+                </child>
+                <child>
+                  <object class="GtkButton">
+                    <property name="visible">1</property>
+                    <property name="can-focus">1</property>
+                    <property name="margin-end">30</property>
+                    <signal name="clicked" handler="on_add_wish" swapped="no"/>
+                    <child>
+                      <object class="GtkBox">
+                        <property name="visible">1</property>
+                        <property name="spacing">5</property>
+                        <child>
+                          <object class="GtkImage">
+                            <property name="visible">1</property>
+                            <property name="icon-name">list-add-symbolic</property>
+                          </object>
+                        </child>
+                        <child>
+                          <object class="GtkLabel">
+                            <property name="visible">1</property>
+                            <property name="label" translatable="yes">Add...</property>
+                            <property name="use-underline">1</property>
+                          </object>
+                        </child>
+                      </object>
+                    </child>
+                  </object>
+                </child>
               </object>
             </child>
             <child>
               <object class="GtkButton">
                 <property name="visible">1</property>
                 <property name="can-focus">1</property>
-                <property name="margin-end">30</property>
-                <signal name="clicked" handler="on_add_wish" swapped="no"/>
+                <signal name="clicked" handler="on_select_all_wishes" swapped="no"/>
                 <child>
                   <object class="GtkBox">
                     <property name="visible">1</property>
@@ -62,13 +95,13 @@
                     <child>
                       <object class="GtkImage">
                         <property name="visible">1</property>
-                        <property name="icon-name">list-add-symbolic</property>
+                        <property name="icon-name">object-select-symbolic</property>
                       </object>
                     </child>
                     <child>
                       <object class="GtkLabel">
                         <property name="visible">1</property>
-                        <property name="label" translatable="yes">Add...</property>
+                        <property name="label" translatable="yes">Select All</property>
                         <property name="use-underline">1</property>
                       </object>
                     </child>
@@ -101,38 +134,6 @@
                   </object>
                 </child>
               </object>
-              <packing>
-                <property name="pack-type">end</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkButton">
-                <property name="visible">1</property>
-                <property name="can-focus">1</property>
-                <signal name="clicked" handler="on_select_all_wishes" swapped="no"/>
-                <child>
-                  <object class="GtkBox">
-                    <property name="visible">1</property>
-                    <property name="spacing">5</property>
-                    <child>
-                      <object class="GtkImage">
-                        <property name="visible">1</property>
-                        <property name="icon-name">object-select-symbolic</property>
-                      </object>
-                    </child>
-                    <child>
-                      <object class="GtkLabel">
-                        <property name="visible">1</property>
-                        <property name="label" translatable="yes">Select All</property>
-                        <property name="use-underline">1</property>
-                      </object>
-                    </child>
-                  </object>
-                </child>
-              </object>
-              <packing>
-                <property name="pack-type">end</property>
-              </packing>
             </child>
           </object>
         </child>

--- a/pynicotine/gtkgui/ui/wishlist.ui
+++ b/pynicotine/gtkgui/ui/wishlist.ui
@@ -40,7 +40,7 @@
         <child>
           <object class="GtkBox">
             <property name="visible">1</property>
-            <property name="border-width">10</property>
+            <property name="margin">10</property>
             <property name="spacing">10</property>
             <child>
               <object class="GtkBox">

--- a/pynicotine/gtkgui/utils.py
+++ b/pynicotine/gtkgui/utils.py
@@ -595,11 +595,11 @@ class BuddiesComboBox:
             del self.items[item]
 
 
-class ImageLabel(Gtk.Box):
+class ImageLabel(Gtk.EventBox):
 
     def __init__(self, label="", onclose=None, closebutton=False, angle=0, hilite_image=None, show_hilite_image=True, status_image=None, show_status_image=False):
 
-        Gtk.Box.__init__(self)
+        Gtk.EventBox.__init__(self)
 
         self.closebutton = closebutton
         self.angle = angle
@@ -630,8 +630,6 @@ class ImageLabel(Gtk.Box):
         self._order_children()
 
     def _pack_children(self):
-        self.set_spacing(0)
-
         if "box" in self.__dict__:
             for widget in self.box.get_children():
                 self.box.remove(widget)
@@ -827,7 +825,7 @@ class IconNotebook:
         self.angle = angle
 
     def get_labels(self, page):
-        tab_label = self.notebook.get_tab_label(page).get_child()
+        tab_label = self.notebook.get_tab_label(page)
         menu_label = self.notebook.get_menu_label(page)
 
         return tab_label, menu_label
@@ -836,14 +834,16 @@ class IconNotebook:
 
         self.reorderable = reorderable
 
-        for page in self.notebook.get_children():
+        for i in range(self.notebook.get_n_pages()):
+            page = self.notebook.get_nth_page(i)
             self.notebook.set_tab_reorderable(page, self.reorderable)
 
     def set_tab_closers(self, closers):
 
         self.tabclosers = closers
 
-        for page in self.notebook.get_children():
+        for i in range(self.notebook.get_n_pages()):
+            page = self.notebook.get_nth_page(i)
             tab_label, menu_label = self.get_labels(page)
 
             tab_label.set_onclose(self.tabclosers)
@@ -852,7 +852,8 @@ class IconNotebook:
 
         self._show_hilite_image = show_image
 
-        for page in self.notebook.get_children():
+        for i in range(self.notebook.get_n_pages()):
+            page = self.notebook.get_nth_page(i)
             tab_label, menu_label = self.get_labels(page)
 
             tab_label.show_hilite_image(self._show_hilite_image)
@@ -868,7 +869,8 @@ class IconNotebook:
 
         self.angle = angle
 
-        for page in self.notebook.get_children():
+        for i in range(self.notebook.get_n_pages()):
+            page = self.notebook.get_nth_page(i)
             tab_label, menu_label = self.get_labels(page)
 
             tab_label.set_angle(angle)
@@ -895,18 +897,10 @@ class IconNotebook:
 
         # menu for all tabs
         label_tab_menu = ImageLabel(label)
-
-        eventbox = Gtk.EventBox()
-        eventbox.set_visible_window(False)
-
+        label_tab.connect('button_press_event', self.on_tab_click, page)
         label_tab.show()
 
-        eventbox.add(label_tab)
-        eventbox.show()
-        eventbox.set_events(Gdk.EventMask.BUTTON_PRESS_MASK)
-        eventbox.connect('button_press_event', self.on_tab_click, page)
-
-        Gtk.Notebook.append_page_menu(self.notebook, page, eventbox, label_tab_menu)
+        Gtk.Notebook.append_page_menu(self.notebook, page, label_tab, label_tab_menu)
 
         self.notebook.set_tab_reorderable(page, self.reorderable)
         self.notebook.set_show_tabs(True)
@@ -954,7 +948,8 @@ class IconNotebook:
 
     def set_text_colors(self, status):
 
-        for page in self.notebook.get_children():
+        for i in range(self.notebook.get_n_pages()):
+            page = self.notebook.get_nth_page(i)
             self.set_text_color(page, status)
 
     def set_text_color(self, page, status):

--- a/pynicotine/gtkgui/utils.py
+++ b/pynicotine/gtkgui/utils.py
@@ -608,6 +608,7 @@ class ImageLabel(Gtk.EventBox):
 
         self.label = Gtk.Label()
         self.label.set_angle(angle)
+        self.label.set_halign(Gtk.Align.START)
         self.label.show()
 
         self.text = label


### PR DESCRIPTION
While we won't be able to switch to GTK 4 for a few years, it's a good idea to do whatever we can right now to make the process easier.

This PR takes care of https://developer.gnome.org/gtk4/stable/gtk-migrating-3-to-4.html#id-1.7.4.3.11 for everything except the preferences window, and also changes a few properties removed in GTK 4 to ones supported in both GTK 3 and GTK 4. The files have been partially edited by hand, and simplified using `gtk-builder-tool simplify x.ui > y.ui`.

Checklist:
- [x] Confirm all changes work on GTK 3.18 (the oldest version we support)