### PR TITLE
Refactor column width/visibility saving, allow column reordering

### DIFF
--- a/pynicotine/config.py
+++ b/pynicotine/config.py
@@ -217,18 +217,12 @@ class Config:
             },
 
             "columns": {
-                "userbrowse": [1, 1, 1, 1],
-                "userbrowse_widths": [600, 100, 70, 0],
-                "userlist": [1, 1, 1, 1, 1, 1, 1, 1, 1, 1],
-                "userlist_widths": [25, 25, 180, 0, 0, 0, 0, 0, 160, 0],
-                "chatrooms": {},
-                "chatrooms_widths": {},
-                "download_columns": [1, 1, 1, 1, 1, 1, 1, 1, 1, 1],
-                "download_widths": [200, 250, 250, 140, 50, 70, 170, 90, 140, 0],
-                "upload_columns": [1, 1, 1, 1, 1, 1, 1, 1, 1, 1],
-                "upload_widths": [200, 250, 250, 140, 50, 70, 170, 90, 140, 0],
-                "filesearch_columns": [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1],
-                "filesearch_widths": [50, 200, 25, 50, 90, 90, 400, 400, 100, 100, 0],
+                "file_search": {},
+                "download": {},
+                "upload": {},
+                "user_browse": {},
+                "buddy_list": {},
+                "chat_room": {},
                 "hideflags": False
             },
 
@@ -630,6 +624,20 @@ class Config:
 
         # Remove "I can receive direct connections"-option, it's redundant now
         self.remove_old_option("server", "firewalled")
+
+        # Remove old column options
+        self.remove_old_option("columns", "userbrowse")
+        self.remove_old_option("columns", "userbrowse_widths")
+        self.remove_old_option("columns", "userlist")
+        self.remove_old_option("columns", "userlist_widths")
+        self.remove_old_option("columns", "chatrooms")
+        self.remove_old_option("columns", "chatrooms_widths")
+        self.remove_old_option("columns", "download_columns")
+        self.remove_old_option("columns", "download_widths")
+        self.remove_old_option("columns", "upload_columns")
+        self.remove_old_option("columns", "upload_widths")
+        self.remove_old_option("columns", "filesearch_columns")
+        self.remove_old_option("columns", "filesearch_widths")
 
     def remove_old_option(self, section, option):
 

--- a/pynicotine/gtkgui/chatrooms.py
+++ b/pynicotine/gtkgui/chatrooms.py
@@ -24,6 +24,7 @@
 
 import os
 import re
+
 from collections import deque
 from os.path import commonprefix
 
@@ -39,7 +40,6 @@ from pynicotine.gtkgui.dialogs import entry_dialog
 from pynicotine.gtkgui.roomwall import RoomWall
 from pynicotine.gtkgui.roomwall import Tickers
 from pynicotine.gtkgui.utils import append_line
-from pynicotine.gtkgui.utils import hide_columns
 from pynicotine.gtkgui.utils import humanize
 from pynicotine.gtkgui.utils import human_speed
 from pynicotine.gtkgui.utils import IconNotebook
@@ -51,6 +51,7 @@ from pynicotine.gtkgui.utils import scroll_bottom
 from pynicotine.gtkgui.utils import TextSearchBar
 from pynicotine.gtkgui.utils import expand_alias
 from pynicotine.gtkgui.utils import is_alias
+from pynicotine.gtkgui.utils import save_columns
 from pynicotine.gtkgui.utils import show_country_tooltip
 from pynicotine.gtkgui.utils import set_widget_color
 from pynicotine.gtkgui.utils import set_widget_font
@@ -109,16 +110,17 @@ class RoomsControl:
         self.frame.roomlist.RoomsList.set_model(self.roomsmodel)
 
         self.cols = initialise_columns(
+            None,
             self.frame.roomlist.RoomsList,
-            [_("Room"), 180, "text", self.room_status],
-            [_("Users"), 0, "number", self.room_status]
+            ["room", _("Room"), 180, "text", self.room_status, None],
+            ["users", _("Users"), 0, "number", self.room_status, None]
         )
-        self.cols[0].set_sort_column_id(0)
-        self.cols[1].set_sort_column_id(1)
+        self.cols["room"].set_sort_column_id(0)
+        self.cols["users"].set_sort_column_id(1)
 
         self.roomsmodel.set_sort_func(1, self.private_rooms_sort, 1)
 
-        for i in range(2):
+        for i in ("room", "users"):
             parent = self.cols[i].get_widget().get_ancestor(Gtk.Button)
             if parent:
                 parent.connect('button_press_event', press_header)
@@ -682,13 +684,9 @@ class RoomsControl:
 
     def save_columns(self):
 
-        for room in list(self.frame.np.config.sections["columns"]["chatrooms"].keys())[:]:
+        for room in list(self.frame.np.config.sections["columns"]["chat_room"].keys())[:]:
             if room not in self.joinedrooms:
-                del self.frame.np.config.sections["columns"]["chatrooms"][room]
-
-        for room in list(self.frame.np.config.sections["columns"]["chatrooms_widths"].keys())[:]:
-            if room not in self.joinedrooms:
-                del self.frame.np.config.sections["columns"]["chatrooms_widths"][room]
+                del self.frame.np.config.sections["columns"]["chat_room"][room]
 
         for room in self.joinedrooms.values():
             room.save_columns()
@@ -798,38 +796,31 @@ class ChatRoom:
         if room in config["server"]["autojoin"]:
             self.AutoJoin.set_active(True)
 
-        if room not in config["columns"]["chatrooms_widths"]:
-            config["columns"]["chatrooms_widths"][room] = [25, 25, 100, 0, 0]
+        if room not in config["columns"]["chat_room"]:
+            config["columns"]["chat_room"][room] = {}
 
-        widths = self.frame.np.config.sections["columns"]["chatrooms_widths"][room]
         self.cols = cols = initialise_columns(
+            ("chat_room", room),
             self.UserList,
-            [_("Status"), widths[0], "pixbuf"],
-            [_("Country"), widths[1], "pixbuf"],
-            [_("User"), widths[2], "text", self.user_column_draw],
-            [_("Speed"), widths[3], "number"],
-            [_("Files"), widths[4], "number"]
+            ["status", _("Status"), 25, "pixbuf", None, None],
+            ["country", _("Country"), 25, "pixbuf", None, None],
+            ["user", _("User"), 100, "text", self.user_column_draw, None],
+            ["speed", _("Speed"), 0, "number", None, None],
+            ["files", _("Files"), 0, "number", None, None]
         )
 
-        cols[0].set_sort_column_id(5)
-        cols[1].set_sort_column_id(8)
-        cols[2].set_sort_column_id(2)
-        cols[3].set_sort_column_id(6)
-        cols[4].set_sort_column_id(7)
-        cols[0].get_widget().hide()
-        cols[1].get_widget().hide()
+        cols["status"].set_sort_column_id(5)
+        cols["country"].set_sort_column_id(8)
+        cols["user"].set_sort_column_id(2)
+        cols["speed"].set_sort_column_id(6)
+        cols["files"].set_sort_column_id(7)
 
-        if room not in config["columns"]["chatrooms"]:
-            config["columns"]["chatrooms"][room] = [1, 1, 1, 1, 1]
-
-        if len(config["columns"]["chatrooms"][room]) != 5:  # Insert new column to old settings.
-            config["columns"]["chatrooms"][room].insert(1, 1)
-
-        hide_columns(cols, config["columns"]["chatrooms"][room])
+        cols["status"].get_widget().hide()
+        cols["country"].get_widget().hide()
 
         if config["columns"]["hideflags"]:
-            cols[1].set_visible(0)
-            config["columns"]["chatrooms"][room][1] = 0
+            cols["country"].set_visible(0)
+            config["columns"]["chat_room"][room]["country"]["visible"] = False
 
         self.users = {}
 
@@ -1692,11 +1683,8 @@ class ChatRoom:
 
         config = self.frame.np.config.sections
 
-        if self.room in config["columns"]["chatrooms"]:
-            del config["columns"]["chatrooms"][self.room]
-
-        if self.room in config["columns"]["chatrooms_widths"]:
-            del config["columns"]["chatrooms_widths"][self.room]
+        if self.room in config["columns"]["chat_room"]:
+            del config["columns"]["chat_room"][self.room]
 
         if not self.meta:
             self.frame.np.queue.put(slskmessages.LeaveRoom(self.room))
@@ -1710,15 +1698,7 @@ class ChatRoom:
         self.frame.np.pluginhandler.leave_chatroom_notification(self.room)
 
     def save_columns(self):
-
-        columns = []
-        widths = []
-        for column in self.UserList.get_columns():
-            columns.append(column.get_visible())
-            widths.append(column.get_width())
-
-        self.frame.np.config.sections["columns"]["chatrooms"][self.room] = columns
-        self.frame.np.config.sections["columns"]["chatrooms_widths"][self.room] = widths
+        save_columns("chat_room", self.UserList.get_columns(), subpage=self.room)
 
     def conn_close(self):
 
@@ -1729,11 +1709,8 @@ class ChatRoom:
         self.count_users()
 
         config = self.frame.np.config.sections
-        if not self.AutoJoin.get_active() and self.room in config["columns"]["chatrooms"]:
-            del config["columns"]["chatrooms"][self.room]
-
-        if not self.AutoJoin.get_active() and self.room in config["columns"]["chatrooms_widths"]:
-            del config["columns"]["chatrooms_widths"][self.room]
+        if not self.AutoJoin.get_active() and self.room in config["columns"]["chat_room"]:
+            del config["columns"]["chat_room"][self.room]
 
         for tag in self.tag_users.values():
             self.update_tag_visuals(tag, "useroffline")

--- a/pynicotine/gtkgui/frame.py
+++ b/pynicotine/gtkgui/frame.py
@@ -1070,11 +1070,11 @@ class NicotineFrame:
 
     def set_show_flags(self, state):
         for room in self.chatrooms.roomsctrl.joinedrooms:
-            self.chatrooms.roomsctrl.joinedrooms[room].cols[1].set_visible(state)
-            self.np.config.sections["columns"]["chatrooms"][room][1] = int(state)
+            self.chatrooms.roomsctrl.joinedrooms[room].cols["country"].set_visible(state)
+            self.np.config.sections["columns"]["chat_room"][room][1] = int(state)
 
-        self.userlist.cols[1].set_visible(state)
-        self.np.config.sections["columns"]["userlist"][1] = int(state)
+        self.userlist.cols["country"].set_visible(state)
+        self.np.config.sections["columns"]["buddy_list"][1] = int(state)
         self.np.config.write_configuration()
 
     def on_show_flags(self, action, *args):
@@ -2812,6 +2812,8 @@ class NicotineFrame:
 
         self.save_columns()
 
+        self.np.config.write_configuration()
+
         if self.np.transfers is not None:
             self.np.transfers.save_downloads()
 
@@ -2819,10 +2821,8 @@ class NicotineFrame:
         self.np.shares.close_shares()
 
     def save_columns(self):
-        for i in [self.userbrowse, self.userlist, self.chatrooms.roomsctrl, self.downloads, self.uploads, self.searches]:
+        for i in (self.userbrowse, self.userlist, self.chatrooms.roomsctrl, self.downloads, self.uploads, self.searches):
             i.save_columns()
-
-        self.np.config.write_configuration()
 
 
 class MainApp(Gtk.Application):

--- a/pynicotine/gtkgui/interests.py
+++ b/pynicotine/gtkgui/interests.py
@@ -47,11 +47,12 @@ class Interests:
         self.likes_model.set_sort_column_id(0, Gtk.SortType.ASCENDING)
 
         cols = initialise_columns(
+            None,
             self.LikesList,
-            [_("I like") + ":", 0, "text"]
+            ["i_like", _("I like") + ":", 0, "text", None, None]
         )
 
-        cols[0].set_sort_column_id(0)
+        cols["i_like"].set_sort_column_id(0)
         self.LikesList.set_model(self.likes_model)
 
         self.til_popup_menu = popup = PopupMenu(self.frame)
@@ -70,11 +71,12 @@ class Interests:
         self.dislikes_model.set_sort_column_id(0, Gtk.SortType.ASCENDING)
 
         cols = initialise_columns(
+            None,
             self.DislikesList,
-            [_("I dislike") + ":", 0, "text"]
+            ["i_dislike", _("I dislike") + ":", 0, "text", None, None]
         )
 
-        cols[0].set_sort_column_id(0)
+        cols["i_dislike"].set_sort_column_id(0)
         self.DislikesList.set_model(self.dislikes_model)
 
         self.tidl_popup_menu = popup = PopupMenu(self.frame)
@@ -88,13 +90,14 @@ class Interests:
         self.DislikesList.connect("button_press_event", self.on_popup_tidl_menu)
 
         cols = initialise_columns(
+            None,
             self.RecommendationsList,
-            [_("Rating"), 0, "text"],
-            [_("Item"), -1, "text"]
+            ["rating", _("Rating"), 0, "text", None, None],
+            ["item", _("Item"), -1, "text", None, None]
         )
 
-        cols[0].set_sort_column_id(2)
-        cols[1].set_sort_column_id(1)
+        cols["rating"].set_sort_column_id(2)
+        cols["item"].set_sort_column_id(1)
 
         self.recommendations_model = Gtk.ListStore(
             str,  # (0) hrating
@@ -116,13 +119,14 @@ class Interests:
         self.RecommendationsList.connect("button_press_event", self.on_popup_r_menu)
 
         cols = initialise_columns(
+            None,
             self.UnrecommendationsList,
-            [_("Rating"), 0, "text"],
-            [_("Item"), -1, "text"]
+            ["rating", _("Rating"), 0, "text", None, None],
+            ["item", _("Item"), -1, "text", None, None]
         )
 
-        cols[0].set_sort_column_id(2)
-        cols[1].set_sort_column_id(1)
+        cols["rating"].set_sort_column_id(2)
+        cols["item"].set_sort_column_id(1)
 
         self.unrecommendations_model = Gtk.ListStore(
             str,  # (0) hrating
@@ -144,17 +148,20 @@ class Interests:
         self.UnrecommendationsList.connect("button_press_event", self.on_popup_un_rec_menu)
 
         cols = initialise_columns(
+            None,
             self.RecommendationUsersList,
-            ["", 25, "pixbuf"],
-            [_("User"), 100, "text"],
-            [_("Speed"), 0, "text"],
-            [_("Files"), 0, "text"],
+            ["country", _("Country"), 25, "pixbuf", None, None],
+            ["user", _("User"), 100, "text", None, None],
+            ["speed", _("Speed"), 0, "text", None, None],
+            ["files", _("Files"), 0, "text", None, None],
         )
 
-        cols[0].set_sort_column_id(4)
-        cols[1].set_sort_column_id(1)
-        cols[2].set_sort_column_id(5)
-        cols[3].set_sort_column_id(6)
+        cols["country"].set_sort_column_id(4)
+        cols["user"].set_sort_column_id(1)
+        cols["speed"].set_sort_column_id(5)
+        cols["files"].set_sort_column_id(6)
+
+        cols["country"].get_widget().hide()
 
         self.recommendation_users = {}
         self.recommendation_users_model = Gtk.ListStore(

--- a/pynicotine/gtkgui/settingswindow.py
+++ b/pynicotine/gtkgui/settingswindow.py
@@ -240,14 +240,15 @@ class DownloadsFrame(BuildFrame):
         self.downloadfilters = []
 
         cols = initialise_columns(
+            None,
             self.FilterView,
-            [_("Filter"), 250, "text"],
-            [_("Escaped"), 40, "toggle"]
+            ["filter", _("Filter"), 250, "text", None, None],
+            ["escaped", _("Escaped"), 40, "toggle", None, None]
         )
 
-        cols[0].set_sort_column_id(0)
-        cols[1].set_sort_column_id(1)
-        renderers = cols[1].get_cells()
+        cols["filter"].set_sort_column_id(0)
+        cols["escaped"].set_sort_column_id(1)
+        renderers = cols["escaped"].get_cells()
 
         for render in renderers:
             render.connect('toggled', self.cell_toggle_callback, self.filterlist, 1)
@@ -585,18 +586,20 @@ class SharesFrame(BuildFrame):
         self.bshareddirs = []
 
         initialise_columns(
+            None,
             self.Shares,
-            [_("Virtual Folder"), 0, "text"],
-            [_("Folder"), 0, "text"]
+            ["virtual_folder", _("Virtual Folder"), 0, "text", None, None],
+            ["folder", _("Folder"), 0, "text", None, None]
         )
 
         self.Shares.set_model(self.shareslist)
         self.Shares.get_selection().set_mode(Gtk.SelectionMode.MULTIPLE)
 
         initialise_columns(
+            None,
             self.BuddyShares,
-            [_("Virtual Folder"), 0, "text"],
-            [_("Folder"), 0, "text"]
+            ["virtual_folder", _("Virtual Folder"), 0, "text", None, None],
+            ["folder", _("Folder"), 0, "text", None, None]
         )
 
         self.BuddyShares.set_model(self.bshareslist)
@@ -1140,12 +1143,13 @@ class IgnoreFrame(BuildFrame):
         self.ignored_ips = {}
         self.ignored_ips_list = Gtk.ListStore(str, str)
         cols = initialise_columns(
+            None,
             self.IgnoredIPs,
-            [_("Addresses"), -1, "text"],
-            [_("Users"), -1, "text"]
+            ["addresses", _("Addresses"), -1, "text", None, None],
+            ["users", _("Users"), -1, "text", None, None]
         )
-        cols[0].set_sort_column_id(0)
-        cols[1].set_sort_column_id(1)
+        cols["addresses"].set_sort_column_id(0)
+        cols["users"].set_sort_column_id(1)
 
         self.IgnoredIPs.set_model(self.ignored_ips_list)
         self.IgnoredIPs.get_selection().set_mode(Gtk.SelectionMode.MULTIPLE)
@@ -1270,12 +1274,13 @@ class BanFrame(BuildFrame):
         self.blocked_list = {}
         self.blocked_list_model = Gtk.ListStore(str, str)
         cols = initialise_columns(
+            None,
             self.BlockedList,
-            [_("Addresses"), -1, "text"],
-            [_("Users"), -1, "text"]
+            ["addresses", _("Addresses"), -1, "text", None, None],
+            ["users", _("Users"), -1, "text", None, None]
         )
-        cols[0].set_sort_column_id(0)
-        cols[1].set_sort_column_id(1)
+        cols["addresses"].set_sort_column_id(0)
+        cols["users"].set_sort_column_id(1)
 
         self.BlockedList.set_model(self.blocked_list_model)
         self.BlockedList.get_selection().set_mode(Gtk.SelectionMode.MULTIPLE)
@@ -2406,18 +2411,19 @@ class UrlCatchFrame(BuildFrame):
         self.protocols = {}
 
         cols = initialise_columns(
+            None,
             self.ProtocolHandlers,
-            [_("Protocol"), -1, "text"],
-            [_("Handler"), -1, "combo"]
+            ["protocol", _("Protocol"), -1, "text", None, None],
+            ["handler", _("Handler"), -1, "combo", None, None]
         )
 
-        cols[0].set_sort_column_id(0)
-        cols[1].set_sort_column_id(1)
+        cols["protocol"].set_sort_column_id(0)
+        cols["handler"].set_sort_column_id(1)
 
         self.ProtocolHandlers.set_model(self.protocolmodel)
         self.ProtocolHandlers.get_selection().connect("changed", self.on_select)
 
-        renderers = cols[1].get_cells()
+        renderers = cols["handler"].get_cells()
         for render in renderers:
             render.connect('edited', self.cell_edited_callback, self.ProtocolHandlers, 1)
 
@@ -2438,7 +2444,7 @@ class UrlCatchFrame(BuildFrame):
         self.Handler.set_model(self.handlermodel)
         self.Handler.set_entry_text_column(0)
 
-        renderers = cols[1].get_cells()
+        renderers = cols["handler"].get_cells()
         for render in renderers:
             render.set_property("model", self.handlermodel)
 
@@ -2571,11 +2577,12 @@ class CensorFrame(BuildFrame):
         self.censor_list_model = Gtk.ListStore(GObject.TYPE_STRING)
 
         cols = initialise_columns(
+            None,
             self.CensorList,
-            [_("Pattern"), -1, "edit"]
+            ["pattern", _("Pattern"), -1, "edit", None, None]
         )
 
-        cols[0].set_sort_column_id(0)
+        cols["pattern"].set_sort_column_id(0)
 
         self.CensorList.set_model(self.censor_list_model)
 
@@ -2590,7 +2597,7 @@ class CensorFrame(BuildFrame):
         self.CensorReplaceCombo.pack_start(cell, True)
         self.CensorReplaceCombo.add_attribute(cell, 'text', 0)
 
-        renderers = cols[0].get_cells()
+        renderers = cols["pattern"].get_cells()
         for render in renderers:
             render.connect('edited', self.cell_edited_callback, self.CensorList, 0)
 
@@ -2685,19 +2692,23 @@ class AutoReplaceFrame(BuildFrame):
         )
 
         cols = initialise_columns(
+            None,
             self.ReplacementList,
-            [_("Pattern"), 150, "edit"],
-            [_("Replacement"), -1, "edit"]
+            ["pattern", _("Pattern"), 150, "edit", None, None],
+            ["replacement", _("Replacement"), -1, "edit", None, None]
         )
-        cols[0].set_sort_column_id(0)
-        cols[1].set_sort_column_id(1)
+        cols["pattern"].set_sort_column_id(0)
+        cols["replacement"].set_sort_column_id(1)
 
         self.ReplacementList.set_model(self.replacelist)
 
-        for column in cols:
+        pos = 0
+        for (column_id, column) in cols.items():
             renderers = column.get_cells()
             for render in renderers:
-                render.connect('edited', self.cell_edited_callback, self.ReplacementList, cols.index(column))
+                render.connect('edited', self.cell_edited_callback, self.ReplacementList, pos)
+
+            pos += 1
 
     def cell_edited_callback(self, widget, index, value, treeview, pos):
 
@@ -3067,7 +3078,11 @@ class BuildDialog(Gtk.Dialog):
 
         self.tw["box%d" % c].pack_start(self.tw[name + "SW"], True, True, 5)
 
-        cols = initialise_columns(self.tw[name], [description, 150, "edit"])
+        cols = initialise_columns(
+            None,
+            self.tw[name],
+            [description, description, 150, "edit", None, None]
+        )
 
         try:
             self.settings.set_widget(self.tw[name], value)
@@ -3084,7 +3099,7 @@ class BuildDialog(Gtk.Dialog):
         self.Main.pack_start(self.tw["box%d" % c], True, True, 0)
         self.Main.pack_start(self.tw["vbox%d" % c], False, False, 0)
 
-        renderers = cols[0].get_cells()
+        renderers = cols[description].get_cells()
         for render in renderers:
             render.connect('edited', self.cell_edited_callback, self.tw[name])
 
@@ -3269,15 +3284,16 @@ class PluginFrame(BuildFrame):
         self.selected_plugin = None
 
         cols = initialise_columns(
+            None,
             self.PluginTreeView,
-            [_("Enabled"), 0, "toggle"],
-            [_("Plugins"), 380, "text"]
+            ["enabled", _("Enabled"), 0, "toggle", None, None],
+            ["plugins", _("Plugins"), 380, "text", None, None]
         )
 
-        cols[0].set_sort_column_id(0)
-        cols[1].set_sort_column_id(1)
+        cols["enabled"].set_sort_column_id(0)
+        cols["plugins"].set_sort_column_id(1)
 
-        renderers = cols[0].get_cells()
+        renderers = cols["enabled"].get_cells()
         for render in renderers:
             render.connect('toggled', self.cell_toggle_callback, self.PluginTreeView, 1)
 

--- a/pynicotine/gtkgui/transferlist.py
+++ b/pynicotine/gtkgui/transferlist.py
@@ -28,11 +28,11 @@ from time import time
 from gi.repository import GObject
 from gi.repository import Gtk
 
-from pynicotine.gtkgui.utils import hide_columns
 from pynicotine.gtkgui.utils import human_size
 from pynicotine.gtkgui.utils import human_speed
 from pynicotine.gtkgui.utils import initialise_columns
 from pynicotine.gtkgui.utils import PopupMenu
+from pynicotine.gtkgui.utils import save_columns
 from pynicotine.gtkgui.utils import select_user_row_iter
 from pynicotine.gtkgui.utils import update_widget_visuals
 
@@ -104,35 +104,31 @@ class TransferList:
 
         text_color = self.frame.np.config.sections["ui"]["search"]
 
-        widths = self.frame.np.config.sections["columns"]["{}_widths".format(type)]
         self.cols = cols = initialise_columns(
+            type,
             widget,
-            [_("User"), widths[0], "text", None, (text_color, None)],
-            [_("Path"), widths[1], "text", None, (text_color, None)],
-            [_("Filename"), widths[2], "text", None, (text_color, None)],
-            [_("Status"), widths[3], "text", None, (text_color, None)],
-            [_("Queue Position"), widths[4], "number", None, (text_color, None)],
-            [_("Percent"), widths[5], "progress"],
-            [_("Size"), widths[6], "number", None, (text_color, None)],
-            [_("Speed"), widths[7], "number", None, (text_color, None)],
-            [_("Time elapsed"), widths[8], "number", None, (text_color, None)],
-            [_("Time left"), widths[9], "number", None, (text_color, None)],
+            ["user", _("User"), 200, "text", None, (text_color, None)],
+            ["path", _("Path"), 400, "text", None, (text_color, None)],
+            ["filename", _("Filename"), 400, "text", None, (text_color, None)],
+            ["status", _("Status"), 140, "text", None, (text_color, None)],
+            ["queue_position", _("Queue Position"), 50, "number", None, (text_color, None)],
+            ["percent", _("Percent"), 70, "progress", None, None],
+            ["size", _("Size"), 170, "number", None, (text_color, None)],
+            ["speed", _("Speed"), 90, "number", None, (text_color, None)],
+            ["time_elapsed", _("Time Elapsed"), 140, "number", None, (text_color, None)],
+            ["time_left", _("Time Left"), 0, "number", None, (text_color, None)],
         )
 
-        self.col_user, self.col_path, self.col_filename, self.col_status, self.col_position, self.col_percent, self.col_human_size, self.col_human_speed, self.col_time_elapsed, self.col_time_left = cols
-
-        hide_columns(cols, self.frame.np.config.sections["columns"][self.type + "_columns"])
-
-        self.col_user.set_sort_column_id(0)
-        self.col_path.set_sort_column_id(1)
-        self.col_filename.set_sort_column_id(2)
-        self.col_status.set_sort_column_id(11)
-        self.col_position.set_sort_column_id(17)
-        self.col_percent.set_sort_column_id(5)
-        self.col_human_size.set_sort_column_id(12)
-        self.col_human_speed.set_sort_column_id(14)
-        self.col_time_elapsed.set_sort_column_id(8)
-        self.col_time_left.set_sort_column_id(9)
+        cols["user"].set_sort_column_id(0)
+        cols["path"].set_sort_column_id(1)
+        cols["filename"].set_sort_column_id(2)
+        cols["status"].set_sort_column_id(11)
+        cols["queue_position"].set_sort_column_id(17)
+        cols["percent"].set_sort_column_id(5)
+        cols["size"].set_sort_column_id(12)
+        cols["speed"].set_sort_column_id(14)
+        cols["time_elapsed"].set_sort_column_id(8)
+        cols["time_left"].set_sort_column_id(9)
 
         widget.set_model(self.transfersmodel)
 
@@ -142,15 +138,7 @@ class TransferList:
         self.update_visuals()
 
     def save_columns(self):
-        columns = []
-        widths = []
-
-        for column in self.widget.get_columns():
-            columns.append(column.get_visible())
-            widths.append(column.get_width())
-
-        self.frame.np.config.sections["columns"][self.type + "_columns"] = columns
-        self.frame.np.config.sections["columns"][self.type + "_widths"] = widths
+        save_columns(self.type, self.widget.get_columns())
 
     def update_visuals(self):
 

--- a/pynicotine/gtkgui/ui/userbrowse.ui
+++ b/pynicotine/gtkgui/ui/userbrowse.ui
@@ -9,7 +9,7 @@
         <property name="visible">1</property>
         <property name="can-focus">1</property>
         <child>
-          <object class="GtkBox">
+          <object class="GtkBox" id="FolderPane">
             <property name="visible">1</property>
             <property name="orientation">vertical</property>
             <child>
@@ -152,7 +152,6 @@
             </child>
             <child>
               <object class="GtkScrolledWindow">
-                <property name="width-request">350</property>
                 <property name="visible">1</property>
                 <property name="can-focus">1</property>
                 <property name="vexpand">1</property>

--- a/pynicotine/gtkgui/userbrowse.py
+++ b/pynicotine/gtkgui/userbrowse.py
@@ -34,13 +34,13 @@ from pynicotine import slskmessages
 from pynicotine.gtkgui.dialogs import choose_dir
 from pynicotine.gtkgui.dialogs import combo_box_dialog
 from pynicotine.gtkgui.fileproperties import FileProperties
-from pynicotine.gtkgui.utils import hide_columns
 from pynicotine.gtkgui.utils import human_size
 from pynicotine.gtkgui.utils import InfoBar
 from pynicotine.gtkgui.utils import initialise_columns
 from pynicotine.gtkgui.utils import load_ui_elements
 from pynicotine.gtkgui.utils import open_file_path
 from pynicotine.gtkgui.utils import PopupMenu
+from pynicotine.gtkgui.utils import save_columns
 from pynicotine.gtkgui.utils import set_treeview_selected_row
 from pynicotine.gtkgui.utils import update_widget_visuals
 from pynicotine.logfacility import log
@@ -89,10 +89,12 @@ class UserBrowse:
         self.FolderTreeView.set_enable_tree_lines(True)
 
         cols = initialise_columns(
+            None,
             self.FolderTreeView,
-            [_("Directories"), -1, "text"]  # 0
+            ["folders", _("Folders"), -1, "text", None, None]  # 0
         )
-        cols[0].set_sort_column_id(0)
+
+        cols["folders"].set_sort_column_id(0)
 
         self.popup_menu_users = PopupMenu(self.frame, False)
         self.popup_menu_users2 = PopupMenu(self.frame, False)
@@ -177,21 +179,20 @@ class UserBrowse:
         self.file_store = Gtk.ListStore(str, str, str, str, GObject.TYPE_INT64, int, str)
 
         self.FileTreeView.set_model(self.file_store)
-        widths = self.frame.np.config.sections["columns"]["userbrowse_widths"]
-        cols = initialise_columns(
-            self.FileTreeView,
-            [_("Filename"), widths[0], "text"],
-            [_("Size"), widths[1], "number"],
-            [_("Bitrate"), widths[2], "number"],
-            [_("Length"), widths[3], "number"]
-        )
-        cols[0].set_sort_column_id(0)
-        cols[1].set_sort_column_id(4)
-        cols[2].set_sort_column_id(2)
-        cols[3].set_sort_column_id(5)
-        self.file_store.set_sort_column_id(0, Gtk.SortType.ASCENDING)
 
-        hide_columns(cols, self.frame.np.config.sections["columns"]["userbrowse"])
+        cols = initialise_columns(
+            "user_browse",
+            self.FileTreeView,
+            ["filename", _("Filename"), 600, "text", None, None],
+            ["size", _("Size"), 100, "number", None, None],
+            ["bitrate", _("Bitrate"), 70, "number", None, None],
+            ["length", _("Length"), 0, "number", None, None]
+        )
+        cols["filename"].set_sort_column_id(0)
+        cols["size"].set_sort_column_id(4)
+        cols["bitrate"].set_sort_column_id(2)
+        cols["length"].set_sort_column_id(5)
+        self.file_store.set_sort_column_id(0, Gtk.SortType.ASCENDING)
 
         self.FileTreeView.get_selection().set_mode(Gtk.SelectionMode.MULTIPLE)
         self.FileTreeView.set_headers_clickable(True)
@@ -562,16 +563,7 @@ class UserBrowse:
             log.add(_("Can't save shares, '%(user)s', reported error: %(error)s"), {'user': self.user, 'error': msg})
 
     def save_columns(self):
-
-        columns = []
-        widths = []
-
-        for column in self.FileTreeView.get_columns():
-            columns.append(column.get_visible())
-            widths.append(column.get_width())
-
-        self.frame.np.config.sections["columns"]["userbrowse"] = columns
-        self.frame.np.config.sections["columns"]["userbrowse_widths"] = widths
+        save_columns("user_browse", self.FileTreeView.get_columns())
 
     def show_user(self, msg, folder=None, indeterminate_progress=False):
 

--- a/pynicotine/gtkgui/userinfo.py
+++ b/pynicotine/gtkgui/userinfo.py
@@ -95,12 +95,10 @@ class UserTabs(IconNotebook):
             self.frame.change_main_page(self.tab_name)
 
     def show_connection_error(self, user):
-
         if user in self.users:
             self.users[user].show_connection_error()
 
     def save_columns(self):
-
         for user in self.users:
             self.users[user].save_columns()
 
@@ -211,16 +209,24 @@ class UserInfo:
         self.hates_store = Gtk.ListStore(str)
         self.Hates.set_model(self.hates_store)
 
-        cols = initialise_columns(self.Hates, [_("Hates"), 0, "text"])
-        cols[0].set_sort_column_id(0)
+        cols = initialise_columns(
+            None,
+            self.Hates,
+            ["hates", _("Hates"), 0, "text", None, None]
+        )
+        cols["hates"].set_sort_column_id(0)
 
         self.hates_store.set_sort_column_id(0, Gtk.SortType.ASCENDING)
 
         self.likes_store = Gtk.ListStore(str)
         self.Likes.set_model(self.likes_store)
 
-        cols = initialise_columns(self.Likes, [_("Likes"), 0, "text"])
-        cols[0].set_sort_column_id(0)
+        cols = initialise_columns(
+            None,
+            self.Likes,
+            ["likes", _("Likes"), 0, "text", None, None]
+        )
+        cols["likes"].set_sort_column_id(0)
 
         self.likes_store.set_sort_column_id(0, Gtk.SortType.ASCENDING)
 

--- a/pynicotine/gtkgui/userlist.py
+++ b/pynicotine/gtkgui/userlist.py
@@ -31,12 +31,12 @@ from gi.repository import Gtk
 
 from pynicotine import slskmessages
 from pynicotine.gtkgui.dialogs import entry_dialog
-from pynicotine.gtkgui.utils import hide_columns
 from pynicotine.gtkgui.utils import humanize
 from pynicotine.gtkgui.utils import human_speed
 from pynicotine.gtkgui.utils import initialise_columns
 from pynicotine.gtkgui.utils import load_ui_elements
 from pynicotine.gtkgui.utils import PopupMenu
+from pynicotine.gtkgui.utils import save_columns
 from pynicotine.gtkgui.utils import show_country_tooltip
 from pynicotine.gtkgui.utils import update_widget_visuals
 from pynicotine.logfacility import log
@@ -74,53 +74,49 @@ class UserList:
             str                   # (14) country
         )
 
-        widths = self.frame.np.config.sections["columns"]["userlist_widths"]
         self.cols = cols = initialise_columns(
+            "buddy_list",
             self.UserListTree,
-            [_("Status"), widths[0], "pixbuf"],
-            [_("Country"), widths[1], "pixbuf"],
-            [_("User"), widths[2], "text"],
-            [_("Speed"), widths[3], "number"],
-            [_("Files"), widths[4], "number"],
-            [_("Trusted"), widths[5], "toggle"],
-            [_("Notify"), widths[6], "toggle"],
-            [_("Privileged"), widths[7], "toggle"],
-            [_("Last seen"), widths[8], "text"],
-            [_("Comments"), widths[9], "edit"]
+            ["status", _("Status"), 25, "pixbuf", None, None],
+            ["country", _("Country"), 25, "pixbuf", None, None],
+            ["user", _("User"), 180, "text", None, None],
+            ["speed", _("Speed"), 0, "number", None, None],
+            ["files", _("Files"), 0, "number", None, None],
+            ["trusted", _("Trusted"), 0, "toggle", None, None],
+            ["notify", _("Notify"), 0, "toggle", None, None],
+            ["privileged", _("Privileged"), 0, "toggle", None, None],
+            ["last_seen", _("Last seen"), 160, "text", None, None],
+            ["comments", _("Comments"), 0, "edit", None, None]
         )
 
-        self.col_status, self.col_country, self.col_user, self.col_speed, self.col_files, self.col_trusted, self.col_notify, self.col_privileged, self.col_last_seen, self.col_comments = cols
+        cols["status"].set_sort_column_id(10)
+        cols["country"].set_sort_column_id(14)
+        cols["user"].set_sort_column_id(2)
+        cols["speed"].set_sort_column_id(11)
+        cols["files"].set_sort_column_id(12)
+        cols["trusted"].set_sort_column_id(5)
+        cols["notify"].set_sort_column_id(6)
+        cols["privileged"].set_sort_column_id(7)
+        cols["last_seen"].set_sort_column_id(13)
+        cols["comments"].set_sort_column_id(9)
 
-        hide_columns(cols, config["columns"]["userlist"])
-
-        self.col_status.set_sort_column_id(10)
-        self.col_country.set_sort_column_id(14)
-        self.col_user.set_sort_column_id(2)
-        self.col_speed.set_sort_column_id(11)
-        self.col_files.set_sort_column_id(12)
-        self.col_trusted.set_sort_column_id(5)
-        self.col_notify.set_sort_column_id(6)
-        self.col_privileged.set_sort_column_id(7)
-        self.col_last_seen.set_sort_column_id(13)
-        self.col_comments.set_sort_column_id(9)
-
-        self.col_status.get_widget().hide()
-        self.col_country.get_widget().hide()
+        cols["status"].get_widget().hide()
+        cols["country"].get_widget().hide()
 
         if config["columns"]["hideflags"]:
-            cols[1].set_visible(0)
-            config["columns"]["userlist"][1] = 0
+            cols["country"].set_visible(0)
+            config["columns"]["buddy_list"]["country"]["visible"] = 0
 
-        for render in self.col_trusted.get_cells():
+        for render in cols["trusted"].get_cells():
             render.connect('toggled', self.cell_toggle_callback, self.UserListTree, 5)
 
-        for render in self.col_notify.get_cells():
+        for render in cols["notify"].get_cells():
             render.connect('toggled', self.cell_toggle_callback, self.UserListTree, 6)
 
-        for render in self.col_privileged.get_cells():
+        for render in cols["privileged"].get_cells():
             render.connect('toggled', self.cell_toggle_callback, self.UserListTree, 7)
 
-        for render in self.col_comments.get_cells():
+        for render in cols["comments"].get_cells():
             render.connect('edited', self.cell_edited_callback, self.UserListTree, 9)
 
         self.UserListTree.set_model(self.usersmodel)
@@ -460,16 +456,7 @@ class UserList:
         self.frame.np.config.write_configuration()
 
     def save_columns(self):
-
-        columns = []
-        widths = []
-
-        for column in self.UserListTree.get_columns():
-            columns.append(column.get_visible())
-            widths.append(column.get_width())
-
-        self.frame.np.config.sections["columns"]["userlist"] = columns
-        self.frame.np.config.sections["columns"]["userlist_widths"] = widths
+        save_columns("buddy_list", self.UserListTree.get_columns())
 
     def remove_from_list(self, user):
 

--- a/pynicotine/gtkgui/utils.py
+++ b/pynicotine/gtkgui/utils.py
@@ -149,77 +149,92 @@ def collapse_treeview(treeview, grouping_mode):
             iterator = model.iter_next(iterator)
 
 
-def initialise_columns(treeview, *args):
+def initialise_columns(treeview_name, treeview, *args):
 
     i = 0
-    cols = []
+    cols = {}
+    column_config = None
 
-    for c in args:
+    for (id, title, width, type, function, colors) in args:
+        if treeview_name:
+            try:
+                column_config = NICOTINE.np.config.sections["columns"][treeview_name[0]][treeview_name[1]]
+            except KeyError:
+                column_config = NICOTINE.np.config.sections["columns"][treeview_name]
 
-        if c[2] == "text":
+            try:
+                width = column_config[id]["width"]
+            except Exception:
+                # Invalid value
+                pass
+
+        if not isinstance(width, int):
+            width = 0
+
+        if type == "text":
             renderer = Gtk.CellRendererText()
             renderer.set_padding(10, 3)
 
-            column = Gtk.TreeViewColumn(c[0], renderer, text=i)
+            column = Gtk.TreeViewColumn(id, renderer, text=i)
 
-        elif c[2] == "center":
+        elif type == "center":
             renderer = Gtk.CellRendererText()
             renderer.set_property("xalign", 0.5)
 
-            column = Gtk.TreeViewColumn(c[0], renderer, text=i)
+            column = Gtk.TreeViewColumn(id, renderer, text=i)
 
-        elif c[2] == "number":
+        elif type == "number":
             renderer = Gtk.CellRendererText()
             renderer.set_property("xalign", 0.9)
 
-            column = Gtk.TreeViewColumn(c[0], renderer, text=i)
+            column = Gtk.TreeViewColumn(id, renderer, text=i)
             column.set_alignment(0.9)
 
-        elif c[2] == "edit":
+        elif type == "edit":
             renderer = Gtk.CellRendererText()
             renderer.set_padding(10, 3)
             renderer.set_property('editable', True)
-            column = Gtk.TreeViewColumn(c[0], renderer, text=i)
+            column = Gtk.TreeViewColumn(id, renderer, text=i)
 
-        elif c[2] == "combo":
+        elif type == "combo":
             renderer = Gtk.CellRendererCombo()
             renderer.set_padding(10, 3)
             renderer.set_property('text-column', 0)
             renderer.set_property('editable', True)
-            column = Gtk.TreeViewColumn(c[0], renderer, text=i)
+            column = Gtk.TreeViewColumn(id, renderer, text=i)
 
-        elif c[2] == "progress":
+        elif type == "progress":
             renderer = Gtk.CellRendererProgress()
-            column = Gtk.TreeViewColumn(c[0], renderer, value=i)
+            column = Gtk.TreeViewColumn(id, renderer, value=i)
 
-        elif c[2] == "toggle":
+        elif type == "toggle":
             renderer = Gtk.CellRendererToggle()
-            column = Gtk.TreeViewColumn(c[0], renderer, active=i)
+            column = Gtk.TreeViewColumn(id, renderer, active=i)
             renderer.set_property("xalign", 0.5)
 
         else:
             renderer = Gtk.CellRendererPixbuf()
-            column = Gtk.TreeViewColumn(c[0], renderer, pixbuf=i)
+            column = Gtk.TreeViewColumn(id, renderer, pixbuf=i)
 
-        if c[1] == -1:
+        if width == -1:
             column.set_resizable(False)
             column.set_sizing(Gtk.TreeViewColumnSizing.AUTOSIZE)
 
         else:
             column.set_resizable(True)
-            if c[1] == 0:
+            if width == 0:
                 column.set_sizing(Gtk.TreeViewColumnSizing.GROW_ONLY)
             else:
                 column.set_sizing(Gtk.TreeViewColumnSizing.FIXED)
-                column.set_fixed_width(c[1])
+                column.set_fixed_width(width)
             column.set_min_width(0)
 
-        if len(c) > 3 and not isinstance(c[3], list):
-            column.set_cell_data_func(renderer, c[3])
+        if function:
+            column.set_cell_data_func(renderer, function)
 
-        if len(c) > 4:
-            foreground = c[4][0]
-            background = c[4][1]
+        if colors:
+            foreground = colors[0]
+            background = colors[1]
 
             if foreground:
                 renderer.set_property("foreground", foreground)
@@ -231,44 +246,89 @@ def initialise_columns(treeview, *args):
             else:
                 renderer.set_property("background-set", False)
 
-        column.set_reorderable(False)
-        column.set_widget(Gtk.Label.new(c[0]))
+        column.set_reorderable(True)
+        column.set_widget(Gtk.Label.new(title))
         column.get_widget().set_margin_start(6)
         column.get_widget().show()
 
-        treeview.append_column(column)
-
-        cols.append(column)
+        cols[id] = column
 
         i += 1
+
+    append_columns(treeview, cols, column_config)
+    hide_columns(treeview, cols, column_config)
 
     return cols
 
 
-def hide_columns(cols, visibility_list):
-    try:
-        for i in range(len(cols)):
+def append_columns(treeview, cols, config):
 
-            parent = cols[i].get_widget().get_ancestor(Gtk.Button)
-            if parent:
-                parent.connect('button_press_event', press_header)
+    if not config:
+        for (column_id, column) in cols.items():
+            treeview.append_column(column)
+        return
 
-            # Read Show / Hide column settings from last session
-            cols[i].set_visible(visibility_list[i])
+    # Restore column order from config
+    for column_id in config:
+        try:
+            treeview.append_column(cols[column_id])
+        except Exception:
+            # Invalid column
+            continue
 
-        # Make sure the width of the last visible column isn't fixed
-        for i in reversed(range(len(cols))):
+    added_columns = treeview.get_columns()
 
-            if cols[i].get_visible():
-                column = cols[i]
-                column.set_sizing(Gtk.TreeViewColumnSizing.AUTOSIZE)
-                column.set_resizable(False)
-                column.set_fixed_width(-1)
-                break
+    # If any columns were missing in the config, append them
+    pos = 0
+    for (column_id, column) in cols.items():
+        if column not in added_columns:
+            treeview.insert_column(column, pos)
 
-    except IndexError:
-        # Column count in config is probably incorrect (outdated?), don't crash
-        pass
+        pos += 1
+
+
+def hide_columns(treeview, cols, config):
+
+    for (column_id, column) in cols.items():
+        parent = column.get_widget().get_ancestor(Gtk.Button)
+        if parent:
+            parent.connect('button_press_event', press_header)
+
+        # Read Show / Hide column settings from last session
+        if config:
+            try:
+                column.set_visible(config[column_id]["visible"])
+            except Exception:
+                # Invalid value
+                pass
+
+    # Make sure the width of the last visible column isn't fixed
+    for (id, column) in reversed(cols.items()):
+        if column.get_visible():
+            column.set_sizing(Gtk.TreeViewColumnSizing.AUTOSIZE)
+            column.set_resizable(False)
+            column.set_fixed_width(-1)
+            break
+
+
+def save_columns(treeview_name, columns, subpage=None):
+
+    saved_columns = {}
+    column_config = NICOTINE.np.config.sections["columns"]
+
+    for column in columns:
+        title = column.get_title()
+        saved_columns[title] = {"visible": column.get_visible(), "width": column.get_width()}
+
+    if subpage is not None:
+        try:
+            column_config[treeview_name]
+        except KeyError:
+            column_config[treeview_name] = {}
+
+        column_config[treeview_name][subpage] = saved_columns
+    else:
+        column_config[treeview_name] = saved_columns
 
 
 def press_header(widget, event):
@@ -282,7 +342,7 @@ def press_header(widget, event):
     pos = 1
 
     for column in columns:
-        title = column.get_title()
+        title = column.get_widget().get_text()
 
         if title == "":
             title = _("Column #%i") % pos

--- a/pynicotine/gtkgui/wishlist.py
+++ b/pynicotine/gtkgui/wishlist.py
@@ -57,8 +57,9 @@ class WishList:
         self.store = Gtk.ListStore(GObject.TYPE_STRING)
 
         cols = initialise_columns(
+            None,
             self.WishlistView,
-            [_("Wishes"), -1, "text"]
+            ["wishes", _("Wishes"), -1, "text", None, None]
         )
 
         self.WishlistView.set_model(self.store)
@@ -69,7 +70,7 @@ class WishList:
         for wish in self.frame.np.config.sections["server"]["autosearch"]:
             self.wishes[wish] = self.store.append([wish])
 
-        renderers = cols[0].get_cells()
+        renderers = cols["wishes"].get_cells()
         for render in renderers:
             render.set_property('editable', True)
             render.connect('edited', self.cell_edited_callback, self.WishlistView, 0)

--- a/pynicotine/shares.py
+++ b/pynicotine/shares.py
@@ -100,7 +100,7 @@ class Shares:
     def real2virtual(self, path):
         path = os.path.normpath(path)
 
-        for (virtual, real) in self._virtualmapping():
+        for (virtual, real, *unused) in self._virtualmapping():
             # Remove slashes from share name to avoid path conflicts
             virtual = virtual.replace('/', '_').replace('\\', '_')
 
@@ -118,7 +118,7 @@ class Shares:
     def virtual2real(self, path):
         path = os.path.normpath(path)
 
-        for (virtual, real) in self._virtualmapping():
+        for (virtual, real, *unused) in self._virtualmapping():
             # Remove slashes from share name to avoid path conflicts
             virtual = os.path.normpath(virtual.replace('/', '_').replace('\\', '_'))
 


### PR DESCRIPTION
This PR includes a refactored column visibility/width saving system, which also takes column positions into consideration. Its more readable, extendable and maintainable than the previous one, and also much less error prone, using non-numerical IDs for columns instead of relying on indices. This will allow us to effortlessly modify and add columns in the future.

Custom column widths and visibility will not be converted from the old system. Not sure if it's worth the effort.