### PR TITLE
Refactor code related to popup/context menus

### DIFF
--- a/pynicotine/gtkgui/chatrooms.py
+++ b/pynicotine/gtkgui/chatrooms.py
@@ -307,7 +307,7 @@ class RoomsControl:
         items[_("Disown Private Room")].set_sensitive(self.is_private_room_owned(self.popup_room))
         items[_("Cancel Room Membership")].set_sensitive((prooms_enabled and self.is_private_room_member(self.popup_room)))
 
-        self.popup_menu.popup(None, None, None, None, event.button, event.time)
+        self.popup_menu.popup()
 
     def on_popup_join(self, widget):
         self.frame.np.queue.put(slskmessages.JoinRoom(self.popup_room))
@@ -1013,7 +1013,7 @@ class ChatRoom:
         me = (self.popup_menu.user is None or self.popup_menu.user == self.frame.np.config.sections["server"]["login"])
         self.popup_menu.get_items()[_("Private Rooms")].set_sensitive(not me)
 
-        self.popup_menu.popup(None, None, None, None, event.button, event.time)
+        self.popup_menu.popup()
 
     def on_show_room_wall(self, widget):
         self.room_wall.show()
@@ -1562,7 +1562,7 @@ class ChatRoom:
             me = (self.popup_menu.user is None or self.popup_menu.user == self.frame.np.config.sections["server"]["login"])
             self.popup_menu.get_items()[_("Private Rooms")].set_sensitive(not me)
 
-            self.popup_menu.popup(None, None, None, None, event.button.button, event.button.time)
+            self.popup_menu.popup(button=event.button.button)
 
         return True
 
@@ -1881,7 +1881,7 @@ class ChatRoom:
             return False
 
         widget.stop_emission_by_name("button-press-event")
-        self.roomlogpopmenu.popup(None, None, None, None, event.button, event.time)
+        self.roomlogpopmenu.popup()
 
         return True
 
@@ -1891,7 +1891,7 @@ class ChatRoom:
             return False
 
         widget.stop_emission_by_name("button-press-event")
-        self.activitylogpopupmenu.popup(None, None, None, None, event.button, event.time)
+        self.activitylogpopupmenu.popup()
 
         return True
 
@@ -2013,7 +2013,7 @@ class ChatRooms(IconNotebook):
 
             if event.button == 3:
                 menu = self.tab_popup(room)
-                menu.popup(None, None, None, None, event.button, event.time)
+                menu.popup()
                 return True
 
             return False

--- a/pynicotine/gtkgui/downloads.py
+++ b/pynicotine/gtkgui/downloads.py
@@ -342,7 +342,7 @@ class Downloads(TransferList):
         for i in (_("_Retry"), _("Abor_t"), _("_Clear")):
             items[i].set_sensitive(act)
 
-        self.popup_menu.popup(None, None, None, None, 3, event.time)
+        self.popup_menu.popup()
 
         if kind == "keyboard":
             widget.stop_emission_by_name("key_press_event")

--- a/pynicotine/gtkgui/downloads.py
+++ b/pynicotine/gtkgui/downloads.py
@@ -50,12 +50,12 @@ class Downloads(TransferList):
         self.popup_menu_users = PopupMenu(frame, False)
         self.popup_menu_clear = popup2 = PopupMenu(frame, False)
         popup2.setup(
-            ("#" + _("Clear finished/aborted"), self.on_clear_finished_aborted),
-            ("#" + _("Clear finished"), self.on_clear_finished),
-            ("#" + _("Clear aborted"), self.on_clear_aborted),
-            ("#" + _("Clear paused"), self.on_clear_paused),
-            ("#" + _("Clear filtered"), self.on_clear_filtered),
-            ("#" + _("Clear queued"), self.on_clear_queued)
+            ("#" + _("Clear Finished/Aborted"), self.on_clear_finished_aborted),
+            ("#" + _("Clear Finished"), self.on_clear_finished),
+            ("#" + _("Clear Aborted"), self.on_clear_aborted),
+            ("#" + _("Clear Paused"), self.on_clear_paused),
+            ("#" + _("Clear Filtered"), self.on_clear_filtered),
+            ("#" + _("Clear Queued"), self.on_clear_queued)
         )
 
         self.popup_menu = popup = PopupMenu(frame)
@@ -318,8 +318,8 @@ class Downloads(TransferList):
         users = len(self.selected_users) > 0
         files = len(self.selected_transfers) > 0
 
-        items = self.popup_menu.get_children()
-        items[9].set_sensitive(users)  # Users Menu
+        items = self.popup_menu.get_items()
+        items[_("User(s)")].set_sensitive(users)  # Users Menu
 
         if files:
             act = True
@@ -328,7 +328,8 @@ class Downloads(TransferList):
             # Send to player, File manager, file properties, Copy File Path, Copy URL, Copy Folder URL, Search filename
             act = False
 
-        for i in range(0, 7):
+        for i in (_("Send to _Player"), _("_Open Folder"), _("File P_roperties"),
+                  _("Copy _File Path"), _("Copy _URL"), _("Copy Folder URL"), _("_Search")):
             items[i].set_sensitive(act)
 
         if not users or not files:
@@ -338,7 +339,7 @@ class Downloads(TransferList):
         else:
             act = True
 
-        for i in range(11, 14):
+        for i in (_("_Retry"), _("Abor_t"), _("_Clear")):
             items[i].set_sensitive(act)
 
         self.popup_menu.popup(None, None, None, None, 3, event.time)

--- a/pynicotine/gtkgui/fastconfigure.py
+++ b/pynicotine/gtkgui/fastconfigure.py
@@ -50,9 +50,10 @@ class FastConfigureAssistant(object):
         )
 
         initialise_columns(
+            None,
             self.shareddirectoriestree,
-            [_("Virtual Folder"), 0, "text"],
-            [_("Folder"), 0, "text"]
+            ["virtual_folder", _("Virtual Folder"), 0, "text", None, None],
+            ["folder", _("Folder"), 0, "text", None, None]
         )
 
         self.shareddirectoriestree.set_model(self.sharelist)

--- a/pynicotine/gtkgui/frame.py
+++ b/pynicotine/gtkgui/frame.py
@@ -228,7 +228,8 @@ class NicotineFrame:
             # Set the menu to hide the tab
             tab_label.connect('button_press_event', self.on_tab_click, eventbox_name + "Menu")
 
-            self.__dict__[eventbox_name + "Menu"] = PopupMenu(self).setup(
+            self.__dict__[eventbox_name + "Menu"] = popup = PopupMenu(self)
+            popup.setup(
                 (
                     "#" + hide_tab_template % {"tab": translated_tablabels[placehold_tab_label]}, self.hide_tab, [tab_label, tab_box]
                 )
@@ -324,7 +325,8 @@ class NicotineFrame:
         """ Log """
 
         # Popup menu on the log windows
-        self.logpopupmenu = PopupMenu(self).setup(
+        self.logpopupmenu = PopupMenu(self)
+        self.logpopupmenu.setup(
             ("#" + _("Find"), self.on_find_log_window),
             ("", None),
             ("#" + _("Copy"), self.on_copy_log_window),

--- a/pynicotine/gtkgui/frame.py
+++ b/pynicotine/gtkgui/frame.py
@@ -1736,7 +1736,7 @@ class NicotineFrame:
     def on_tab_click(self, widget, event, popup_id):
 
         if event.type == Gdk.EventType.BUTTON_PRESS and event.button == 3:
-            self.__dict__[popup_id].popup(None, None, None, None, event.button, event.time)
+            self.__dict__[popup_id].popup()
 
     def set_tab_expand(self, tab_box):
 
@@ -2489,7 +2489,7 @@ class NicotineFrame:
             return False
 
         widget.stop_emission_by_name("button-press-event")
-        self.logpopupmenu.popup(None, None, None, None, event.button, event.time)
+        self.logpopupmenu.popup()
         return True
 
     def on_find_log_window(self, widget):

--- a/pynicotine/gtkgui/interests.py
+++ b/pynicotine/gtkgui/interests.py
@@ -49,7 +49,7 @@ class Interests:
         cols = initialise_columns(
             None,
             self.LikesList,
-            ["i_like", _("I like") + ":", 0, "text", None, None]
+            ["i_like", _("I Like") + ":", 0, "text", None, None]
         )
 
         cols["i_like"].set_sort_column_id(0)
@@ -58,10 +58,10 @@ class Interests:
         self.til_popup_menu = popup = PopupMenu(self.frame)
 
         popup.setup(
-            ("#" + _("_Remove this item"), self.on_remove_thing_i_like),
-            ("#" + _("Re_commendations for this item"), self.on_recommend_item),
+            ("#" + _("_Remove Item"), self.on_remove_thing_i_like),
+            ("#" + _("Re_commendations For Item"), self.on_recommend_item),
             ("", None),
-            ("#" + _("_Search for this item"), self.on_recommend_search)
+            ("#" + _("_Search For Item"), self.on_recommend_search)
         )
 
         self.LikesList.connect("button_press_event", self.on_popup_til_menu)
@@ -73,7 +73,7 @@ class Interests:
         cols = initialise_columns(
             None,
             self.DislikesList,
-            ["i_dislike", _("I dislike") + ":", 0, "text", None, None]
+            ["i_dislike", _("I Dislike") + ":", 0, "text", None, None]
         )
 
         cols["i_dislike"].set_sort_column_id(0)
@@ -82,9 +82,9 @@ class Interests:
         self.tidl_popup_menu = popup = PopupMenu(self.frame)
 
         popup.setup(
-            ("#" + _("_Remove this item"), self.on_remove_thing_i_dislike),
+            ("#" + _("_Remove Item"), self.on_remove_thing_i_dislike),
             ("", None),
-            ("#" + _("_Search for this item"), self.on_recommend_search)
+            ("#" + _("_Search For Item"), self.on_recommend_search)
         )
 
         self.DislikesList.connect("button_press_event", self.on_popup_tidl_menu)
@@ -109,11 +109,11 @@ class Interests:
         self.r_popup_menu = popup = PopupMenu(self.frame)
 
         popup.setup(
-            ("$" + _("I _like this"), self.on_like_recommendation),
-            ("$" + _("I _don't like this"), self.on_dislike_recommendation),
-            ("#" + _("_Recommendations for this item"), self.on_recommend_recommendation),
+            ("$" + _("I _Like This"), self.on_like_recommendation),
+            ("$" + _("I _Dislike This"), self.on_dislike_recommendation),
+            ("#" + _("_Recommendations For Item"), self.on_recommend_recommendation),
             ("", None),
-            ("#" + _("_Search for this item"), self.on_recommend_search)
+            ("#" + _("_Search For Item"), self.on_recommend_search)
         )
 
         self.RecommendationsList.connect("button_press_event", self.on_popup_r_menu)
@@ -138,11 +138,11 @@ class Interests:
         self.ur_popup_menu = popup = PopupMenu(self.frame)
 
         popup.setup(
-            ("$" + _("I _like this"), self.on_like_recommendation),
-            ("$" + _("I _don't like this"), self.on_dislike_recommendation),
-            ("#" + _("_Recommendations for this item"), self.on_recommend_recommendation),
+            ("$" + _("I _Like This"), self.on_like_recommendation),
+            ("$" + _("I _Dislike This"), self.on_dislike_recommendation),
+            ("#" + _("_Recommendations For Item"), self.on_recommend_recommendation),
             ("", None),
-            ("#" + _("_Search for this item"), self.on_recommend_search)
+            ("#" + _("_Search For Item"), self.on_recommend_search)
         )
 
         self.UnrecommendationsList.connect("button_press_event", self.on_popup_un_rec_menu)
@@ -177,18 +177,7 @@ class Interests:
         self.recommendation_users_model.set_sort_column_id(1, Gtk.SortType.ASCENDING)
 
         self.ru_popup_menu = popup = PopupMenu(self.frame)
-        popup.setup(
-            ("#" + _("Send _message"), popup.on_send_message),
-            ("", None),
-            ("#" + _("Show IP a_ddress"), popup.on_show_ip_address),
-            ("#" + _("Get user i_nfo"), popup.on_get_user_info),
-            ("#" + _("Brow_se files"), popup.on_browse_user),
-            ("#" + _("Gi_ve privileges"), popup.on_give_privileges),
-            ("", None),
-            ("$" + _("_Add user to list"), popup.on_add_to_list),
-            ("$" + _("_Ban this user"), popup.on_ban_user),
-            ("$" + _("_Ignore this user"), popup.on_ignore_user)
-        )
+        popup.setup_user_menu()
 
         self.RecommendationUsersList.connect("button_press_event", self.on_popup_ru_menu)
 
@@ -359,7 +348,7 @@ class Interests:
         self.recommendation_users_model.set(self.recommendation_users[msg.user], 2, human_speed(msg.avgspeed), 3, humanize(msg.files), 5, msg.avgspeed, 6, msg.files)
 
     def on_popup_ru_menu(self, widget, event):
-        items = self.ru_popup_menu.get_children()
+
         d = self.RecommendationUsersList.get_path_at_pos(int(event.x), int(event.y))
 
         if not d:
@@ -375,9 +364,7 @@ class Interests:
             return
 
         self.ru_popup_menu.set_user(user)
-        items[7].set_active(user in (i[0] for i in self.np.config.sections["server"]["userlist"]))
-        items[8].set_active(user in self.np.config.sections["server"]["banlist"])
-        items[9].set_active(user in self.np.config.sections["server"]["ignorelist"])
+        self.ru_popup_menu.toggle_user_items()
 
         self.ru_popup_menu.popup(None, None, None, None, event.button, event.time)
 
@@ -414,6 +401,7 @@ class Interests:
         self.tidl_popup_menu.popup(None, None, None, None, event.button, event.time)
 
     def on_popup_r_menu(self, widget, event):
+
         if event.button != 3:
             return
 
@@ -424,16 +412,17 @@ class Interests:
 
         path, column, x, y = d
         iterator = self.recommendations_model.get_iter(path)
-        thing = self.recommendations_model.get_value(iterator, 0)
-        items = self.r_popup_menu.get_children()
+        thing = self.recommendations_model.get_value(iterator, 1)
+        items = self.r_popup_menu.get_items()
 
         self.r_popup_menu.set_user(thing)
-        items[0].set_active(thing in self.np.config.sections["interests"]["likes"])
-        items[1].set_active(thing in self.np.config.sections["interests"]["dislikes"])
+        items[_("I _Like This")].set_active(thing in self.np.config.sections["interests"]["likes"])
+        items[_("I _Dislike This")].set_active(thing in self.np.config.sections["interests"]["dislikes"])
 
         self.r_popup_menu.popup(None, None, None, None, event.button, event.time)
 
     def on_popup_un_rec_menu(self, widget, event):
+
         if event.button != 3:
             return
 
@@ -444,12 +433,12 @@ class Interests:
 
         path, column, x, y = d
         iterator = self.unrecommendations_model.get_iter(path)
-        thing = self.unrecommendations_model.get_value(iterator, 0)
-        items = self.ur_popup_menu.get_children()
+        thing = self.unrecommendations_model.get_value(iterator, 1)
+        items = self.ur_popup_menu.get_items()
 
         self.ur_popup_menu.set_user(thing)
-        items[0].set_active(thing in self.np.config.sections["interests"]["likes"])
-        items[1].set_active(thing in self.np.config.sections["interests"]["dislikes"])
+        items[_("I _Like This")].set_active(thing in self.np.config.sections["interests"]["likes"])
+        items[_("I _Dislike This")].set_active(thing in self.np.config.sections["interests"]["dislikes"])
 
         self.ur_popup_menu.popup(None, None, None, None, event.button, event.time)
 

--- a/pynicotine/gtkgui/interests.py
+++ b/pynicotine/gtkgui/interests.py
@@ -366,7 +366,7 @@ class Interests:
         self.ru_popup_menu.set_user(user)
         self.ru_popup_menu.toggle_user_items()
 
-        self.ru_popup_menu.popup(None, None, None, None, event.button, event.time)
+        self.ru_popup_menu.popup()
 
     def on_popup_til_menu(self, widget, event):
         if event.button != 3:
@@ -382,7 +382,7 @@ class Interests:
         thing = self.likes_model.get_value(iterator, 0)
 
         self.til_popup_menu.set_user(thing)
-        self.til_popup_menu.popup(None, None, None, None, event.button, event.time)
+        self.til_popup_menu.popup()
 
     def on_popup_tidl_menu(self, widget, event):
         if event.button != 3:
@@ -398,7 +398,7 @@ class Interests:
         thing = self.dislikes_model.get_value(iterator, 0)
 
         self.tidl_popup_menu.set_user(thing)
-        self.tidl_popup_menu.popup(None, None, None, None, event.button, event.time)
+        self.tidl_popup_menu.popup()
 
     def on_popup_r_menu(self, widget, event):
 
@@ -419,7 +419,7 @@ class Interests:
         items[_("I _Like This")].set_active(thing in self.np.config.sections["interests"]["likes"])
         items[_("I _Dislike This")].set_active(thing in self.np.config.sections["interests"]["dislikes"])
 
-        self.r_popup_menu.popup(None, None, None, None, event.button, event.time)
+        self.r_popup_menu.popup()
 
     def on_popup_un_rec_menu(self, widget, event):
 
@@ -440,7 +440,7 @@ class Interests:
         items[_("I _Like This")].set_active(thing in self.np.config.sections["interests"]["likes"])
         items[_("I _Dislike This")].set_active(thing in self.np.config.sections["interests"]["dislikes"])
 
-        self.ur_popup_menu.popup(None, None, None, None, event.button, event.time)
+        self.ur_popup_menu.popup()
 
     def update_visuals(self):
 

--- a/pynicotine/gtkgui/privatechat.py
+++ b/pynicotine/gtkgui/privatechat.py
@@ -169,35 +169,13 @@ class PrivateChats(IconNotebook):
             return
 
         popup = PopupMenu(self.frame)
-        popup.setup(
-            ("#" + _("Show IP a_ddress"), popup.on_show_ip_address),
-            ("#" + _("Get user i_nfo"), popup.on_get_user_info),
-            ("#" + _("Brow_se files"), popup.on_browse_user),
-            ("#" + _("Gi_ve privileges"), popup.on_give_privileges),
-            ("#" + _("Client Version"), popup.on_version),
-            ("", None),
-            ("$" + _("Add user to list"), popup.on_add_to_list),
-            ("$" + _("Ban this user"), popup.on_ban_user),
-            ("$" + _("Ignore this user"), popup.on_ignore_user),
-            ("$" + _("B_lock this user's IP Address"), popup.on_block_user),
-            ("$" + _("Ignore this user's IP Address"), popup.on_ignore_ip),
-            ("", None),
-            ("#" + _("Close All Tabs"), popup.on_close_all_tabs, self),
-            ("#" + _("_Close Tab"), self.users[user].on_close)
-        )
+        popup.setup_user_menu(user)
+        popup.get_items()[_("Send _Message")].set_visible(False)
 
-        popup.set_user(user)
-
-        me = (popup.user is None or popup.user == self.frame.np.config.sections["server"]["login"])
-        items = popup.get_children()
-
-        items[6].set_active(user in (i[0] for i in self.frame.np.config.sections["server"]["userlist"]))
-        items[7].set_active(user in self.frame.np.config.sections["server"]["banlist"])
-        items[8].set_active(user in self.frame.np.config.sections["server"]["ignorelist"])
-        items[9].set_active(self.frame.user_ip_is_blocked(user))
-        items[9].set_sensitive(not me)
-        items[10].set_active(self.frame.user_ip_is_ignored(user))
-        items[10].set_sensitive(not me)
+        popup.append_item(("", None))
+        popup.append_item(("#" + _("Close All Tabs"), popup.on_close_all_tabs, self))
+        popup.append_item(("#" + _("_Close Tab"), self.users[user].on_close))
+        popup.toggle_user_items()
 
         return popup
 
@@ -398,21 +376,8 @@ class PrivateChat:
         self.Log.set_active(self.frame.np.config.sections["logging"]["privatechat"])
 
         self.popup_menu_user = popup = PopupMenu(self.frame, False)
-        popup.setup(
-            ("#" + _("Show IP a_ddress"), popup.on_show_ip_address),
-            ("#" + _("Get user i_nfo"), popup.on_get_user_info),
-            ("#" + _("Brow_se files"), popup.on_browse_user),
-            ("#" + _("Gi_ve privileges"), popup.on_give_privileges),
-            ("#" + _("Client Version"), popup.on_version),
-            ("", None),
-            ("$" + _("Add user to list"), popup.on_add_to_list),
-            ("$" + _("Ban this user"), popup.on_ban_user),
-            ("$" + _("Ignore this user"), popup.on_ignore_user),
-            ("$" + _("B_lock this user's IP Address"), popup.on_block_user),
-            ("$" + _("Ignore this user's IP Address"), popup.on_ignore_ip)
-        )
-
-        popup.set_user(user)
+        popup.setup_user_menu(user)
+        popup.get_items()[_("Send _Message")].set_visible(False)
 
         self.popup_menu = popup = PopupMenu(self.frame)
         popup.setup(
@@ -504,18 +469,7 @@ class PrivateChat:
         return False
 
     def on_popup_menu_user(self, widget):
-
-        items = self.popup_menu_user.get_children()
-        me = (self.popup_menu_user.user is None or self.popup_menu_user.user == self.frame.np.config.sections["server"]["login"])
-
-        items[6].set_active(self.user in (i[0] for i in self.frame.np.config.sections["server"]["userlist"]))
-        items[7].set_active(self.user in self.frame.np.config.sections["server"]["banlist"])
-        items[8].set_active(self.user in self.frame.np.config.sections["server"]["ignorelist"])
-        items[9].set_active(self.frame.user_ip_is_blocked(self.user))
-        items[9].set_sensitive(not me)
-        items[10].set_active(self.frame.user_ip_is_ignored(self.user))
-        items[10].set_sensitive(not me)
-
+        self.popup_menu_user.toggle_user_items()
         return True
 
     def on_find_chat_log(self, widget):

--- a/pynicotine/gtkgui/privatechat.py
+++ b/pynicotine/gtkgui/privatechat.py
@@ -193,7 +193,7 @@ class PrivateChats(IconNotebook):
 
             if event.button == 3:
                 menu = self.tab_popup(username)
-                menu.popup(None, None, None, None, event.button, event.time)
+                menu.popup()
                 return True
 
             return False
@@ -454,7 +454,7 @@ class PrivateChat:
 
         if event.type == Gdk.EventType.BUTTON_PRESS and event.button == 3:
 
-            self.popup_menu.popup(None, None, None, None, event.button, event.time)
+            self.popup_menu.popup()
             self.ChatScroll.stop_emission_by_name("button_press_event")
             return True
 
@@ -462,7 +462,7 @@ class PrivateChat:
 
             if event.keyval == Gdk.keyval_from_name("Menu"):
 
-                self.popup_menu.popup(None, None, None, None, 0, 0)
+                self.popup_menu.popup(button=0)
                 self.ChatScroll.stop_emission_by_name("key_press_event")
                 return True
 

--- a/pynicotine/gtkgui/search.py
+++ b/pynicotine/gtkgui/search.py
@@ -957,19 +957,9 @@ class Search:
 
             for user in self.selected_users:
                 popup = PopupMenu(self.frame, False)
-                popup.setup(
-                    ("#" + _("Send _message"), popup.on_send_message),
-                    ("#" + _("Show IP a_ddress"), popup.on_show_ip_address),
-                    ("#" + _("Get user i_nfo"), popup.on_get_user_info),
-                    ("#" + _("Brow_se files"), popup.on_browse_user),
-                    ("#" + _("Gi_ve privileges"), popup.on_give_privileges),
-                    ("", None),
-                    ("$" + _("_Add user to list"), popup.on_add_to_list),
-                    ("$" + _("_Ban this user"), popup.on_ban_user),
-                    ("$" + _("_Ignore this user"), popup.on_ignore_user),
-                    ("#" + _("Select User's Results"), self.on_select_user_results)
-                )
-                popup.set_user(user)
+                popup.setup_user_menu(user)
+                popup.append_item(("", None))
+                popup.append_item(("#" + _("Select User's Transfers"), self.on_select_user_results))
 
                 items.append((1, user, popup, self.on_popup_menu_user, popup))
 
@@ -982,26 +972,7 @@ class Search:
         if popup is None:
             return
 
-        menu = popup
-        user = menu.user
-        items = menu.get_children()
-
-        act = False
-        if len(self.selected_users) >= 1:
-            act = True
-
-        items[0].set_sensitive(act)
-        items[1].set_sensitive(act)
-        items[2].set_sensitive(act)
-        items[3].set_sensitive(act)
-
-        items[6].set_active(user in (i[0] for i in self.frame.np.config.sections["server"]["userlist"]))
-        items[7].set_active(user in self.frame.np.config.sections["server"]["banlist"])
-        items[8].set_active(user in self.frame.np.config.sections["server"]["ignorelist"])
-
-        for i in range(4, 9):
-            items[i].set_sensitive(act)
-
+        popup.toggle_user_items()
         return True
 
     def on_select_user_results(self, widget):
@@ -1104,26 +1075,28 @@ class Search:
         set_treeview_selected_row(widget, event)
         self.select_results()
 
-        items = self.popup_menu.get_children()
+        items = self.popup_menu.get_items()
         users = len(self.selected_users) > 0
         files = len(self.selected_results) > 0
 
-        items[0].set_sensitive(False)   # Download File
-        items[1].set_sensitive(False)   # Download File To
-        items[4].set_sensitive(files)   # Browse Folder
-        items[5].set_sensitive(False)   # File Properties
-        items[7].set_sensitive(files)   # Copy File Path
-        items[8].set_sensitive(False)   # Copy URL
-        items[9].set_sensitive(files)   # Copy Folder URL
-        items[11].set_sensitive(users)  # Users
+        for i in (_("_Download File(s)"), _("Download File(s) _To..."), _("File _Properties"),
+                  _("Copy _URL")):
+            items[i].set_sensitive(False)
+
+        for i in (_("Download _Folder(s)"), _("Download F_older(s) To..."), _("_Browse Folder"),
+                  _("Copy _File Path"), _("Copy Folder U_RL")):
+            items[i].set_sensitive(files)
+
+        items[_("User(s)")].set_sensitive(users)
 
         for result in self.selected_results:
             if not result[1].endswith('\\'):
                 # At least one selected result is a file, activate file-related items
-                items[0].set_sensitive(True)  # Download File
-                items[1].set_sensitive(True)  # Download File To
-                items[5].set_sensitive(True)  # File Properties
-                items[8].set_sensitive(True)  # Copy URL
+
+                for i in (_("_Download File(s)"), _("Download File(s) _To..."), _("File _Properties"),
+                          _("Copy _URL")):
+                    items[i].set_sensitive(True)
+
                 break
 
         self.popup_menu.popup(None, None, None, None, event.button, event.time)

--- a/pynicotine/gtkgui/search.py
+++ b/pynicotine/gtkgui/search.py
@@ -412,7 +412,7 @@ class Searches(IconNotebook):
 
             if event.button == 3:
                 menu = self.tab_popup(search_id)
-                menu.popup(None, None, None, None, event.button, event.time)
+                menu.popup()
                 return True
 
         return False
@@ -1099,7 +1099,7 @@ class Search:
 
                 break
 
-        self.popup_menu.popup(None, None, None, None, event.button, event.time)
+        self.popup_menu.popup()
         widget.stop_emission_by_name("button_press_event")
 
         return True

--- a/pynicotine/gtkgui/transferlist.py
+++ b/pynicotine/gtkgui/transferlist.py
@@ -563,19 +563,9 @@ class TransferList:
             for user in self.selected_users:
 
                 popup = PopupMenu(self.frame, False)
-                popup.setup(
-                    ("#" + _("Send _message"), popup.on_send_message),
-                    ("#" + _("Show IP a_ddress"), popup.on_show_ip_address),
-                    ("#" + _("Get user i_nfo"), popup.on_get_user_info),
-                    ("#" + _("Brow_se files"), popup.on_browse_user),
-                    ("#" + _("Gi_ve privileges"), popup.on_give_privileges),
-                    ("", None),
-                    ("$" + _("_Add user to list"), popup.on_add_to_list),
-                    ("$" + _("_Ban this user"), popup.on_ban_user),
-                    ("$" + _("_Ignore this user"), popup.on_ignore_user),
-                    ("#" + _("Select User's Transfers"), self.on_select_user_transfers)
-                )
-                popup.set_user(user)
+                popup.setup_user_menu(user)
+                popup.append_item(("", None))
+                popup.append_item(("#" + _("Select User's Transfers"), self.on_select_user_transfers))
 
                 items.append((1, user, popup, self.on_popup_menu_user, popup))
 
@@ -588,26 +578,7 @@ class TransferList:
         if popup is None:
             return
 
-        menu = popup
-        user = menu.user
-        items = menu.get_children()
-
-        act = False
-        if len(self.selected_users) >= 1:
-            act = True
-
-        items[0].set_sensitive(act)
-        items[1].set_sensitive(act)
-        items[2].set_sensitive(act)
-        items[3].set_sensitive(act)
-
-        items[6].set_active(user in (i[0] for i in self.frame.np.config.sections["server"]["userlist"]))
-        items[7].set_active(user in self.frame.np.config.sections["server"]["banlist"])
-        items[8].set_active(user in self.frame.np.config.sections["server"]["ignorelist"])
-
-        for i in range(4, 9):
-            items[i].set_sensitive(act)
-
+        popup.toggle_user_items()
         return True
 
     def on_select_user_transfers(self, widget):

--- a/pynicotine/gtkgui/tray.py
+++ b/pynicotine/gtkgui/tray.py
@@ -255,7 +255,7 @@ class Tray:
                 trayicon.set_menu(self.tray_popup_menu)
 
                 # Action to hide/unhide main window when middle clicking the tray icon
-                hide_unhide_item = self.tray_popup_menu.get_children()[0]
+                hide_unhide_item = self.tray_popup_menu.get_items()[_("Hide / Show Nicotine+")]
                 trayicon.set_secondary_activate_target(hide_unhide_item)
 
             else:
@@ -363,7 +363,7 @@ class Tray:
         self.set_image()
 
         # Toggle away checkbox in tray menu
-        away_item = self.tray_popup_menu.get_children()[8]
+        away_item = self.tray_popup_menu.get_items()[_("Away")]
         handler_id = self.tray_popup_menu.handlers[away_item]
 
         with away_item.handler_block(handler_id):
@@ -381,21 +381,25 @@ class Tray:
 
     def set_server_actions_sensitive(self, status):
 
-        items = self.tray_popup_menu.get_children()
+        items = self.tray_popup_menu.get_items()
 
-        for i in range(4, 9):
-            """ Disable Send Message, IP lookup, info lookup, shares lookup and away toggle
-            when disconnected from server """
+        for i in (_("Send Message"), _("Lookup a User's IP"), _("Lookup a User's Info"),
+                  _("Lookup a User's Shares"), _("Away")):
 
+            """ Disable menu items when disconnected from server """
             items[i].set_sensitive(status)
 
-        items = self.tray_popup_menu_server.get_children()
+        items = self.tray_popup_menu_server.get_items()
 
-        items[0].set_sensitive(not status)  # Connect
-        items[1].set_sensitive(status)      # Disconnect
+        items[_("Connect")].set_sensitive(not status)
+        items[_("Disconnect")].set_sensitive(status)
 
     def set_transfer_status(self, download, upload):
 
-        if self.trayicon is not None:
-            self.tray_popup_menu.get_children()[2].set_label(download)
-            self.tray_popup_menu.get_children()[3].set_label(upload)
+        if self.trayicon is None:
+            return
+
+        items = self.tray_popup_menu.get_items()
+
+        items[_("Downloads")].set_label(download)
+        items[_("Uploads")].set_label(upload)

--- a/pynicotine/gtkgui/tray.py
+++ b/pynicotine/gtkgui/tray.py
@@ -180,7 +180,7 @@ class Tray:
     # GtkStatusIcon fallback
     def on_status_icon_popup(self, status_icon, button, activate_time):
         if button == 3:
-            self.tray_popup_menu.popup(None, None, None, None, button, activate_time)
+            self.tray_popup_menu.popup()
 
     def check_icon_path(self, icon_name, icon_path, icon_type="local"):
 

--- a/pynicotine/gtkgui/uploads.py
+++ b/pynicotine/gtkgui/uploads.py
@@ -47,12 +47,12 @@ class Uploads(TransferList):
         self.popup_menu_users = PopupMenu(frame, False)
         self.popup_menu_clear = popup2 = PopupMenu(frame, False)
         popup2.setup(
-            ("#" + _("Clear finished/erred"), self.on_clear_finished_erred),
-            ("#" + _("Clear finished/aborted"), self.on_clear_finished_aborted),
-            ("#" + _("Clear finished"), self.on_clear_finished),
-            ("#" + _("Clear aborted"), self.on_clear_aborted),
-            ("#" + _("Clear queued"), self.on_clear_queued),
-            ("#" + _("Clear failed"), self.on_clear_failed)
+            ("#" + _("Clear Finished/Erred"), self.on_clear_finished_erred),
+            ("#" + _("Clear Finished/Aborted"), self.on_clear_finished_aborted),
+            ("#" + _("Clear Finished"), self.on_clear_finished),
+            ("#" + _("Clear Aborted"), self.on_clear_aborted),
+            ("#" + _("Clear Queued"), self.on_clear_queued),
+            ("#" + _("Clear Failed"), self.on_clear_failed)
         )
 
         self.popup_menu = popup = PopupMenu(frame)
@@ -206,8 +206,8 @@ class Uploads(TransferList):
         users = len(self.selected_users) > 0
         files = len(self.selected_transfers) > 0
 
-        items = self.popup_menu.get_children()
-        items[8].set_sensitive(users)  # Users Menu
+        items = self.popup_menu.get_items()
+        items[_("User(s)")].set_sensitive(users)  # Users Menu
 
         if files:
             act = True
@@ -216,7 +216,8 @@ class Uploads(TransferList):
             # Send to player, File manager, Copy File Path, Copy URL, Copy Folder URL, Search filename
             act = False
 
-        for i in range(0, 6):
+        for i in (_("Send to _Player"), _("_Open Folder"), _("Copy _File Path"),
+                  _("Copy _URL"), _("Copy Folder URL"), _("_Search")):
             items[i].set_sensitive(act)
 
         if users and files:
@@ -226,7 +227,7 @@ class Uploads(TransferList):
             # Retry, Abort, Clear
             act = False
 
-        for i in range(10, 13):
+        for i in (_("_Retry"), _("Abor_t"), _("_Clear")):
             items[i].set_sensitive(act)
 
         self.popup_menu.popup(None, None, None, None, 3, event.time)

--- a/pynicotine/gtkgui/uploads.py
+++ b/pynicotine/gtkgui/uploads.py
@@ -230,7 +230,7 @@ class Uploads(TransferList):
         for i in (_("_Retry"), _("Abor_t"), _("_Clear")):
             items[i].set_sensitive(act)
 
-        self.popup_menu.popup(None, None, None, None, 3, event.time)
+        self.popup_menu.popup()
 
         if kind == "keyboard":
             widget.stop_emission_by_name("key_press_event")

--- a/pynicotine/gtkgui/userbrowse.py
+++ b/pynicotine/gtkgui/userbrowse.py
@@ -276,7 +276,7 @@ class UserBrowse:
         return False
 
     def on_folder_popup_menu(self, widget, event):
-        self.folder_popup_menu.popup(None, None, None, None, event.button, event.time)
+        self.folder_popup_menu.popup()
 
     def select_files(self):
         self.selected_files = []
@@ -326,7 +326,7 @@ class UserBrowse:
                 items[i].set_sensitive(files)
 
         self.FileTreeView.stop_emission_by_name("button_press_event")
-        self.file_popup_menu.popup(None, None, None, None, event.button, event.time)
+        self.file_popup_menu.popup()
 
         return True
 

--- a/pynicotine/gtkgui/userbrowse.py
+++ b/pynicotine/gtkgui/userbrowse.py
@@ -99,23 +99,15 @@ class UserBrowse:
         self.popup_menu_users = PopupMenu(self.frame, False)
         self.popup_menu_users2 = PopupMenu(self.frame, False)
         self.popup_menu_users_tab = PopupMenu(self.frame)
+
         for menu in (self.popup_menu_users, self.popup_menu_users2, self.popup_menu_users_tab):
-            menu.setup(
-                ("#" + _("Send _message"), menu.on_send_message),
-                ("#" + _("Show IP a_ddress"), menu.on_show_ip_address),
-                ("#" + _("Get user i_nfo"), menu.on_get_user_info),
-                ("#" + _("Gi_ve privileges"), menu.on_give_privileges),
-                ("#" + _("Client Version"), menu.on_version),
-                ("", None),
-                ("#" + _("_Save shares list to disk"), self.on_save),
-                ("", None),
-                ("$" + _("_Add user to list"), menu.on_add_to_list),
-                ("$" + _("_Ban this user"), menu.on_ban_user),
-                ("$" + _("_Ignore this user"), menu.on_ignore_user),
-                ("", None),
-                ("#" + _("Close All Tabs"), menu.on_close_all_tabs, self.userbrowses),
-                ("#" + _("_Close This Tab"), self.on_close)
-            )
+            menu.setup_user_menu(user)
+            menu.get_items()[_("Brow_se Files")].set_visible(False)
+
+            menu.append_item(("", None))
+            menu.append_item(("#" + _("_Save Shares List To Disk"), self.on_save))
+            menu.append_item(("#" + _("Close All Tabs"), menu.on_close_all_tabs, self.userbrowses))
+            menu.append_item(("#" + _("_Close Tab"), self.on_close))
 
         self.popup_menu_downloads_folders = PopupMenu(self.frame, False)
         self.popup_menu_downloads_folders.setup(
@@ -244,13 +236,7 @@ class UserBrowse:
         self.on_popup_menu_users(self.popup_menu_users)
 
     def on_popup_menu_users(self, menu):
-
-        items = menu.get_children()
-
-        items[8].set_active(self.user in (i[0] for i in self.frame.np.config.sections["server"]["userlist"]))
-        items[9].set_active(self.user in self.frame.np.config.sections["server"]["banlist"])
-        items[10].set_active(self.user in self.frame.np.config.sections["server"]["ignorelist"])
-
+        menu.toggle_user_items()
         return True
 
     def update_visuals(self):
@@ -290,15 +276,6 @@ class UserBrowse:
         return False
 
     def on_folder_popup_menu(self, widget, event):
-
-        act = True
-        if self.selected_folder is None:
-            act = False
-
-        items = self.folder_popup_menu.get_children()
-        for item in items[1:]:
-            item.set_sensitive(act)
-
         self.folder_popup_menu.popup(None, None, None, None, event.button, event.time)
 
     def select_files(self):
@@ -338,20 +315,15 @@ class UserBrowse:
         else:
             files = False
 
-        items = self.file_popup_menu.get_children()
+        items = self.file_popup_menu.get_items()
 
         if self.user == self.frame.np.config.sections["server"]["login"]:
-            items[2].set_sensitive(files)  # Downloads
-            items[3].set_sensitive(files)  # Uploads
-            items[5].set_sensitive(files)  # Send to player
-            items[7].set_sensitive(files)  # File Properties
-            items[9].set_sensitive(files)  # Copy File Path
-            items[10].set_sensitive(files)  # Copy URL
+            for i in (_("Download"), _("Upload"), _("Send to _Player"), _("File _Properties"),
+                      _("Copy _File Path"), _("Copy _URL")):
+                items[i].set_sensitive(files)
         else:
-            items[2].set_sensitive(files)  # Downloads
-            items[4].set_sensitive(files)  # File Properties
-            items[6].set_sensitive(files)  # Copy File Path
-            items[7].set_sensitive(files)  # Copy URL
+            for i in (_("Download"), _("File _Properties"), _("Copy _File Path"), _("Copy _URL")):
+                items[i].set_sensitive(files)
 
         self.FileTreeView.stop_emission_by_name("button_press_event")
         self.file_popup_menu.popup(None, None, None, None, event.button, event.time)
@@ -633,13 +605,7 @@ class UserBrowse:
         self.progressbar1.set_fraction(fraction)
 
     def tab_popup(self, user):
-
-        items = self.popup_menu_users_tab.get_children()
-
-        items[8].set_active(user in (i[0] for i in self.frame.np.config.sections["server"]["userlist"]))
-        items[9].set_active(user in self.frame.np.config.sections["server"]["banlist"])
-        items[10].set_active(user in self.frame.np.config.sections["server"]["ignorelist"])
-
+        self.popup_menu_users_tab.toggle_user_items()
         return self.popup_menu_users_tab
 
     def on_select_dir(self, selection):

--- a/pynicotine/gtkgui/userinfo.py
+++ b/pynicotine/gtkgui/userinfo.py
@@ -243,39 +243,29 @@ class UserInfo:
         self.update_visuals()
 
         self.user_popup = popup = PopupMenu(self.frame)
-        popup.setup(
-            ("#" + _("Send _message"), popup.on_send_message),
-            ("#" + _("Show IP a_ddress"), popup.on_show_ip_address),
-            ("#" + _("Get user i_nfo"), popup.on_get_user_info),
-            ("#" + _("Brow_se files"), popup.on_browse_user),
-            ("#" + _("Gi_ve privileges"), popup.on_give_privileges),
-            ("#" + _("Client Version"), popup.on_version),
-            ("", None),
-            ("$" + _("_Add user to list"), popup.on_add_to_list),
-            ("$" + _("_Ban this user"), popup.on_ban_user),
-            ("$" + _("_Ignore this user"), popup.on_ignore_user),
-            ("", None),
-            ("#" + _("Close All Tabs"), popup.on_close_all_tabs, self.userinfos),
-            ("#" + _("_Close This Tab"), self.on_close)
-        )
-        popup.set_user(user)
+        popup.setup_user_menu(user)
+        popup.get_items()[_("Show User I_nfo")].set_visible(False)
+
+        popup.append_item(("", None))
+        popup.append_item(("#" + _("Close All Tabs"), popup.on_close_all_tabs, self.userinfos))
+        popup.append_item(("#" + _("_Close Tab"), self.on_close))
 
         self.likes_popup_menu = popup = PopupMenu(self.frame)
         popup.setup(
-            ("$" + _("I _like this"), self.frame.interests.on_like_recommendation),
-            ("$" + _("I _don't like this"), self.frame.interests.on_dislike_recommendation),
+            ("$" + _("I _Like This"), self.frame.interests.on_like_recommendation),
+            ("$" + _("I _Dislike This"), self.frame.interests.on_dislike_recommendation),
             ("", None),
-            ("#" + _("_Search for this item"), self.frame.interests.on_recommend_search)
+            ("#" + _("_Search For Item"), self.frame.interests.on_recommend_search)
         )
 
         self.Likes.connect("button_press_event", self.on_popup_likes_menu)
 
         self.hates_popup_menu = popup = PopupMenu(self.frame)
         popup.setup(
-            ("$" + _("I _like this"), self.frame.interests.on_like_recommendation),
-            ("$" + _("I _don't like this"), self.frame.interests.on_dislike_recommendation),
+            ("$" + _("I _Like This"), self.frame.interests.on_like_recommendation),
+            ("$" + _("I _Dislike This"), self.frame.interests.on_dislike_recommendation),
             ("", None),
-            ("#" + _("_Search for this item"), self.frame.interests.on_recommend_search)
+            ("#" + _("_Search For Item"), self.frame.interests.on_recommend_search)
         )
 
         self.Hates.connect("button_press_event", self.on_popup_hates_menu)
@@ -302,12 +292,10 @@ class UserInfo:
 
         iterator = self.likes_store.get_iter(path)
         thing = self.likes_store.get_value(iterator, 0)
-        items = self.likes_popup_menu.get_children()
+        items = self.likes_popup_menu.get_items()
 
-        self.likes_popup_menu.set_user(thing)
-
-        items[0].set_active(thing in self.frame.np.config.sections["interests"]["likes"])
-        items[1].set_active(thing in self.frame.np.config.sections["interests"]["dislikes"])
+        items[_("I _Like This")].set_active(thing in self.frame.np.config.sections["interests"]["likes"])
+        items[_("I _Dislike This")].set_active(thing in self.frame.np.config.sections["interests"]["dislikes"])
 
         self.likes_popup_menu.popup(None, None, None, None, event.button, event.time)
 
@@ -324,12 +312,10 @@ class UserInfo:
 
         iterator = self.hates_store.get_iter(path)
         thing = self.hates_store.get_value(iterator, 0)
-        items = self.hates_popup_menu.get_children()
+        items = self.hates_popup_menu.get_items()
 
-        self.hates_popup_menu.set_user(thing)
-
-        items[0].set_active(thing in self.frame.np.config.sections["interests"]["likes"])
-        items[1].set_active(thing in self.frame.np.config.sections["interests"]["dislikes"])
+        items[_("I _Like This")].set_active(thing in self.frame.np.config.sections["interests"]["likes"])
+        items[_("I _Dislike This")].set_active(thing in self.frame.np.config.sections["interests"]["dislikes"])
 
         self.hates_popup_menu.popup(None, None, None, None, event.button, event.time)
 
@@ -436,13 +422,7 @@ class UserInfo:
         self.progressbar.set_fraction(fraction)
 
     def tab_popup(self, user):
-
-        items = self.user_popup.get_children()
-
-        items[7].set_active(user in (i[0] for i in self.frame.np.config.sections["server"]["userlist"]))
-        items[8].set_active(user in self.frame.np.config.sections["server"]["banlist"])
-        items[9].set_active(user in self.frame.np.config.sections["server"]["ignorelist"])
-
+        self.user_popup.toggle_user_items()
         return self.user_popup
 
     """ Events """
@@ -513,8 +493,8 @@ class UserInfo:
         if self.image is None or self.image_pixbuf is None:
             act = False
 
-        items = self.image_menu.get_children()
-        for item in items:
+        items = self.image_menu.get_items()
+        for (item_id, item) in items.items():
             item.set_sensitive(act)
 
         self.image_menu.popup(None, None, None, None, event.button, event.time)

--- a/pynicotine/gtkgui/userinfo.py
+++ b/pynicotine/gtkgui/userinfo.py
@@ -162,7 +162,7 @@ class UserTabs(IconNotebook):
                 menu = self.tab_popup(username)
 
                 if menu is not None:
-                    menu.popup(None, None, None, None, event.button, event.time)
+                    menu.popup()
 
                 return True
 
@@ -297,7 +297,7 @@ class UserInfo:
         items[_("I _Like This")].set_active(thing in self.frame.np.config.sections["interests"]["likes"])
         items[_("I _Dislike This")].set_active(thing in self.frame.np.config.sections["interests"]["dislikes"])
 
-        self.likes_popup_menu.popup(None, None, None, None, event.button, event.time)
+        self.likes_popup_menu.popup()
 
     def on_popup_hates_menu(self, widget, event):
 
@@ -317,7 +317,7 @@ class UserInfo:
         items[_("I _Like This")].set_active(thing in self.frame.np.config.sections["interests"]["likes"])
         items[_("I _Dislike This")].set_active(thing in self.frame.np.config.sections["interests"]["dislikes"])
 
-        self.hates_popup_menu.popup(None, None, None, None, event.button, event.time)
+        self.hates_popup_menu.popup()
 
     def update_visuals(self):
 
@@ -497,7 +497,7 @@ class UserInfo:
         for (item_id, item) in items.items():
             item.set_sensitive(act)
 
-        self.image_menu.popup(None, None, None, None, event.button, event.time)
+        self.image_menu.popup()
 
         return True  # Don't scroll the Gtk.ScrolledWindow
 

--- a/pynicotine/gtkgui/userlist.py
+++ b/pynicotine/gtkgui/userlist.py
@@ -162,40 +162,17 @@ class UserList:
 
         self.popup_menu_private_rooms = PopupMenu(self.frame, False)
         self.popup_menu = popup = PopupMenu(frame)
+        popup.setup_user_menu()
+        popup.get_items()[_("_Add User To List")].set_visible(False)
 
-        popup.setup(
-            ("#" + _("Send _message"), popup.on_send_message),
-            ("", None),
-            ("#" + _("Show IP a_ddress"), popup.on_show_ip_address),
-            ("#" + _("Get user i_nfo"), popup.on_get_user_info),
-            ("#" + _("Brow_se files"), popup.on_browse_user),
-            ("#" + _("Gi_ve privileges"), popup.on_give_privileges),
-            ("$" + _("_Ban this user"), popup.on_ban_user),
-            ("$" + _("_Ignore this user"), popup.on_ignore_user),
-            ("", None),
-            ("$" + _("_Online notify"), self.on_notify),
-            ("$" + _("_Privileged"), self.on_privileged),
-            ("$" + _("_Trusted"), self.on_trusted),
-            ("", None),
-            ("#" + _("Edit _comments"), self.on_edit_comments),
-            ("#" + _("_Remove"), self.on_remove_user),
-            (1, _("Private rooms"), self.popup_menu_private_rooms, popup.on_private_rooms, self.popup_menu_private_rooms)
-        )
-
-        items = self.popup_menu.get_children()
-        self.menu_send_message = items[0]
-        self.menu_show_ip_address = items[2]
-        self.menu_get_user_info = items[3]
-        self.menu_browse_user = items[4]
-        self.menu_give_privileges = items[5]
-        self.menu_ban_user = items[6]
-        self.menu_ignore_user = items[7]
-        self.menu_on_notify = items[9]
-        self.menu_on_privileged = items[10]
-        self.menu_on_trusted = items[11]
-        self.menu_edit_comments = items[13]
-        self.menu_remove_user = items[14]
-        self.menu_private_rooms = items[15]
+        popup.append_item(("", None))
+        popup.append_item(("$" + _("_Online Notify"), self.on_notify))
+        popup.append_item(("$" + _("_Privileged"), self.on_privileged))
+        popup.append_item(("$" + _("_Trusted"), self.on_trusted))
+        popup.append_item(("", None))
+        popup.append_item((1, _("Private Rooms"), self.popup_menu_private_rooms, popup.on_private_rooms, self.popup_menu_private_rooms))
+        popup.append_item(("#" + _("Edit _Comments"), self.on_edit_comments))
+        popup.append_item(("#" + _("_Remove"), self.on_remove_user))
 
         self.UserListTree.connect("button_press_event", self.on_popup_menu)
 
@@ -305,22 +282,18 @@ class UserList:
                 return
 
             self.popup_menu.set_user(user)
+            self.popup_menu.toggle_user_items()
 
-            self.menu_send_message.set_sensitive(status)
-            self.menu_show_ip_address.set_sensitive(status)
-            self.menu_get_user_info.set_sensitive(status)
-            self.menu_browse_user.set_sensitive(status)
-            self.menu_give_privileges.set_sensitive(status)
-            self.menu_private_rooms.set_sensitive(
+            items = self.popup_menu.get_items()
+
+            items[_("Private Rooms")].set_sensitive(
                 status or
                 self.popup_menu.user != self.frame.np.config.sections["server"]["login"]
             )
 
-            self.menu_ban_user.set_active(user in self.frame.np.config.sections["server"]["banlist"])
-            self.menu_ignore_user.set_active(user in self.frame.np.config.sections["server"]["ignorelist"])
-            self.menu_on_notify.set_active(model.get_value(iterator, 6))
-            self.menu_on_privileged.set_active(model.get_value(iterator, 7))
-            self.menu_on_trusted.set_active(model.get_value(iterator, 5))
+            items[_("_Online Notify")].set_active(model.get_value(iterator, 6))
+            items[_("_Privileged")].set_active(model.get_value(iterator, 7))
+            items[_("_Trusted")].set_active(model.get_value(iterator, 5))
 
             self.popup_menu.popup(None, None, None, None, event.button, event.time)
 

--- a/pynicotine/gtkgui/userlist.py
+++ b/pynicotine/gtkgui/userlist.py
@@ -295,7 +295,7 @@ class UserList:
             items[_("_Privileged")].set_active(model.get_value(iterator, 7))
             items[_("_Trusted")].set_active(model.get_value(iterator, 5))
 
-            self.popup_menu.popup(None, None, None, None, event.button, event.time)
+            self.popup_menu.popup()
 
     def get_iter(self, user):
 

--- a/pynicotine/gtkgui/utils.py
+++ b/pynicotine/gtkgui/utils.py
@@ -339,7 +339,7 @@ def press_header(widget, event):
     columns = widget.get_parent().get_columns()
     visible_columns = [column for column in columns if column.get_visible()]
     one_visible_column = len(visible_columns) == 1
-    menu = Gtk.Menu()
+    menu = PopupMenu(widget.get_toplevel())
     pos = 1
 
     for column in columns:
@@ -348,7 +348,7 @@ def press_header(widget, event):
         if title == "":
             title = _("Column #%i") % pos
 
-        item = Gtk.CheckMenuItem(title)
+        item = menu.append_item(("$" + title, None))
 
         if column in visible_columns:
             item.set_active(True)
@@ -358,17 +358,14 @@ def press_header(widget, event):
             item.set_active(False)
 
         item.connect('activate', header_toggle, columns, pos - 1)
-        menu.append(item)
         pos += 1
 
-    menu.show_all()
-    menu.attach_to_widget(widget.get_toplevel(), None)
-    menu.popup(None, None, None, None, event.button, event.time)
-
+    menu.popup()
     return True
 
 
 def header_toggle(menuitem, columns, index):
+
     column = columns[index]
     column.set_visible(not column.get_visible())
 
@@ -1162,6 +1159,8 @@ class PopupMenu(Gtk.Menu):
         menuitem = self.create_item(item)
         self.append(menuitem)
 
+        return menuitem
+
     def get_items(self):
         return self.items
 
@@ -1218,6 +1217,15 @@ class PopupMenu(Gtk.Menu):
         if self.useritem is not None:
             self.useritem.destroy()
             self.useritem = None
+
+    def popup(self, button=3):
+
+        try:
+            self.popup_at_pointer()
+
+        except AttributeError:
+            time = Gtk.get_current_event_time()
+            self.popup_at_device(None, None, None, None, button, time)
 
     def set_user(self, user):
 


### PR DESCRIPTION
Over the years, Nicotine+ has accumulated nine pieces of duplicated code for creating a user context menu, resulting in a maintenance nightmare. Refactor the code to create a base user menu that can be extended for certain pages, and eliminate index-based modifications for context menu items, as this has caused a lot of pain when adding or removing items from menus.