### PR TITLE
Format Preferences' dialog strings

### DIFF
--- a/po/nicotine.pot
+++ b/po/nicotine.pot
@@ -1989,7 +1989,7 @@ msgid "Completion"
 msgstr ""
 
 #: ../pynicotine/gtkgui/settingswindow.py:3440
-msgid "Text To Speech"
+msgid "Text-to-Speech"
 msgstr ""
 
 #. Title of the treeview

--- a/po/nicotine.pot
+++ b/po/nicotine.pot
@@ -1990,7 +1990,7 @@ msgstr ""
 
 #: ../pynicotine/gtkgui/settingswindow.py:3440
 msgid "Text To Speech"
-msgstr "Text-to-Speech"
+msgstr ""
 
 #. Title of the treeview
 #: ../pynicotine/gtkgui/settingswindow.py:3472

--- a/po/nicotine.pot
+++ b/po/nicotine.pot
@@ -1989,8 +1989,8 @@ msgid "Completion"
 msgstr ""
 
 #: ../pynicotine/gtkgui/settingswindow.py:3440
-msgid "Text-to-Speech"
-msgstr ""
+msgid "Text To Speech"
+msgstr "Text-to-Speech"
 
 #. Title of the treeview
 #: ../pynicotine/gtkgui/settingswindow.py:3472

--- a/pynicotine/gtkgui/settingswindow.py
+++ b/pynicotine/gtkgui/settingswindow.py
@@ -3441,7 +3441,7 @@ class Settings:
         self.tree["Auto-Replace List"] = model.append(row, [_("Auto-Replace List"), "Auto-Replace List"])
         self.tree["URL Catching"] = model.append(row, [_("URL Catching"), "URL Catching"])
         self.tree["Completion"] = model.append(row, [_("Completion"), "Completion"])
-        self.tree["Text To Speech"] = model.append(row, [_("Text To Speech"), "Text To Speech"])
+        self.tree["Text-to-Speech"] = model.append(row, [_("Text-to-Speech"), "Text-to-Speech"])
 
         # Build individual categories
         p["Server"] = ServerFrame(self)
@@ -3470,7 +3470,7 @@ class Settings:
         p["Auto-Replace List"] = AutoReplaceFrame(self)
         p["URL Catching"] = UrlCatchFrame(self)
         p["Completion"] = CompletionFrame(self)
-        p["Text To Speech"] = TTSFrame(self)
+        p["Text-to-Speech"] = TTSFrame(self)
 
         # Title of the treeview
         column = Gtk.TreeViewColumn(_("Categories"), Gtk.CellRendererText(), text=0)

--- a/pynicotine/gtkgui/ui/settings/autoreplace.ui
+++ b/pynicotine/gtkgui/ui/settings/autoreplace.ui
@@ -145,7 +145,7 @@
                       <object class="GtkLabel">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
-                        <property name="label" translatable="yes">Clear</property>
+                        <property name="label" translatable="yes">Clear All</property>
                         <property name="use_underline">True</property>
                       </object>
                     </child>

--- a/pynicotine/gtkgui/ui/settings/away.ui
+++ b/pynicotine/gtkgui/ui/settings/away.ui
@@ -21,7 +21,7 @@
           <object class="GtkLabel">
             <property name="visible">True</property>
             <property name="can_focus">False</property>
-            <property name="label" translatable="yes">Toggle away after </property>
+            <property name="label" translatable="yes">Toggle Away after </property>
           </object>
           <packing>
             <property name="expand">False</property>

--- a/pynicotine/gtkgui/ui/settings/ban.ui
+++ b/pynicotine/gtkgui/ui/settings/ban.ui
@@ -355,6 +355,7 @@
             <property name="visible">True</property>
             <property name="can_focus">True</property>
             <property name="receives_default">False</property>
+            <property name="tooltip_text" translatable="yes">Sent when banning a user via command or context menu, not when appending to the preference's banned users list.</property>
             <property name="use_underline">True</property>
             <property name="draw_indicator">True</property>
             <signal name="toggled" handler="on_use_custom_ban_toggled" swapped="no"/>

--- a/pynicotine/gtkgui/ui/settings/ban.ui
+++ b/pynicotine/gtkgui/ui/settings/ban.ui
@@ -22,7 +22,7 @@
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <property name="halign">start</property>
-                <property name="label" translatable="yes">Banned Users:</property>
+                <property name="label" translatable="yes">Banned users:</property>
               </object>
               <packing>
                 <property name="expand">False</property>
@@ -148,7 +148,7 @@
                           <object class="GtkLabel">
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
-                            <property name="label" translatable="yes">Clear</property>
+                            <property name="label" translatable="yes">Clear All</property>
                             <property name="use_underline">True</property>
                           </object>
                         </child>
@@ -186,7 +186,7 @@
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <property name="halign">start</property>
-                <property name="label" translatable="yes">Blocked IP Addresses:</property>
+                <property name="label" translatable="yes">Blocked IP addresses:</property>
               </object>
               <packing>
                 <property name="expand">False</property>
@@ -311,7 +311,7 @@
                           <object class="GtkLabel">
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
-                            <property name="label" translatable="yes">Clear</property>
+                            <property name="label" translatable="yes">Clear All</property>
                             <property name="use_underline">True</property>
                           </object>
                         </child>

--- a/pynicotine/gtkgui/ui/settings/ban.ui
+++ b/pynicotine/gtkgui/ui/settings/ban.ui
@@ -355,7 +355,7 @@
             <property name="visible">True</property>
             <property name="can_focus">True</property>
             <property name="receives_default">False</property>
-            <property name="tooltip_text" translatable="yes">Sent when banning a user via command or context menu, not when appending to the preference's banned users list.</property>
+            <property name="tooltip_text" translatable="yes">Sent to users you ban as the reason for being banned.</property>
             <property name="use_underline">True</property>
             <property name="draw_indicator">True</property>
             <signal name="toggled" handler="on_use_custom_ban_toggled" swapped="no"/>

--- a/pynicotine/gtkgui/ui/settings/censor.ui
+++ b/pynicotine/gtkgui/ui/settings/censor.ui
@@ -8,7 +8,7 @@
     <property name="orientation">vertical</property>
     <child>
       <object class="GtkCheckButton" id="CensorCheck">
-        <property name="label" translatable="yes">Enable Censorship</property>
+        <property name="label" translatable="yes">Enable censoring</property>
         <property name="visible">True</property>
         <property name="can_focus">True</property>
         <property name="receives_default">False</property>
@@ -26,7 +26,7 @@
         <property name="visible">True</property>
         <property name="can_focus">False</property>
         <property name="xalign">0</property>
-        <property name="label" translatable="yes">Add spaces around words if you don't wish to match strings inside words (may fail at beginning and end of lines)</property>
+        <property name="label" translatable="yes">Add spaces around patterns if you don't wish to match strings inside words (may fail at the beginning and end of lines)</property>
         <property name="wrap">True</property>
       </object>
       <packing>
@@ -195,7 +195,7 @@
                       <object class="GtkLabel">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
-                        <property name="label" translatable="yes">Clear</property>
+                        <property name="label" translatable="yes">Clear All</property>
                         <property name="use_underline">True</property>
                       </object>
                     </child>

--- a/pynicotine/gtkgui/ui/settings/colours.ui
+++ b/pynicotine/gtkgui/ui/settings/colours.ui
@@ -22,7 +22,7 @@
     </child>
     <child>
       <object class="GtkCheckButton" id="DarkMode">
-        <property name="label" translatable="yes">Prefer dark mode</property>
+        <property name="label" translatable="yes">Enable Dark Mode</property>
         <property name="visible">True</property>
         <property name="can_focus">True</property>
         <property name="receives_default">False</property>
@@ -179,7 +179,7 @@
               <object class="GtkLabel">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
-                <property name="label" translatable="yes">Username Font Style:</property>
+                <property name="label" translatable="yes">Username font style:</property>
               </object>
               <packing>
                 <property name="expand">False</property>
@@ -732,10 +732,11 @@
             <property name="spacing">5</property>
             <child>
               <object class="GtkCheckButton" id="UsernameHotspots">
-                <property name="label" translatable="yes">Username Colors and Hotspots</property>
+                <property name="label" translatable="yes">Enable colored and clickable usernames</property>
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
                 <property name="receives_default">False</property>
+                <property name="tooltip_text" translatable="yes">Clicked usernames reveal the same user context menu accessed via the User List.</property>
                 <property name="use_underline">True</property>
                 <property name="draw_indicator">True</property>
                 <signal name="toggled" handler="on_username_hotspots_toggled" swapped="no"/>
@@ -748,7 +749,7 @@
             </child>
             <child>
               <object class="GtkCheckButton" id="DisplayAwayColours">
-                <property name="label" translatable="yes">Display away colors</property>
+                <property name="label" translatable="yes">Usernames display Away colors</property>
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
                 <property name="receives_default">False</property>
@@ -2006,7 +2007,7 @@
                   <object class="GtkLabel">
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
-                    <property name="label" translatable="yes">Clear</property>
+                    <property name="label" translatable="yes">Clear Colors</property>
                     <property name="use_underline">True</property>
                   </object>
                   <packing>

--- a/pynicotine/gtkgui/ui/settings/colours.ui
+++ b/pynicotine/gtkgui/ui/settings/colours.ui
@@ -22,10 +22,11 @@
     </child>
     <child>
       <object class="GtkCheckButton" id="DarkMode">
-        <property name="label" translatable="yes">Enable Dark Mode</property>
+        <property name="label" translatable="yes">Prefer Dark Mode</property>
         <property name="visible">True</property>
         <property name="can_focus">True</property>
         <property name="receives_default">False</property>
+        <property name="label" translatable="yes">Note that the operating system's theme may take precedence.</property>
         <property name="draw_indicator">True</property>
       </object>
       <packing>

--- a/pynicotine/gtkgui/ui/settings/colours.ui
+++ b/pynicotine/gtkgui/ui/settings/colours.ui
@@ -736,7 +736,7 @@
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
                 <property name="receives_default">False</property>
-                <property name="tooltip_text" translatable="yes">Clicked usernames reveal the same user context menu accessed via the User List.</property>
+                <property name="tooltip_text" translatable="yes">Clicked usernames reveal the user context menu.</property>
                 <property name="use_underline">True</property>
                 <property name="draw_indicator">True</property>
                 <signal name="toggled" handler="on_username_hotspots_toggled" swapped="no"/>

--- a/pynicotine/gtkgui/ui/settings/completion.ui
+++ b/pynicotine/gtkgui/ui/settings/completion.ui
@@ -63,7 +63,7 @@
         </child>
         <child>
           <object class="GtkCheckButton" id="CompletionCycleCheck">
-            <property name="label" translatable="yes">Cycle completions instead of showing a dropdown</property>
+            <property name="label" translatable="yes">Cycle completions instead of showing a drop-down</property>
             <property name="visible">True</property>
             <property name="can_focus">True</property>
             <property name="receives_default">False</property>
@@ -103,8 +103,8 @@
           </packing>
         </child>
         <child>
-          <object class="GtkCheckButton" id="CompleteRoomNamesCheck">
-            <property name="label" translatable="yes">Complete room names in chat rooms</property>
+          <object class="GtkCheckButton" id="CompleteBuddiesCheck">
+            <property name="label" translatable="yes">Complete buddy names</property>
             <property name="visible">True</property>
             <property name="can_focus">True</property>
             <property name="receives_default">False</property>
@@ -114,20 +114,6 @@
             <property name="expand">False</property>
             <property name="fill">True</property>
             <property name="position">1</property>
-          </packing>
-        </child>
-        <child>
-          <object class="GtkCheckButton" id="CompleteBuddiesCheck">
-            <property name="label" translatable="yes">Complete Buddy Names</property>
-            <property name="visible">True</property>
-            <property name="can_focus">True</property>
-            <property name="receives_default">False</property>
-            <property name="draw_indicator">True</property>
-          </object>
-          <packing>
-            <property name="expand">False</property>
-            <property name="fill">True</property>
-            <property name="position">2</property>
           </packing>
         </child>
         <child>
@@ -141,12 +127,26 @@
           <packing>
             <property name="expand">False</property>
             <property name="fill">True</property>
+            <property name="position">2</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkCheckButton" id="CompleteRoomNamesCheck">
+            <property name="label" translatable="yes">Complete room names in chat rooms</property>
+            <property name="visible">True</property>
+            <property name="can_focus">True</property>
+            <property name="receives_default">False</property>
+            <property name="draw_indicator">True</property>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
             <property name="position">3</property>
           </packing>
         </child>
         <child>
           <object class="GtkCheckButton" id="CompleteCommandsCheck">
-            <property name="label" translatable="yes">Complete built-in /Commands</property>
+            <property name="label" translatable="yes">Complete built-in /commands</property>
             <property name="visible">True</property>
             <property name="can_focus">True</property>
             <property name="receives_default">False</property>
@@ -160,7 +160,7 @@
         </child>
         <child>
           <object class="GtkCheckButton" id="CompleteAliasesCheck">
-            <property name="label" translatable="yes">Complete alias /Commands</property>
+            <property name="label" translatable="yes">Complete alias /commands</property>
             <property name="visible">True</property>
             <property name="can_focus">True</property>
             <property name="receives_default">False</property>

--- a/pynicotine/gtkgui/ui/settings/downloads.ui
+++ b/pynicotine/gtkgui/ui/settings/downloads.ui
@@ -222,7 +222,7 @@
                 <property name="label" translatable="yes">Share Download folder</property>
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
-                <property name="tooltip_text" translatable="yes">The equivalent of adding your Download folder as a public share.</property>
+                <property name="tooltip_text" translatable="yes">The equivalent of adding your Download folder as a public share. Files downloaded to this folder will be immediately accessible to others (no rescan required).</property>
                 <property name="receives_default">False</property>
                 <property name="use_underline">True</property>
                 <property name="draw_indicator">True</property>

--- a/pynicotine/gtkgui/ui/settings/downloads.ui
+++ b/pynicotine/gtkgui/ui/settings/downloads.ui
@@ -75,7 +75,7 @@
               <object class="GtkLabel">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
-                <property name="label" translatable="yes">Limit total download speeds to (KBytes/sec):</property>
+                <property name="label" translatable="yes">Limit total download speeds to (kB/s):</property>
                 <property name="single_line_mode">True</property>
                 <property name="xalign">0</property>
               </object>
@@ -88,6 +88,7 @@
               <object class="GtkSpinButton" id="DownloadSpeed">
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
+                <property name="tooltip_text">Kilobytes per second.</property>
                 <property name="adjustment">adjustment_DownloadSpeed</property>
                 <property name="numeric">True</property>
               </object>

--- a/pynicotine/gtkgui/ui/settings/downloads.ui
+++ b/pynicotine/gtkgui/ui/settings/downloads.ui
@@ -102,7 +102,7 @@
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
                 <property name="receives_default">False</property>
-                <property name="tooltip_text" translatable="yes">The users will be able to send you files. These files will be downloaded into the Buddy Uploads subfolder in your Download folder</property>
+                <property name="tooltip_text" translatable="yes">The users will be able to send you files. These files will be downloaded into the Buddy Uploads subfolder in your Download folder.</property>
                 <property name="use_underline">True</property>
                 <property name="draw_indicator">True</property>
                 <signal name="toggled" handler="on_remote_downloads" swapped="no"/>
@@ -206,7 +206,7 @@
               <object class="GtkFileChooserButton" id="UploadDir">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
-                <property name="tooltip_text" translatable="yes">Where buddies' uploads will be stored (with a subfolder for each buddy)</property>
+                <property name="tooltip_text" translatable="yes">Where buddies' uploads will be stored (with a subfolder for each buddy).</property>
                 <property name="action">select-folder</property>
                 <property name="show_hidden">True</property>
                 <property name="title" translatable="yes">Select a Folder</property>
@@ -234,7 +234,7 @@
               <object class="GtkFileChooserButton" id="IncompleteDir">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
-                <property name="tooltip_text" translatable="yes">Where incomplete downloads are stored temporarily</property>
+                <property name="tooltip_text" translatable="yes">Where incomplete downloads are stored temporarily.</property>
                 <property name="action">select-folder</property>
                 <property name="show_hidden">True</property>
                 <property name="title" translatable="yes">Select a folder</property>
@@ -297,7 +297,7 @@
         </child>
         <child>
           <object class="GtkCheckButton" id="DownloadFilter">
-            <property name="label" translatable="yes">Enable Filters</property>
+            <property name="label" translatable="yes">Enable filters</property>
             <property name="visible">True</property>
             <property name="can_focus">True</property>
             <property name="receives_default">False</property>
@@ -316,7 +316,7 @@
             <property name="visible">True</property>
             <property name="can_focus">False</property>
             <property name="xalign">0</property>
-            <property name="label" translatable="yes">&lt;b&gt;Syntax:&lt;/b&gt; Letters are Case Insensitive, All Python Regular Expressions are supported if escaping is disabled. For simple filters, keep escaping enabled.</property>
+            <property name="label" translatable="yes">&lt;b&gt;Syntax:&lt;/b&gt; Letters are case insensitive. All Python regular expressions are supported if escaping is disabled. For simple filters, keeping escaping enabled is recommended.</property>
             <property name="use_markup">True</property>
             <property name="wrap">True</property>
           </object>

--- a/pynicotine/gtkgui/ui/settings/downloads.ui
+++ b/pynicotine/gtkgui/ui/settings/downloads.ui
@@ -75,7 +75,7 @@
               <object class="GtkLabel">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
-                <property name="label" translatable="yes">Limit total download speeds to (kB/s):</property>
+                <property name="label" translatable="yes">Limit total download speeds to (KiB/s):</property>
                 <property name="single_line_mode">True</property>
                 <property name="xalign">0</property>
               </object>
@@ -88,7 +88,7 @@
               <object class="GtkSpinButton" id="DownloadSpeed">
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
-                <property name="tooltip_text">Kilobytes per second.</property>
+                <property name="tooltip_text">Kibibytes (2^10 bytes) per second.</property>
                 <property name="adjustment">adjustment_DownloadSpeed</property>
                 <property name="numeric">True</property>
               </object>

--- a/pynicotine/gtkgui/ui/settings/downloads.ui
+++ b/pynicotine/gtkgui/ui/settings/downloads.ui
@@ -218,9 +218,10 @@
             </child>
             <child>
               <object class="GtkCheckButton" id="ShareDownloadDir">
-                <property name="label" translatable="yes">Share download folder</property>
+                <property name="label" translatable="yes">Share Download folder</property>
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
+                <property name="tooltip_text" translatable="yes">The equivalent of adding your Download folder as a public share.</property>
                 <property name="receives_default">False</property>
                 <property name="use_underline">True</property>
                 <property name="draw_indicator">True</property>

--- a/pynicotine/gtkgui/ui/settings/events.ui
+++ b/pynicotine/gtkgui/ui/settings/events.ui
@@ -114,7 +114,7 @@
           <object class="GtkLabel">
             <property name="visible">True</property>
             <property name="can_focus">False</property>
-            <property name="label" translatable="yes">Audio Player command ($ for file path):</property>
+            <property name="label" translatable="yes">Media Player command ($ for file path):</property>
             <property name="xalign">0</property>
           </object>
           <packing>

--- a/pynicotine/gtkgui/ui/settings/events.ui
+++ b/pynicotine/gtkgui/ui/settings/events.ui
@@ -31,7 +31,7 @@
             <property name="visible">True</property>
             <property name="can_focus">False</property>
             <property name="xalign">0</property>
-            <property name="label" translatable="yes">Run command after download finishes ($ for folder path):</property>
+            <property name="label" translatable="yes">Run command after file download finishes ($ for file path):</property>
           </object>
           <packing>
             <property name="expand">False</property>
@@ -61,7 +61,7 @@
             <property name="visible">True</property>
             <property name="can_focus">False</property>
             <property name="xalign">0</property>
-            <property name="label" translatable="yes">Run command after folder finishes ($ for folder path):</property>
+            <property name="label" translatable="yes">Run command after folder download finishes ($ for folder path):</property>
           </object>
           <packing>
             <property name="expand">False</property>
@@ -114,7 +114,7 @@
           <object class="GtkLabel">
             <property name="visible">True</property>
             <property name="can_focus">False</property>
-            <property name="label" translatable="yes">Audio Player command ($ for folder path):</property>
+            <property name="label" translatable="yes">Audio Player command ($ for file path):</property>
             <property name="xalign">0</property>
           </object>
           <packing>
@@ -173,7 +173,7 @@
               <object class="GtkLabel">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
-                <property name="label" translatable="yes">Download transfers</property>
+                <property name="label" translatable="yes">Download transfers:</property>
                 <property name="xalign">0</property>
               </object>
               <packing>
@@ -185,7 +185,7 @@
               <object class="GtkLabel">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
-                <property name="label" translatable="yes">Upload transfers</property>
+                <property name="label" translatable="yes">Upload transfers:</property>
                 <property name="xalign">0</property>
               </object>
               <packing>

--- a/pynicotine/gtkgui/ui/settings/events.ui
+++ b/pynicotine/gtkgui/ui/settings/events.ui
@@ -114,7 +114,7 @@
           <object class="GtkLabel">
             <property name="visible">True</property>
             <property name="can_focus">False</property>
-            <property name="label" translatable="yes">Audio Player Command ($ for folder path):</property>
+            <property name="label" translatable="yes">Audio Player command ($ for folder path):</property>
             <property name="xalign">0</property>
           </object>
           <packing>

--- a/pynicotine/gtkgui/ui/settings/fonts.ui
+++ b/pynicotine/gtkgui/ui/settings/fonts.ui
@@ -17,7 +17,7 @@
           <object class="GtkLabel" id="chatfontlabel">
             <property name="visible">True</property>
             <property name="can_focus">False</property>
-            <property name="label" translatable="yes">Chat Font:</property>
+            <property name="label" translatable="yes">Chat font:</property>
             <property name="width_chars">15</property>
             <property name="xalign">0</property>
           </object>
@@ -100,7 +100,7 @@
           <object class="GtkLabel" id="listfontlabel">
             <property name="visible">True</property>
             <property name="can_focus">False</property>
-            <property name="label" translatable="yes">List Font:</property>
+            <property name="label" translatable="yes">List font:</property>
             <property name="width_chars">15</property>
             <property name="xalign">0</property>
           </object>
@@ -182,7 +182,7 @@
           <object class="GtkLabel" id="transfersfontlabel">
             <property name="visible">True</property>
             <property name="can_focus">False</property>
-            <property name="label" translatable="yes">Transfers Font:</property>
+            <property name="label" translatable="yes">Transfers font:</property>
             <property name="width_chars">15</property>
             <property name="xalign">0</property>
           </object>
@@ -264,7 +264,7 @@
           <object class="GtkLabel" id="searchfontlabel">
             <property name="visible">True</property>
             <property name="can_focus">False</property>
-            <property name="label" translatable="yes">Search Font:</property>
+            <property name="label" translatable="yes">Search font:</property>
             <property name="width_chars">15</property>
             <property name="xalign">0</property>
           </object>
@@ -346,7 +346,7 @@
           <object class="GtkLabel" id="browsefontlabel">
             <property name="visible">True</property>
             <property name="can_focus">False</property>
-            <property name="label" translatable="yes">Browse Font:</property>
+            <property name="label" translatable="yes">Browse font:</property>
             <property name="width_chars">15</property>
             <property name="xalign">0</property>
           </object>

--- a/pynicotine/gtkgui/ui/settings/geoblock.ui
+++ b/pynicotine/gtkgui/ui/settings/geoblock.ui
@@ -42,6 +42,7 @@
         <property name="visible">True</property>
         <property name="can_focus">True</property>
         <property name="receives_default">False</property>
+        <property name="tooltip_text" translatable="yes">If the source country of an IP cannot be determined, it will be blocked.</property>
         <property name="use_underline">True</property>
         <property name="draw_indicator">True</property>
       </object>

--- a/pynicotine/gtkgui/ui/settings/ignore.ui
+++ b/pynicotine/gtkgui/ui/settings/ignore.ui
@@ -148,7 +148,7 @@
                           <object class="GtkLabel">
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
-                            <property name="label" translatable="yes">Clear</property>
+                            <property name="label" translatable="yes">Clear All</property>
                             <property name="use_underline">True</property>
                           </object>
                         </child>
@@ -312,7 +312,7 @@
                           <object class="GtkLabel">
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
-                            <property name="label" translatable="yes">Clear</property>
+                            <property name="label" translatable="yes">Clear All</property>
                             <property name="use_underline">True</property>
                           </object>
                         </child>

--- a/pynicotine/gtkgui/ui/settings/log.ui
+++ b/pynicotine/gtkgui/ui/settings/log.ui
@@ -439,94 +439,13 @@
               <object class="GtkLabel">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
-                <property name="label" translatable="yes">Log file format:</property>
-                <property name="width_chars">18</property>
-                <property name="xalign">0</property>
-              </object>
-              <packing>
-                <property name="left_attach">0</property>
-                <property name="top_attach">0</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkBox">
-                <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="spacing">10</property>
-                <child>
-                  <object class="GtkEntry" id="LogFileFormat">
-                    <property name="visible">True</property>
-                    <property name="can_focus">True</property>
-                    <property name="tooltip_text">https://docs.python.org/3/library/time.html</property>
-                  </object>
-                  <packing>
-                    <property name="expand">True</property>
-                    <property name="fill">True</property>
-                    <property name="position">0</property>
-                  </packing>
-                </child>
-                <child>
-                  <object class="GtkButton" id="DefaultTimestamp">
-                    <property name="visible">True</property>
-                    <property name="can_focus">True</property>
-                    <property name="receives_default">False</property>
-                    <signal name="clicked" handler="on_default_timestamp" swapped="no"/>
-                    <child>
-                      <object class="GtkBox">
-                        <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="spacing">5</property>
-                        <child>
-                          <object class="GtkImage">
-                            <property name="visible">True</property>
-                            <property name="can_focus">False</property>
-                            <property name="icon_name">view-refresh-symbolic</property>
-                          </object>
-                          <packing>
-                            <property name="expand">False</property>
-                            <property name="fill">True</property>
-                            <property name="position">0</property>
-                          </packing>
-                        </child>
-                        <child>
-                          <object class="GtkLabel">
-                            <property name="visible">True</property>
-                            <property name="can_focus">False</property>
-                            <property name="label" translatable="yes">Default</property>
-                            <property name="use_underline">True</property>
-                          </object>
-                          <packing>
-                            <property name="expand">False</property>
-                            <property name="fill">True</property>
-                            <property name="position">1</property>
-                          </packing>
-                        </child>
-                      </object>
-                    </child>
-                  </object>
-                  <packing>
-                    <property name="expand">False</property>
-                    <property name="fill">False</property>
-                    <property name="position">1</property>
-                  </packing>
-                </child>
-              </object>
-              <packing>
-                <property name="left_attach">1</property>
-                <property name="top_attach">0</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkLabel">
-                <property name="visible">True</property>
-                <property name="can_focus">False</property>
                 <property name="label" translatable="yes">Chat room format:</property>
                 <property name="width_chars">18</property>
                 <property name="xalign">0</property>
               </object>
               <packing>
                 <property name="left_attach">0</property>
-                <property name="top_attach">1</property>
+                <property name="top_attach">0</property>
               </packing>
             </child>
             <child>
@@ -594,7 +513,7 @@
               </object>
               <packing>
                 <property name="left_attach">1</property>
-                <property name="top_attach">1</property>
+                <property name="top_attach">0</property>
               </packing>
             </child>
             <child>
@@ -607,7 +526,7 @@
               </object>
               <packing>
                 <property name="left_attach">0</property>
-                <property name="top_attach">2</property>
+                <property name="top_attach">1</property>
               </packing>
             </child>
             <child>
@@ -633,6 +552,87 @@
                     <property name="can_focus">True</property>
                     <property name="receives_default">False</property>
                     <signal name="clicked" handler="on_private_default_timestamp" swapped="no"/>
+                    <child>
+                      <object class="GtkBox">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="spacing">5</property>
+                        <child>
+                          <object class="GtkImage">
+                            <property name="visible">True</property>
+                            <property name="can_focus">False</property>
+                            <property name="icon_name">view-refresh-symbolic</property>
+                          </object>
+                          <packing>
+                            <property name="expand">False</property>
+                            <property name="fill">True</property>
+                            <property name="position">0</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkLabel">
+                            <property name="visible">True</property>
+                            <property name="can_focus">False</property>
+                            <property name="label" translatable="yes">Default</property>
+                            <property name="use_underline">True</property>
+                          </object>
+                          <packing>
+                            <property name="expand">False</property>
+                            <property name="fill">True</property>
+                            <property name="position">1</property>
+                          </packing>
+                        </child>
+                      </object>
+                    </child>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">False</property>
+                    <property name="position">1</property>
+                  </packing>
+                </child>
+              </object>
+              <packing>
+                <property name="left_attach">1</property>
+                <property name="top_attach">1</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkLabel">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="label" translatable="yes">Log file format:</property>
+                <property name="width_chars">18</property>
+                <property name="xalign">0</property>
+              </object>
+              <packing>
+                <property name="left_attach">0</property>
+                <property name="top_attach">2</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkBox">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="spacing">10</property>
+                <child>
+                  <object class="GtkEntry" id="LogFileFormat">
+                    <property name="visible">True</property>
+                    <property name="can_focus">True</property>
+                    <property name="tooltip_text">https://docs.python.org/3/library/time.html</property>
+                  </object>
+                  <packing>
+                    <property name="expand">True</property>
+                    <property name="fill">True</property>
+                    <property name="position">0</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkButton" id="DefaultTimestamp">
+                    <property name="visible">True</property>
+                    <property name="can_focus">True</property>
+                    <property name="receives_default">False</property>
+                    <signal name="clicked" handler="on_default_timestamp" swapped="no"/>
                     <child>
                       <object class="GtkBox">
                         <property name="visible">True</property>

--- a/pynicotine/gtkgui/ui/settings/log.ui
+++ b/pynicotine/gtkgui/ui/settings/log.ui
@@ -134,7 +134,7 @@
               <object class="GtkLabel" id="RoomLogDirLabel">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
-                <property name="label" translatable="yes">Chatroom Logs folder:</property>
+                <property name="label" translatable="yes">Chatroom logs folder:</property>
                 <property name="xalign">0</property>
               </object>
               <packing>
@@ -146,7 +146,7 @@
               <object class="GtkLabel" id="PrivateLogDirLabel">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
-                <property name="label" translatable="yes">Private Chat Logs folder:</property>
+                <property name="label" translatable="yes">Private chat logs folder:</property>
                 <property name="xalign">0</property>
               </object>
               <packing>
@@ -158,7 +158,7 @@
               <object class="GtkLabel" id="TransfersLogDirLabel">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
-                <property name="label" translatable="yes">Transfer Logs folder:</property>
+                <property name="label" translatable="yes">Transfer logs folder:</property>
                 <property name="xalign">0</property>
               </object>
               <packing>
@@ -170,7 +170,7 @@
               <object class="GtkLabel" id="DebugLogDirLabel">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
-                <property name="label" translatable="yes">Debug Logs folder:</property>
+                <property name="label" translatable="yes">Debug logs folder:</property>
                 <property name="xalign">0</property>
               </object>
               <packing>
@@ -283,7 +283,7 @@
               <object class="GtkLabel">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
-                <property name="label" translatable="yes">Read</property>
+                <property name="label" translatable="yes">Show the last</property>
               </object>
               <packing>
                 <property name="expand">False</property>
@@ -325,7 +325,7 @@
         </child>
         <child>
           <object class="GtkCheckButton" id="ReopenPrivateChats">
-            <property name="label" translatable="yes">Reopen last Private Chat messages</property>
+            <property name="label" translatable="yes">Display logged private chat messages when starting a chat</property>
             <property name="visible">True</property>
             <property name="can_focus">True</property>
             <property name="receives_default">False</property>
@@ -347,7 +347,7 @@
               <object class="GtkLabel">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
-                <property name="label" translatable="yes">Read</property>
+                <property name="label" translatable="yes">Show the last</property>
               </object>
               <packing>
                 <property name="expand">False</property>

--- a/pynicotine/gtkgui/ui/settings/log.ui
+++ b/pynicotine/gtkgui/ui/settings/log.ui
@@ -325,7 +325,7 @@
         </child>
         <child>
           <object class="GtkCheckButton" id="ReopenPrivateChats">
-            <property name="label" translatable="yes">Display logged private chat messages when starting a chat</property>
+            <property name="label" translatable="yes">Restore previously open private chats on startup</property>
             <property name="visible">True</property>
             <property name="can_focus">True</property>
             <property name="receives_default">False</property>

--- a/pynicotine/gtkgui/ui/settings/notebook.ui
+++ b/pynicotine/gtkgui/ui/settings/notebook.ui
@@ -92,10 +92,11 @@
         </child>
         <child>
           <object class="GtkCheckButton" id="TabReorderable">
-            <property name="label" translatable="yes">Tabs can be repositioned</property>
+            <property name="label" translatable="yes">Tabs can be reordered</property>
             <property name="visible">True</property>
             <property name="can_focus">True</property>
             <property name="receives_default">False</property>
+            <property name="tooltip_text" translatable="yes">When disabled, tabs are locked in their current order.</property>
             <property name="draw_indicator">True</property>
           </object>
           <packing>
@@ -106,7 +107,7 @@
         </child>
         <child>
           <object class="GtkCheckButton" id="TabStatusIcons">
-            <property name="label" translatable="yes">Show user status icons instead of status text</property>
+            <property name="label" translatable="yes">Tabs show user status icons instead of status text</property>
             <property name="visible">True</property>
             <property name="can_focus">True</property>
             <property name="receives_default">False</property>
@@ -135,7 +136,7 @@
           <object class="GtkLabel">
             <property name="visible">True</property>
             <property name="can_focus">False</property>
-            <property name="label" translatable="yes">&lt;b&gt;Tab Positioning&lt;/b&gt;</property>
+            <property name="label" translatable="yes">&lt;b&gt;Tab Bar Positioning&lt;/b&gt;</property>
             <property name="halign">start</property>
             <property name="use_markup">True</property>
           </object>
@@ -155,7 +156,7 @@
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <property name="xalign">0</property>
-                <property name="label" translatable="yes">Main</property>
+                <property name="label" translatable="yes">Main:</property>
                 <property name="width_chars">20</property>
               </object>
               <packing>
@@ -179,7 +180,7 @@
               <object class="GtkLabel" id="MainAngleLabel">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
-                <property name="label" translatable="yes">Label Angle:</property>
+                <property name="label" translatable="yes">Label angle:</property>
                 <property name="width_chars">12</property>
               </object>
               <packing>
@@ -219,7 +220,7 @@
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <property name="xalign">0</property>
-                <property name="label" translatable="yes">Chat rooms</property>
+                <property name="label" translatable="yes">Chat rooms:</property>
                 <property name="width_chars">20</property>
               </object>
               <packing>
@@ -243,7 +244,7 @@
               <object class="GtkLabel" id="ChatRoomsAngleLabel">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
-                <property name="label" translatable="yes">Label Angle:</property>
+                <property name="label" translatable="yes">Label angle:</property>
                 <property name="width_chars">12</property>
               </object>
               <packing>
@@ -282,7 +283,7 @@
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <property name="xalign">0</property>
-                <property name="label" translatable="yes">Private chat</property>
+                <property name="label" translatable="yes">Private chat:</property>
                 <property name="width_chars">20</property>
               </object>
               <packing>
@@ -306,7 +307,7 @@
               <object class="GtkLabel" id="PrivateChatAngleLabel">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
-                <property name="label" translatable="yes">Label Angle:</property>
+                <property name="label" translatable="yes">Label angle:</property>
                 <property name="width_chars">12</property>
               </object>
               <packing>
@@ -345,7 +346,7 @@
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <property name="xalign">0</property>
-                <property name="label" translatable="yes">Search</property>
+                <property name="label" translatable="yes">Search:</property>
                 <property name="width_chars">20</property>
               </object>
               <packing>
@@ -369,7 +370,7 @@
               <object class="GtkLabel" id="SearchAngleLabel">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
-                <property name="label" translatable="yes">Label Angle:</property>
+                <property name="label" translatable="yes">Label angle:</property>
                 <property name="width_chars">12</property>
               </object>
               <packing>
@@ -409,7 +410,7 @@
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <property name="xalign">0</property>
-                <property name="label" translatable="yes">User info</property>
+                <property name="label" translatable="yes">User info:</property>
                 <property name="width_chars">20</property>
               </object>
               <packing>
@@ -433,7 +434,7 @@
               <object class="GtkLabel" id="UserInfoAngleLabel">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
-                <property name="label" translatable="yes">Label Angle:</property>
+                <property name="label" translatable="yes">Label angle:</property>
                 <property name="width_chars">12</property>
               </object>
               <packing>
@@ -472,7 +473,7 @@
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <property name="xalign">0</property>
-                <property name="label" translatable="yes">User browse</property>
+                <property name="label" translatable="yes">User browse:</property>
                 <property name="width_chars">20</property>
               </object>
               <packing>
@@ -496,7 +497,7 @@
               <object class="GtkLabel" id="UserBrowseAngleLabel">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
-                <property name="label" translatable="yes">Label Angle:</property>
+                <property name="label" translatable="yes">Label angle:</property>
                 <property name="width_chars">12</property>
               </object>
               <packing>

--- a/pynicotine/gtkgui/ui/settings/notifications.ui
+++ b/pynicotine/gtkgui/ui/settings/notifications.ui
@@ -28,7 +28,7 @@
         </child>
         <child>
           <object class="GtkCheckButton" id="NotificationWindowTitle">
-            <property name="label" translatable="yes">Show notification for private chat and mentions in window title</property>
+            <property name="label" translatable="yes">Show notification for private chats and mentions in window title</property>
             <property name="visible">True</property>
             <property name="can_focus">True</property>
             <property name="receives_default">False</property>
@@ -70,7 +70,7 @@
         </child>
         <child>
           <object class="GtkCheckButton" id="NotificationPopupSound">
-            <property name="label" translatable="yes">Play sound for notification popups</property>
+            <property name="label" translatable="yes">Play a sound for notification popups</property>
             <property name="visible">True</property>
             <property name="can_focus">True</property>
             <property name="receives_default">False</property>
@@ -111,7 +111,7 @@
         </child>
         <child>
           <object class="GtkCheckButton" id="NotificationPopupFile">
-            <property name="label" translatable="yes">When a file has finished downloading</property>
+            <property name="label" translatable="yes">when a file has finished downloading</property>
             <property name="visible">True</property>
             <property name="can_focus">True</property>
             <property name="receives_default">False</property>
@@ -125,7 +125,7 @@
         </child>
         <child>
           <object class="GtkCheckButton" id="NotificationPopupFolder">
-            <property name="label" translatable="yes">When a folder has finished downloading</property>
+            <property name="label" translatable="yes">when a folder has finished downloading</property>
             <property name="visible">True</property>
             <property name="can_focus">True</property>
             <property name="receives_default">False</property>
@@ -139,7 +139,7 @@
         </child>
         <child>
           <object class="GtkCheckButton" id="NotificationPopupPrivateMessage">
-            <property name="label" translatable="yes">When you receive a private message</property>
+            <property name="label" translatable="yes">when you receive a private message</property>
             <property name="visible">True</property>
             <property name="can_focus">True</property>
             <property name="receives_default">False</property>
@@ -153,7 +153,7 @@
         </child>
         <child>
           <object class="GtkCheckButton" id="NotificationPopupChatroom">
-            <property name="label" translatable="yes">When someone sends a message in a chat room</property>
+            <property name="label" translatable="yes">when someone sends a message in a chat room</property>
             <property name="visible">True</property>
             <property name="can_focus">True</property>
             <property name="receives_default">False</property>
@@ -167,7 +167,7 @@
         </child>
         <child>
           <object class="GtkCheckButton" id="NotificationPopupChatroomMention">
-            <property name="label" translatable="yes">When you're mentioned in a chat room</property>
+            <property name="label" translatable="yes">when you're mentioned in a chat room</property>
             <property name="visible">True</property>
             <property name="can_focus">True</property>
             <property name="receives_default">False</property>

--- a/pynicotine/gtkgui/ui/settings/nowplaying.ui
+++ b/pynicotine/gtkgui/ui/settings/nowplaying.ui
@@ -16,7 +16,7 @@
             <property name="visible">True</property>
             <property name="can_focus">False</property>
             <property name="halign">start</property>
-            <property name="label" translatable="yes">Display what your Media Player is playing in Chat with the /now command</property>
+            <property name="label" translatable="yes">Display what your media player is playing in chat with the /now command.</property>
             <property name="single_line_mode">True</property>
           </object>
           <packing>
@@ -217,7 +217,7 @@
             <property name="visible">True</property>
             <child>
               <object class="GtkButton" id="test_now_playing">
-                <property name="label" translatable="yes">Test the configuration</property>
+                <property name="label" translatable="yes">Test the Configuration</property>
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
                 <property name="receives_default">True</property>

--- a/pynicotine/gtkgui/ui/settings/plugin.ui
+++ b/pynicotine/gtkgui/ui/settings/plugin.ui
@@ -8,7 +8,7 @@
     <property name="orientation">vertical</property>
     <child>
       <object class="GtkCheckButton" id="PluginsEnable">
-        <property name="label" translatable="yes">Enable Plugins</property>
+        <property name="label" translatable="yes">Enable plugins</property>
         <property name="visible">True</property>
         <property name="can_focus">True</property>
         <property name="receives_default">False</property>
@@ -65,7 +65,7 @@
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
                     <property name="halign">start</property>
-                    <property name="label" translatable="yes">&lt;b&gt;No Plugin Selected&lt;/b&gt;</property>
+                    <property name="label" translatable="yes">&lt;b&gt;No plugin selected&lt;/b&gt;</property>
                     <property name="use_markup">True</property>
                   </object>
                   <packing>

--- a/pynicotine/gtkgui/ui/settings/search.ui
+++ b/pynicotine/gtkgui/ui/settings/search.ui
@@ -255,7 +255,7 @@
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <property name="xalign">0</property>
-                <property name="label" translatable="yes">Max visible results per search:</property>
+                <property name="label" translatable="yes">Maximum results per search visible at a time:</property>
               </object>
               <packing>
                 <property name="expand">False</property>
@@ -267,6 +267,7 @@
               <object class="GtkSpinButton" id="MaxDisplayedResults">
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
+                <property name="tooltip_text">When the maximum number of visible results is smaller than the maximum total results, use the search filters to refine the results that you see. Alternatively, use the same value for both (at the potential cost of performance).</property>
                 <property name="width_chars">6</property>
                 <property name="primary_icon_activatable">False</property>
                 <property name="secondary_icon_activatable">False</property>
@@ -297,7 +298,7 @@
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <property name="xalign">0</property>
-                <property name="label" translatable="yes">Max stored results per search:</property>
+                <property name="label" translatable="yes">Maximum total results per search:</property>
               </object>
               <packing>
                 <property name="expand">False</property>

--- a/pynicotine/gtkgui/ui/settings/server.ui
+++ b/pynicotine/gtkgui/ui/settings/server.ui
@@ -43,7 +43,7 @@
         <property name="visible">True</property>
         <property name="can_focus">False</property>
         <property name="xalign">0</property>
-        <property name="label" translatable="yes">You can create a new account by entering the desired details below. Please keep in mind that some usernames may already be taken. If you're unable to connect with your selected username, choose another one.</property>
+        <property name="label" translatable="yes">You can create a new account by entering your desired details below. Please keep in mind that some usernames may already be taken. If you're unable to connect with your selected username, try choosing another one. If connecting remains a problem, verify the settings below and those of your internet connection.</property>
         <property name="wrap">True</property>
       </object>
       <packing>
@@ -135,7 +135,7 @@
             </child>
             <child>
               <object class="GtkButton" id="ChangePassword">
-                <property name="label">Change password</property>
+                <property name="label">Change Password</property>
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
                 <property name="receives_default">True</property>
@@ -263,7 +263,7 @@
         </child>
         <child>
           <object class="GtkButton" id="CheckPortButton">
-            <property name="label" translatable="yes">Check port status</property>
+            <property name="label" translatable="yes">Check Port Status</property>
             <property name="visible">True</property>
             <property name="can_focus">True</property>
             <property name="can_default">True</property>
@@ -310,7 +310,7 @@
             <property name="visible">True</property>
             <property name="can_focus">False</property>
             <property name="xalign">1</property>
-            <property name="label" translatable="yes">Automatically renew port mappings every</property>
+            <property name="label" translatable="yes">Automatically renew port mappings every:</property>
           </object>
           <packing>
             <property name="expand">False</property>
@@ -368,7 +368,7 @@
     </child>
     <child>
       <object class="GtkCheckButton" id="ctcptogglebutton">
-        <property name="label" translatable="yes">Enable CTCP-like PM responses (Client Version)</property>
+        <property name="label" translatable="yes">Enable CTCP-like private message responses (client version)</property>
         <property name="visible">True</property>
         <property name="can_focus">True</property>
         <property name="receives_default">False</property>

--- a/pynicotine/gtkgui/ui/settings/tts.ui
+++ b/pynicotine/gtkgui/ui/settings/tts.ui
@@ -8,7 +8,7 @@
     <property name="orientation">vertical</property>
     <child>
       <object class="GtkCheckButton" id="TextToSpeech">
-        <property name="label" translatable="yes">Enable Text To Speech</property>
+        <property name="label" translatable="yes">Enable Text-to-Speech</property>
         <property name="visible">True</property>
         <property name="can_focus">True</property>
         <property name="receives_default">False</property>
@@ -33,7 +33,7 @@
             <property name="visible">True</property>
             <property name="can_focus">False</property>
             <property name="halign">start</property>
-            <property name="label" translatable="yes">Text To Speech command:</property>
+            <property name="label" translatable="yes">Text-to-Speech command:</property>
           </object>
           <packing>
             <property name="left_attach">0</property>

--- a/pynicotine/gtkgui/ui/settings/uploads.ui
+++ b/pynicotine/gtkgui/ui/settings/uploads.ui
@@ -89,7 +89,7 @@
               <object class="GtkLabel">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
-                <property name="label" translatable="yes">Upload Queue type:</property>
+                <property name="label" translatable="yes">Upload queue type:</property>
                 <property name="xalign">0</property>
               </object>
               <packing>
@@ -103,7 +103,7 @@
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
                 <property name="receives_default">False</property>
-                <property name="tooltip_text" translatable="yes">Users will be sent one file and then another user will be selected</property>
+                <property name="tooltip_text" translatable="yes">Queued users will be uploaded one file at a time in a cyclical fashion.</property>
                 <property name="use_underline">True</property>
                 <property name="active">True</property>
                 <property name="draw_indicator">True</property>
@@ -119,7 +119,7 @@
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
                 <property name="receives_default">False</property>
-                <property name="tooltip_text" translatable="yes">Files will be sent in the order they were queued</property>
+                <property name="tooltip_text" translatable="yes">Files will be uploaded in the order they were queued.</property>
                 <property name="use_underline">True</property>
                 <property name="draw_indicator">True</property>
                 <property name="group">RoundRobin</property>
@@ -133,7 +133,7 @@
               <object class="GtkLabel" id="QueueBandwidthText1">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
-                <property name="label" translatable="yes">Queue Uploads if total transfer speed reaches</property>
+                <property name="label" translatable="yes">Queue uploads if total transfer speed reaches</property>
                 <property name="xalign">0</property>
               </object>
               <packing>
@@ -145,6 +145,7 @@
               <object class="GtkSpinButton" id="QueueBandwidth">
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
+                <property name="tooltip_text">Kilobytes per second.</property>
                 <property name="adjustment">adjustment_QueueBandwidth</property>
                 <property name="hexpand">True</property>
               </object>
@@ -157,7 +158,7 @@
               <object class="GtkLabel" id="QueueBandwidthText2">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
-                <property name="label" translatable="yes">KBytes/sec</property>
+                <property name="label" translatable="yes">kB/s</property>
                 <property name="wrap">True</property>
                 <property name="xalign">0</property>
               </object>
@@ -168,11 +169,11 @@
             </child>
             <child>
               <object class="GtkCheckButton" id="QueueUseSlots">
-                <property name="label" translatable="yes">Limit number of upload slots to</property>
+                <property name="label" translatable="yes">Limit number of upload slots to:</property>
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
                 <property name="receives_default">False</property>
-                <property name="tooltip_text" translatable="yes">If disabled, slots will automatically be determined by available bandwidth limitations</property>
+                <property name="tooltip_text" translatable="yes">If disabled, slots will automatically be determined by available bandwidth limitations.</property>
                 <property name="use_underline">True</property>
                 <property name="draw_indicator">True</property>
                 <signal name="toggled" handler="on_queue_use_slots_toggled" swapped="no"/>
@@ -213,6 +214,7 @@
               <object class="GtkSpinButton" id="LimitSpeed">
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
+                <property name="tooltip_text">Kilobytes per second.</property>
                 <property name="adjustment">adjustment_LimitSpeed</property>
                 <property name="hexpand">True</property>
               </object>
@@ -225,7 +227,7 @@
               <object class="GtkLabel">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
-                <property name="label" translatable="yes">KBytes/sec</property>
+                <property name="label" translatable="yes">kB/s</property>
               </object>
               <packing>
                 <property name="left_attach">2</property>
@@ -240,7 +242,7 @@
                 <property name="spacing">2</property>
                 <child>
                   <object class="GtkRadioButton" id="LimitPerTransfer">
-                    <property name="label" translatable="yes">per transfer</property>
+                    <property name="label" translatable="yes">Per transfer</property>
                     <property name="visible">True</property>
                     <property name="can_focus">True</property>
                     <property name="receives_default">False</property>
@@ -256,7 +258,7 @@
                 </child>
                 <child>
                   <object class="GtkRadioButton" id="LimitTotalTransfers">
-                    <property name="label" translatable="yes">total transfers</property>
+                    <property name="label" translatable="yes">Total transfers</property>
                     <property name="visible">True</property>
                     <property name="can_focus">True</property>
                     <property name="receives_default">False</property>
@@ -280,7 +282,7 @@
               <object class="GtkLabel">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
-                <property name="label" translatable="yes">Each user may queue a maximum of</property>
+                <property name="label" translatable="yes">Each user may queue a maximum of either:</property>
                 <property name="xalign">0</property>
               </object>
               <packing>
@@ -292,6 +294,7 @@
               <object class="GtkSpinButton" id="MaxUserQueue">
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
+                <property name="tooltip_text">Megabytes.</property>
                 <property name="adjustment">adjustment_MaxUserQueue</property>
                 <property name="hexpand">True</property>
               </object>
@@ -316,7 +319,7 @@
               <object class="GtkLabel">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
-                <property name="label" translatable="yes">Megabytes</property>
+                <property name="label" translatable="yes">MBs</property>
                 <property name="xalign">0</property>
               </object>
               <packing>
@@ -328,7 +331,7 @@
               <object class="GtkLabel">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
-                <property name="label" translatable="yes">Files</property>
+                <property name="label" translatable="yes">files</property>
                 <property name="xalign">0</property>
               </object>
               <packing>
@@ -393,7 +396,7 @@
             <property name="visible">True</property>
             <property name="can_focus">True</property>
             <property name="receives_default">False</property>
-            <property name="tooltip_text" translatable="yes">Friends will have higher priority in the queue, the same as globally privileged users</property>
+            <property name="tooltip_text" translatable="yes">Friends will have higher priority in the queue, the same as globally privileged users.</property>
             <property name="use_underline">True</property>
             <property name="draw_indicator">True</property>
           </object>

--- a/pynicotine/gtkgui/ui/settings/uploads.ui
+++ b/pynicotine/gtkgui/ui/settings/uploads.ui
@@ -145,7 +145,7 @@
               <object class="GtkSpinButton" id="QueueBandwidth">
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
-                <property name="tooltip_text">Kilobytes per second.</property>
+                <property name="tooltip_text">Kibibytes (2^10 bytes) per second.</property>
                 <property name="adjustment">adjustment_QueueBandwidth</property>
                 <property name="hexpand">True</property>
               </object>
@@ -158,7 +158,7 @@
               <object class="GtkLabel" id="QueueBandwidthText2">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
-                <property name="label" translatable="yes">kB/s</property>
+                <property name="label" translatable="yes">KiB/s</property>
                 <property name="wrap">True</property>
                 <property name="xalign">0</property>
               </object>
@@ -214,7 +214,7 @@
               <object class="GtkSpinButton" id="LimitSpeed">
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
-                <property name="tooltip_text">Kilobytes per second.</property>
+                <property name="tooltip_text">Kibibytes (2^10 bytes) per second.</property>
                 <property name="adjustment">adjustment_LimitSpeed</property>
                 <property name="hexpand">True</property>
               </object>
@@ -227,7 +227,7 @@
               <object class="GtkLabel">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
-                <property name="label" translatable="yes">kB/s</property>
+                <property name="label" translatable="yes">KiB/s</property>
               </object>
               <packing>
                 <property name="left_attach">2</property>
@@ -294,7 +294,7 @@
               <object class="GtkSpinButton" id="MaxUserQueue">
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
-                <property name="tooltip_text">Megabytes.</property>
+                <property name="tooltip_text">Mebibytes (2^17 bytes).</property>
                 <property name="adjustment">adjustment_MaxUserQueue</property>
                 <property name="hexpand">True</property>
               </object>
@@ -319,7 +319,7 @@
               <object class="GtkLabel">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
-                <property name="label" translatable="yes">MBs</property>
+                <property name="label" translatable="yes">MiBs</property>
                 <property name="xalign">0</property>
               </object>
               <packing>

--- a/pynicotine/gtkgui/ui/settings/urlcatch.ui
+++ b/pynicotine/gtkgui/ui/settings/urlcatch.ui
@@ -24,7 +24,7 @@
     </child>
     <child>
       <object class="GtkCheckButton" id="HumanizeURLs">
-        <property name="label" translatable="yes">Humanize slsk:// urls</property>
+        <property name="label" translatable="yes">Humanize slsk:// URLs</property>
         <property name="visible">True</property>
         <property name="can_focus">True</property>
         <property name="receives_default">False</property>


### PR DESCRIPTION
Please excuse my sloppy use of Git. I'm out of practice and was only using the GitHub interface to submit commits.

With this patch, I've tried to bring some consistency across all the settings, how they're formatted, their wording, etc. An attempt was made to avoid changing strings too much so that translations would still make sense.

- `GtkCheckButton` labels were updated to all be sentence case and without a period (unless describing a section of options).
  - Sometimes all lowercase if part of a list of options that have a group title ending with an ellipsis (see, `General > Notifications`).

- `GtkLabel`s end in a colon if followed by a related UI element (and if that UI element isn't followed by a word part of the original sentence).
  - `GtkLabel`s for section titles (groups of options) were made to be title case.

- `GtkButton` labels are all title case (`GtkRadioButton`s sentence case).

- All tooltips end in a period, and a handful more have been added.

- Values displayed in drop-downs weren't touched and some remain "out of sync" with this new formatting.

- Mentions of "dropdown" now as "drop-down". "Text To Speech" as "Text-to-Speech".

- Mentions of "Megabytes" to "MB" and "KBytes/sec" to "kB/s" (tooltips added to the number fields if users are unsure of what a "kB/s" is etc).

- Change "Clear" buttons to "Clear All" (unless it only clears a single item). "Clear" on `Interface > Colors` was changed to "Clear Colors" to make it less ambiguous and follow the "Default Colors" button's style.

- "Load Defaults" should be used when loading the defaults of multiple related items. "Default" when only a single item. In the future "Reset Page" should be used if defaulting every visible setting to the shipped default (to avoid ambiguity).

- Likely a few undocumented other changes…

There are still [a couple outstanding ambiguous settings](https://github.com/Nicotine-Plus/nicotine-plus/issues/924#issuecomment-756351272) that could be made less so.

---

Now for some bugs and general comments that you may wish to consider at a later date:

- Bug: `General > Searches > "Enable filters by default"` does not visually effect the Country field in the UI below (always looks enabled, but correctly does not affect search results when this optios is disabled).

- Bug: `General > Plugins > Plugins` are deselected when disabling "Enable Plugins", i.e. re-enabling them means reselecting which plugins you wish to use (rather than just re-enabling the "Enable Plugins" button).

- Bug: `General > Logging > "Reopen last Private Chat messages"` has no effect: it is always enabled. The number of desired lines is working correctly however. Tested by sending messages to myself.

- Bug: `Interface > Colors`: the "Username Colors and Hotspots" checkbox en-/disables all three Online/Offline/Away options, yet when disabled, "Display away colors" is still able to be enabled (though has no effect).

- Bug(?): `Chat > Completion > "Hide drop-down when only one matches"` isn't disabled when "Enable completion drop-down list" is disabled.

- If `Transfers > Uploads > "Privilege all my friends"` is enabled, perhaps the UI should reflect this somehow? E.g. the Buddly list showing grayed, non-interactive ticks in every Privileged checkbox. This way it is clear this option is enabled (I assume it overrides any unticked, unprivileged buddies). Of course, the previously set states of privileged or not should not be overwritten once this option is disabled.

- Should `Interface > Colors > Chat Colors` be moved to `Chat > Colors` instead?

- `Transfers > Shares` could do with a "Clear All" button in both sections (public and buddy shares).

- `Chat > URL Catching` could also do with a "Clear All" button.

Some of the comments left on the commits may be worth looking over. But I think that's it. Hopefully there'll be something worth merging. Being new to submitting patches, I'm receptive to any feedback.

Thanks! 🙂