### PR TITLE
macOS build: ad-hoc signing

### DIFF
--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -71,6 +71,10 @@ jobs:
           pyinstaller packaging/macos/nicotine.spec
           rm -rf dist/Nicotine+/
 
+      - name: Ad-hoc signing
+        run: |
+          codesign --deep --entitlements packaging/macos/entitlements.plist --options runtime --sign - dist/Nicotine+.app
+
       - name: Generate .dmg
         run: |
           packaging/macos/create-dmg.sh

--- a/packaging/macos/dependencies-packaging.sh
+++ b/packaging/macos/dependencies-packaging.sh
@@ -32,4 +32,4 @@ brew install \
 # Install dependencies with pip
 pip3 install \
   pygobject \
-  pyinstaller==4.1
+  git+https://github.com/pyinstaller/pyinstaller@da88bc85211befe10c4090a880db1a4c8d3ea625

--- a/packaging/macos/entitlements.plist
+++ b/packaging/macos/entitlements.plist
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <!-- Required for binaries built by PyInstaller -->
+    <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+    <true/>
+</dict>
+</plist>


### PR DESCRIPTION
Ad-hoc sign our macOS builds in preparation for the day we're able to generate [universal binaries](https://developer.apple.com/documentation/xcode/building_a_universal_macos_binary).

> New in macOS 11 on Macs with Apple silicon, and starting in macOS Big Sur 11 beta 6, the operating system enforces that any executable must be signed before it’s allowed to run. There isn’t a specific identity requirement for this signature: a simple ad-hoc signature is sufficient. This new behavior doesn’t change the long-established policy that our users and developers can run arbitrary code on their Macs, and is designed to simplify the execution policies on Macs with Apple silicon and enable the system to better detect code modifications. This new policy doesn’t apply to translated x86 binaries running under Rosetta 2, nor does it apply to macOS 11 running on Intel-based platforms.

https://developer.apple.com/documentation/macos-release-notes/macos-big-sur-11_0_1-universal-apps-release-notes