### PR TITLE
Additional Preferences UI layout and strings tweaks

### DIFF
--- a/pynicotine/gtkgui/ui/settings/away.ui
+++ b/pynicotine/gtkgui/ui/settings/away.ui
@@ -41,10 +41,11 @@
     <child>
       <object class="GtkBox">
         <property name="visible">1</property>
+        <property name="spacing">5</property>
         <child>
           <object class="GtkLabel">
             <property name="visible">1</property>
-            <property name="label" translatable="yes">Auto-reply when away:</property>
+            <property name="label" translatable="yes">Auto-reply message when away:</property>
           </object>
         </child>
         <child>

--- a/pynicotine/gtkgui/ui/settings/log.ui
+++ b/pynicotine/gtkgui/ui/settings/log.ui
@@ -197,7 +197,7 @@
         <child>
           <object class="GtkBox">
             <property name="visible">1</property>
-            <property name="spacing">10</property>
+            <property name="spacing">5</property>
             <child>
               <object class="GtkLabel">
                 <property name="visible">1</property>
@@ -232,7 +232,7 @@
         <child>
           <object class="GtkBox">
             <property name="visible">1</property>
-            <property name="spacing">10</property>
+            <property name="spacing">5</property>
             <child>
               <object class="GtkLabel">
                 <property name="visible">1</property>

--- a/pynicotine/gtkgui/ui/settings/search.ui
+++ b/pynicotine/gtkgui/ui/settings/search.ui
@@ -142,7 +142,7 @@
         <child>
           <object class="GtkBox">
             <property name="visible">1</property>
-            <property name="spacing">10</property>
+            <property name="spacing">5</property>
             <child>
               <object class="GtkLabel" id="MaxDisLabel">
                 <property name="visible">1</property>
@@ -165,7 +165,7 @@
         <child>
           <object class="GtkBox">
             <property name="visible">1</property>
-            <property name="spacing">10</property>
+            <property name="spacing">5</property>
             <child>
               <object class="GtkLabel" id="MaxStoredLabel">
                 <property name="visible">1</property>

--- a/pynicotine/gtkgui/ui/settings/server.ui
+++ b/pynicotine/gtkgui/ui/settings/server.ui
@@ -117,12 +117,11 @@
                 </child>
                 <child>
                   <object class="GtkButton" id="ChangePassword">
-                    <property name="label">Change password</property>
+                    <property name="label">Change Password</property>
                     <property name="visible">1</property>
                     <property name="can-focus">1</property>
                     <property name="receives-default">1</property>
                     <property name="has-tooltip">1</property>
-                    <property name="tooltip-text" translatable="yes">Change Password</property>
                     <signal name="clicked" handler="on_change_password" swapped="no"/>
                   </object>
                 </child>
@@ -229,7 +228,7 @@
               <object class="GtkLabel" id="UPnPIntervalL1">
                 <property name="visible">1</property>
                 <property name="xalign">1</property>
-                <property name="label" translatable="yes">Automatically renew port mappings every:</property>
+                <property name="label" translatable="yes">Automatically renew port mappings every</property>
               </object>
             </child>
             <child>

--- a/pynicotine/gtkgui/ui/settings/shares.ui
+++ b/pynicotine/gtkgui/ui/settings/shares.ui
@@ -94,32 +94,6 @@
               </object>
             </child>
             <child>
-              <object class="GtkButton" id="removeSharesButton">
-                <property name="visible">1</property>
-                <property name="can-focus">1</property>
-                <signal name="clicked" handler="on_remove_shared_dir" swapped="no"/>
-                <child>
-                  <object class="GtkBox">
-                    <property name="visible">1</property>
-                    <property name="spacing">5</property>
-                    <child>
-                      <object class="GtkImage">
-                        <property name="visible">1</property>
-                        <property name="icon-name">list-remove-symbolic</property>
-                      </object>
-                    </child>
-                    <child>
-                      <object class="GtkLabel">
-                        <property name="visible">1</property>
-                        <property name="label" translatable="yes">Remove</property>
-                        <property name="use-underline">1</property>
-                      </object>
-                    </child>
-                  </object>
-                </child>
-              </object>
-            </child>
-            <child>
               <object class="GtkButton" id="renameVirtualsButton">
                 <property name="visible">1</property>
                 <property name="can-focus">1</property>
@@ -138,6 +112,32 @@
                       <object class="GtkLabel">
                         <property name="visible">1</property>
                         <property name="label" translatable="yes">Rename</property>
+                        <property name="use-underline">1</property>
+                      </object>
+                    </child>
+                  </object>
+                </child>
+              </object>
+            </child>
+            <child>
+              <object class="GtkButton" id="removeSharesButton">
+                <property name="visible">1</property>
+                <property name="can-focus">1</property>
+                <signal name="clicked" handler="on_remove_shared_dir" swapped="no"/>
+                <child>
+                  <object class="GtkBox">
+                    <property name="visible">1</property>
+                    <property name="spacing">5</property>
+                    <child>
+                      <object class="GtkImage">
+                        <property name="visible">1</property>
+                        <property name="icon-name">list-remove-symbolic</property>
+                      </object>
+                    </child>
+                    <child>
+                      <object class="GtkLabel">
+                        <property name="visible">1</property>
+                        <property name="label" translatable="yes">Remove</property>
                         <property name="use-underline">1</property>
                       </object>
                     </child>
@@ -229,32 +229,6 @@
               </object>
             </child>
             <child>
-              <object class="GtkButton" id="removeBuddySharesButton">
-                <property name="visible">1</property>
-                <property name="can-focus">1</property>
-                <signal name="clicked" handler="on_remove_shared_buddy_dir" swapped="no"/>
-                <child>
-                  <object class="GtkBox">
-                    <property name="visible">1</property>
-                    <property name="spacing">5</property>
-                    <child>
-                      <object class="GtkImage">
-                        <property name="visible">1</property>
-                        <property name="icon-name">list-remove-symbolic</property>
-                      </object>
-                    </child>
-                    <child>
-                      <object class="GtkLabel">
-                        <property name="visible">1</property>
-                        <property name="label" translatable="yes">Remove</property>
-                        <property name="use-underline">1</property>
-                      </object>
-                    </child>
-                  </object>
-                </child>
-              </object>
-            </child>
-            <child>
               <object class="GtkButton" id="renameBuddyVirtualsButton">
                 <property name="visible">1</property>
                 <property name="can-focus">1</property>
@@ -273,6 +247,32 @@
                       <object class="GtkLabel">
                         <property name="visible">1</property>
                         <property name="label" translatable="yes">Rename</property>
+                        <property name="use-underline">1</property>
+                      </object>
+                    </child>
+                  </object>
+                </child>
+              </object>
+            </child>
+            <child>
+              <object class="GtkButton" id="removeBuddySharesButton">
+                <property name="visible">1</property>
+                <property name="can-focus">1</property>
+                <signal name="clicked" handler="on_remove_shared_buddy_dir" swapped="no"/>
+                <child>
+                  <object class="GtkBox">
+                    <property name="visible">1</property>
+                    <property name="spacing">5</property>
+                    <child>
+                      <object class="GtkImage">
+                        <property name="visible">1</property>
+                        <property name="icon-name">list-remove-symbolic</property>
+                      </object>
+                    </child>
+                    <child>
+                      <object class="GtkLabel">
+                        <property name="visible">1</property>
+                        <property name="label" translatable="yes">Remove</property>
                         <property name="use-underline">1</property>
                       </object>
                     </child>

--- a/pynicotine/gtkgui/ui/settings/uploads.ui
+++ b/pynicotine/gtkgui/ui/settings/uploads.ui
@@ -177,7 +177,7 @@
             </child>
             <child>
               <object class="GtkCheckButton" id="Limit">
-                <property name="label" translatable="yes">Limit uploads speed to</property>
+                <property name="label" translatable="yes">Limit uploads speed to:</property>
                 <property name="visible">1</property>
                 <property name="can-focus">1</property>
                 <property name="use-underline">1</property>

--- a/pynicotine/gtkgui/ui/settings/uploads.ui
+++ b/pynicotine/gtkgui/ui/settings/uploads.ui
@@ -206,6 +206,8 @@
               <object class="GtkLabel">
                 <property name="visible">1</property>
                 <property name="label" translatable="yes">KiB/s</property>
+                <property name="wrap">1</property>
+                <property name="xalign">0</property>
               </object>
               <packing>
                 <property name="left-attach">2</property>


### PR DESCRIPTION
Some additional Preferences tweaks: Changed a couple spacings between texts and UI elements, removed an erroneous tooltip, aligned a label, and reordered "Add, Remove, Rename" buttons to the more logical "Add, Rename, Remove". Tested and working.