### PR TITLE
Replace usage of pickle with json

### DIFF
--- a/pynicotine/gtkgui/chatrooms.py
+++ b/pynicotine/gtkgui/chatrooms.py
@@ -41,6 +41,7 @@ from pynicotine.gtkgui.dialogs import option_dialog
 from pynicotine.gtkgui.roomlist import RoomList
 from pynicotine.gtkgui.roomwall import RoomWall
 from pynicotine.gtkgui.roomwall import Tickers
+from pynicotine.gtkgui.utils import add_alias
 from pynicotine.gtkgui.utils import append_line
 from pynicotine.gtkgui.utils import humanize
 from pynicotine.gtkgui.utils import human_speed
@@ -58,6 +59,7 @@ from pynicotine.gtkgui.utils import set_treeview_selected_row
 from pynicotine.gtkgui.utils import set_widget_color
 from pynicotine.gtkgui.utils import set_widget_font
 from pynicotine.gtkgui.utils import triggers_context_menu
+from pynicotine.gtkgui.utils import unalias
 from pynicotine.gtkgui.utils import update_widget_visuals
 from pynicotine.logfacility import log
 from pynicotine.utils import clean_file
@@ -502,7 +504,7 @@ class ChatRooms(IconNotebook):
                 clist += [i[0] for i in self.frame.np.config.sections["server"]["userlist"]]
 
             if config["aliases"]:
-                clist += ["/" + k for k in list(self.frame.np.config.aliases.keys())]
+                clist += ["/" + k for k in list(self.frame.np.config.sections["server"]["command_aliases"].keys())]
 
             if config["commands"]:
                 clist += self.CMDS
@@ -952,7 +954,7 @@ class ChatRoom:
 
     def thread_alias(self, alias):
 
-        text = expand_alias(self.frame.np.config.aliases, alias)
+        text = expand_alias(alias)
         if not text:
             log.add(_('Alias "%s" returned nothing'), alias)
             return
@@ -970,7 +972,7 @@ class ChatRoom:
             widget.set_text("")
             return
 
-        if is_alias(self.frame.np.config.aliases, text):
+        if is_alias(text):
             import _thread
             _thread.start_new_thread(self.thread_alias, (text,))
             widget.set_text("")
@@ -987,13 +989,13 @@ class ChatRoom:
         byteargs = args.encode('utf-8')  # bytes
 
         if cmd in ("/alias", "/al"):
-            append_line(self.ChatScroll, self.frame.np.config.add_alias(args), self.tag_remote, "")
+            append_line(self.ChatScroll, add_alias(args), self.tag_remote, "")
             if self.frame.np.config.sections["words"]["aliases"]:
                 self.frame.chatrooms.update_completions()
                 self.frame.privatechats.update_completions()
 
         elif cmd in ("/unalias", "/un"):
-            append_line(self.ChatScroll, self.frame.np.config.unalias(args), self.tag_remote, "")
+            append_line(self.ChatScroll, unalias(args), self.tag_remote, "")
             if self.frame.np.config.sections["words"]["aliases"]:
                 self.frame.chatrooms.update_completions()
                 self.frame.privatechats.update_completions()

--- a/pynicotine/gtkgui/frame.py
+++ b/pynicotine/gtkgui/frame.py
@@ -1902,6 +1902,7 @@ class NicotineFrame:
         clear_entry(widget)
 
     def on_load_from_disk(self, widget):
+
         sharesdir = os.path.join(self.data_dir, "usershares")
         try:
             if not os.path.exists(sharesdir):
@@ -1914,11 +1915,19 @@ class NicotineFrame:
             return
         for share in shares:
             try:
-                import bz2
+                try:
+                    # Try legacy format first
+                    import bz2
 
-                sharefile = bz2.BZ2File(share)
-                mylist = RestrictedUnpickler(sharefile, encoding='utf-8').load()
-                sharefile.close()
+                    with bz2.BZ2File(share) as sharefile:
+                        mylist = RestrictedUnpickler(sharefile, encoding='utf-8').load()
+
+                except Exception:
+                    # Try new format
+
+                    with open(share, encoding="utf-8") as sharefile:
+                        import json
+                        mylist = json.load(sharefile)
 
                 if not isinstance(mylist, (list, dict)):
                     raise TypeError("Bad data in file %(sharesdb)s" % {'sharesdb': share})

--- a/pynicotine/gtkgui/privatechat.py
+++ b/pynicotine/gtkgui/privatechat.py
@@ -37,6 +37,7 @@ from gi.repository import Pango
 from pynicotine import slskmessages
 from pynicotine.gtkgui.chatrooms import get_completion
 from pynicotine.gtkgui.dialogs import option_dialog
+from pynicotine.gtkgui.utils import add_alias
 from pynicotine.gtkgui.utils import append_line
 from pynicotine.gtkgui.utils import expand_alias
 from pynicotine.gtkgui.utils import IconNotebook
@@ -48,6 +49,7 @@ from pynicotine.gtkgui.utils import TextSearchBar
 from pynicotine.gtkgui.utils import set_widget_color
 from pynicotine.gtkgui.utils import set_widget_font
 from pynicotine.gtkgui.utils import triggers_context_menu
+from pynicotine.gtkgui.utils import unalias
 from pynicotine.gtkgui.utils import update_widget_visuals
 from pynicotine.logfacility import log
 from pynicotine.utils import clean_file
@@ -316,7 +318,7 @@ class PrivateChats(IconNotebook):
             clist += [i[0] for i in self.frame.np.config.sections["server"]["userlist"]]
 
         if config["aliases"]:
-            clist += ["/" + k for k in list(self.frame.np.config.aliases.keys())]
+            clist += ["/" + k for k in list(self.frame.np.config.sections["server"]["command_aliases"].keys())]
 
         if config["commands"]:
             clist += self.CMDS
@@ -614,7 +616,7 @@ class PrivateChat:
 
     def thread_alias(self, alias):
 
-        text = expand_alias(self.frame.np.config.aliases, alias)
+        text = expand_alias(alias)
         if not text:
             log.add(_('Alias "%s" returned nothing'), alias)
             return
@@ -632,7 +634,7 @@ class PrivateChat:
             widget.set_text("")
             return
 
-        if is_alias(self.frame.np.config.aliases, text):
+        if is_alias(text):
             import _thread
             _thread.start_new_thread(self.thread_alias, (text,))
             widget.set_text("")
@@ -648,14 +650,14 @@ class PrivateChat:
 
         if cmd in ("/alias", "/al"):
 
-            append_line(self.ChatScroll, self.frame.np.config.add_alias(realargs), None, "")
+            append_line(self.ChatScroll, add_alias(realargs), None, "")
             if self.frame.np.config.sections["words"]["aliases"]:
                 self.frame.chatrooms.update_completions()
                 self.frame.privatechats.update_completions()
 
         elif cmd in ("/unalias", "/un"):
 
-            append_line(self.ChatScroll, self.frame.np.config.unalias(realargs), None, "")
+            append_line(self.ChatScroll, unalias(realargs), None, "")
             if self.frame.np.config.sections["words"]["aliases"]:
                 self.frame.chatrooms.update_completions()
                 self.frame.privatechats.update_completions()

--- a/pynicotine/gtkgui/userbrowse.py
+++ b/pynicotine/gtkgui/userbrowse.py
@@ -515,11 +515,12 @@ class UserBrowse:
             log.add(_("Can't create directory '%(folder)s', reported error: %(error)s"), {'folder': sharesdir, 'error': msg})
 
         try:
-            import pickle as mypickle
-            import bz2
-            sharesfile = bz2.BZ2File(os.path.join(sharesdir, clean_file(self.user)), 'w')
-            mypickle.dump(self.shares, sharesfile, protocol=mypickle.HIGHEST_PROTOCOL)
-            sharesfile.close()
+            filepath = os.path.join(sharesdir, clean_file(self.user))
+
+            with open(filepath, "w", encoding="utf-8") as sharesfile:
+                import json
+                json.dump(self.shares, sharesfile, ensure_ascii=False)
+
             log.add(_("Saved list of shared files for user '%(user)s' to %(dir)s"), {'user': self.user, 'dir': sharesdir})
 
         except Exception as msg:

--- a/pynicotine/gtkgui/utils.py
+++ b/pynicotine/gtkgui/utils.py
@@ -1547,23 +1547,73 @@ def humanize(number):
     return neg + ret[:-1]
 
 
-def is_alias(aliases, cmd):
+""" Command Aliases """
+
+
+def add_alias(rest):
+
+    aliases = NICOTINE.np.config.sections["server"]["command_aliases"]
+
+    if rest:
+        args = rest.split(" ", 1)
+
+        if len(args) == 2:
+            if args[0] in ("alias", "unalias"):
+                return "I will not alias that!\n"
+
+            aliases[args[0]] = args[1]
+
+        if args[0] in aliases:
+            return "Alias %s: %s\n" % (args[0], aliases[args[0]])
+        else:
+            return _("No such alias (%s)") % rest + "\n"
+
+    else:
+        m = "\n" + _("Aliases:") + "\n"
+
+        for (key, value) in aliases.items():
+            m = m + "%s: %s\n" % (key, value)
+
+        return m + "\n"
+
+
+def unalias(rest):
+
+    aliases = NICOTINE.np.config.sections["server"]["command_aliases"]
+
+    if rest and rest in aliases:
+        x = aliases[rest]
+        del aliases[rest]
+
+        return _("Removed alias %(alias)s: %(action)s\n") % {'alias': rest, 'action': x}
+
+    else:
+        return _("No such alias (%(alias)s)\n") % {'alias': rest}
+
+
+def is_alias(cmd):
+
     if not cmd:
         return False
+
     if cmd[0] != "/":
         return False
+
     cmd = cmd[1:].split(" ")
-    if cmd[0] in aliases:
+
+    if cmd[0] in NICOTINE.np.config.sections["server"]["command_aliases"]:
         return True
+
     return False
 
 
-def expand_alias(aliases, cmd):
-    output = _expand_alias(aliases, cmd)
+def expand_alias(cmd):
+    output = _expand_alias(NICOTINE.np.config.sections["server"]["command_aliases"], cmd)
     return output
 
 
 def _expand_alias(aliases, cmd):
+
     def getpart(line):
         if line[0] != "(":
             return ""
@@ -1582,7 +1632,7 @@ def _expand_alias(aliases, cmd):
             ix = ix + 1
         return ""
 
-    if not is_alias(aliases, cmd):
+    if not is_alias(cmd):
         return None
     try:
         cmd = cmd[1:].split(" ")

--- a/pynicotine/transfers.py
+++ b/pynicotine/transfers.py
@@ -30,7 +30,6 @@ the transfer manager.
 
 import os
 import os.path
-import pickle
 import re
 import stat
 import threading
@@ -191,19 +190,10 @@ class Transfers:
 
     def get_download_queue_file_name(self):
 
-        downloads_file_json = os.path.join(
-            self.eventprocessor.config.data_dir, 'transfers.json'
-        )
-
-        downloads_file_1_4_2 = os.path.join(
-            self.eventprocessor.config.data_dir, 'config.transfers.pickle'
-        )
-
-        downloads_file_1_4_1 = os.path.join(
-            self.eventprocessor.config.data_dir, 'transfers.pickle'
-        )
-
-        download_queue = []
+        data_dir = self.eventprocessor.config.data_dir
+        downloads_file_json = os.path.join(data_dir, 'downloads.json')
+        downloads_file_1_4_2 = os.path.join(data_dir, 'config.transfers.pickle')
+        downloads_file_1_4_1 = os.path.join(data_dir, 'transfers.pickle')
 
         if os.path.exists(downloads_file_json):
             # New file format
@@ -256,7 +246,7 @@ class Transfers:
         if not downloads_file:
             return []
 
-        if not downloads_file.endswith("transfers.json"):
+        if not downloads_file.endswith("downloads.json"):
             return self.load_legacy_queue_format(downloads_file)
 
         return self.load_current_queue_format(downloads_file)
@@ -2229,17 +2219,13 @@ class Transfers:
     def save_downloads(self):
         """ Save list of files to be downloaded """
 
-        import json
-
         self.eventprocessor.config.create_data_folder()
-        downloads_file = os.path.join(self.eventprocessor.config.data_dir, 'transfers.json')
+        downloads_file = os.path.join(self.eventprocessor.config.data_dir, 'downloads.json')
 
         try:
             with open(downloads_file, "w", encoding="utf-8") as handle:
+                import json
                 json.dump(self.get_downloads(), handle, ensure_ascii=False)
-
-        except IOError as inst:
-            log.add_warning(_("Something went wrong while opening your transfer list: %(error)s"), {'error': str(inst)})
 
         except Exception as inst:
             log.add_warning(_("Something went wrong while writing your transfer list: %(error)s"), {'error': str(inst)})


### PR DESCRIPTION
Stop using pickles in favor of a sensible, readable and safe format, like json.