### PR TITLE
Bump version number to 3.0.0-dev1

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,8 +1,8 @@
-nicotine (2.3.0-dev1) groovy; urgency=medium
+nicotine (3.0.0-dev1) groovy; urgency=medium
 
   * Development version.
 
- -- Mat <mail@mathias.is>  Fri, 01 Jan 2021 10:33:12 +0300
+ -- Mat <mail@mathias.is>  Mon, 18 Jan 2021 18:45:34 +0300
 
 nicotine (2.2.2-1) groovy; urgency=medium
 

--- a/packaging/windows/nicotine.nsi
+++ b/packaging/windows/nicotine.nsi
@@ -1,5 +1,5 @@
 !define PRODUCT_NAME "Nicotine+"
-!define PRODUCT_VERSION "2.3.0-dev1"
+!define PRODUCT_VERSION "3.0.0-dev1"
 !define PRODUCT_PUBLISHER "Nicotine+ Team"
 !define PRODUCT_WEB_SITE "https://nicotine-plus.org"
 !define PRODUCT_DIR_REGKEY "Software\Nicotine+"

--- a/pynicotine/utils.py
+++ b/pynicotine/utils.py
@@ -32,7 +32,7 @@ import pickle
 import sys
 import time
 
-version = "2.3.0.dev1"
+version = "3.0.0.dev1"
 
 win32 = sys.platform.startswith("win")
 


### PR DESCRIPTION
Due to the number of user-facing changes and GUI code refactors since 2.2.2, I propose increasing the major version.