### PR TITLE
Debian: remove deprecated get-orig-source target

### DIFF
--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -1,8 +1,51 @@
-name: Packaging (Windows and macOS)
+name: Packaging (Debian, Windows and macOS)
 
 on: [push, pull_request]
 
 jobs:
+
+  debian:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.9
+
+      - name: Install dependencies
+        run: |
+          BUILD_DEPS=$(perl -ne 'next if /^#/; $p=(s/^Build-Depends:\s*/ / or (/^ / and $p)); s/,|\n|\([^)]+\)//mg; print if $p' < debian/control)
+
+          sudo apt update
+          sudo apt -y install $BUILD_DEPS build-essential devscripts sbuild
+
+      - name: Build Debian package
+        run: |
+          # Generate tarball
+          python setup.py sdist
+          mk-origtargz dist/nicotine-plus-*.tar.gz
+
+          # Build source package
+          debuild -S -sa -us -uc
+
+          # Build binary
+          debuild -b -sa -us -uc
+
+      - name: Prepare artifacts
+        run: |
+          mkdir ../build/
+          cp -Lr ../nicotine_* ../build/
+
+      - name: Archive artifacts
+        uses: actions/upload-artifact@v1
+        with:
+          name: debian-package
+          path: ../build/
 
   windows:
     runs-on: windows-latest
@@ -42,13 +85,13 @@ jobs:
           cp -r packaging/windows/Nicotine*.exe installer/
 
       - name: Archive installer artifacts
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v2
         with:
           name: windows-${{ matrix.arch }}-installer
           path: installer
 
       - name: Archive package artifacts
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v2
         with:
           name: windows-${{ matrix.arch }}-package
           path: dist
@@ -80,7 +123,7 @@ jobs:
           packaging/macos/create-dmg.sh
 
       - name: Archive installer artifacts
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v2
         with:
           name: macos-installer
           path: dmg

--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -19,10 +19,9 @@ jobs:
 
       - name: Install dependencies
         run: |
-          BUILD_DEPS=$(perl -ne 'next if /^#/; $p=(s/^Build-Depends:\s*/ / or (/^ / and $p)); s/,|\n|\([^)]+\)//mg; print if $p' < debian/control)
-
+          sudo sed -Ei 's/^# deb-src /deb-src /' /etc/apt/sources.list
           sudo apt update
-          sudo apt -y install $BUILD_DEPS build-essential devscripts sbuild
+          sudo apt build-dep .
 
       - name: Build Debian package
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,10 +23,14 @@ jobs:
 
       - name: Install dependencies
         run: |
-          BUILD_DEPS=$(perl -ne 'next if /^#/; $p=(s/^Build-Depends:\s*/ / or (/^ / and $p)); s/,|\n|\([^)]+\)//mg; print if $p' < debian/control)
-
+          sudo sed -Ei 's/^# deb-src /deb-src /' /etc/apt/sources.list
           sudo apt update
-          sudo apt -y install $BUILD_DEPS
+
+          # Ubuntu 16.04 support
+          if ! sudo apt build-dep .; then
+            BUILD_DEPS=$(perl -ne 'next if /^#/; $p=(s/^Build-Depends:\s*/ / or (/^ / and $p)); s/,|\n|\([^)]+\)//mg; print if $p' < debian/control)
+            sudo apt -y install $BUILD_DEPS
+          fi
 
       - name: Lint with flake8
         run: |

--- a/debian/control
+++ b/debian/control
@@ -1,9 +1,10 @@
 Source: nicotine
 Section: net
 Priority: optional
-Maintainer: Kip Warner <kip@thevertigo.com>
+Maintainer: Nicotine+ Team <nicotine-team@lists.launchpad.net>
 Standards-Version: 3.9.7
 Build-Depends:
+    appstream,
     debhelper (>= 9~),
     dh-python,
     flake8,

--- a/debian/control
+++ b/debian/control
@@ -6,6 +6,7 @@ Standards-Version: 3.9.7
 Build-Depends:
     appstream,
     debhelper (>= 9~),
+    devscripts,
     dh-python,
     flake8,
     gettext,

--- a/debian/copyright
+++ b/debian/copyright
@@ -1,10 +1,10 @@
 Format: http://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
 Upstream-Name: nicotine
-Upstream-Contact: Kip Warner <kip@thevertigo.com>
+Upstream-Contact: Nicotine+ Team <nicotine-team@lists.launchpad.net>
 Source: https://github.com/Nicotine-Plus/nicotine-plus/
 
 Files: *
-Copyright: Copyright (C) 2020 Nicotine+ Contributors
+Copyright: Copyright (C) 2020 Nicotine+ Team
 License: GPL-3+
  /usr/share/common-licenses/GPL-3
 

--- a/debian/copyright
+++ b/debian/copyright
@@ -4,7 +4,7 @@ Upstream-Contact: Nicotine+ Team <nicotine-team@lists.launchpad.net>
 Source: https://github.com/Nicotine-Plus/nicotine-plus/
 
 Files: *
-Copyright: Copyright (C) 2020 Nicotine+ Team
+Copyright: Copyright (C) 2004-2021 Nicotine+ Team
 License: GPL-3+
  /usr/share/common-licenses/GPL-3
 

--- a/debian/rules
+++ b/debian/rules
@@ -1,6 +1,7 @@
 #! /usr/bin/make -f
 #
 # 	Nicotine+
+#	Copyright (C) 2021 Nicotine+ Team
 #	Copyright (C) 2016 Kip Warner. Released under the GPLv3 or later.
 #
 
@@ -8,54 +9,10 @@
 DH_VERBOSE = 1
 export DH_OPTIONS=-v
 
-# Set flags for how the package will be built. Note separated with white
-#  space and not comma, as per DPM § 4.9.1...
-
-    # Use as many CPUs as possible for pkgstripfiles which takes forever on
-    #  all our PNGs...
-    DEB_BUILD_OPTIONS +=parallel=0
-
-    # The above should be reflected when dpkg-buildflags is called and merged
-    #  with the defaults...
-    export DEB_BUILD_OPTIONS
-    export DPKG_EXPORT_BUILDFLAGS = 1
-
-# Standard rules and preset shell variables...
-include /usr/share/dpkg/default.mk
-
-# Directory containing package since may not be called from current working
-#  directory. MAKEFILE_LIST pre-defined by Make and appended each time another
-#  makefile is included, so first one should be debian/rules...
-PACKAGE_DIR = $(abspath $(dir $(firstword $(MAKEFILE_LIST))))
-
-# Source directory...
-SOURCE_DIR  = $(abspath $(PACKAGE_DIR)/../)
-
-# Get the upstream version according to distutils. Distutils gets it from a variable
-#  embedded directly in the Python source...
-VERSION_UPSTREAM_DISTUTILS = $(shell sed -n 's/^version\s*=\s*"\(\S*\)"$$/\1/p' $(SOURCE_DIR)/pynicotine/utils.py)
-
 # Disable shares test, since shares are not saved for some reason...
 # Disable version test during Pybuild process, since Pybuild sets the proxy to 127.0.0.1:9.
 # We don't have internet access...
 export PYBUILD_TEST_ARGS=-k "not test_shares and not test_version"
 
-# Catch all debhelper rule...
 %:
 	dh $@ --with python3 --buildsystem=pybuild
-
-# Prepare an upstream vanilla distribution tarball as per DPM § 4.9...
-#  http://wiki.debian.org/onlyjob/get-orig-source
-get-orig-source: $(DEB_SOURCE)_$(DEB_VERSION_UPSTREAM).orig.tar.gz $(info I: $(DEB_SOURCE)_$(DEB_VERSION_UPSTREAM))
-	@
-
-# Prepare an upstream vanilla distribution tarball...
-$(DEB_SOURCE)_$(DEB_VERSION_UPSTREAM).orig.tar.gz:
-	@echo "# Preparing source for $(DEB_SOURCE) v$(DEB_VERSION_UPSTREAM)..."
-	cd $(SOURCE_DIR) \
-	&& python3 setup.py sdist --formats=gztar --dist-dir=../ \
-	&& mv -v ../$(DEB_SOURCE)-$(VERSION_UPSTREAM_DISTUTILS).tar.gz ../$@
-
-# Targets which aren't actually files...
-.PHONY: get-orig-source
-

--- a/debian/watch
+++ b/debian/watch
@@ -1,3 +1,2 @@
 version=3
-opts=filenamemangle=s/.+\/v?(\d\S+)\.tar\.gz/<project>-$1\.tar\.gz/ \
-    https://github.com/Nicotine-Plus/nicotine-plus/tags .*/(\d\S+)\.tar\.gz
+https://pypi.debian.net/nicotine-plus/nicotine-plus-(.+)\.(?:zip|tgz|tbz|txz|(?:tar\.(?:gz|bz2|xz)))

--- a/doc/DEVELOPING.md
+++ b/doc/DEVELOPING.md
@@ -70,19 +70,10 @@ Next create the test image, substituting `groovy` or `amd64` for other releases 
 autopkgtest-buildvm-ubuntu-cloud -r groovy -a amd64
 ```
 
-Generate a Nicotine+ source package in the parent directory of `nicotine_source`:
+Test your changes on the host architecture in QEMU with KVM support and 8GB of RAM and four CPUs:
 
 ```sh
-cd nicotine_source
-sudo apt build-dep nicotine
-./debian/rules get-orig-source
-debuild -S -sa
-```
-
-Test the source package on the host architecture in QEMU with KVM support and 8GB of RAM and four CPUs:
-
-```sh
-autopkgtest --shell-fail --apt-upgrade ../nicotine_(...).dsc -- \
+autopkgtest --shell-fail --apt-upgrade . -- \
       qemu --ram-size=8192 --cpus=4 --show-boot path_to_build_image.img \
       --qemu-options='-enable-kvm'
 ```

--- a/doc/PACKAGING.md
+++ b/doc/PACKAGING.md
@@ -23,7 +23,13 @@ The source distribution files will be located in the `dist` subdirectory of your
 
 Unstable and stable PPAs are already provided for pre-compiled packages, as described in the `README.md`. However, if you wish to build your own package perform the following.
 
-Start by generating the "upstream" tarball:
+Start by installing the build dependencies:
+
+```console
+sudo apt build-dep .
+```
+
+Generate the "upstream" tarball:
 
 ```console
 python setup.py sdist
@@ -39,7 +45,7 @@ debuild -S -sa
 Build the binary from the source package and upstream tarball via `sbuild`:
 
 ```console
-sbuild ../nicotine*.dsc
+sbuild ../nicotine_*.dsc
 ```
 
 #### Building a RPM package

--- a/doc/PACKAGING.md
+++ b/doc/PACKAGING.md
@@ -26,8 +26,8 @@ Unstable and stable PPAs are already provided for pre-compiled packages, as desc
 Start by generating the "upstream" tarball:
 
 ```console
-cd nicotine_source
-./debian/rules get-orig-source
+python setup.py sdist
+mk-origtargz dist/nicotine-plus-*.tar.gz
 ```
 
 Build the Debian source package:
@@ -39,7 +39,7 @@ debuild -S -sa
 Build the binary from the source package and upstream tarball via `sbuild`:
 
 ```console
-sbuild ../nicotine(...).dsc
+sbuild ../nicotine*.dsc
 ```
 
 #### Building a RPM package

--- a/packaging/windows/dependencies-core.sh
+++ b/packaging/windows/dependencies-core.sh
@@ -25,10 +25,10 @@
 pacman --noconfirm -S --needed \
   mingw-w64-$ARCH-python \
   mingw-w64-$ARCH-python-flake8 \
-  mingw-w64-$ARCH-python-pip \
-  mingw-w64-$ARCH-python-pytest
+  mingw-w64-$ARCH-python-pip
 
 # Install dependencies with pip
 pip3 install \
   pep8-naming \
+  pytest \
   semidbm


### PR DESCRIPTION
- Remove the "get-orig-source" target, as it is deprecated. Add updated commands to PACKAGING.md utilizing Python's sdist and "mk-origtargz" from devscripts. https://wiki.debian.org/onlyjob/get-orig-source
- Add Debian packaging workflow to GitHub Actions, to allow for easier inspection of logs and built packages.
- Remove old "parallel" build option. This seems to be from a time when we used to ship .png files, nowadays it doesn't seem to make a noticeable difference.

@kiplingw Since you are the author of a large part of the "Debianization", and have more experience with this process, I would appreciate your feedback on these changes.