### PR TITLE
Use PyPi for version checker instead of GitHub

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -86,5 +86,4 @@ jobs:
 
       - name: Unit tests
         run: |
-          # Disable version test due to macOS machines hitting GitHub's rate limits
-          pytest -v -k 'not version'
+          pytest

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # Auto-generated files
 *.desktop
 *.metainfo.xml
+temp_config
 
 # Translation Machine Object files
 *.mo

--- a/packaging/windows/dependencies-core.sh
+++ b/packaging/windows/dependencies-core.sh
@@ -25,10 +25,10 @@
 pacman --noconfirm -S --needed \
   mingw-w64-$ARCH-python \
   mingw-w64-$ARCH-python-flake8 \
-  mingw-w64-$ARCH-python-pip \
-  mingw-w64-$ARCH-python-pytest
+  mingw-w64-$ARCH-python-pip
 
 # Install dependencies with pip
 pip3 install \
   pep8-naming \
+  pytest \
   semidbm

--- a/pynicotine/gtkgui/frame.py
+++ b/pynicotine/gtkgui/frame.py
@@ -1202,11 +1202,16 @@ class NicotineFrame:
             return
 
         if latest > myversion:
+            version_label = _("Version %s is available") % hlatest
+
+            if date:
+                version_label += ", " + _("released on %s") % date
+
             GLib.idle_add(
                 message_dialog,
                 self.MainWindow,
                 _("Out of date"),
-                _("A newer version %s is available, released on %s.") % (hlatest, date)
+                version_label
             )
 
         elif myversion > latest:

--- a/test/unit/test_version.py
+++ b/test/unit/test_version.py
@@ -34,7 +34,7 @@ def test_version():
     assert isinstance(latest_version, int)
 
     # Validate date of latest release
-    date_format = "%Y-%m-%dT%H:%M:%SZ"
+    date_format = "%Y-%m-%dT%H:%M:%S"
     datetime.datetime.strptime(date, date_format)
 
     # Test a sample dev version to ensure it's older than the stable counterpart


### PR DESCRIPTION
Now that Nicotine+ is available on PyPi, it seems like a more reliable source for checking the latest Nicotine+ version long-term wise.