### PR TITLE
Optimize file uploads

### DIFF
--- a/pynicotine/gtkgui/frame.py
+++ b/pynicotine/gtkgui/frame.py
@@ -854,7 +854,7 @@ class NicotineFrame:
 
         # Clear any potential messages queued up to this point (should not happen)
         while not self.np.queue.empty():
-            self.np.queue.get(0)
+            print(self.np.queue.get(0))
 
         self.set_user_status("...")
 

--- a/pynicotine/gtkgui/frame.py
+++ b/pynicotine/gtkgui/frame.py
@@ -1838,7 +1838,7 @@ class NicotineFrame:
             if self.np.transfers is not None:
 
                 msg.totalupl = self.np.transfers.get_total_uploads_allowed()
-                msg.queuesize = self.np.transfers.get_upload_queue_sizes()[0]
+                msg.queuesize = self.np.transfers.get_upload_queue_sizes()
                 msg.slotsavail = self.np.transfers.allow_new_uploads()
                 ua = self.np.config.sections["transfers"]["remotedownloads"]
                 if ua:

--- a/pynicotine/gtkgui/uploads.py
+++ b/pynicotine/gtkgui/uploads.py
@@ -238,17 +238,11 @@ class Uploads(TransferList):
                     i.transfertimer.cancel()
                 self.remove_specific(i)
 
-        self.frame.np.transfers.calc_upload_queue_sizes()
-        self.frame.np.transfers.check_upload_queue()
-
     def on_abort_transfer(self, widget, remove_file=False, clear=False):
 
         self.select_transfers()
 
         self.abort_transfers(remove_file, clear)
-
-        self.frame.np.transfers.calc_upload_queue_sizes()
-        self.frame.np.transfers.check_upload_queue()
 
     def on_abort_user(self, widget):
 
@@ -260,22 +254,12 @@ class Uploads(TransferList):
                     self.selected_transfers.add(i)
 
         self.on_abort_transfer(widget)
-        self.frame.np.transfers.calc_upload_queue_sizes()
-        self.frame.np.transfers.check_upload_queue()
 
     def on_clear_queued(self, widget):
-
         self.clear_transfers(["Queued"])
 
-        self.frame.np.transfers.calc_upload_queue_sizes()
-        self.frame.np.transfers.check_upload_queue()
-
     def on_clear_failed(self, widget):
-
         self.clear_transfers(["Cannot connect", "Connection closed by peer", "Local file error", "Remote file error", "Getting address", "Waiting for peer to connect", "Initializing transfer"])
-
-        self.frame.np.transfers.calc_upload_queue_sizes()
-        self.frame.np.transfers.check_upload_queue()
 
     def on_upload_transfer(self, widget):
 
@@ -286,7 +270,7 @@ class Uploads(TransferList):
             path = transfer.path
             user = transfer.user
 
-            if user in self.frame.np.transfers.get_transferring_users():
+            if user in self.frame.np.transfers.get_uploading_users():
                 continue
 
             self.frame.np.send_message_to_peer(user, slskmessages.UploadQueueNotification(None))

--- a/pynicotine/gtkgui/userbrowse.py
+++ b/pynicotine/gtkgui/userbrowse.py
@@ -851,7 +851,6 @@ class UserBrowse:
                 realfilename = "\\".join([realpath, file[1]])
                 size = file[2]
                 self.frame.np.transfers.push_file(user, filename, realfilename, ldir, size=size)
-                self.frame.np.transfers.check_upload_queue()
 
         if not recurse:
             return
@@ -888,7 +887,6 @@ class UserBrowse:
 
         for fn in self.selected_files:
             self.frame.np.transfers.push_file(user, "\\".join([folder, fn]), "\\".join([realpath, fn]), prefix)
-            self.frame.np.transfers.check_upload_queue()
 
     def on_key_press_event(self, widget, event):
 

--- a/pynicotine/gtkgui/userlist.py
+++ b/pynicotine/gtkgui/userlist.py
@@ -429,6 +429,7 @@ class UserList:
         self.usersmodel.append(row)
 
         self.save_user_list()
+
         self.frame.np.queue.put(slskmessages.AddUser(user))
         self.frame.np.queue.put(slskmessages.GetPeerAddress(user))
 

--- a/pynicotine/pynicotine.py
+++ b/pynicotine/pynicotine.py
@@ -216,6 +216,7 @@ class NetworkEventProcessor:
             slskmessages.Relogged: self.relogged,
             slskmessages.PeerInit: self.peer_init,
             slskmessages.CheckDownloadQueue: self.check_download_queue,
+            slskmessages.CheckUploadQueue: self.check_upload_queue,
             slskmessages.DownloadFile: self.file_download,
             slskmessages.UploadFile: self.file_upload,
             slskmessages.FileRequest: self.file_request,
@@ -1651,7 +1652,7 @@ class NetworkEventProcessor:
 
         if self.transfers is not None:
             totalupl = self.transfers.get_total_uploads_allowed()
-            queuesize = self.transfers.get_upload_queue_sizes()[0]
+            queuesize = self.transfers.get_upload_queue_sizes()
             slotsavail = self.transfers.allow_new_uploads()
 
             if self.config.sections["transfers"]["remotedownloads"]:
@@ -1708,10 +1709,13 @@ class NetworkEventProcessor:
 
     def check_download_queue(self, msg):
 
-        log.add_msg_contents("%s %s", (msg.__class__, self.contents(msg)))
-
         if self.transfers is not None:
             self.transfers.check_download_queue()
+
+    def check_upload_queue(self, msg):
+
+        if self.transfers is not None:
+            self.transfers.check_upload_queue(start_timer=True)
 
     def file_download(self, msg):
 

--- a/pynicotine/pynicotine.py
+++ b/pynicotine/pynicotine.py
@@ -151,13 +151,6 @@ class NetworkEventProcessor:
         self.upnp_timer = None
         _thread.start_new_thread(self.add_upnp_portmapping, ())
 
-        uselimit = self.config.sections["transfers"]["uselimit"]
-        uploadlimit = self.config.sections["transfers"]["uploadlimit"]
-        limitby = self.config.sections["transfers"]["limitby"]
-
-        self.queue.put(slskmessages.SetUploadLimit(uselimit, uploadlimit, limitby))
-        self.queue.put(slskmessages.SetDownloadLimit(self.config.sections["transfers"]["downloadlimit"]))
-
         self.active_server_conn = None
         self.waitport = None
         self.chatrooms = None

--- a/pynicotine/slskmessages.py
+++ b/pynicotine/slskmessages.py
@@ -132,6 +132,12 @@ class CheckDownloadQueue(InternalMessage):
     pass
 
 
+class CheckUploadQueue(InternalMessage):
+    """ Sent from a timer to the main thread to indicate that the upload queue
+    should be checked. """
+    pass
+
+
 class DownloadFile(InternalMessage):
     """ Sent by networking thread to indicate file transfer progress.
     Sent by UI to pass the file object to write and offset to resume download
@@ -2145,8 +2151,6 @@ class FileSearchResult(PeerMessage):
         self.pos, self.inqueue = self.get_object(message, int, self.pos, getunsignedlonglong=True)
 
     def make_network_message(self):
-        queuesize = self.inqueue[0]
-
         msg = bytearray()
         msg.extend(self.pack_object(self.user))
         msg.extend(self.pack_object(self.token, unsignedint=True))
@@ -2197,7 +2201,7 @@ class FileSearchResult(PeerMessage):
 
         msg.extend(bytes([self.freeulslots]))
         msg.extend(self.pack_object(self.ulspeed, unsignedint=True))
-        msg.extend(self.pack_object(queuesize, unsignedlonglong=True))
+        msg.extend(self.pack_object(self.inqueue, unsignedlonglong=True))
 
         return zlib.compress(msg)
 

--- a/pynicotine/transfers.py
+++ b/pynicotine/transfers.py
@@ -1748,24 +1748,27 @@ class Transfers:
 
     def get_upload_candidate(self, queued_uploads):
 
+        if not queued_uploads:
+            return None
+
         if self.eventprocessor.config.sections["transfers"]["fifoqueue"]:
             # FIFO
             # Get the first item in the list
-            transfercandidate = queued_uploads[0]
+            upload_candidate = queued_uploads[0]
 
         else:
             # Round Robin
             # Get first transfer that was queued less than one second from now
-            transfercandidate = None
+            upload_candidate = None
             mintimequeued = time.time() + 1
 
             for i in queued_uploads:
                 if i.timequeued is not None and i.timequeued < mintimequeued:
-                    transfercandidate = i
+                    upload_candidate = i
                     # Break loop
                     mintimequeued = i.timequeued
 
-        return transfercandidate
+        return upload_candidate
 
     # Find next file to upload
     def check_upload_queue(self, start_timer=False):

--- a/pynicotine/transfers.py
+++ b/pynicotine/transfers.py
@@ -131,6 +131,13 @@ class Transfers:
         self.privilegedusers = set()
         userstatus = set()
 
+        uselimit = self.eventprocessor.config.sections["transfers"]["uselimit"]
+        uploadlimit = self.eventprocessor.config.sections["transfers"]["uploadlimit"]
+        limitby = self.eventprocessor.config.sections["transfers"]["limitby"]
+
+        self.queue.put(slskmessages.SetUploadLimit(uselimit, uploadlimit, limitby))
+        self.queue.put(slskmessages.SetDownloadLimit(self.eventprocessor.config.sections["transfers"]["downloadlimit"]))
+
         for i in self.load_download_queue():
             size = currentbytes = bitrate = length = None
 
@@ -1821,9 +1828,9 @@ class Transfers:
             uploading_users = set()
 
             for i in self.uploads:
-                if i.req is not None or i.conn is not None or \
-                        i.status == "Getting status":
-                    uploading_users.add(i.user)
+                if i.req is not None or i.conn is not None or i.status == "Getting status":
+                    if i.user not in uploading_users:
+                        uploading_users.add(i.user)
 
                 # Ignore non-queued files
                 if i.status != "Queued":


### PR DESCRIPTION
- Remove a lot of needless calls to check_upload_queue, and check the upload queue every five seconds instead of each time a part of a file is uploaded.
- If a maximum upload speed is set in the preferences, and a limit for queuing files isn't set, multiple files are now uploaded even when the maximum upload speed is reached. Closes https://github.com/Nicotine-Plus/nicotine-plus/issues/956.