### PR TITLE
Update result filter's help text

### DIFF
--- a/pynicotine/gtkgui/ui/popovers/searchfilters.ui
+++ b/pynicotine/gtkgui/ui/popovers/searchfilters.ui
@@ -41,7 +41,7 @@
               <object class="GtkLabel">
                 <property name="visible">1</property>
                 <property name="halign">start</property>
-                <property name="label" translatable="yes">Each list of search results has its own filter which can be revealed by toggling the Filter Results button. A filter is made up of multiple fields, all of which are applied when pressing Enter in any one of its fields. Filtering is applied immediately to results already received, and also to those yet to arrive. To view the full results again, simply clear the filter of all terms and re-apply it. As the name suggests, a search result filter cannot expand your original search, it can only narrow it down. To broaden or change your search terms, perform a new search.</property>
+                <property name="label" translatable="yes">Each list of search results has its own filter which can be revealed by toggling the Result Filters button. A filter is made up of multiple fields, all of which are applied when pressing Enter in any one of its fields. Filtering is applied immediately to results already received, and also to those yet to arrive. To view the full results again, simply clear the filter of all terms and re-apply it. As the name suggests, a search result filter cannot expand your original search, it can only narrow it down. To broaden or change your search terms, perform a new search.</property>
                 <property name="width-chars">40</property>
                 <property name="justify">fill</property>
                 <property name="selectable">1</property>
@@ -63,7 +63,7 @@
               <object class="GtkLabel">
                 <property name="visible">1</property>
                 <property name="halign">start</property>
-                <property name="label" translatable="yes">Included Text</property>
+                <property name="label" translatable="yes">Include Text</property>
                 <property name="selectable">1</property>
                 <attributes>
                   <attribute name="style" value="italic"/>
@@ -115,7 +115,7 @@ Example: Spears|Brittany|My beautiful album|hello</property>
               <object class="GtkLabel">
                 <property name="visible">1</property>
                 <property name="halign">start</property>
-                <property name="label" translatable="yes">Excluded Text</property>
+                <property name="label" translatable="yes">Exclude Text</property>
                 <property name="selectable">1</property>
                 <attributes>
                   <attribute name="style" value="italic"/>
@@ -149,7 +149,7 @@ Example: Spears|Brittany|My beautiful album|hello</property>
                 <property name="visible">1</property>
                 <property name="halign">start</property>
                 <property name="xpad">10</property>
-                <property name="label" translatable="yes">Filters files based on their file extension.</property>
+                <property name="label" translatable="yes">Filters files based upon their file extension.</property>
                 <property name="justify">fill</property>
                 <property name="selectable">1</property>
                 <property name="wrap">1</property>
@@ -172,7 +172,7 @@ Example: flac|wav|ape</property>
                 <property name="visible">1</property>
                 <property name="halign">start</property>
                 <property name="xpad">10</property>
-                <property name="label" translatable="yes">It is also possible to invert the filter, specifying file extensions you don't want in your results.
+                <property name="label" translatable="yes">It is also possible to invert the filter, specifying file extensions you don&apos;t want in your results.
 Example: !mp3|!jpg</property>
                 <property name="justify">fill</property>
                 <property name="selectable">1</property>
@@ -200,7 +200,18 @@ Example: !mp3|!jpg</property>
                     <property name="visible">1</property>
                     <property name="halign">start</property>
                     <property name="xpad">10</property>
-                    <property name="label" translatable="yes">Filters results based upon their file size. By default, the unit used is bytes and files greater than or equal to the value will be matched.</property>
+                    <property name="label" translatable="yes">Filters files based upon their file size.</property>
+                    <property name="justify">fill</property>
+                    <property name="selectable">1</property>
+                    <property name="wrap">1</property>
+                  </object>
+                </child>
+                <child>
+                  <object class="GtkLabel">
+                    <property name="visible">1</property>
+                    <property name="halign">start</property>
+                    <property name="xpad">10</property>
+                    <property name="label" translatable="yes">By default, the unit used is bytes and files greater than or equal to the value will be matched.</property>
                     <property name="justify">fill</property>
                     <property name="selectable">1</property>
                     <property name="wrap">1</property>
@@ -234,8 +245,19 @@ Example: !mp3|!jpg</property>
                     <property name="visible">1</property>
                     <property name="halign">start</property>
                     <property name="xpad">10</property>
-                    <property name="label" translatable="yes">Append b, k, or m to specify byte, kibibyte, or mebibyte units:
+                    <property name="label" translatable="yes">Append b, k, m, or g (alternatively kib, mib, or gib) to specify byte, kibibyte, mebibyte, or gibibyte units:
 &lt;128k will find files 128 kibibytes (i.e. 1 mebibyte) or smaller.</property>
+                    <property name="justify">fill</property>
+                    <property name="selectable">1</property>
+                    <property name="wrap">1</property>
+                  </object>
+                </child>
+                <child>
+                  <object class="GtkLabel">
+                    <property name="visible">1</property>
+                    <property name="halign">start</property>
+                    <property name="xpad">10</property>
+                    <property name="label" translatable="yes">For convenience, the variants kb, mb, and gb for the better-known kilo-, mega-, and gigabyte units can also be used.</property>
                     <property name="justify">fill</property>
                     <property name="selectable">1</property>
                     <property name="wrap">1</property>
@@ -310,8 +332,19 @@ Example: !mp3|!jpg</property>
                 <property name="visible">1</property>
                 <property name="halign">start</property>
                 <property name="xpad">10</property>
+                <property name="label" translatable="yes">Filters files based upon users&apos; countries.</property>
+                <property name="justify">fill</property>
+                <property name="selectable">1</property>
+                <property name="wrap">1</property>
+              </object>
+            </child>
+            <child>
+              <object class="GtkLabel">
+                <property name="visible">1</property>
+                <property name="halign">start</property>
+                <property name="xpad">10</property>
                 <property name="label" translatable="yes">Uses country codes defined by ISO 3166-2 (see Wikipedia):
-US will only return files from users connected via the United States. Similarly, GB returns files from users with IPs in the United Kingdom.</property>
+&apos;US&apos; will only return files from users connected via the United States. Similarly, &apos;GB&apos; returns files from users with IPs in the United Kingdom.</property>
                 <property name="justify">fill</property>
                 <property name="selectable">1</property>
                 <property name="wrap">1</property>


### PR DESCRIPTION
~~If you can, double-check that the XML is correct as I am unable to build on Windows currently.~~

The pull request just adds mention of `?ib` and `?b` unit variants for File Size suffixes, and updates the formatting slightly.

**Edit:** I forgot that CI runs on a pull request; I should be able to check if the formatting didn't break. 