### PR TITLE
Move scanning of shared files to a separate process

### DIFF
--- a/nicotine
+++ b/nicotine
@@ -147,7 +147,7 @@ def rescanshares(config, data_dir):
     from pynicotine.shares import Shares
 
     config = Config(config, data_dir)
-    config.read_config()
+    config.parse_config()
 
     # Show normal log messages in console
     console.set_log_levels((0, 1))
@@ -158,10 +158,10 @@ your shares this way, keep Nicotine+ closed until rescanning is done."""))
     queue = queue.Queue(0)
     shares = Shares(None, config, queue)
 
-    shares.rescan_shares()
+    shares.rescan_public_shares(thread=False)
 
     if config.sections["transfers"]["enablebuddyshares"]:
-        shares.rescan_buddy_shares()
+        shares.rescan_buddy_shares(thread=False)
 
 
 def run():

--- a/nicotine
+++ b/nicotine
@@ -27,6 +27,7 @@ Nicotine+ Launcher.
 """
 
 import importlib
+import multiprocessing
 import sys
 
 from pynicotine.utils import apply_translation
@@ -167,6 +168,10 @@ your shares this way, keep Nicotine+ closed until rescanning is done."""))
 def run():
 
     renameprocess('nicotine')
+
+    # Support for file scanning process in frozen Windows and macOS binaries
+    multiprocessing.freeze_support()
+    multiprocessing.set_start_method("spawn")
 
     # Setting gettext and locale
     apply_translation()

--- a/pynicotine/config.py
+++ b/pynicotine/config.py
@@ -130,17 +130,7 @@ class Config:
                 "uploadallowed": 2,
                 "autoclear_downloads": False,
                 "autoclear_uploads": False,
-                "sharedfiles": {},
-                "sharedfilesstreams": {},
                 "uploadsinsubdirs": True,
-                "wordindex": {},
-                "fileindex": {},
-                "sharedmtimes": {},
-                "bsharedfiles": {},
-                "bsharedfilesstreams": {},
-                "bwordindex": {},
-                "bfileindex": {},
-                "bsharedmtimes": {},
                 "rescanonstartup": True,
                 "enablefilters": True,
                 "downloadregexp": "",
@@ -676,21 +666,12 @@ class Config:
 
     def write_configuration(self):
 
-        external_sections = (
-            "sharedfiles", "sharedfilesstreams", "wordindex", "fileindex", "sharedmtimes",
-            "bsharedfiles", "bsharedfilesstreams", "bwordindex", "bfileindex", "bsharedmtimes"
-        )
-
         for i in self.sections:
             if not self.parser.has_section(i):
                 self.parser.add_section(i)
 
             for j in self.sections[i]:
-                if j not in external_sections:
-                    self.parser.set(i, j, self.sections[i][j])
-
-                else:
-                    self.parser.remove_option(i, j)
+                self.parser.set(i, j, self.sections[i][j])
 
         if not self.create_config_folder():
             return

--- a/pynicotine/gtkgui/frame.py
+++ b/pynicotine/gtkgui/frame.py
@@ -1106,7 +1106,7 @@ class NicotineFrame:
 
         log.add(_("Rescanning started"))
 
-        _thread.start_new_thread(self.np.shares.rescan_shares, (rebuild,))
+        _thread.start_new_thread(self.np.shares.rescan_public_shares, (rebuild,))
 
     def on_buddy_rescan(self, *args, rebuild=False):
 

--- a/pynicotine/gtkgui/frame.py
+++ b/pynicotine/gtkgui/frame.py
@@ -1105,8 +1105,6 @@ class NicotineFrame:
         self.rescan_public_action.set_enabled(False)
         self.browse_public_shares_action.set_enabled(False)
 
-        log.add(_("Rescanning started"))
-
         _thread.start_new_thread(self.np.shares.rescan_public_shares, (rebuild,))
 
     def on_buddy_rescan(self, *args, rebuild=False):
@@ -1118,8 +1116,6 @@ class NicotineFrame:
 
         self.rescan_buddy_action.set_enabled(False)
         self.browse_buddy_shares_action.set_enabled(False)
-
-        log.add(_("Rescanning Buddy Shares started"))
 
         _thread.start_new_thread(self.np.shares.rescan_buddy_shares, (rebuild,))
 
@@ -1755,6 +1751,7 @@ class NicotineFrame:
 
         if type == "buddy":
             GLib.idle_add(self._buddy_rescan_finished)
+
         elif type == "normal":
             GLib.idle_add(self._rescan_finished)
 
@@ -1765,8 +1762,6 @@ class NicotineFrame:
             self.browse_buddy_shares_action.set_enabled(True)
 
         self.brescanning = False
-        log.add(_("Rescanning Buddy Shares finished"))
-
         self.BuddySharesProgress.hide()
 
     def _rescan_finished(self):
@@ -1776,8 +1771,6 @@ class NicotineFrame:
             self.browse_public_shares_action.set_enabled(True)
 
         self.rescanning = False
-        log.add(_("Rescanning finished"))
-
         self.SharesProgress.hide()
 
     """ Transfer Statistics """

--- a/pynicotine/gtkgui/frame.py
+++ b/pynicotine/gtkgui/frame.py
@@ -26,6 +26,7 @@ import os
 import signal
 import sys
 import threading
+import time
 
 import gi
 from gi.repository import Gdk
@@ -2442,18 +2443,38 @@ class NicotineFrame:
         self.SocketStatus.set_text("%(current)s/%(limit)s" % {'current': status, 'limit': slskproto.MAXSOCKETS})
 
     def show_scan_progress(self, sharestype):
+
+        self.scan_progress_indeterminate = True
+
         if sharestype == "normal":
             GLib.idle_add(self.SharesProgress.show)
         else:
             GLib.idle_add(self.BuddySharesProgress.show)
 
     def set_scan_progress(self, sharestype, value):
+
+        self.scan_progress_indeterminate = False
+
         if sharestype == "normal":
             GLib.idle_add(self.SharesProgress.set_fraction, value)
         else:
             GLib.idle_add(self.BuddySharesProgress.set_fraction, value)
 
+    def set_scan_indeterminate(self, sharestype):
+        _thread.start_new_thread(self._set_scan_indeterminate, (sharestype,))
+
+    def _set_scan_indeterminate(self, sharestype):
+
+        while self.scan_progress_indeterminate:
+            if sharestype == "normal":
+                GLib.idle_add(self.SharesProgress.pulse)
+            else:
+                GLib.idle_add(self.BuddySharesProgress.pulse)
+
+            time.sleep(0.2)
+
     def hide_scan_progress(self, sharestype):
+
         if sharestype == "normal":
             GLib.idle_add(self.SharesProgress.hide)
         else:

--- a/pynicotine/pynicotine.py
+++ b/pynicotine/pynicotine.py
@@ -1909,9 +1909,9 @@ class NetworkEventProcessor:
             return
 
         if checkuser == 1:
-            shares = self.shares.shares["streams"]
+            shares = self.shares.share_dbs["streams"]
         elif checkuser == 2:
-            shares = self.shares.shares["streams"]
+            shares = self.shares.share_dbs["streams"]
         else:
             self.queue.put(slskmessages.TransferResponse(conn, 0, reason=reason, req=0))
             shares = {}
@@ -1923,7 +1923,7 @@ class NetworkEventProcessor:
                 self.queue.put(slskmessages.FolderContentsResponse(conn, msg.dir, shares[msg.dir.rstrip('\\')]))
             else:
                 if checkuser == 2:
-                    shares = self.shares.shares["streams"]
+                    shares = self.shares.share_dbs["streams"]
                     if msg.dir in shares:
                         self.queue.put(slskmessages.FolderContentsResponse(conn, msg.dir, shares[msg.dir]))
                     elif msg.dir.rstrip("\\") in shares:

--- a/pynicotine/pynicotine.py
+++ b/pynicotine/pynicotine.py
@@ -1909,9 +1909,9 @@ class NetworkEventProcessor:
             return
 
         if checkuser == 1:
-            shares = self.config.sections["transfers"]["sharedfilesstreams"]
+            shares = self.shares.shares["streams"]
         elif checkuser == 2:
-            shares = self.config.sections["transfers"]["bsharedfilesstreams"]
+            shares = self.shares.shares["streams"]
         else:
             self.queue.put(slskmessages.TransferResponse(conn, 0, reason=reason, req=0))
             shares = {}
@@ -1923,7 +1923,7 @@ class NetworkEventProcessor:
                 self.queue.put(slskmessages.FolderContentsResponse(conn, msg.dir, shares[msg.dir.rstrip('\\')]))
             else:
                 if checkuser == 2:
-                    shares = self.config.sections["transfers"]["sharedfilesstreams"]
+                    shares = self.shares.shares["streams"]
                     if msg.dir in shares:
                         self.queue.put(slskmessages.FolderContentsResponse(conn, msg.dir, shares[msg.dir]))
                     elif msg.dir.rstrip("\\") in shares:

--- a/pynicotine/shares.py
+++ b/pynicotine/shares.py
@@ -794,8 +794,8 @@ class Shares:
         self.scanner.start()
 
         if self.ui_callback:
-            self.ui_callback.set_scan_progress(sharestype, 0.0)
             self.ui_callback.show_scan_progress(sharestype)
+            self.ui_callback.set_scan_indeterminate(sharestype)
 
         while self.scanner.is_alive():
             time.sleep(0.5)
@@ -828,8 +828,6 @@ class Shares:
                 elif item == "compress_shares":
                     self.create_compressed_shares_message(sharestype)
                     self.compress_shares(sharestype)
-
-        self.scanner.join()
 
         if self.connected:
             """ Don't attempt to send file stats to the server before we're connected. If we skip the

--- a/pynicotine/shares.py
+++ b/pynicotine/shares.py
@@ -472,6 +472,12 @@ class Shares:
 
     def __init__(self, np, config, queue, ui_callback=None, connected=False):
 
+        try:
+            multiprocessing.set_start_method("spawn")
+        except RuntimeError:
+            # Start method already set
+            pass
+
         self.np = np
         self.ui_callback = ui_callback
         self.config = config

--- a/pynicotine/shares.py
+++ b/pynicotine/shares.py
@@ -470,12 +470,6 @@ class Shares:
 
     def __init__(self, np, config, queue, ui_callback=None, connected=False):
 
-        try:
-            multiprocessing.set_start_method("spawn")
-        except RuntimeError:
-            # Start method already set
-            pass
-
         self.np = np
         self.ui_callback = ui_callback
         self.config = config

--- a/pynicotine/slskmessages.py
+++ b/pynicotine/slskmessages.py
@@ -2047,9 +2047,15 @@ class SharedFileList(PeerMessage):
         msg = bytearray()
 
         try:
-            msg.extend(self.pack_object(len(self.list)))
-        except TypeError:
-            msg.extend(self.pack_object(len(list(self.list))))
+            try:
+                msg.extend(self.pack_object(len(self.list)))
+
+            except TypeError:
+                msg.extend(self.pack_object(len(list(self.list))))
+
+        except ValueError:
+            # DB is closed
+            return None
 
         for key in self.list:
             try:

--- a/pynicotine/transfers.py
+++ b/pynicotine/transfers.py
@@ -960,13 +960,13 @@ class Transfers:
 
         if self.eventprocessor.config.sections["transfers"]["enablebuddyshares"]:
             if user in (i[0] for i in self.eventprocessor.config.sections["server"]["userlist"]):
-                bshared = self.eventprocessor.shares.shares["buddyfiles"]
+                bshared = self.eventprocessor.shares.share_dbs["buddyfiles"]
 
                 for i in bshared.get(str(folder), ''):
                     if file == i[0]:
                         return True
 
-        shared = self.eventprocessor.shares.shares["files"]
+        shared = self.eventprocessor.shares.share_dbs["files"]
 
         for i in shared.get(str(folder), ''):
             if file == i[0]:

--- a/pynicotine/transfers.py
+++ b/pynicotine/transfers.py
@@ -960,13 +960,13 @@ class Transfers:
 
         if self.eventprocessor.config.sections["transfers"]["enablebuddyshares"]:
             if user in (i[0] for i in self.eventprocessor.config.sections["server"]["userlist"]):
-                bshared = self.eventprocessor.config.sections["transfers"]["bsharedfiles"]
+                bshared = self.eventprocessor.shares.shares["buddyfiles"]
 
                 for i in bshared.get(str(folder), ''):
                     if file == i[0]:
                         return True
 
-        shared = self.eventprocessor.config.sections["transfers"]["sharedfiles"]
+        shared = self.eventprocessor.shares.shares["files"]
 
         for i in shared.get(str(folder), ''):
             if file == i[0]:

--- a/test/unit/shares/test_shares.py
+++ b/test/unit/shares/test_shares.py
@@ -16,6 +16,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+import multiprocessing
 import os
 import pytest
 import queue
@@ -29,9 +30,12 @@ SHARES_DIR = os.path.join(os.path.dirname(os.path.realpath(__file__)), "sharedfi
 
 
 @pytest.fixture(scope="module", autouse=True)
-def translation():
+def setup():
     # Setting gettext and locale
     apply_translation()
+
+    # Use 'spawn' start method for file scanning process
+    multiprocessing.set_start_method("spawn")
 
 
 def test_shares_scan():

--- a/test/unit/shares/test_shares.py
+++ b/test/unit/shares/test_shares.py
@@ -20,8 +20,6 @@ import os
 import pytest
 import queue
 
-from time import sleep
-
 from pynicotine.shares import Shares
 from pynicotine.config import Config
 from pynicotine.utils import apply_translation
@@ -69,9 +67,6 @@ def test_shares_scan():
     # File ID associated with word "ogg" should return our nicotinetestdata.ogg file
     assert ogg_indexes[0] in nicotinetestdata_indexes
     assert shares.shares["fileindex"][str(ogg_indexes[0])][0] == 'Shares\\nicotinetestdata.ogg'
-
-    # Slight delay to ensure shares compression finishes in different thread
-    sleep(4)
 
     shares.close_shares()
 

--- a/test/unit/shares/test_shares.py
+++ b/test/unit/shares/test_shares.py
@@ -44,17 +44,17 @@ def test_shares_scan():
     shares.rescan_public_shares(thread=False)
 
     # Verify that modification time was saved for shares folder
-    assert SHARES_DIR in list(shares.shares["mtimes"])
+    assert SHARES_DIR in list(shares.share_dbs["mtimes"])
 
     # Verify that shared files were added
-    assert ('dummy_file', 0, None, None) in shares.shares["files"]["Shares"]
-    assert ('nicotinetestdata.mp3', 80919, (128, 0), 5) in shares.shares["files"]["Shares"]
+    assert ('dummy_file', 0, None, None) in shares.share_dbs["files"]["Shares"]
+    assert ('nicotinetestdata.mp3', 80919, (128, 0), 5) in shares.share_dbs["files"]["Shares"]
 
     # Verify that expected folder is empty
-    assert len(shares.shares["files"]["Shares\\folder2"]) == 0
+    assert len(shares.share_dbs["files"]["Shares\\folder2"]) == 0
 
     # Verify that search index was updated
-    word_index = shares.shares["wordindex"]
+    word_index = shares.share_dbs["wordindex"]
     nicotinetestdata_indexes = list(word_index["nicotinetestdata"])
     ogg_indexes = list(word_index["ogg"])
 
@@ -66,7 +66,7 @@ def test_shares_scan():
 
     # File ID associated with word "ogg" should return our nicotinetestdata.ogg file
     assert ogg_indexes[0] in nicotinetestdata_indexes
-    assert shares.shares["fileindex"][str(ogg_indexes[0])][0] == 'Shares\\nicotinetestdata.ogg'
+    assert shares.share_dbs["fileindex"][str(ogg_indexes[0])][0] == 'Shares\\nicotinetestdata.ogg'
 
     shares.close_shares()
 
@@ -81,7 +81,7 @@ def test_hidden_file_folder_scan():
     shares.rescan_public_shares(thread=False)
 
     # Check folders
-    mtimes = list(shares.shares["mtimes"])
+    mtimes = list(shares.share_dbs["mtimes"])
 
     assert os.path.join(SHARES_DIR, ".abc") not in mtimes
     assert os.path.join(SHARES_DIR, ".xyz") not in mtimes
@@ -92,7 +92,7 @@ def test_hidden_file_folder_scan():
     assert os.path.join(SHARES_DIR, "something") in mtimes
 
     # Check files
-    files = shares.shares["files"]["Shares"]
+    files = shares.share_dbs["files"]["Shares"]
 
     assert (".abc_file", 0, None, None) not in files
     assert (".hidden_file", 0, None, None) not in files
@@ -113,7 +113,7 @@ def test_shares_add_downloaded():
     shares = Shares(None, config, queue.Queue(0), None)
     shares.add_file_to_shared(os.path.join(SHARES_DIR, 'nicotinetestdata.mp3'))
 
-    assert ('nicotinetestdata.mp3', 80919, (128, 0), 5) in shares.shares["files"]["Downloaded"]
-    assert ('Downloaded\\nicotinetestdata.mp3', 80919, (128, 0), 5) in shares.shares["fileindex"].values()
+    assert ('nicotinetestdata.mp3', 80919, (128, 0), 5) in shares.share_dbs["files"]["Downloaded"]
+    assert ('Downloaded\\nicotinetestdata.mp3', 80919, (128, 0), 5) in shares.share_dbs["fileindex"].values()
 
     shares.close_shares()

--- a/test/unit/shares/test_shares.py
+++ b/test/unit/shares/test_shares.py
@@ -43,7 +43,7 @@ def test_shares_scan():
     config.sections["transfers"]["shared"] = [("Shares", SHARES_DIR)]
 
     shares = Shares(None, config, queue.Queue(0))
-    shares.rescan_shares()
+    shares.rescan_public_shares(thread=False)
 
     # Verify that modification time was saved for shares folder
     assert SHARES_DIR in list(config.sections["transfers"]["sharedmtimes"])
@@ -85,7 +85,7 @@ def test_hidden_file_folder_scan():
     config.sections["transfers"]["shared"] = [("Shares", SHARES_DIR)]
 
     shares = Shares(None, config, queue.Queue(0))
-    shares.rescan_shares()
+    shares.rescan_public_shares(thread=False)
 
     # Check folders
     mtimes = list(config.sections["transfers"]["sharedmtimes"])


### PR DESCRIPTION
This PR decouples file scanning and share db generation from the main Nicotine+ process, which results in significantly increased UI performance while scanning.