### PR TITLE
Add OpenBSD port and build instructions in the README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,18 @@ To install Nicotine+ on Guix, run the following:
 guix install nicotine+
 ```
 
+## OpenBSD
+This port has been submitted to the OpenBSD ports team and is awaiting approval. Here is how you can build and install the port on systems up to 6.9.
+
+```
+git clone https://github.com/Nicotine-Plus/nicotine-plus.git
+mkdir -p /usr/ports/mystuff/net
+cp -r nicotine-plus/packaging/openbsd /usr/ports/mystuff/net/nicotine-plus
+cd  /usr/ports/mystuff/net/nicotine-plus
+make package
+sudo make install
+```
+
 ### Other Distributions
 If Nicotine+ isn't packaged for your distribution/operating system yet, there are other recommended ways of installing Nicotine+.
 


### PR DESCRIPTION
As discussed previously, this port will only remain until it is accepted by the OpenBSD team, and a bit thereafter to ensure proper propagation in the OpenBSD community. I will maintain this port to keep it up to date with further nicotine releases.