### PR TITLE
WIP: Use Deluge port checker, show result in a separate icon

### DIFF
--- a/pynicotine/gtkgui/settingswindow.py
+++ b/pynicotine/gtkgui/settingswindow.py
@@ -39,7 +39,6 @@ from pynicotine.gtkgui.dialogs import save_file
 from pynicotine.gtkgui.utils import FileChooserButton
 from pynicotine.gtkgui.utils import initialise_columns
 from pynicotine.gtkgui.utils import load_ui_elements
-from pynicotine.gtkgui.utils import open_uri
 from pynicotine.gtkgui.utils import update_widget_visuals
 from pynicotine.logfacility import log
 from pynicotine.utils import unescape
@@ -167,7 +166,6 @@ class ServerFrame(BuildFrame):
         except Exception as exc:
             log.add(_('Error testing listen port: %s' % exc))
             return False
-
 
     def on_toggle_upnp(self, widget, *args):
 

--- a/pynicotine/gtkgui/ui/settings/server.ui
+++ b/pynicotine/gtkgui/ui/settings/server.ui
@@ -223,6 +223,12 @@
                     <signal name="clicked" handler="on_check_port" swapped="no"/>
                   </object>
                 </child>
+                <child>
+                  <object class="GtkImage" id="CheckPortImage">
+                    <property name="can_focus">False</property>
+                    <property name="icon_name">dialog-question-symbolic</property>
+                  </object>
+                </child>
               </object>
             </child>
             <child>


### PR DESCRIPTION
It seems like "Check port status" button in Settings/Server frame opens a dead link for some time. This PR replaces this link with call to API provided by Deluge infrastructure. Depending on was this call successful or not OK or warning sing appears next to the button.Code was also poorly ripped from Deluge GTK client. This operation needs to be non-UI-blocking before this PR could be merged and some tests would also be great. But before continuing to digging into this I would ask community if it's a good idea to depend on Deluge's API? Maybe there are more suitable solutions for this issue?