### PR TITLE
Don't use deprecated method of queuing downloads

### DIFF
--- a/doc/SLSKPROTOCOL.md
+++ b/doc/SLSKPROTOCOL.md
@@ -2543,7 +2543,7 @@ Order](#peer-connection-message-order)
 | 41   | [Download Reply](#peer-code-41-b)          |
 | 41   | [Transfer Reply](#peer-code-41-c)          |
 | 42   | [Upload Placehold](#peer-code-42)          |
-| 43   | [Queue Upload or Download](#peer-code-43)  |
+| 43   | [Queue Upload](#peer-code-43)              |
 | 44   | [Place In Queue Reply](#peer-code-44)      |
 | 46   | [Upload Failed](#peer-code-46)             |
 | 50   | [Upload Denied](#peer-code-50)             |
@@ -2828,7 +2828,7 @@ Nicotine: TransferRequest
 
 #### Description
 
-We request a file from a peer, or tell a peer that we want to send a file to them.
+This message is sent when attempting to upload a file. It can also be used to send a download request, but Nicotine+ and the official client uses QueueUpload for this purpose instead.
 
 #### Data Order
 
@@ -2945,7 +2945,7 @@ Nicotine: PlaceholdUpload
 
 ### Peer Code 43
 
-**Queue Upload or Download**
+**Queue Upload**
 
 #### Function Names
 
@@ -2953,6 +2953,8 @@ Museekd: PQueueDownload
 Nicotine: QueueUpload
 
 #### Description
+
+This message is used to tell a peer that an upload should be queued on their end.
 
 #### Data Order
 
@@ -2971,6 +2973,8 @@ Museekd: PPlaceInQueueReply
 Nicotine: PlaceInQueue
 
 #### Description
+
+The peer replies with the upload queue placement of the requested file.
 
 #### Data Order
 
@@ -2992,6 +2996,8 @@ Nicotine: UploadFailed
 
 #### Description
 
+This message is sent whenever a file connection closes. The recipient either re-queues the file, or ignores the message if the download finished.
+
 #### Data Order
 
   - Send
@@ -3009,6 +3015,8 @@ Museekd: PQueueFailed
 Nicotine: UploadDenied
 
 #### Description
+
+This message is sent to reject a download attempt, in cases where a transfer hasn't been initiated.
 
 #### Data Order
 
@@ -3030,6 +3038,8 @@ Nicotine: PlaceInQueueRequest
 
 #### Description
 
+This message is sent to ask for the upload queue placement of a file.
+
 #### Data Order
 
   - Send
@@ -3047,6 +3057,8 @@ Museekd: PUploadQueueNotification
 Nicotine: UploadQueueNotification
 
 #### Description
+
+**DEPRECATED**
 
 #### Data Order
 

--- a/doc/SLSKPROTOCOL.md
+++ b/doc/SLSKPROTOCOL.md
@@ -2528,27 +2528,27 @@ Order](#peer-connection-message-order)
 
 #### Message Index
 
-| Code | Message                                    |
-| ---- | ------------------------------------------ |
-| 4    | [Shares Request](#peer-code-4)             |
-| 5    | [Shares Reply](#peer-code-5)               |
-| 8    | [Search Request](#peer-code-8)             |
-| 9    | [Search Reply](#peer-code-9)               |
-| 15   | [User Info Request](#peer-code-15)         |
-| 16   | [User Info Reply](#peer-code-16)           |
-| 36   | [Folder Contents Request](#peer-code-36)   |
-| 37   | [Folder Contents Reply](#peer-code-37)     |
-| 40   | [Transfer Request](#peer-code-40)          |
-| 41   | [Upload Reply](#peer-code-41-a)            |
-| 41   | [Download Reply](#peer-code-41-b)          |
-| 41   | [Transfer Reply](#peer-code-41-c)          |
-| 42   | [Upload Placehold](#peer-code-42)          |
-| 43   | [Queue Upload](#peer-code-43)              |
-| 44   | [Place In Queue Reply](#peer-code-44)      |
-| 46   | [Upload Failed](#peer-code-46)             |
-| 50   | [Upload Denied](#peer-code-50)             |
-| 51   | [Place In Queue Request](#peer-code-51)    |
-| 52   | [Upload Queue Notification](#peer-code-52) |
+| Code | Message                                    | Status     |
+| ---- | ------------------------------------------ | ---------- |
+| 4    | [Shares Request](#peer-code-4)             |            |
+| 5    | [Shares Reply](#peer-code-5)               |            |
+| 8    | [Search Request](#peer-code-8)             |            |
+| 9    | [Search Reply](#peer-code-9)               |            |
+| 15   | [User Info Request](#peer-code-15)         |            |
+| 16   | [User Info Reply](#peer-code-16)           |            |
+| 36   | [Folder Contents Request](#peer-code-36)   |            |
+| 37   | [Folder Contents Reply](#peer-code-37)     |            |
+| 40   | [Transfer Request](#peer-code-40)          |            |
+| 41   | [Upload Reply](#peer-code-41-a)            |            |
+| 41   | [Download Reply](#peer-code-41-b)          | Deprecated |
+| 41   | [Transfer Reply](#peer-code-41-c)          |            |
+| 42   | [Upload Placehold](#peer-code-42)          |            |
+| 43   | [Queue Upload](#peer-code-43)              |            |
+| 44   | [Place In Queue Reply](#peer-code-44)      |            |
+| 46   | [Upload Failed](#peer-code-46)             |            |
+| 50   | [Upload Denied](#peer-code-50)             |            |
+| 51   | [Place In Queue Request](#peer-code-51)    |            |
+| 52   | [Upload Queue Notification](#peer-code-52) | Deprecated |
 
 ### Peer Code 4
 
@@ -2828,7 +2828,7 @@ Nicotine: TransferRequest
 
 #### Description
 
-This message is sent when attempting to upload a file. It can also be used to send a download request, but Nicotine+ and the official client uses QueueUpload for this purpose instead.
+This message is sent when attempting to upload a file. It was formely used to send a download request as well, but Nicotine+, Museek+ and the official clients use QueueUpload for this purpose today.
 
 #### Data Order
 
@@ -2883,6 +2883,8 @@ Museekd: PDownloadReply
 Nicotine: TransferResponse
 
 #### Description
+
+**DEPRECATED**
 
 Response to TransferRequest - either we (or the other peer) agrees, or tells the reason for rejecting the file transfer.
 
@@ -2954,7 +2956,7 @@ Nicotine: QueueUpload
 
 #### Description
 
-This message is used to tell a peer that an upload should be queued on their end.
+This message is used to tell a peer that an upload should be queued on their end. Once the recipient is ready to transfer the requested file, they will send an upload request.
 
 #### Data Order
 
@@ -2996,7 +2998,7 @@ Nicotine: UploadFailed
 
 #### Description
 
-This message is sent whenever a file connection closes. The recipient either re-queues the file, or ignores the message if the download finished.
+This message is sent whenever a file connection of an active upload closes. Soulseek NS clients can also send this message when a file can not be read. The recipient either re-queues the upload (download on their end), or ignores the message if the transfer finished.
 
 #### Data Order
 
@@ -3016,7 +3018,7 @@ Nicotine: UploadDenied
 
 #### Description
 
-This message is sent to reject a download attempt, in cases where a transfer hasn't been initiated.
+This message is sent to reject QueueUpload attempts and previously queued files. The reason for rejection will appear in the transfer list of the recipient.
 
 #### Data Order
 
@@ -3038,7 +3040,7 @@ Nicotine: PlaceInQueueRequest
 
 #### Description
 
-This message is sent to ask for the upload queue placement of a file.
+This message is sent when asking for the upload queue placement of a file.
 
 #### Data Order
 

--- a/pynicotine/gtkgui/userbrowse.py
+++ b/pynicotine/gtkgui/userbrowse.py
@@ -861,7 +861,7 @@ class UserBrowse:
 
             for file in f:
                 filename = "\\".join([folder, file[1]])
-                realfilename = "\\".join([realpath, file[1]])
+                realfilename = os.path.join(realpath, file[1])
                 size = file[2]
                 self.frame.np.transfers.push_file(user, filename, realfilename, ldir, size=size)
                 self.frame.np.transfers.check_upload_queue()
@@ -900,7 +900,7 @@ class UserBrowse:
         self.frame.np.send_message_to_peer(user, slskmessages.UploadQueueNotification(None))
 
         for fn in self.selected_files:
-            self.frame.np.transfers.push_file(user, "\\".join([folder, fn]), "\\".join([realpath, fn]), prefix)
+            self.frame.np.transfers.push_file(user, "\\".join([folder, fn]), os.path.join(realpath, fn), prefix)
             self.frame.np.transfers.check_upload_queue()
 
     def on_key_press_event(self, widget, event):

--- a/pynicotine/pynicotine.py
+++ b/pynicotine/pynicotine.py
@@ -409,9 +409,6 @@ class NetworkEventProcessor:
         if addr is None:
             self.queue.put(slskmessages.GetPeerAddress(user))
 
-            if message.__class__ is slskmessages.TransferRequest and self.transfers is not None:
-                self.transfers.getting_address(message.req)
-
             log.add_conn("Requesting address for user %(user)s", {
                 'user': user
             })
@@ -445,10 +442,6 @@ class NetworkEventProcessor:
 
         conn.token = new_id()
         self.queue.put(slskmessages.ConnectToPeer(conn.token, conn.username, conn.type))
-
-        for j in conn.msgs:
-            if j.__class__ is slskmessages.TransferRequest and self.transfers is not None:
-                self.transfers.got_connect_error(j.req)
 
         conntimeout = ConnectToPeerTimeout(conn, self.network_callback)
         timer = threading.Timer(20.0, conntimeout.timeout)
@@ -556,9 +549,6 @@ class NetworkEventProcessor:
 
                     self.connect_to_peer_direct(user, i.addr, i.type)
 
-                    for j in i.msgs:
-                        if j.__class__ is slskmessages.TransferRequest and self.transfers is not None:
-                            self.transfers.got_address(j.req)
                 else:
 
                     """ Server responded with an incorrect port, request peer address again """
@@ -902,7 +892,7 @@ class NetworkEventProcessor:
                         connect to them. """
 
                         for j in i.msgs:
-                            if j.__class__ in (slskmessages.TransferRequest, slskmessages.FileRequest) and self.transfers is not None:
+                            if j.__class__ in (slskmessages.FileRequest, slskmessages.TransferRequest) and self.transfers is not None:
                                 self.transfers.got_cant_connect(j.req)
 
                         log.add_conn("Can't connect to user %(user)s indirectly. Error: %(error)s", {

--- a/pynicotine/slskmessages.py
+++ b/pynicotine/slskmessages.py
@@ -2554,6 +2554,7 @@ class UnknownPeerMessage(PeerMessage):
         self.conn = conn
 
     def parse_network_message(self, message):
+        print(message)
         # Empty message
         pass
 

--- a/pynicotine/slskmessages.py
+++ b/pynicotine/slskmessages.py
@@ -2394,8 +2394,9 @@ class FolderContentsResponse(PeerMessage):
 
 class TransferRequest(PeerMessage):
     """ Peer code: 40 """
-    """ We request a file from a peer, or tell a peer that we want to send
-    a file to them. """
+    """ This message is sent when attempting to initiate an upload. It was formely used
+    to send a download request as well, but Nicotine+, Museek+ and the official clients
+    use QueueUpload for this purpose today. """
 
     def __init__(self, conn, direction=None, req=None, file=None, filesize=None, realfile=None, legacy_client=False):
         self.conn = conn
@@ -2480,11 +2481,15 @@ class PlaceholdUpload(PeerMessage):
 
 class QueueUpload(PlaceholdUpload):
     """ Peer code: 43 """
+    """ This message is used to tell a peer that an upload should be queued on their end.
+    Once the recipient is ready to transfer the requested file, they will send an upload
+    request."""
     pass
 
 
 class PlaceInQueue(PeerMessage):
     """ Peer code: 44 """
+    """ The peer replies with the upload queue placement of the requested file. """
 
     def __init__(self, conn, filename=None, place=None):
         self.conn = conn
@@ -2505,11 +2510,17 @@ class PlaceInQueue(PeerMessage):
 
 class UploadFailed(PlaceholdUpload):
     """ Peer code: 46 """
+    """ This message is sent whenever a file connection of an active upload
+    closes. Soulseek NS clients can also send this message when a file can
+    not be read. The recipient either re-queues the upload (download on their
+    end), or ignores the message if the transfer finished. """
     pass
 
 
 class UploadDenied(PeerMessage):
     """ Peer code: 50 """
+    """ This message is sent to reject QueueUpload attempts and previously queued
+    files. The reason for rejection will appear in the transfer list of the recipient. """
 
     def __init__(self, conn, file=None, reason=None):
         self.conn = conn
@@ -2530,11 +2541,13 @@ class UploadDenied(PeerMessage):
 
 class PlaceInQueueRequest(PlaceholdUpload):
     """ Peer code: 51 """
+    """ This message is sent when asking for the upload queue placement of a file. """
     pass
 
 
 class UploadQueueNotification(PeerMessage):
     """ Peer code: 52 """
+    """ DEPRECATED """
 
     def __init__(self, conn):
         self.conn = conn
@@ -2554,7 +2567,6 @@ class UnknownPeerMessage(PeerMessage):
         self.conn = conn
 
     def parse_network_message(self, message):
-        print(message)
         # Empty message
         pass
 

--- a/pynicotine/transfers.py
+++ b/pynicotine/transfers.py
@@ -447,35 +447,6 @@ class Transfers:
                 self.get_file(i.user, i.filename, i.path, i)
                 break
 
-    def getting_address(self, req):
-
-        for i in self.uploads:
-            if i.req == req:
-                i.status = "Getting address"
-                self.uploadsview.update(i)
-                break
-
-    def got_address(self, req):
-        """ A connection is in progress, we got the address for a user we need
-        to connect to."""
-
-        for i in self.uploads:
-            if i.req == req:
-                i.status = "Connecting"
-                self.uploadsview.update(i)
-                break
-
-    def got_connect_error(self, req):
-        """ We couldn't connect to the user, now we are waitng for him to
-        connect to us. Note that all this logic is handled by the network
-        event processor, we just provide a visual feedback to the user."""
-
-        for i in self.uploads:
-            if i.req == req:
-                i.status = "Waiting for peer to connect"
-                self.uploadsview.update(i)
-                break
-
     def got_cant_connect(self, req):
         """ We can't connect to the user, either way. """
 
@@ -969,7 +940,6 @@ class Transfers:
                                      "filename": i.filename
                                  })
 
-                print("TF")
                 self.abort_transfer(i, send_fail_message=False)
                 i.legacy_attempt = True
                 self.get_file(i.user, i.filename, i.path, i)

--- a/pynicotine/transfers.py
+++ b/pynicotine/transfers.py
@@ -436,7 +436,7 @@ class Transfers:
             return
 
         for i in self.downloads:
-            if i.user != user and i.filename != msg.file:
+            if i.user != user or i.filename != msg.file:
                 continue
 
             if i.status in ("Aborted", "Paused", "Local file error", "User logged off"):
@@ -455,6 +455,12 @@ class Transfers:
 
                 i.status = "Remote file error"
                 self.downloadsview.update(i)
+
+                log.add_transfer("Upload attempt by user %(user)s for file %(filename)s failed. Reason: %(reason)s", {
+                    "filename": i.filename,
+                    "user": user,
+                    "reason": "Remote file error"
+                })
 
     def got_cant_connect(self, req):
         """ We can't connect to the user, either way. """
@@ -949,8 +955,9 @@ class Transfers:
                 """ The peer is possibly using an old client that doesn't support Unicode
                 (Soulseek NS). Attempt to request file name encoded as latin-1 once. """
 
-                log.add_transfer("Peer responded with reason '%(reason)s' for download request %(filename)s. "
+                log.add_transfer("User %(user)s responded with reason '%(reason)s' for download request %(filename)s. "
                                  "Attempting to request file as latin-1.", {
+                                     "user": user,
                                      "reason": msg.reason,
                                      "filename": i.filename
                                  })
@@ -967,6 +974,11 @@ class Transfers:
                 i.status = msg.reason
                 self.downloadsview.update(i)
 
+                log.add_transfer("Download request denied by user %(user)s for file %(filename)s. Reason: %(reason)s", {
+                    "user": user,
+                    "filename": i.filename,
+                    "reason": msg.reason
+                })
                 break
 
     def file_is_shared(self, user, virtualfilename, realfilename):

--- a/pynicotine/transfers.py
+++ b/pynicotine/transfers.py
@@ -54,7 +54,7 @@ class Transfer(object):
     __slots__ = "conn", "user", "realfilename", "filename", \
                 "path", "req", "size", "file", "starttime", "lasttime", \
                 "offset", "currentbytes", "lastbytes", "speed", "timeelapsed", \
-                "timeleft", "timequeued", "transfertimer", "requestconn", \
+                "timeleft", "timequeued", "transfertimer", \
                 "modifier", "place", "bitrate", "length", "iter", "_status", \
                 "laststatuschange", "legacy_attempt"
 
@@ -84,7 +84,6 @@ class Transfer(object):
         self.timeleft = timeleft
         self.timequeued = timequeued
         self.transfertimer = transfertimer
-        self.requestconn = None
         self.place = place  # Queue position
         self.bitrate = bitrate
         self.length = length
@@ -340,7 +339,7 @@ class Transfers:
         if transfer is None:
             transfer = Transfer(
                 user=user, filename=filename, realfilename=realfilename, path=path,
-                status="Getting status", size=size, bitrate=bitrate,
+                status="Queued", size=size, bitrate=bitrate,
                 length=length
             )
 
@@ -349,15 +348,15 @@ class Transfers:
             else:
                 self._append_upload(user, filename, transfer)
         else:
-            transfer.status = "Getting status"
+            transfer.status = "Queued"
 
-        log.add_transfer(
-            "Initializing transfer request for file %(file)s to user %(user)s, direction: %(direction)s", {
-                'file': filename,
-                'user': user,
-                'direction': direction
-            }
-        )
+        if direction == 1:
+            log.add_transfer(
+                "Initializing upload request for file %(file)s to user %(user)s", {
+                    'file': filename,
+                    'user': user
+                }
+            )
 
         try:
             status = self.users[user].status
@@ -385,23 +384,23 @@ class Transfers:
                 self.queue.put(slskmessages.AddUser(user))
 
         if transfer.status != "Filtered":
-            transfer.req = new_id()
-            realpath = self.eventprocessor.shares.virtual2real(filename)
-            request = slskmessages.TransferRequest(None, direction, transfer.req, filename, self.get_file_size(realpath), realpath)
-            self.eventprocessor.send_message_to_peer(user, request)
-
             if direction == 0:
-                log.add_transfer("Requesting to download file %(filename)s with transfer request %(request)s from user %(user)s", {
+                log.add_transfer("Adding file %(filename)s from user %(user)s to download queue", {
                     "filename": filename,
-                    "request": transfer.req,
                     "user": user
                 })
+                self.eventprocessor.send_message_to_peer(user, slskmessages.QueueUpload(None, filename, transfer.legacy_attempt))
+                self.eventprocessor.send_message_to_peer(user, slskmessages.PlaceInQueueRequest(None, transfer.filename, transfer.legacy_attempt))
+
             else:
                 log.add_transfer("Requesting to upload file %(filename)s with transfer request %(request)s to user %(user)s", {
                     "filename": filename,
                     "request": transfer.req,
                     "user": user
                 })
+                transfer.req = new_id()
+                realpath = self.eventprocessor.shares.virtual2real(filename)
+                self.eventprocessor.send_message_to_peer(user, slskmessages.TransferRequest(None, direction, transfer.req, filename, self.get_file_size(realpath), realpath))
 
         if shouldupdate:
             if direction == 0:
@@ -427,81 +426,55 @@ class Transfers:
 
     def upload_failed(self, msg):
 
+        user = None
         for i in self.peerconns:
             if i.conn is msg.conn.conn:
                 user = i.username
                 break
-        else:
+
+        if user is None:
             return
 
         for i in self.downloads:
-            if i.user == user and i.filename == msg.file and (i.conn is not None or i.status in ["Connection closed by peer", "Establishing connection", "Waiting for download"]):
-                self.abort_transfer(i)
+            if i.user != user and i.filename != msg.file:
+                continue
+
+            if not i.legacy_attempt:
+                """ Attempt to request file name encoded as latin-1 once. """
+
+                self.abort_transfer(i, send_fail_message=False)
+                i.legacy_attempt = True
                 self.get_file(i.user, i.filename, i.path, i)
-                self.log_transfer(
-                    _("Retrying failed download: user %(user)s, file %(file)s") % {
-                        'user': i.user,
-                        'file': i.filename
-                    },
-                    show_ui=1
-                )
                 break
 
-    def getting_address(self, req, direction):
+    def getting_address(self, req):
 
-        if direction == 0:
-            for i in self.downloads:
-                if i.req == req:
-                    i.status = "Getting address"
-                    self.downloadsview.update(i)
-                    break
+        for i in self.uploads:
+            if i.req == req:
+                i.status = "Getting address"
+                self.uploadsview.update(i)
+                break
 
-        elif direction == 1:
-
-            for i in self.uploads:
-                if i.req == req:
-                    i.status = "Getting address"
-                    self.uploadsview.update(i)
-                    break
-
-    def got_address(self, req, direction):
+    def got_address(self, req):
         """ A connection is in progress, we got the address for a user we need
         to connect to."""
 
-        if direction == 0:
-            for i in self.downloads:
-                if i.req == req:
-                    i.status = "Connecting"
-                    self.downloadsview.update(i)
-                    break
+        for i in self.uploads:
+            if i.req == req:
+                i.status = "Connecting"
+                self.uploadsview.update(i)
+                break
 
-        elif direction == 1:
-
-            for i in self.uploads:
-                if i.req == req:
-                    i.status = "Connecting"
-                    self.uploadsview.update(i)
-                    break
-
-    def got_connect_error(self, req, direction):
+    def got_connect_error(self, req):
         """ We couldn't connect to the user, now we are waitng for him to
         connect to us. Note that all this logic is handled by the network
         event processor, we just provide a visual feedback to the user."""
 
-        if direction == 0:
-            for i in self.downloads:
-                if i.req == req:
-                    i.status = "Waiting for peer to connect"
-                    self.downloadsview.update(i)
-                    break
-
-        elif direction == 1:
-
-            for i in self.uploads:
-                if i.req == req:
-                    i.status = "Waiting for peer to connect"
-                    self.uploadsview.update(i)
-                    break
+        for i in self.uploads:
+            if i.req == req:
+                i.status = "Waiting for peer to connect"
+                self.uploadsview.update(i)
+                break
 
     def got_cant_connect(self, req):
         """ We can't connect to the user, either way. """
@@ -558,26 +531,15 @@ class Transfers:
                 self.uploadsview.update(i)
                 break
 
-    def got_connect(self, req, conn, direction):
+    def got_connect(self, req):
         """ A connection has been established, now exchange initialisation
         messages."""
 
-        if direction == 0:
-            for i in self.downloads:
-                if i.req == req:
-                    i.status = "Requesting file"
-                    i.requestconn = conn
-                    self.downloadsview.update(i)
-                    break
-
-        elif direction == 1:
-
-            for i in self.uploads:
-                if i.req == req:
-                    i.status = "Requesting file"
-                    i.requestconn = conn
-                    self.uploadsview.update(i)
-                    break
+        for i in self.uploads:
+            if i.req == req:
+                i.status = "Requesting file"
+                self.uploadsview.update(i)
+                break
 
     def transfer_request(self, msg):
 
@@ -672,7 +634,7 @@ class Transfers:
 
                 transfer = Transfer(
                     user=user, filename=msg.file, path=path,
-                    status="Getting status", size=msg.filesize, req=msg.req
+                    status="Queued", size=msg.filesize, req=msg.req
                 )
                 self.downloads.append(transfer)
 
@@ -993,7 +955,27 @@ class Transfers:
             return
 
         for i in self.downloads:
-            if i.user == user and i.filename == msg.file and i.status not in ["Aborted", "Paused"]:
+            if i.user != user and i.filename != msg.file:
+                continue
+
+            if i.status in ("File not shared.", "File not shared", "Remote file error") and \
+                    not i.legacy_attempt:
+                """ The peer is possibly using an old client that doesn't support Unicode
+                (Soulseek NS). Attempt to request file name encoded as latin-1 once. """
+
+                log.add_transfer("Peer responded with reason '%(reason)s' for download request %(filename)s. "
+                                 "Attempting to request file as latin-1.", {
+                                     "reason": msg.reason,
+                                     "filename": i.filename
+                                 })
+
+                print("TF")
+                self.abort_transfer(i, send_fail_message=False)
+                i.legacy_attempt = True
+                self.get_file(i.user, i.filename, i.path, i)
+                break
+
+            elif i.status not in ("Aborted", "Paused"):
                 if i.status in self.TRANSFER:
                     self.abort_transfer(i, reason=msg.reason)
 
@@ -1114,47 +1096,6 @@ class Transfers:
 
         if msg.reason is not None:
 
-            for i in self.downloads:
-
-                if i.req != msg.req:
-                    continue
-
-                if msg.reason in ("File not shared.", "File not shared", "Remote file error") and \
-                        not i.legacy_attempt:
-                    """ The peer is possibly using an old client that doesn't support Unicode
-                    (Soulseek NS). Attempt to request file name encoded as latin-1 once. """
-
-                    i.req = new_id()
-                    realpath = self.eventprocessor.shares.virtual2real(i.filename)
-                    request = slskmessages.TransferRequest(None, 0, i.req, i.filename, self.get_file_size(realpath), realpath, legacy_client=True)
-                    self.eventprocessor.send_message_to_peer(i.user, request)
-                    i.legacy_attempt = True
-
-                    log.add_transfer("Peer responded with reason '%(reason)s' for download request %(request)s for file %(filename)s. "
-                                     "Attempting to request file as latin-1.", {
-                                         "reason": msg.reason,
-                                         "request": msg.req,
-                                         "filename": i.filename
-                                     })
-                    break
-
-                i.status = msg.reason
-                i.req = None
-                self.downloadsview.update(i)
-
-                if msg.reason == "Queued":
-
-                    if i.user not in self.users or self.users[i.user].status is None:
-                        if i.user not in self.eventprocessor.watchedusers:
-                            self.queue.put(slskmessages.AddUser(i.user))
-
-                    self.queue.put(
-                        slskmessages.PlaceInQueueRequest(msg.conn.conn, i.filename, i.legacy_attempt)
-                    )
-
-                self.check_upload_queue()
-                break
-
             for i in self.uploads:
 
                 if i.req != msg.req:
@@ -1190,18 +1131,6 @@ class Transfers:
                 self.check_upload_queue()
                 break
 
-        elif msg.filesize is not None:
-            for i in self.downloads:
-
-                if i.req != msg.req:
-                    continue
-
-                i.size = msg.filesize
-                i.status = "Establishing connection"
-                # Have to establish 'F' connection here
-                self.eventprocessor.send_message_to_peer(i.user, slskmessages.FileRequest(None, msg.req))
-                self.downloadsview.update(i)
-                break
         else:
             for i in self.uploads:
 
@@ -1801,8 +1730,7 @@ class Transfers:
     # Also ask for the queue position of downloads.
     def check_download_queue(self):
 
-        statuslist = self.FAILED_TRANSFERS + \
-            ["Getting status", "Getting address", "Connecting", "Waiting for peer to connect", "Requesting file", "Initializing transfer"]
+        statuslist = self.FAILED_TRANSFERS + ["Getting status", "Initializing transfer"]
 
         for transfer in self.downloads:
             if transfer.status in statuslist:
@@ -2076,12 +2004,6 @@ class Transfers:
             self._conn_close(conn, addr, i, "upload")
 
     def _conn_close(self, conn, addr, i, type):
-
-        if i.requestconn == conn and i.status == "Requesting file":
-            # This code is probably not needed anymore?
-            i.requestconn = None
-            i.status = "Connection closed by peer"
-            i.req = None
 
         self.abort_transfer(i, send_fail_message=False)  # Don't send "Aborted" message, let remote user recover
 

--- a/pynicotine/transfers.py
+++ b/pynicotine/transfers.py
@@ -1976,9 +1976,10 @@ class Transfers:
     def _conn_close(self, conn, addr, i, type):
 
         self.abort_transfer(i, send_fail_message=False)  # Don't send "Cancelled" message, let remote user recover
-        self.eventprocessor.send_message_to_peer(i.user, slskmessages.UploadFailed(None, i.filename, i.legacy_attempt))
 
         if i.status != "Finished":
+            self.eventprocessor.send_message_to_peer(i.user, slskmessages.UploadFailed(None, i.filename, i.legacy_attempt))
+
             if type == "download":
                 if self.user_logged_out(i.user):
                     i.status = "User logged off"


### PR DESCRIPTION
This PR reworks download queuing to send QueueUpload messages instead of TransferRequest, which has been deprecated for at least 13 years. See https://github.com/eLvErDe/museek-plus/commit/285a4a4a6292a93208443df6b713ae0076e11431#diff-e106f5596240e8c28bc4fbd5afd8ce4a9b807e4065c91b2b6fb32194dfdba1f2R197-R199

SoulseekQt, Soulseek NS and Museek+ have been sending QueueUpload messages for many years now, and Nicotine+ has accepted such requests for a long time as well.