### PR TITLE
Fix invalid path character issues on NTFS/FAT drives

### DIFF
--- a/pynicotine/gtkgui/userbrowse.py
+++ b/pynicotine/gtkgui/userbrowse.py
@@ -46,7 +46,7 @@ from pynicotine.gtkgui.utils import set_treeview_selected_row
 from pynicotine.gtkgui.utils import triggers_context_menu
 from pynicotine.gtkgui.utils import update_widget_visuals
 from pynicotine.logfacility import log
-from pynicotine.utils import clean_file
+from pynicotine.utils import get_path
 from pynicotine.utils import get_result_bitrate_length
 
 
@@ -544,16 +544,17 @@ class UserBrowse:
             log.add(_("Can't create directory '%(folder)s', reported error: %(error)s"), {'folder': sharesdir, 'error': msg})
 
         try:
-            filepath = os.path.join(sharesdir, clean_file(self.user))
-
-            with open(filepath, "w", encoding="utf-8") as sharesfile:
-                import json
-                json.dump(self.shares, sharesfile, ensure_ascii=False)
-
+            get_path(sharesdir, self.user, self.dump_shares_to_file)
             log.add(_("Saved list of shared files for user '%(user)s' to %(dir)s"), {'user': self.user, 'dir': sharesdir})
 
         except Exception as msg:
             log.add(_("Can't save shares, '%(user)s', reported error: %(error)s"), {'user': self.user, 'error': msg})
+
+    def dump_shares_to_file(self, path):
+
+        with open(path, "w", encoding="utf-8") as sharesfile:
+            import json
+            json.dump(self.shares, sharesfile, ensure_ascii=False)
 
     def save_columns(self):
         save_columns("user_browse", self.FileTreeView.get_columns())

--- a/pynicotine/gtkgui/utils.py
+++ b/pynicotine/gtkgui/utils.py
@@ -44,8 +44,8 @@ from pynicotine.gtkgui.dialogs import choose_image
 from pynicotine.gtkgui.dialogs import entry_dialog
 from pynicotine.gtkgui.dialogs import option_dialog
 from pynicotine.logfacility import log
-from pynicotine.utils import clean_file
 from pynicotine.utils import execute_command
+from pynicotine.utils import get_path
 
 
 URL_RE = re.compile("(\\w+\\://[^\\s]+)|(www\\.\\w+\\.\\w+.*?)|(mailto\\:[^\\s]+)")
@@ -484,22 +484,43 @@ def open_file_path(file_path, command=None):
 
 
 def open_log(folder, filename):
+    _handle_log(folder, filename, open_log_callback)
+
+
+def delete_log(folder, filename):
+    _handle_log(folder, filename, delete_log_callback)
+
+
+def _handle_log(folder, filename, callback):
 
     try:
         if not os.path.isdir(folder):
             os.makedirs(folder)
 
-        path = os.path.join(folder, clean_file(filename.replace(os.sep, "-")) + ".log")
-
-        if not os.path.exists(path):
-            with open(path, "w"):
-                # No logs, create empty file
-                pass
-
-        open_file_path(path)
+        filename = filename.replace(os.sep, "-") + ".log"
+        get_path(folder, filename, callback)
 
     except Exception as e:
-        log.add("Failed to open log file: %s", e)
+        log.add("Failed to process log file: %s", e)
+
+
+def open_log_callback(path, data):
+
+    if not os.path.exists(path):
+        with open(path, "w"):
+            # No logs, create empty file
+            pass
+
+    open_file_path(path)
+
+
+def delete_log_callback(path, data):
+
+    with open(path, "w"):
+        # Check if path should contain special characters
+        pass
+
+    os.remove(path)
 
 
 def open_uri(uri, window):

--- a/pynicotine/pynicotine.py
+++ b/pynicotine/pynicotine.py
@@ -46,7 +46,6 @@ from pynicotine.search import Search
 from pynicotine.shares import Shares
 from pynicotine.slskmessages import new_id
 from pynicotine.transfers import Statistics
-from pynicotine.utils import clean_file
 from pynicotine.utils import unescape
 
 
@@ -120,7 +119,7 @@ class NetworkEventProcessor:
 
         except Exception:
             import shutil
-            corruptfile = ".".join([config, clean_file(time.strftime("%Y-%m-%d_%H_%M_%S")), "corrupt"])
+            corruptfile = ".".join([config, time.strftime("%Y-%m-%d_%H_%M_%S"), "corrupt"])
             shutil.move(config, corruptfile)
             short = _("Your config file is corrupt")
             long = _("We're sorry, but it seems your configuration file is corrupt. Please reconfigure Nicotine+.\n\nWe renamed your old configuration file to\n%(corrupt)s\nIf you open this file with a text editor you might be able to rescue some of your settings.") % {'corrupt': corruptfile}


### PR DESCRIPTION
- Rework our path handling to strip out illegal characters for NTFS and FAT drives, instead of hardcoding this behavior for Windows.
- Remove some old code from the PySoulSeek days related to incomplete downloads.

Fixes #1019