### PR TITLE
Bump Flatpak runtime version to GNOME 40 

### DIFF
--- a/packaging/flatpak/org.nicotine_plus.Nicotine.yaml
+++ b/packaging/flatpak/org.nicotine_plus.Nicotine.yaml
@@ -91,8 +91,8 @@ modules:
        - '*'
     sources:
       - url: https://github.com/freedesktop/dbus-glib.git
-        tag: dbus-glib-0.110
-        commit: ffeb6909967ff79585a7ede85227da94f04ecb01
+        tag: dbus-glib-0.112
+        commit: f16a4ec9a37d067aea4772ce35ae5b88d9416cab
         type: git
 
   - name: libayatana-appindicator

--- a/packaging/flatpak/org.nicotine_plus.Nicotine.yaml
+++ b/packaging/flatpak/org.nicotine_plus.Nicotine.yaml
@@ -1,7 +1,7 @@
 ---
 app-id: org.nicotine_plus.Nicotine
 runtime: org.gnome.Platform
-runtime-version: '3.38'
+runtime-version: '40'
 sdk: org.gnome.Sdk
 command: nicotine
 


### PR DESCRIPTION
Tested it, seems to work fine.