### PR TITLE
Stop using blocking dialog functions in preparation for GTK 4

### DIFF
--- a/pynicotine/gtkgui/chatrooms.py
+++ b/pynicotine/gtkgui/chatrooms.py
@@ -1577,14 +1577,14 @@ class ChatRoom:
     def on_view_room_log(self, *args):
         open_log(config.sections["logging"]["roomlogsdir"], self.room)
 
-    def delete_room_log_response(self, dialog, response, data):
-
-        if response == Gtk.ResponseType.OK:
-            delete_log(config.sections["logging"]["roomlogsdir"], self.room)
-            self.on_clear_messages(dialog)
-            self.on_clear_activity_log(dialog)
+    def on_delete_room_log_response(self, dialog, response_id, data):
 
         dialog.destroy()
+
+        if response_id == Gtk.ResponseType.OK:
+            delete_log(config.sections["logging"]["roomlogsdir"], self.room)
+            self.on_clear_messages()
+            self.on_clear_activity_log()
 
     def on_delete_room_log(self, *args):
 
@@ -1592,7 +1592,7 @@ class ChatRoom:
             parent=self.frame.MainWindow,
             title=_('Delete Logged Messages?'),
             message=_('Are you sure you wish to permanently delete all logged messages for this room?'),
-            callback=self.delete_room_log_response
+            callback=self.on_delete_room_log_response
         )
 
     def on_clear_messages(self, *args):

--- a/pynicotine/gtkgui/downloads.py
+++ b/pynicotine/gtkgui/downloads.py
@@ -62,6 +62,14 @@ class Downloads(TransferList):
             callback=self.on_clear_response
         )
 
+    def folder_download_response(self, dialog, response_id, data):
+
+        dialog.destroy()
+
+        if response_id == Gtk.ResponseType.OK:
+            conn, file_list = data
+            self.frame.np.transfers.folder_contents_response(conn, file_list)
+
     def download_large_folder(self, username, folder, numfiles, conn, file_list):
 
         option_dialog(
@@ -71,13 +79,6 @@ class Downloads(TransferList):
             callback=self.folder_download_response,
             callback_data=(conn, file_list)
         )
-
-    def folder_download_response(self, dialog, response, data):
-
-        if response == Gtk.ResponseType.OK:
-            self.frame.np.transfers.folder_contents_response(data[0], data[1])
-
-        dialog.destroy()
 
     def update_download_filters(self):
 

--- a/pynicotine/gtkgui/fileproperties.py
+++ b/pynicotine/gtkgui/fileproperties.py
@@ -21,6 +21,8 @@
 
 import os
 
+from gi.repository import Gdk
+
 from pynicotine.gtkgui.utils import load_ui_elements
 
 
@@ -142,4 +144,4 @@ class FileProperties:
 
     def show(self):
         self.update_current_file()
-        self.FilePropertiesDialog.show()
+        self.FilePropertiesDialog.present_with_time(Gdk.CURRENT_TIME)

--- a/pynicotine/gtkgui/privatechat.py
+++ b/pynicotine/gtkgui/privatechat.py
@@ -463,13 +463,13 @@ class PrivateChat:
     def on_view_chat_log(self, *args):
         open_log(config.sections["logging"]["privatelogsdir"], self.user)
 
-    def delete_chat_log_response(self, dialog, response, data):
-
-        if response == Gtk.ResponseType.OK:
-            delete_log(config.sections["logging"]["privatelogsdir"], self.user)
-            self.on_clear_messages(dialog)
+    def on_delete_chat_log_response(self, dialog, response_id, data):
 
         dialog.destroy()
+
+        if response_id == Gtk.ResponseType.OK:
+            delete_log(config.sections["logging"]["privatelogsdir"], self.user)
+            self.on_clear_messages()
 
     def on_delete_chat_log(self, *args):
 
@@ -477,7 +477,7 @@ class PrivateChat:
             parent=self.frame.MainWindow,
             title=_('Delete Logged Messages?'),
             message=_('Are you sure you wish to permanently delete all logged messages for this user?'),
-            callback=self.delete_chat_log_response
+            callback=self.on_delete_chat_log_response
         )
 
     def on_clear_messages(self, *args):

--- a/pynicotine/gtkgui/roomwall.py
+++ b/pynicotine/gtkgui/roomwall.py
@@ -18,6 +18,8 @@
 
 import os
 
+from gi.repository import Gdk
+
 from pynicotine import slskmessages
 from pynicotine.config import config
 from pynicotine.gtkgui.utils import append_line
@@ -69,7 +71,7 @@ class RoomWall:
 
         tickers = self.room.tickers.get_tickers()
         append_line(self.RoomWallList, "%s" % ("\n".join(["[%s] %s" % (user, msg) for (user, msg) in tickers])), showstamp=False, scroll=False)
-        self.RoomWallDialog.show()
+        self.RoomWallDialog.present_with_time(Gdk.CURRENT_TIME)
 
 
 class Tickers:

--- a/pynicotine/gtkgui/search.py
+++ b/pynicotine/gtkgui/search.py
@@ -1216,16 +1216,17 @@ class Search:
             if not file[1].endswith('\\'):
                 self.frame.np.transfers.get_file(file[0], file[1], prefix, size=file[2], bitrate=file[3], length=file[4], checkduplicate=True)
 
+    def on_download_files_to_selected(self, selected, data):
+        self.on_download_files(prefix=selected)
+
     def on_download_files_to(self, *args):
 
-        folder = choose_dir(self.frame.MainWindow, config.sections["transfers"]["downloaddir"], multichoice=False)
-
-        if folder is None:
-            return
-
-        for folders in folder:
-            self.on_download_files(prefix=folders)
-            break
+        choose_dir(
+            parent=self.frame.MainWindow,
+            callback=self.on_download_files_to_selected,
+            initialdir=config.sections["transfers"]["downloaddir"],
+            multichoice=False
+        )
 
     def on_download_folders(self, *args, download_location=""):
 
@@ -1277,12 +1278,17 @@ class Search:
             # Ask for the rest of the files in the folder
             self.frame.np.send_message_to_peer(user, slskmessages.FolderContentsRequest(None, folder))
 
+    def on_download_folders_to_selected(self, selected, data):
+        self.on_download_folders(download_location=selected)
+
     def on_download_folders_to(self, *args):
 
-        directories = choose_dir(self.frame.MainWindow, config.sections["transfers"]["downloaddir"], multichoice=False)
-
-        if directories:
-            self.on_download_folders(download_location=directories[0])
+        choose_dir(
+            parent=self.frame.MainWindow,
+            callback=self.on_download_folders_to_selected,
+            initialdir=config.sections["transfers"]["downloaddir"],
+            multichoice=False
+        )
 
     def on_copy_file_path(self, *args):
         user, path = next(iter(self.selected_results))[:2]

--- a/pynicotine/gtkgui/statistics.py
+++ b/pynicotine/gtkgui/statistics.py
@@ -18,6 +18,7 @@
 
 import os
 
+from gi.repository import Gdk
 from gi.repository import Gtk
 
 from pynicotine.config import config
@@ -53,19 +54,20 @@ class Statistics:
         getattr(self, stat_id + "_session").set_text(session_value)
         getattr(self, stat_id + "_total").set_text(total_value)
 
-    def reset_stats_response(self, dialog, response, data):
-
-        if response == Gtk.ResponseType.OK:
-            self.frame.np.statistics.reset_stats()
+    def on_reset_statistics_response(self, dialog, response_id, data):
 
         dialog.destroy()
 
+        if response_id == Gtk.ResponseType.OK:
+            self.frame.np.statistics.reset_stats()
+
     def on_reset_statistics(self, *args):
+
         option_dialog(
             parent=self.StatisticsDialog,
             title=_('Reset Transfer Statistics?'),
             message=_('Are you sure you wish to reset transfer statistics?'),
-            callback=self.reset_stats_response
+            callback=self.on_reset_statistics_response
         )
 
     def hide(self, *args):
@@ -73,4 +75,4 @@ class Statistics:
         return True
 
     def show(self):
-        self.StatisticsDialog.show()
+        self.StatisticsDialog.present_with_time(Gdk.CURRENT_TIME)

--- a/pynicotine/gtkgui/transferlist.py
+++ b/pynicotine/gtkgui/transferlist.py
@@ -905,11 +905,12 @@ class TransferList:
         self.select_transfers()
         self.abort_transfers(clear=True)
 
-    def on_clear_response(self, dialog, response, data=None):
-        if response == Gtk.ResponseType.OK:
-            self.clear_transfers(["Queued"])
+    def on_clear_response(self, dialog, response_id, data):
 
         dialog.destroy()
+
+        if response_id == Gtk.ResponseType.OK:
+            self.clear_transfers(["Queued"])
 
     def on_clear_queued(self, *args):
         self.clear_transfers(["Queued"])

--- a/pynicotine/gtkgui/userinfo.py
+++ b/pynicotine/gtkgui/userinfo.py
@@ -434,28 +434,26 @@ class UserInfo:
     def on_ignore_user(self, *args):
         self.frame.np.network_filter.ignore_user(self.user)
 
+    def on_save_picture_response(self, selected, data):
+
+        if not os.path.exists(selected):
+            self.image_pixbuf.savev(selected, "jpeg", ["quality"], ["100"])
+            log.add(_("Picture saved to %s"), selected)
+        else:
+            log.add(_("Picture not saved, %s already exists."), selected)
+
     def on_save_picture(self, *args):
 
         if self.image is None or self.image_pixbuf is None:
             return
 
-        response = save_file(
-            self.frame.MainWindow,
-            config.sections["transfers"]["downloaddir"],
-            "%s %s.jpg" % (self.user, time.strftime("%Y-%m-%d %H_%M_%S")),
+        save_file(
+            parent=self.frame.MainWindow,
+            callback=self.on_save_picture_response,
+            initialdir=config.sections["transfers"]["downloaddir"],
+            initialfile="%s %s.jpg" % (self.user, time.strftime("%Y-%m-%d %H_%M_%S")),
             title="Save as..."
         )
-
-        if not response:
-            return
-
-        pathname = response[0]
-
-        if not os.path.exists(pathname):
-            self.image_pixbuf.savev(pathname, "jpeg", ["quality"], ["100"])
-            log.add(_("Picture saved to %s"), pathname)
-        else:
-            log.add(_("Picture not saved, %s already exists."), pathname)
 
     def on_image_click(self, widget, event):
 

--- a/pynicotine/gtkgui/userlist.py
+++ b/pynicotine/gtkgui/userlist.py
@@ -535,6 +535,22 @@ class UserList:
         self.save_user_list()
         action.set_state(state)
 
+    def on_edit_comments_response(self, dialog, response_id, user):
+
+        comments = dialog.get_response_value()
+        dialog.destroy()
+
+        if comments is None:
+            return
+
+        for i in self.usersmodel:
+            if i[2] == user:
+                i[9] = comments
+                self.usersmodel.set_value(i.iter, 9, comments)
+                break
+
+        self.save_user_list()
+
     def on_edit_comments(self, *args):
 
         user = self.popup_menu.get_user()
@@ -546,16 +562,14 @@ class UserList:
         else:
             comments = ""
 
-        comments = entry_dialog(self.frame.MainWindow, _("Edit comments") + "...", _("Comments") + ":", comments)
-
-        if comments is not None:
-            for i in self.usersmodel:
-                if i[2] == user:
-                    i[9] = comments
-                    self.usersmodel.set_value(i.iter, 9, comments)
-                    break
-
-            self.save_user_list()
+        entry_dialog(
+            parent=self.frame.MainWindow,
+            title=_("Edit comments") + "...",
+            message=_("Comments") + ":",
+            callback=self.on_edit_comments_response,
+            callback_data=user,
+            default=comments
+        )
 
     def on_remove_user(self, *args):
         self.remove_from_list(self.popup_menu.get_user())

--- a/pynicotine/gtkgui/widgets/iconnotebook.py
+++ b/pynicotine/gtkgui/widgets/iconnotebook.py
@@ -359,23 +359,23 @@ class IconNotebook:
         if self.notebook.get_n_pages() == 0:
             self.notebook.set_show_tabs(False)
 
+    def remove_all_pages_response(self, dialog, response_id, data):
+
+        dialog.destroy()
+
+        if response_id == Gtk.ResponseType.OK:
+            for page in self.notebook.get_children():
+                tab_label, menu_label = self.get_labels(page)
+                tab_label.onclose(dialog)
+
     def remove_all_pages(self):
 
         option_dialog(
             parent=self.notebook.get_toplevel(),
             title=_('Close All Tabs?'),
             message=_('Are you sure you wish to close all tabs?'),
-            callback=self.remove_all_pages_cb
+            callback=self.remove_all_pages_response
         )
-
-    def remove_all_pages_cb(self, dialog, response, data):
-
-        if response == Gtk.ResponseType.OK:
-            for page in self.notebook.get_children():
-                tab_label, menu_label = self.get_labels(page)
-                tab_label.onclose(dialog)
-
-        dialog.destroy()
 
     def get_page_owner(self, page, items):
 

--- a/pynicotine/gtkgui/widgets/trayicon.py
+++ b/pynicotine/gtkgui/widgets/trayicon.py
@@ -110,81 +110,96 @@ class TrayIcon:
         self.frame.on_uploads()
         self.show_window()
 
-    def on_open_private_chat(self, *args):
+    def on_open_private_chat_response(self, dialog, response_id, data):
 
-        # popup
-        users = []
-        for entry in config.sections["server"]["userlist"]:
-            users.append(entry[0])
+        user = dialog.get_response_value()
+        dialog.destroy()
 
-        users.sort()
-        user = combo_box_dialog(
-            parent=self.frame.application.get_active_window(),
-            title=GLib.get_application_name() + ": " + _("Start Messaging"),
-            message=_('Enter the User who you wish to send a private message:'),
-            droplist=users
-        )
+        if response_id != Gtk.ResponseType.OK:
+            return
 
         if user:
             self.frame.privatechats.send_message(user, show_user=True)
             self.frame.change_main_page("private")
             self.show_window()
 
-    def on_get_a_users_info(self, *args):
+    def on_open_private_chat(self, *args):
 
-        # popup
-        users = []
-        for entry in config.sections["server"]["userlist"]:
-            users.append(entry[0])
-
-        users.sort()
-
-        user = combo_box_dialog(
+        users = (i[0] for i in config.sections["server"]["userlist"])
+        combo_box_dialog(
             parent=self.frame.application.get_active_window(),
-            title=GLib.get_application_name() + ": " + _("Get User Info"),
-            message=_('Enter the User whose User Info you wish to receive:'),
+            title=GLib.get_application_name() + ": " + _("Start Messaging"),
+            message=_('Enter the User who you wish to send a private message:'),
+            callback=self.on_open_private_chat_response,
             droplist=users
         )
+
+    def on_get_a_users_info_response(self, dialog, response_id, data):
+
+        user = dialog.get_response_value()
+        dialog.destroy()
+
+        if response_id != Gtk.ResponseType.OK:
+            return
 
         if user:
             self.frame.local_user_info_request(user)
 
-    def on_get_a_users_ip(self, *args):
-        users = []
+    def on_get_a_users_info(self, *args):
 
-        for entry in config.sections["server"]["userlist"]:
-            users.append(entry[0])
-
-        users.sort()
-
-        user = combo_box_dialog(
+        users = (i[0] for i in config.sections["server"]["userlist"])
+        combo_box_dialog(
             parent=self.frame.application.get_active_window(),
-            title=GLib.get_application_name() + ": " + _("Get A User's IP"),
-            message=_('Enter the User whose IP Address you wish to receive:'),
+            title=GLib.get_application_name() + ": " + _("Get User Info"),
+            message=_('Enter the User whose User Info you wish to receive:'),
+            callback=self.on_get_a_users_info_response,
             droplist=users
         )
+
+    def on_get_a_users_ip_response(self, dialog, response_id, data):
+
+        user = dialog.get_response_value()
+        dialog.destroy()
+
+        if response_id != Gtk.ResponseType.OK:
+            return
 
         if user:
             self.frame.np.ip_requested.add(user)
             self.frame.np.queue.append(slskmessages.GetPeerAddress(user))
 
-    def on_get_a_users_shares(self, *args):
+    def on_get_a_users_ip(self, *args):
 
-        users = []
-        for entry in config.sections["server"]["userlist"]:
-            users.append(entry[0])
-
-        users.sort()
-
-        user = combo_box_dialog(
+        users = (i[0] for i in config.sections["server"]["userlist"])
+        combo_box_dialog(
             parent=self.frame.application.get_active_window(),
-            title=GLib.get_application_name() + ": " + _("Get A User's Shares List"),
-            message=_('Enter the User whose Shares List you wish to receive:'),
+            title=GLib.get_application_name() + ": " + _("Get A User's IP"),
+            message=_('Enter the User whose IP Address you wish to receive:'),
+            callback=self.on_get_a_users_ip_response,
             droplist=users
         )
 
+    def on_get_a_users_shares_response(self, dialog, response_id, data):
+
+        user = dialog.get_response_value()
+        dialog.destroy()
+
+        if response_id != Gtk.ResponseType.OK:
+            return
+
         if user:
             self.frame.browse_user(user)
+
+    def on_get_a_users_shares(self, *args):
+
+        users = (i[0] for i in config.sections["server"]["userlist"])
+        combo_box_dialog(
+            parent=self.frame.application.get_active_window(),
+            title=GLib.get_application_name() + ": " + _("Get A User's Shares List"),
+            message=_('Enter the User whose Shares List you wish to receive:'),
+            callback=self.on_get_a_users_shares_response,
+            droplist=users
+        )
 
     # GtkStatusIcon fallback
     def on_status_icon_popup(self, status_icon, button, activate_time):

--- a/pynicotine/gtkgui/wishlist.py
+++ b/pynicotine/gtkgui/wishlist.py
@@ -23,6 +23,7 @@
 
 import os
 
+from gi.repository import Gdk
 from gi.repository import GLib
 from gi.repository import Gtk
 
@@ -103,15 +104,16 @@ class WishList:
     def _remove_wish(self, model, path, iterator, line):
         line.append(iterator)
 
-    def clear_wishlist_response(self, dialog, response, data):
-
-        if response == Gtk.ResponseType.OK:
-            for wish in self.wishes.copy():
-                self.remove_wish(wish)
+    def clear_wishlist_response(self, dialog, response_id, data):
 
         dialog.destroy()
 
+        if response_id == Gtk.ResponseType.OK:
+            for wish in self.wishes.copy():
+                self.remove_wish(wish)
+
     def on_clear_wishlist(self, *args):
+
         option_dialog(
             parent=self.WishListDialog,
             title=_('Clear Wishlist?'),
@@ -223,7 +225,7 @@ class WishList:
             update_widget_visuals(widget)
 
     def show(self, *args):
-        self.WishListDialog.show()
+        self.WishListDialog.present_with_time(Gdk.CURRENT_TIME)
 
     def quit(self, *args):
         self.WishListDialog.hide()


### PR DESCRIPTION
GtkDialog.run() has been removed in GTK 4. Replace it with GtkDialog.show() and the "response" signal.

See https://developer.gnome.org/gtk4/stable/ch41s02.html#id-1.7.4.4.81