### PR TITLE
Improve performance by prepending new transfers instead of appending

### DIFF
--- a/pynicotine/gtkgui/transferlist.py
+++ b/pynicotine/gtkgui/transferlist.py
@@ -293,7 +293,7 @@ class TransferList:
             self.update_specific(transfer)
 
         elif self.list is not None:
-            for transfer in self.list:
+            for transfer in reversed(self.list):
                 self.update_specific(transfer)
 
         if forceupdate or finished or \


### PR DESCRIPTION
When we have a large number of finished downloads or uploads, we needlessly iterate over these transfers each time we need to find a specific, active transfer, due to new transfers being appended to the list. By prepending these transfers instead, we can avoid doing unnecessary work.

Note that this PR does not change the behavior of the UI; new transfers are still appended in the transfer views.