### PR TITLE
Flatpak: Use Freedesktop runtime instead of GNOME runtime

### DIFF
--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -49,7 +49,7 @@ jobs:
   flatpak:
     runs-on: ubuntu-20.04
     container:
-      image: bilelmoussaoui/flatpak-github-actions:gnome-40
+      image: bilelmoussaoui/flatpak-github-actions:freedesktop-20.08
       options: --privileged
     steps:
     - uses: actions/checkout@v2

--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,5 @@ build/
 dist/
 debian/files
 nicotine_plus.egg-info/
+packaging/flatpak/build-dir/
+packaging/flatpak/.flatpak-builder/

--- a/packaging/flatpak/disable-gspell-vapigen.patch
+++ b/packaging/flatpak/disable-gspell-vapigen.patch
@@ -1,0 +1,13 @@
+--- a/configure.ac
++++ b/configure.ac
+@@ -117,9 +117,7 @@ AM_CONDITIONAL(INSTALLED_TESTS, test "x$enable_installed_tests" = "xyes")
+ AX_REQUIRE_DEFINED([GOBJECT_INTROSPECTION_CHECK])
+ GOBJECT_INTROSPECTION_CHECK([1.42.0])
+
+-# Vala
+-AX_REQUIRE_DEFINED([VAPIGEN_CHECK])
+-VAPIGEN_CHECK
++AM_CONDITIONAL(ENABLE_VAPIGEN, false)
+
+ # Code coverage for unit tests
+ AX_REQUIRE_DEFINED([AX_CODE_COVERAGE])

--- a/packaging/flatpak/org.nicotine_plus.Nicotine.yaml
+++ b/packaging/flatpak/org.nicotine_plus.Nicotine.yaml
@@ -1,8 +1,8 @@
 ---
 app-id: org.nicotine_plus.Nicotine
-runtime: org.gnome.Platform
-runtime-version: '40'
-sdk: org.gnome.Sdk
+runtime: org.freedesktop.Platform
+runtime-version: '20.08'
+sdk: org.freedesktop.Sdk
 command: nicotine
 
 finish-args:
@@ -31,42 +31,53 @@ cleanup:
   - '*.la'
 
 modules:
+  # Bindings
+
+  - name: pygobject
+    buildsystem: meson
+    config-opts:
+      - -Dpycairo=disabled
+      - -Dtests=false
+    sources:
+      - url: https://download.gnome.org/sources/pygobject/3.40/pygobject-3.40.1.tar.xz
+        sha256: 00c6d591f4cb40c335ab1fd3e8c17869ba15cfda54416fe363290af766790035
+        type: archive
+
   # App Indicator
-
-  - name: mate-common
-    cleanup:
-      - '*'
-    sources:
-      - url: https://github.com/mate-desktop/mate-common.git
-        tag: v1.24.2
-        commit: 93ca8c7f6ec902e5963f4d0ec12b32cf833de2d0
-        type: git
-
-  - name: intltool
-    cleanup:
-      - '*'
-    sources:
-      - url: https://gitlab.gnome.org/World/intltool.git
-        tag: release-0_51_0
-        commit: e6cf4480c8df86e02d6f2160ed93e9e27d4451dd
-        type: git
 
   - name: libdbusmenu
     config-opts:
       - --disable-dumper
       - --disable-introspection
       - --disable-static
+      - --disable-tests
       - --disable-vala
       - --with-gtk=3
     build-options:
       cflags: -Wno-error
+      env:
+        HAVE_VALGRIND_TRUE: '#'
+        HAVE_VALGRIND_FALSE: ''
     cleanup:
       - /share/doc
       - /share/libdbusmenu
     sources:
-      - url: https://launchpad.net/libdbusmenu/16.04/16.04.0/+download/libdbusmenu-16.04.0.tar.gz
-        sha256: b9cc4a2acd74509435892823607d966d424bd9ad5d0b00938f27240a1bfa878a
+      - url: https://launchpad.net/ubuntu/+archive/primary/+sourcefiles/libdbusmenu/16.04.1+18.10.20180917-0ubuntu6/libdbusmenu_16.04.1+18.10.20180917.orig.tar.gz
+        sha256: 9be5dc0f2657a9eb76b02d2cdfafa4490652c70bcdfafba5574c505afd2bbe79
         type: archive
+    modules:
+      - name: gnome-common
+        sources:
+          - url: https://download.gnome.org/sources/gnome-common/3.18/gnome-common-3.18.0.tar.xz
+            sha256: 22569e370ae755e04527b76328befc4c73b62bfd4a572499fde116b8318af8cf
+            type: archive
+      - name: intltool
+        cleanup:
+          - '*'
+        sources:
+          - url: https://launchpad.net/intltool/trunk/0.51.0/+download/intltool-0.51.0.tar.gz
+            sha256: 67c74d94196b153b774ab9f89b2fa6c6ba79352407037c8c14d5aeb334e959cd
+            type: archive
 
   - name: libayatana-indicator
     config-opts:
@@ -77,23 +88,17 @@ modules:
     cleanup:
       - /share/libayatana-indicator
     sources:
-      - url: https://github.com/AyatanaIndicators/libayatana-indicator.git
-        tag: 0.7.1
-        commit: 74cfb2106eefed78279c01d69079a29fb0232564
-        type: git
-
-  - name: dbus-glib
-    config-opts:
-      - --disable-gtk-doc
-      - --disable-static
-      - --disable-tests
-    cleanup:
-       - '*'
-    sources:
-      - url: https://github.com/freedesktop/dbus-glib.git
-        tag: dbus-glib-0.112
-        commit: f16a4ec9a37d067aea4772ce35ae5b88d9416cab
-        type: git
+      - url: https://github.com/AyatanaIndicators/libayatana-indicator/archive/refs/tags/0.7.1.tar.gz
+        sha256: 63f6cfc96b212ce0e65a4507b9830da7263d82cb80374f098b5d863a13de93e8
+        type: archive
+    modules:
+      - name: mate-common
+        cleanup:
+          - '*'
+        sources:
+          - url: https://github.com/mate-desktop/mate-common/releases/download/v1.24.2/mate-common-1.24.2.tar.xz
+            sha256: 71d2013f5743c71e10e04f3c2205d3bb8db1ddb26954a4197801cb5b3c152b6b
+            type: archive
 
   - name: libayatana-appindicator
     config-opts:
@@ -101,22 +106,41 @@ modules:
       - --disable-static
       - --disable-tests
       - --with-gtk=3
+    build-options:
+      env:
+        TESTDEPS_CFLAGS: ' '
+        TESTDEPS_LIBS: '-lz'
     sources:
-      - url: https://github.com/AyatanaIndicators/libayatana-appindicator.git
-        tag: 0.5.5
-        commit: c43a76e643ab930725d20d306bc3ca5e7874eebe
-        type: git
+      - url: https://github.com/AyatanaIndicators/libayatana-appindicator/archive/refs/tags/0.5.5.tar.gz
+        sha256: 55e47e94f54e6f2f13bcc06ab20530ad0a1412282a8775331af41788b59ee331
+        type: archive
 
   # Spell Checking
 
   - name: gspell
+    config-opts:
+      - --disable-gtk-doc
+      - --disable-static
+      - --disable-valgrind
     cleanup:
       - /bin
     sources:
-      - url: https://gitlab.gnome.org/GNOME/gspell.git
-        tag: 1.9.1
-        commit: 5300d93dae00998801ef1be48da71dac4e2ebd1b
-        type: git
+      - url: https://download.gnome.org/sources/gspell/1.9/gspell-1.9.1.tar.xz
+        sha256: dcbb769dfdde8e3c0a8ed3102ce7e661abbf7ddf85df08b29915e92cd723abdd
+        type: archive
+      - path: disable-gspell-vapigen.patch
+        type: patch
+    modules:
+      - name: enchant
+        config-opts:
+          - --disable-gcc-warnings
+        cleanup:
+          - /bin
+          - /share/man
+        sources:
+          - url: https://github.com/AbiWord/enchant/releases/download/v2.2.15/enchant-2.2.15.tar.gz
+            sha256: 3b0f2215578115f28e2a6aa549b35128600394304bd79d6f28b0d3b3d6f46c03
+            type: archive
 
   # Nicotine+
 
@@ -126,4 +150,4 @@ modules:
       - path: '../../'
         type: dir
     build-commands:
-      - pip3 install . --no-deps --prefix="${FLATPAK_DEST}"
+      - pip3 install . --prefix="${FLATPAK_DEST}"


### PR DESCRIPTION
- Use Freedesktop runtime instead of GNOME runtime, since we use few GNOME dependencies
- Use source archives instead of repos, since the former downloads faster