### PR TITLE
Remove Python 3.5 from list of supported versions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python: [3.5, 3.6, 3.7, 3.8, 3.9, 3.10.0-beta.1, pypy-3.6, pypy-3.7]
+        python: [3.6, 3.7, 3.8, 3.9, 3.10.0-beta.1, pypy-3.6, pypy-3.7]
     steps:
       - name: Checkout code
         uses: actions/checkout@v2

--- a/debian/control
+++ b/debian/control
@@ -11,14 +11,14 @@ Build-Depends:
     gettext,
     gir1.2-gtk-3.0,
     lintian,
-    python3 (>= 3.5),
+    python3 (>= 3.6),
     python3-gdbm,
     python3-gi,
     python3-pytest,
     xvfb
 Vcs-Git: https://github.com/Nicotine-Plus/nicotine-plus.git
 Vcs-browser: https://github.com/Nicotine-Plus/nicotine-plus
-X-Python-Version: >= 3.5
+X-Python-Version: >= 3.6
 Homepage: https://nicotine-plus.org
 Rules-Requires-Root: no
 
@@ -28,7 +28,7 @@ Depends:
     ${python3:Depends},
     ${misc:Depends},
     gir1.2-gtk-3.0,
-    python3 (>= 3.5),
+    python3 (>= 3.6),
     python3-gdbm,
     python3-gi
 Recommends:

--- a/doc/DEPENDENCIES.md
+++ b/doc/DEPENDENCIES.md
@@ -4,7 +4,7 @@
 
 ### Required
 
-* [python3](https://www.python.org/) >= 3.5 for interpreter;
+* [python3](https://www.python.org/) >= 3.6 for interpreter;
 * [python3-gi](https://pygobject.readthedocs.io/en/latest/getting_started.html) for using GObject introspection with Python 3;
 * [gir1.2-gtk-3.0](https://www.gtk.org/) for GObject introspection bindings for GTK;
 * [gdbm](https://www.gnu.org.ua/software/gdbm/) or [semidbm](https://semidbm.readthedocs.io/en/latest/) for scanning shared files.
@@ -70,7 +70,7 @@ sudo dnf install python3-flake8 python3-pep8-naming python3-pytest
 ```
 
 #### Check the Python version.
-To check that the Python version you are using is 3.5 or newer, use `python -V`. On a lot of older systems, the response will look something like this:
+To check that the Python version you are using is recent enough, use `python -V`. On a lot of older systems, the response will look something like this:
 
 ```console
 % python -V

--- a/doc/DEVELOPING.md
+++ b/doc/DEVELOPING.md
@@ -17,7 +17,7 @@ This document contains important information about Nicotine+ design decisions an
 
 Nicotine+ is Python application, built on backend code from the PySoulSeek project started in 2001. We only allow Python code in the main client, as this makes it easy to distribute and run Nicotine+ on virtually any system. In turn, we are able to devote more time towards implementing bug fixes and additional functionality.
 
-We aim to support the oldest minor Python 3 version still used by active, supported releases of distributions and operating systems. In Nicotine+, support for a Python version should be removed once no distributions use it anymore. The minimum version Nicotine+ currently supports is 3.5. This version should be dropped once Ubuntu 16.04 reaches EOL in 2021.
+We aim to support the oldest minor Python 3 version still used by supported releases of distributions and operating systems. The minimum version Nicotine+ currently supports is 3.6.
 
 ## GTK
 

--- a/nicotine
+++ b/nicotine
@@ -102,17 +102,20 @@ def check_arguments():
 
 def check_dependencies():
 
-    # Require Python 3.5 or newer
+    # Require Python >= 3.6
     try:
-        assert sys.version_info[:2] >= (3, 5), '.'.join(
+        assert sys.version_info[:2] >= (3, 6), '.'.join(
             map(str, sys.version_info[:3])
         )
 
     except AssertionError as e:
-        return _("""You're using an unsupported version of Python (%s).
-You should install Python 3.5 or newer.""") % (e)
+        return _("""You are using an unsupported version of Python (%(old_version)s).
+You should install Python %(min_version)s or newer.""") % {
+            "old_version": e,
+            "min_version": "3.6"
+        }
 
-    # Require GTK+ >= 3
+    # Require GTK+ >= 3.18
     try:
         import gi
 
@@ -122,9 +125,10 @@ You should install Python 3.5 or newer.""") % (e)
     else:
         try:
             gi.require_version('Gtk', '3.0')
+
         except ValueError as e:
-            return _("""You're using an unsupported version of GTK (%s).
-You should install GTK 3.0 or newer.""") % e
+            return _("""You are using an unsupported version of GTK.
+You should install GTK %s or newer.""") % "3.18"
 
     try:
         from gi.repository import Gtk  # noqa: F401

--- a/setup.py
+++ b/setup.py
@@ -133,7 +133,7 @@ functionality while keeping current with the Soulseek protocol."""
         package_data=PACKAGE_DATA,
         scripts=SCRIPTS,
         data_files=DATA_FILES,
-        python_requires=">=3.5",
+        python_requires=">=3.6",
         install_requires=["PyGObject>=3.18"],
         cmdclass={"update_pot": UpdatePot}
     )


### PR DESCRIPTION
Python 3.5 reached EOL last year, and support for Ubuntu 16.04 has also ended. While Debian 9 LTS still uses Python 3.5, I feel it's time to start encouraging users to upgrade. This initial step will be used to verify whether a substantial number of users still want support for this Python version or not. If not, we can start introducing Python 3.6 features into the code base, if desired.