### PR TITLE
PyInstaller: rebuild bootloader on WS2016 to reduce false positives

### DIFF
--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -61,7 +61,7 @@ jobs:
         cache-key: flatpak-builder-${{ github.sha }}
 
   windows:
-    runs-on: windows-latest
+    runs-on: windows-2016
     strategy:
       matrix:
         include: [

--- a/packaging/windows/dependencies-packaging.sh
+++ b/packaging/windows/dependencies-packaging.sh
@@ -22,10 +22,24 @@
 
 # Install dependencies from the main MinGW repos
 pacman --noconfirm -S --needed \
+  unzip \
   mingw-w64-$ARCH-nsis \
   mingw-w64-$ARCH-python-certifi
 
 # Install dependencies with pip
 pip3 install \
-  plyer \
-  pyinstaller==4.3
+  plyer
+
+# Install PyInstaller dependency
+# Rebuild bootloader to reduce false positives in anti-malware software
+wget https://github.com/pyinstaller/pyinstaller/archive/refs/tags/v4.3.zip
+unzip v4.3.zip
+cd pyinstaller-4.3/bootloader/
+
+if [ $ARCH == "i686" ]; then
+  python3 ./waf all --target-arch=32bit
+else
+  python3 ./waf all --target-arch=64bit
+fi
+
+pip3 install ..


### PR DESCRIPTION
This combination seems to yield the smallest number of false positives.
Closes https://github.com/Nicotine-Plus/nicotine-plus/issues/1373