### PR TITLE
Add debug log categories for downloads, uploads and chats

### DIFF
--- a/pynicotine/config.py
+++ b/pynicotine/config.py
@@ -174,7 +174,7 @@ class Config:
 
             "logging": {
                 "debug": False,
-                "debugmodes": [0, 1],
+                "debugmodes": [],
                 "debuglogsdir": os.path.join(log_dir, "debug"),
                 "logcollapsed": True,
                 "transferslogsdir": os.path.join(log_dir, "transfers"),
@@ -421,7 +421,7 @@ class Config:
                 os.makedirs(path)
 
         except OSError as msg:
-            log.add_warning(_("Can't create directory '%(path)s', reported error: %(error)s"), {'path': path, 'error': msg})
+            log.add(_("Can't create directory '%(path)s', reported error: %(error)s"), {'path': path, 'error': msg})
             return False
 
         return True
@@ -435,7 +435,7 @@ class Config:
                 os.makedirs(self.data_dir)
 
         except OSError as msg:
-            log.add_warning(_("Can't create directory '%(path)s', reported error: %(error)s"), {'path': self.data_dir, 'error': msg})
+            log.add(_("Can't create directory '%(path)s', reported error: %(error)s"), {'path': self.data_dir, 'error': msg})
 
     def load_config(self):
 
@@ -525,11 +525,11 @@ class Config:
 
                 # Check if config section exists in defaults
                 if i not in self.defaults:
-                    log.add_warning(_("Unknown config section '%s'"), i)
+                    log.add(_("Unknown config section '%s'"), i)
 
                 # Check if config option exists in defaults
                 elif j not in self.defaults[i] and i != "plugins" and j != "filter":
-                    log.add_warning(_("Unknown config option '%(option)s' in section '%(section)s'"), {'option': j, 'section': i})
+                    log.add(_("Unknown config option '%(option)s' in section '%(section)s'"), {'option': j, 'section': i})
 
                 else:
                     """ Attempt to get the default value for a config option. If there's no default
@@ -571,7 +571,7 @@ class Config:
                         # Value was unexpected, reset option
                         self.sections[i][j] = default_val
 
-                        log.add_warning("Config error: Couldn't decode '%s' section '%s' value '%s', value has been reset", (
+                        log.add("Config error: Couldn't decode '%s' section '%s' value '%s', value has been reset", (
                             (i[:120] + '..') if len(i) > 120 else i,
                             (j[:120] + '..') if len(j) > 120 else j,
                             (val[:120] + '..') if len(val) > 120 else val

--- a/pynicotine/gtkgui/chatrooms.py
+++ b/pynicotine/gtkgui/chatrooms.py
@@ -1082,12 +1082,10 @@ class ChatRoom:
 
         if not self.meta:
             self.frame.np.queue.append(slskmessages.LeaveRoom(self.room))
-        else:
-            if self.room == 'Public ':
-                self.frame.np.queue.append(slskmessages.LeavePublicRoom())
-                self.chatrooms.leave_room(slskmessages.LeaveRoom(self.room))  # Faking protocol msg
-            else:
-                log.add_warning(_("Unknown meta chatroom closed"))
+
+        elif self.room == 'Public ':
+            self.frame.np.queue.append(slskmessages.LeavePublicRoom())
+            self.chatrooms.leave_room(slskmessages.LeaveRoom(self.room))  # Faking protocol msg
 
         self.frame.np.pluginhandler.leave_chatroom_notification(self.room)
 

--- a/pynicotine/gtkgui/frame.py
+++ b/pynicotine/gtkgui/frame.py
@@ -872,34 +872,44 @@ class NicotineFrame:
 
         # Debug Logging
 
-        state = (1 in config.sections["logging"]["debugmodes"])
-        action = Gio.SimpleAction.new_stateful("debugwarnings", None, GLib.Variant.new_boolean(state))
-        action.connect("change-state", self.on_debug_warnings)
+        state = ("download" in config.sections["logging"]["debugmodes"])
+        action = Gio.SimpleAction.new_stateful("debugdownloads", None, GLib.Variant.new_boolean(state))
+        action.connect("change-state", self.on_debug_downloads)
         self.application.add_action(action)
 
-        state = (2 in config.sections["logging"]["debugmodes"])
+        state = ("upload" in config.sections["logging"]["debugmodes"])
+        action = Gio.SimpleAction.new_stateful("debuguploads", None, GLib.Variant.new_boolean(state))
+        action.connect("change-state", self.on_debug_uploads)
+        self.application.add_action(action)
+
+        state = ("search" in config.sections["logging"]["debugmodes"])
         action = Gio.SimpleAction.new_stateful("debugsearches", None, GLib.Variant.new_boolean(state))
         action.connect("change-state", self.on_debug_searches)
         self.application.add_action(action)
 
-        state = (3 in config.sections["logging"]["debugmodes"])
+        state = ("chat" in config.sections["logging"]["debugmodes"])
+        action = Gio.SimpleAction.new_stateful("debugchat", None, GLib.Variant.new_boolean(state))
+        action.connect("change-state", self.on_debug_chat)
+        self.application.add_action(action)
+
+        state = ("connection" in config.sections["logging"]["debugmodes"])
         action = Gio.SimpleAction.new_stateful("debugconnections", None, GLib.Variant.new_boolean(state))
         action.connect("change-state", self.on_debug_connections)
         self.application.add_action(action)
 
-        state = (4 in config.sections["logging"]["debugmodes"])
+        state = ("message" in config.sections["logging"]["debugmodes"])
         action = Gio.SimpleAction.new_stateful("debugmessages", None, GLib.Variant.new_boolean(state))
         action.connect("change-state", self.on_debug_messages)
         self.application.add_action(action)
 
-        state = (5 in config.sections["logging"]["debugmodes"])
+        state = ("transfer" in config.sections["logging"]["debugmodes"])
         action = Gio.SimpleAction.new_stateful("debugtransfers", None, GLib.Variant.new_boolean(state))
         action.connect("change-state", self.on_debug_transfers)
         self.application.add_action(action)
 
-        state = (6 in config.sections["logging"]["debugmodes"])
-        action = Gio.SimpleAction.new_stateful("debugstatistics", None, GLib.Variant.new_boolean(state))
-        action.connect("change-state", self.on_debug_statistics)
+        state = ("miscellaneous" in config.sections["logging"]["debugmodes"])
+        action = Gio.SimpleAction.new_stateful("debugmiscellaneous", None, GLib.Variant.new_boolean(state))
+        action.connect("change-state", self.on_debug_miscellaneous)
         self.application.add_action(action)
 
     """ Menu """
@@ -1037,10 +1047,10 @@ class NicotineFrame:
     def set_show_log(self, show):
         if show:
             self.set_status_text("")
-            self.debugLogBox.show()
+            self.DebugLog.show()
             scroll_bottom(self.LogScrolledWindow)
         else:
-            self.debugLogBox.hide()
+            self.DebugLog.hide()
 
     def on_show_log(self, action, *args):
 
@@ -1051,7 +1061,7 @@ class NicotineFrame:
         config.sections["logging"]["logcollapsed"] = not state
 
     def set_show_debug(self, show):
-        self.debugButtonsBox.set_visible(show)
+        self.DebugButtons.set_visible(show)
 
     def on_show_debug(self, action, *args):
 
@@ -2006,7 +2016,7 @@ class NicotineFrame:
             if not os.path.exists(sharesdir):
                 os.makedirs(sharesdir)
         except Exception as msg:
-            log.add_warning(_("Can't create directory '%(folder)s', reported error: %(error)s"), {'folder': sharesdir, 'error': msg})
+            log.add(_("Can't create directory '%(folder)s', reported error: %(error)s"), {'folder': sharesdir, 'error': msg})
 
         choose_file(
             parent=self.MainWindow.get_toplevel(),
@@ -2141,9 +2151,6 @@ class NicotineFrame:
             GLib.idle_add(self.update_log, msg, debug_level, priority=GLib.PRIORITY_DEFAULT)
 
     def update_log(self, msg, debug_level=None):
-        '''For information about debug levels see
-        pydoc pynicotine.logfacility.logger.add
-        '''
 
         if self.shutdown:
             return
@@ -2210,59 +2217,38 @@ class NicotineFrame:
         if debug_level in config.sections["logging"]["debugmodes"]:
             config.sections["logging"]["debugmodes"].remove(debug_level)
 
-    def on_debug_warnings(self, action, state):
+    def set_debug_level(self, action, state, level):
 
         if state.get_boolean():
-            self.add_debug_level(1)
+            self.add_debug_level(level)
         else:
-            self.remove_debug_level(1)
+            self.remove_debug_level(level)
 
         action.set_state(state)
+
+    def on_debug_downloads(self, action, state):
+        self.set_debug_level(action, state, "download")
+
+    def on_debug_uploads(self, action, state):
+        self.set_debug_level(action, state, "upload")
 
     def on_debug_searches(self, action, state):
+        self.set_debug_level(action, state, "search")
 
-        if state.get_boolean():
-            self.add_debug_level(2)
-        else:
-            self.remove_debug_level(2)
-
-        action.set_state(state)
+    def on_debug_chat(self, action, state):
+        self.set_debug_level(action, state, "chat")
 
     def on_debug_connections(self, action, state):
-
-        if state.get_boolean():
-            self.add_debug_level(3)
-        else:
-            self.remove_debug_level(3)
-
-        action.set_state(state)
+        self.set_debug_level(action, state, "connection")
 
     def on_debug_messages(self, action, state):
-
-        if state.get_boolean():
-            self.add_debug_level(4)
-        else:
-            self.remove_debug_level(4)
-
-        action.set_state(state)
+        self.set_debug_level(action, state, "message")
 
     def on_debug_transfers(self, action, state):
+        self.set_debug_level(action, state, "transfer")
 
-        if state.get_boolean():
-            self.add_debug_level(5)
-        else:
-            self.remove_debug_level(5)
-
-        action.set_state(state)
-
-    def on_debug_statistics(self, action, state):
-
-        if state.get_boolean():
-            self.add_debug_level(6)
-        else:
-            self.remove_debug_level(6)
-
-        action.set_state(state)
+    def on_debug_miscellaneous(self, action, state):
+        self.set_debug_level(action, state, "miscellaneous")
 
     """ Status Bar """
 

--- a/pynicotine/gtkgui/notifications.py
+++ b/pynicotine/gtkgui/notifications.py
@@ -164,7 +164,7 @@ class Notifications:
             execute_command(config.sections["ui"]["speechcommand"], message, background=False)
 
         except Exception as error:
-            log.add_warning(_("Text-to-speech for message failed: %s"), str(error))
+            log.add(_("Text-to-speech for message failed: %s"), str(error))
 
     def new_notification(self, message, title=None, priority=Gio.NotificationPriority.NORMAL):
 

--- a/pynicotine/gtkgui/roomlist.py
+++ b/pynicotine/gtkgui/roomlist.py
@@ -198,7 +198,7 @@ class RoomList:
             try:
                 self.private_rooms[room[0]]['joined'] = room[1]
                 if self.private_rooms[room[0]]['owner'] != myusername:
-                    log.add_warning(_("I remember the room %(room)s being owned by %(previous)s, but the server says its owned by %(new)s."), {
+                    log.add("I remember the room %(room)s being owned by %(previous)s, but the server says its owned by %(new)s.", {
                         'room': room[0],
                         'previous': self.private_rooms[room[0]]['owner'],
                         'new': myusername
@@ -211,7 +211,7 @@ class RoomList:
             try:
                 self.private_rooms[room[0]]['joined'] = room[1]
                 if self.private_rooms[room[0]]['owner'] == myusername:
-                    log.add_warning(_("I remember the room %(room)s being owned by %(old)s, but the server says that's not true."), {
+                    log.add("I remember the room %(room)s being owned by %(old)s, but the server says that's not true.", {
                         'room': room[0],
                         'old': self.private_rooms[room[0]]['owner'],
                     })

--- a/pynicotine/gtkgui/search.py
+++ b/pynicotine/gtkgui/search.py
@@ -157,7 +157,7 @@ class Searches(IconNotebook):
                 (users, text) = feedback
 
         else:
-            log.add_warning("Unknown search mode, not using plugin system. Fix me!")
+            log.add("Unknown search mode, not using plugin system. Fix me!")
             feedback = True
 
         if feedback is None:
@@ -340,7 +340,7 @@ class Searches(IconNotebook):
         search_id = self.get_search_id(child)
 
         if search_id is None:
-            log.add_warning(_("Search ID was none when clicking tab"))
+            log.add("Search ID was none when clicking tab")
             return False
 
         menu = self.searches[search_id]["tab"].tab_menu
@@ -802,7 +802,7 @@ class Search:
             types = []
             for i in row:
                 types.append(type(i))
-            log.add_warning(_("Search row error: %(exception)s %(row)s"), {'exception': e, 'row': row})
+            log.add("Search row error: %(exception)s %(row)s", {'exception': e, 'row': row})
             iterator = None
 
         return iterator

--- a/pynicotine/gtkgui/ui/mainwindow.ui
+++ b/pynicotine/gtkgui/ui/mainwindow.ui
@@ -1298,22 +1298,23 @@
             </child>
             <!-- Log Window -->
             <child>
-              <object class="GtkBox" id="debugLogBox">
+              <object class="GtkBox" id="DebugLog">
                 <property name="visible">1</property>
                 <property name="orientation">vertical</property>
                 <child>
-                  <object class="GtkFlowBox" id="debugButtonsBox">
+                  <object class="GtkFlowBox" id="DebugButtons">
                     <property name="visible">1</property>
                     <property name="margin-top">3</property>
                     <property name="margin-bottom">3</property>
                     <property name="column-spacing">5</property>
+                    <property name="max-children-per-line">9</property>
                     <property name="selection-mode">none</property>
                     <child>
                       <object class="GtkFlowBoxChild">
                         <property name="visible">1</property>
                         <property name="can-focus">0</property>
                         <child>
-                          <object class="GtkLabel" id="debugLabel">
+                          <object class="GtkLabel">
                             <property name="visible">1</property>
                             <property name="label" translatable="yes">Debug Logging</property>
                             <property name="xalign">0</property>
@@ -1332,9 +1333,24 @@
                         <property name="can-focus">0</property>
                         <child>
                           <object class="GtkCheckButton">
-                            <property name="label" translatable="yes">Warnings</property>
+                            <property name="label" translatable="yes">Downloads</property>
                             <property name="visible">1</property>
-                            <property name="action-name">app.debugwarnings</property>
+                            <property name="can-focus">1</property>
+                            <property name="action-name">app.debugdownloads</property>
+                          </object>
+                        </child>
+                      </object>
+                    </child>
+                    <child>
+                      <object class="GtkFlowBoxChild">
+                        <property name="visible">1</property>
+                        <property name="can-focus">0</property>
+                        <child>
+                          <object class="GtkCheckButton">
+                            <property name="label" translatable="yes">Uploads</property>
+                            <property name="visible">1</property>
+                            <property name="can-focus">1</property>
+                            <property name="action-name">app.debuguploads</property>
                           </object>
                         </child>
                       </object>
@@ -1349,6 +1365,20 @@
                             <property name="visible">1</property>
                             <property name="can-focus">1</property>
                             <property name="action-name">app.debugsearches</property>
+                          </object>
+                        </child>
+                      </object>
+                    </child>
+                    <child>
+                      <object class="GtkFlowBoxChild">
+                        <property name="visible">1</property>
+                        <property name="can-focus">0</property>
+                        <child>
+                          <object class="GtkCheckButton">
+                            <property name="label" translatable="yes">Chat</property>
+                            <property name="visible">1</property>
+                            <property name="can-focus">1</property>
+                            <property name="action-name">app.debugchat</property>
                           </object>
                         </child>
                       </object>
@@ -1401,10 +1431,10 @@
                         <property name="can-focus">0</property>
                         <child>
                           <object class="GtkCheckButton">
-                            <property name="label" translatable="yes">Statistics</property>
+                            <property name="label" translatable="yes">Miscellaneous</property>
                             <property name="visible">1</property>
                             <property name="can-focus">1</property>
-                            <property name="action-name">app.debugstatistics</property>
+                            <property name="action-name">app.debugmiscellaneous</property>
                           </object>
                         </child>
                       </object>

--- a/pynicotine/gtkgui/utils.py
+++ b/pynicotine/gtkgui/utils.py
@@ -64,7 +64,7 @@ def load_ui_elements(ui_class, filename):
         builder.connect_signals(ui_class)
 
     except Exception as e:
-        log.add_warning(_("Failed to load ui file %(file)s: %(error)s"), {
+        log.add(_("Failed to load ui file %(file)s: %(error)s"), {
             "file": filename,
             "error": e
         })
@@ -92,7 +92,7 @@ def open_file_path(file_path, command=None):
             Gio.AppInfo.launch_default_for_uri("file:///" + file_path.lstrip("/"))
 
     except Exception as error:
-        log.add_warning(_("Failed to open file path: %s"), str(error))
+        log.add(_("Failed to open file path: %s"), str(error))
 
 
 def open_log(folder, filename):
@@ -149,7 +149,7 @@ def open_uri(uri, window):
             execute_command(protocol_handlers[protocol], uri)
             return
         except RuntimeError as e:
-            log.add_warning("%s", e)
+            log.add("%s", e)
 
     if protocol == "slsk":
         on_soul_seek_uri(uri.strip())
@@ -167,7 +167,7 @@ def open_uri(uri, window):
             Gio.AppInfo.launch_default_for_uri(uri)
 
     except Exception as error:
-        log.add_warning(_("Failed to open URL: %s"), str(error))
+        log.add(_("Failed to open URL: %s"), str(error))
 
 
 def on_soul_seek_uri(url):

--- a/pynicotine/gtkgui/wishlist.py
+++ b/pynicotine/gtkgui/wishlist.py
@@ -189,7 +189,7 @@ class WishList:
 
         # Wishlists supported by server?
         if self.interval == 0:
-            log.add_warning(_("The server forbid us from doing wishlist searches."))
+            log.add(_("The server forbid us from doing wishlist searches."))
             return False
 
         searches = config.sections["server"]["autosearch"]

--- a/pynicotine/nowplaying.py
+++ b/pynicotine/nowplaying.py
@@ -76,7 +76,7 @@ class NowPlaying:
                 result = self.mpris(command)
 
         except RuntimeError:
-            log.add_warning(_("ERROR: Could not execute now playing code. Are you sure you picked the right player?"))
+            log.add(_("ERROR: Could not execute now playing code. Are you sure you picked the right player?"))
             return None
 
         if not result:
@@ -130,13 +130,13 @@ class NowPlaying:
         try:
             (user, apikey) = user.split(';')
         except ValueError:
-            log.add_warning(_("ERROR: lastfm: Please provide both your lastfm username and API key"))
+            log.add(_("ERROR: lastfm: Please provide both your lastfm username and API key"))
             return None
 
         try:
             conn = http.client.HTTPSConnection("ws.audioscrobbler.com")
         except Exception as error:
-            log.add_warning(_("ERROR: lastfm: Could not connect to audioscrobbler: %(error)s"), {"error": error})
+            log.add(_("ERROR: lastfm: Could not connect to audioscrobbler: %(error)s"), {"error": error})
             return None
 
         conn.request("GET", "/2.0/?method=user.getrecenttracks&user=" + user + "&api_key=" + apikey + "&limit=1&format=json", headers={"User-Agent": "Nicotine+"})
@@ -145,7 +145,7 @@ class NowPlaying:
         conn.close()
 
         if resp.status != 200 or resp.reason != "OK":
-            log.add_warning(_("ERROR: lastfm: Could not get recent track from audioscrobbler: %(error)s"), {"error": str(data)})
+            log.add(_("ERROR: lastfm: Could not get recent track from audioscrobbler: %(error)s"), {"error": str(data)})
             return None
 
         json_api = json.loads(data)
@@ -189,7 +189,7 @@ class NowPlaying:
                     players.append(name[len(dbus_mpris_service):])
 
             if not players:
-                log.add_warning(_("ERROR: MPRIS: Could not find a suitable MPRIS player."))
+                log.add(_("ERROR: MPRIS: Could not find a suitable MPRIS player."))
                 return None
 
             player = players[0]
@@ -210,7 +210,7 @@ class NowPlaying:
             metadata = dbus_proxy.Get('(ss)', dbus_mpris_player_service, 'Metadata')
 
         except Exception as exception:
-            log.add_warning(_("ERROR: MPRIS: Something went wrong while querying %(player)s: %(exception)s"), {'player': player, 'exception': exception})
+            log.add(_("ERROR: MPRIS: Something went wrong while querying %(player)s: %(exception)s"), {'player': player, 'exception': exception})
             return None
 
         self.title['program'] = player
@@ -278,5 +278,5 @@ class NowPlaying:
             self.title["nowplaying"] = output
             return True
         except Exception as error:
-            log.add_warning(_("ERROR: Executing '%(command)s' failed: %(error)s"), {"command": command, "error": error})
+            log.add(_("ERROR: Executing '%(command)s' failed: %(error)s"), {"command": command, "error": error})
             return None

--- a/pynicotine/pynicotine.py
+++ b/pynicotine/pynicotine.py
@@ -92,7 +92,7 @@ class Timeout:
         try:
             self.callback([self])
         except Exception as e:
-            log.add_warning(_("Exception in callback %s: %s"), (self.callback, e))
+            log.add(_("Exception in callback %s: %s"), (self.callback, e))
 
 
 class ConnectToPeerTimeout:
@@ -1218,6 +1218,7 @@ class NetworkEventProcessor:
         """ Server code: 13 """
 
         log.add_msg_contents(msg)
+        log.add_chat(msg)
 
         if self.chatrooms is not None:
             event = self.pluginhandler.incoming_public_chat_event(msg.room, msg.user, msg.msg)
@@ -1263,6 +1264,7 @@ class NetworkEventProcessor:
         """ Server code: 22 """
 
         log.add_msg_contents(msg)
+        log.add_chat(msg)
 
         if self.privatechat is not None:
             self.privatechat.show_message(msg, msg.msg, msg.newmessage)
@@ -1779,7 +1781,7 @@ class NetworkEventProcessor:
             return
 
         if self.network_filter.is_user_banned(user):
-            log.add_warning(
+            log.add(
                 _("%(user)s is banned, but is making a UserInfo request"), {
                     'user': user
                 }

--- a/pynicotine/shares.py
+++ b/pynicotine/shares.py
@@ -643,11 +643,11 @@ class Shares:
                 exception = format_exc()
 
         if errors:
-            log.add_warning(_("Failed to process the following databases: %(names)s"), {
+            log.add(_("Failed to process the following databases: %(names)s"), {
                 'names': '\n'.join(errors)
             })
-            log.add_warning(exception)
-            log.add_warning(_("Shared files database seems to be corrupted, rescan your shares"))
+            log.add(exception)
+            log.add(_("Shared files database seems to be corrupted, rescan your shares"))
 
             if not reset_shares:
                 cls.load_shares(shares, dbs, reset_shares=True)

--- a/pynicotine/slskmessages.py
+++ b/pynicotine/slskmessages.py
@@ -250,7 +250,7 @@ class SlskMessage:
                     try:
                         string = string.decode("latin-1")
                     except Exception as error:
-                        log.add_warning("Error trying to decode string '%s': %s", (string, error))
+                        log.add("Error trying to decode string '%s': %s", (string, error))
 
                 return length + intsize + start, string
 
@@ -258,7 +258,7 @@ class SlskMessage:
                 return start, None
 
         except struct.error as error:
-            log.add_warning("%s %s trying to unpack %s at '%s' at %s/%s", (self.__class__, error, type, message[start:].__repr__(), start, len(message)))
+            log.add("%s %s trying to unpack %s at '%s' at %s/%s", (self.__class__, error, type, message[start:].__repr__(), start, len(message)))
             raise struct.error(error)
 
     def pack_object(self, object, unsignedint=False, unsignedlonglong=False, latin1=False):
@@ -288,20 +288,20 @@ class SlskMessage:
 
             return struct.pack("<i", len(encoded)) + encoded
 
-        log.add_warning("Warning: unknown object type %(obj_type)s in message %(msg_type)s", {'obj_type': type(object), 'msg_type': self.__class__})
+        log.add("Warning: unknown object type %(obj_type)s in message %(msg_type)s", {'obj_type': type(object), 'msg_type': self.__class__})
         return b""
 
     def make_network_message(self):
         """ Returns binary array, that can be sent over the network"""
 
-        log.add_warning("Empty message made, class %s", self.__class__)
+        log.add("Empty message made, class %s", self.__class__)
         return None
 
     def parse_network_message(self, message):
         """ Extracts information from the message and sets up fields
         in an object"""
 
-        log.add_warning("Can't parse incoming messages, class %s", self.__class__)
+        log.add("Can't parse incoming messages, class %s", self.__class__)
 
     def strrev(self, str):
         strlist = list(str)
@@ -369,7 +369,7 @@ class Login(ServerMessage):
             pos, self.ip = pos + 4, socket.inet_ntoa(message[pos:pos + 4][::-1])
 
         except Exception as error:
-            log.add_warning("Error unpacking IP address: %s", error)
+            log.add("Error unpacking IP address: %s", error)
 
         # MD5 hexdigest of the password you sent
         if message[pos:]:
@@ -1096,7 +1096,7 @@ class RoomList(ServerMessage):
             return (pos, rooms)
 
         except Exception as error:
-            log.add_warning(_("Exception during parsing %(area)s: %(exception)s"), {'area': 'RoomList', 'exception': error})
+            log.add(_("Exception during parsing %(area)s: %(exception)s"), {'area': 'RoomList', 'exception': error})
             return (originalpos, [])
 
 
@@ -2010,7 +2010,7 @@ class SharedFileList(PeerMessage):
 
             self._parse_network_message(message)
         except Exception as error:
-            log.add_warning(_("Exception during parsing %(area)s: %(exception)s"), {'area': 'SharedFileList', 'exception': error})
+            log.add(_("Exception during parsing %(area)s: %(exception)s"), {'area': 'SharedFileList', 'exception': error})
             self.list = {}
 
     def _parse_network_message(self, message):
@@ -2141,7 +2141,7 @@ class FileSearchResult(PeerMessage):
             message = zlib.decompress(message)
             self._parse_network_message(message)
         except Exception as error:
-            log.add_warning(_("Exception during parsing %(area)s: %(exception)s"), {'area': 'FileSearchResult', 'exception': error})
+            log.add(_("Exception during parsing %(area)s: %(exception)s"), {'area': 'FileSearchResult', 'exception': error})
             self.list = {}
 
     def _parse_network_message(self, message):
@@ -2360,7 +2360,7 @@ class FolderContentsResponse(PeerMessage):
             message = zlib.decompress(message)
             self._parse_network_message(message)
         except Exception as error:
-            log.add_warning(_("Exception during parsing %(area)s: %(exception)s"), {'area': 'FolderContentsResponse', 'exception': error})
+            log.add(_("Exception during parsing %(area)s: %(exception)s"), {'area': 'FolderContentsResponse', 'exception': error})
             self.list = {}
 
     def _parse_network_message(self, message):
@@ -2647,7 +2647,7 @@ class DistribSearch(DistribMessage):
         try:
             self._parse_network_message(message)
         except Exception as error:
-            log.add_warning(_("Exception during parsing %(area)s: %(exception)s"), {'area': 'DistribSearch', 'exception': error})
+            log.add(_("Exception during parsing %(area)s: %(exception)s"), {'area': 'DistribSearch', 'exception': error})
             return False
 
     def _parse_network_message(self, message):

--- a/pynicotine/slskproto.py
+++ b/pynicotine/slskproto.py
@@ -199,7 +199,7 @@ else:
     try:
         resource.setrlimit(resource.RLIMIT_NOFILE, (maxfilelimit, maxfilelimit))
     except Exception as e:
-        log.add_warning("Failed to set RLIMIT_NOFILE: %s", e)
+        log.add("Failed to set RLIMIT_NOFILE: %s", e)
 
     """ Set the maximum number of open sockets to a lower value than the hard limit,
     otherwise we just waste resources.
@@ -694,7 +694,7 @@ class SlskProtoThread(threading.Thread):
                     try:
                         msg.parse_network_message(msg_buffer[5:msgsize + 4])
                     except Exception as error:
-                        log.add_warning("%s", error)
+                        log.add("%s", error)
                     else:
                         conn.piercefw = msg
                         msgs.append(msg)
@@ -705,7 +705,7 @@ class SlskProtoThread(threading.Thread):
                     try:
                         msg.parse_network_message(msg_buffer[5:msgsize + 4])
                     except Exception as error:
-                        log.add_warning("%s", error)
+                        log.add("%s", error)
                     else:
                         conn.init = msg
                         msgs.append(msg)
@@ -1228,7 +1228,7 @@ class SlskProtoThread(threading.Thread):
                 print(time.strftime("%H:%M:%S"), "select OSError:", error)
                 self._want_abort = 1
 
-                log.add_warning("Major Socket Error: Networking terminated! %s", str(error))
+                log.add("Major Socket Error: Networking terminated! %s", str(error))
 
             except ValueError as error:
                 # Possibly opened too many sockets

--- a/pynicotine/upnp/portmapper.py
+++ b/pynicotine/upnp/portmapper.py
@@ -47,8 +47,8 @@ class UPnPPortMapping:
             self._add_port_mapping(np)
 
         except Exception as e:
-            log.add_warning(_('UPnP exception: %(error)s'), {'error': str(e)})
-            log.add_warning(_('Failed to automate the creation of UPnP Port Mapping rule.'))
+            log.add(_('UPnP exception: %(error)s'), {'error': str(e)})
+            log.add(_('Failed to automate the creation of UPnP Port Mapping rule.'))
             return
 
         log.add_debug(

--- a/pynicotine/utils.py
+++ b/pynicotine/utils.py
@@ -442,7 +442,7 @@ def write_file_and_backup(path, callback, protect=False):
                 os.chmod(path + ".old", 0o600)
 
     except Exception as error:
-        log.add_warning(_("Unable to back up file %(path)s: %(error)s"), {
+        log.add(_("Unable to back up file %(path)s: %(error)s"), {
             "path": path,
             "error": error
         })
@@ -456,7 +456,7 @@ def write_file_and_backup(path, callback, protect=False):
             callback(f)
 
     except Exception as error:
-        log.add_warning(_("Unable to save file %(path)s: %(error)s"), {
+        log.add(_("Unable to save file %(path)s: %(error)s"), {
             "path": path,
             "error": error
         })
@@ -467,7 +467,7 @@ def write_file_and_backup(path, callback, protect=False):
                 os.rename(path + ".old", path)
 
         except Exception as error:
-            log.add_warning(_("Unable to restore previous file %(path)s: %(error)s"), {
+            log.add(_("Unable to restore previous file %(path)s: %(error)s"), {
                 "path": path,
                 "error": error
             })
@@ -645,7 +645,7 @@ def _expand_alias(aliases, cmd):
                 i = i + 1
         return ret
     except Exception as error:
-        log.add_warning("%s", error)
+        log.add("%s", error)
 
     return ""
 


### PR DESCRIPTION
- Add new log categories for downloads, uploads and chats. Disable download log output by default.
- Remove `Warnings` log category, log all non-debug messages in the terminal. These messages contain important information, and should not be disabled.

Fixes #1371