### PR TITLE
Refactor context menus to use GtkGesture when possible

### DIFF
--- a/pynicotine/gtkgui/chatrooms.py
+++ b/pynicotine/gtkgui/chatrooms.py
@@ -514,8 +514,7 @@ class ChatRoom:
             (">" + _("Private Rooms"), self.popup_menu_private_rooms)
         )
 
-        self.activitylogpopupmenu = PopupMenu(self.frame, self.RoomLog, self.on_popup_activity_log_menu)
-        self.activitylogpopupmenu.setup(
+        PopupMenu(self.frame, self.RoomLog).setup(
             ("#" + _("Find..."), self.on_find_activity_log),
             ("", None),
             ("#" + _("Copy"), self.on_copy_activity_log),
@@ -526,8 +525,7 @@ class ChatRoom:
             ("#" + _("_Leave Room"), self.on_leave)
         )
 
-        self.roomlogpopmenu = PopupMenu(self.frame, self.ChatScroll, self.on_popup_room_log_menu)
-        self.roomlogpopmenu.setup(
+        PopupMenu(self.frame, self.ChatScroll).setup(
             ("#" + _("Find..."), self.on_find_room_log),
             ("", None),
             ("#" + _("Copy"), self.on_copy_room_log),
@@ -540,7 +538,7 @@ class ChatRoom:
             ("#" + _("_Leave Room"), self.on_leave)
         )
 
-        self.tab_menu = PopupMenu(self.frame, None, self.on_tab_popup)
+        self.tab_menu = PopupMenu(self.frame)
         self.tab_menu.setup(
             ("#" + _("_Leave Room"), self.on_leave)
         )
@@ -684,10 +682,6 @@ class ChatRoom:
 
         return model.get_value(iterator, 2)
 
-    def on_tab_popup(self, *args):
-        self.tab_menu.popup()
-        return True
-
     def on_row_activated(self, treeview, path, column):
 
         user = self.get_selected_username(treeview)
@@ -696,15 +690,13 @@ class ChatRoom:
             self.frame.privatechats.send_message(user, show_user=True)
             self.frame.change_main_page("private")
 
-    def on_popup_menu(self, widget):
+    def on_popup_menu(self, menu, treeview):
 
-        user = self.get_selected_username(widget)
+        user = self.get_selected_username(treeview)
         if user is None:
-            return False
+            return True
 
         self.populate_user_menu(user)
-        self.popup_menu.popup()
-        return True
 
     def on_show_room_wall(self, *args):
         self.room_wall.show()
@@ -1158,14 +1150,6 @@ class ChatRoom:
 
         if self.room not in config.sections["logging"]["rooms"]:
             config.sections["logging"]["rooms"].append(self.room)
-
-    def on_popup_room_log_menu(self, *args):
-        self.roomlogpopmenu.popup()
-        return True
-
-    def on_popup_activity_log_menu(self, *args):
-        self.activitylogpopupmenu.popup()
-        return True
 
     def on_copy_all_activity_log(self, *args):
         copy_all_text(self.RoomLog, self.frame.clipboard)

--- a/pynicotine/gtkgui/fastconfigure.py
+++ b/pynicotine/gtkgui/fastconfigure.py
@@ -52,7 +52,7 @@ class FastConfigureAssistant(object):
 
         self.column_numbers = list(range(self.sharelist.get_n_columns()))
         initialise_columns(
-            None, self.shareddirectoriestree, None,
+            None, self.shareddirectoriestree,
             ["virtual_folder", _("Virtual Folder"), 0, "text", None],
             ["folder", _("Folder"), 0, "text", None]
         )

--- a/pynicotine/gtkgui/frame.py
+++ b/pynicotine/gtkgui/frame.py
@@ -262,8 +262,7 @@ class NicotineFrame:
         """ Log """
 
         # Popup menu on the log windows
-        self.logpopupmenu = PopupMenu(self, self.LogWindow, self.on_popup_log_menu)
-        self.logpopupmenu.setup(
+        PopupMenu(self, self.LogWindow).setup(
             ("#" + _("Find..."), self.on_find_log_window),
             ("", None),
             ("#" + _("Copy"), self.on_copy_log_window),
@@ -346,6 +345,10 @@ class NicotineFrame:
 
         if self.MainWindow.get_urgency_hint():
             self.MainWindow.set_urgency_hint(False)
+
+    def cancel(self, popup, *args):
+        print(args)
+        del popup
 
     def save_window_state(self):
 
@@ -1395,7 +1398,7 @@ class NicotineFrame:
             tab_label.show()
 
             # Set the menu to hide the tab
-            popup = PopupMenu(self, tab_label, self.on_tab_popup)
+            popup = PopupMenu(self, tab_label)
             popup.setup(("#" + hide_tab_template % {"tab": tab_text}, self.hide_tab, (tab_label, page)))
 
     def request_tab_icon(self, tab_label, status=1):
@@ -1604,10 +1607,6 @@ class NicotineFrame:
         self.MainNotebook.set_tab_reorderable(tab_box, config.sections["ui"]["tab_reorderable"])
 
         del self.hidden_tabs[tab_box]
-
-    def on_tab_popup(self, widget, *args):
-        menu = args[-1]
-        menu.popup()
 
     def set_tab_expand(self, tab_box):
 
@@ -2061,10 +2060,6 @@ class NicotineFrame:
         append_line(self.LogWindow, msg, scroll=should_scroll, find_urls=False)
 
         return False
-
-    def on_popup_log_menu(self, *args):
-        self.logpopupmenu.popup()
-        return True
 
     def on_find_log_window(self, *args):
         self.LogSearchBar.set_search_mode(True)

--- a/pynicotine/gtkgui/interests.py
+++ b/pynicotine/gtkgui/interests.py
@@ -376,37 +376,31 @@ class Interests:
 
         return model.get_value(iterator, column)
 
-    def on_popup_til_menu(self, widget):
+    def on_popup_til_menu(self, menu, widget):
 
         item = self.get_selected_item(widget, column=0)
         if item is None:
-            return False
+            return True
 
-        self.til_popup_menu.set_user(item)
+        menu.set_user(item)
 
-        self.til_popup_menu.popup()
-        return True
-
-    def on_popup_tidl_menu(self, widget):
+    def on_popup_tidl_menu(self, menu, widget):
 
         item = self.get_selected_item(widget, column=0)
         if item is None:
-            return False
+            return True
 
-        self.tidl_popup_menu.set_user(item)
+        menu.set_user(item)
 
-        self.tidl_popup_menu.popup()
-        return True
-
-    def on_popup_r_menu(self, widget):
+    def on_popup_r_menu(self, menu, widget):
 
         item = self.get_selected_item(widget, column=1)
         if item is None:
-            return False
+            return True
 
-        self.r_popup_menu.set_user(item)
+        menu.set_user(item)
 
-        actions = self.r_popup_menu.get_actions()
+        actions = menu.get_actions()
         actions[_("I _Like This")].set_state(
             GLib.Variant.new_boolean(item in config.sections["interests"]["likes"])
         )
@@ -414,20 +408,14 @@ class Interests:
             GLib.Variant.new_boolean(item in config.sections["interests"]["dislikes"])
         )
 
-        self.r_popup_menu.popup()
-        return True
-
-    def on_popup_ru_menu(self, widget):
+    def on_popup_ru_menu(self, menu, widget):
 
         user = self.get_selected_item(widget, column=1)
         if user is None:
-            return False
+            return True
 
-        self.ru_popup_menu.set_user(user)
-        self.ru_popup_menu.toggle_user_items()
-
-        self.ru_popup_menu.popup()
-        return True
+        menu.set_user(user)
+        menu.toggle_user_items()
 
     def on_ru_row_activated(self, treeview, path, column):
 

--- a/pynicotine/gtkgui/interests.py
+++ b/pynicotine/gtkgui/interests.py
@@ -50,7 +50,7 @@ class Interests:
 
         self.likes_column_numbers = list(range(self.likes_model.get_n_columns()))
         cols = initialise_columns(
-            None, self.LikesList, self.on_popup_til_menu,
+            None, self.LikesList,
             ["i_like", _("I Like"), -1, "text", None]
         )
 
@@ -63,7 +63,7 @@ class Interests:
 
         self.dislikes_column_numbers = list(range(self.dislikes_model.get_n_columns()))
         cols = initialise_columns(
-            None, self.DislikesList, self.on_popup_tidl_menu,
+            None, self.DislikesList,
             ["i_dislike", _("I Dislike"), -1, "text", None]
         )
 
@@ -78,7 +78,7 @@ class Interests:
 
         self.recommendations_column_numbers = list(range(self.recommendations_model.get_n_columns()))
         cols = initialise_columns(
-            None, self.RecommendationsList, self.on_popup_r_menu,
+            None, self.RecommendationsList,
             ["rating", _("Rating"), 0, "number", None],
             ["item", _("Item"), -1, "text", None]
         )
@@ -96,7 +96,7 @@ class Interests:
 
         self.unrecommendations_column_numbers = list(range(self.unrecommendations_model.get_n_columns()))
         cols = initialise_columns(
-            None, self.UnrecommendationsList, self.on_popup_ru_menu,
+            None, self.UnrecommendationsList,
             ["rating", _("Rating"), 0, "number", None],
             ["item", _("Item"), -1, "text", None]
         )
@@ -119,7 +119,7 @@ class Interests:
 
         self.recommendation_users_column_numbers = list(range(self.recommendation_users_model.get_n_columns()))
         cols = initialise_columns(
-            None, self.RecommendationUsersList, self.on_popup_ru_menu,
+            None, self.RecommendationUsersList,
             ["status", _("Status"), 25, "pixbuf", None],
             ["user", _("User"), 100, "text", None],
             ["speed", _("Speed"), 100, "text", None],
@@ -146,7 +146,7 @@ class Interests:
 
         """ Popup """
 
-        self.til_popup_menu = popup = PopupMenu(self.frame)
+        self.til_popup_menu = popup = PopupMenu(self.frame, self.LikesList, self.on_popup_til_menu)
         popup.setup(
             ("#" + _("_Remove Item"), self.on_remove_thing_i_like),
             ("#" + _("Re_commendations for Item"), self.on_recommend_item),
@@ -154,14 +154,14 @@ class Interests:
             ("#" + _("_Search for Item"), self.on_til_recommend_search)
         )
 
-        self.tidl_popup_menu = popup = PopupMenu(self.frame)
+        self.tidl_popup_menu = popup = PopupMenu(self.frame, self.DislikesList, self.on_popup_tidl_menu)
         popup.setup(
             ("#" + _("_Remove Item"), self.on_remove_thing_i_dislike),
             ("", None),
             ("#" + _("_Search for Item"), self.on_tidl_recommend_search)
         )
 
-        self.r_popup_menu = popup = PopupMenu(self.frame)
+        self.r_popup_menu = popup = PopupMenu(self.frame, self.RecommendationsList, self.on_popup_r_menu)
         popup.setup(
             ("$" + _("I _Like This"), self.on_like_recommendation),
             ("$" + _("I _Dislike This"), self.on_dislike_recommendation),
@@ -170,7 +170,7 @@ class Interests:
             ("#" + _("_Search for Item"), self.on_r_recommend_search)
         )
 
-        self.ru_popup_menu = popup = PopupMenu(self.frame)
+        self.ru_popup_menu = popup = PopupMenu(self.frame, self.RecommendationUsersList, self.on_popup_ru_menu)
         popup.setup_user_menu()
 
         self.update_visuals()

--- a/pynicotine/gtkgui/privatechat.py
+++ b/pynicotine/gtkgui/privatechat.py
@@ -314,7 +314,7 @@ class PrivateChat:
         self.Log.set_active(config.sections["logging"]["privatechat"])
 
         tab_label, menu_label = self.chats.get_labels(self.Main)
-        self.popup_menu_user = popup = PopupMenu(self.frame, tab_label, self.on_tab_popup)
+        self.popup_menu_user = popup = PopupMenu(self.frame, tab_label, self.on_popup_menu)
         popup.setup_user_menu(user, page="privatechat")
         popup.setup(
             ("", None),
@@ -322,7 +322,7 @@ class PrivateChat:
             ("#" + _("_Close Tab"), self.on_close)
         )
 
-        self.popup_menu = popup = PopupMenu(self.frame, self.ChatScroll, self.on_popup_menu)
+        popup = PopupMenu(self.frame, self.ChatScroll, self.on_popup_menu)
         popup.setup(
             ("#" + _("Find..."), self.on_find_chat_log),
             ("", None),
@@ -394,15 +394,8 @@ class PrivateChat:
     def set_label(self, label):
         self.popup_menu_user.set_widget(label)
 
-    def on_tab_popup(self, *args):
+    def on_popup_menu(self, menu, widget):
         self.popup_menu_user.toggle_user_items()
-        self.popup_menu_user.popup()
-        return True
-
-    def on_popup_menu(self, *args):
-        self.popup_menu_user.toggle_user_items()
-        self.popup_menu.popup()
-        return True
 
     def on_find_chat_log(self, *args):
         self.SearchBar.set_search_mode(True)

--- a/pynicotine/gtkgui/roomlist.py
+++ b/pynicotine/gtkgui/roomlist.py
@@ -52,7 +52,7 @@ class RoomList:
 
         self.column_numbers = list(range(self.room_model.get_n_columns()))
         self.cols = initialise_columns(
-            None, self.RoomsList, self.on_popup_menu,
+            None, self.RoomsList,
             ["room", _("Room"), 260, "text", self.room_status],
             ["users", _("Users"), 100, "number", self.room_status]
         )
@@ -60,7 +60,7 @@ class RoomList:
         self.cols["users"].set_sort_column_id(1)
 
         self.popup_room = None
-        self.popup_menu = PopupMenu(self.frame)
+        self.popup_menu = PopupMenu(self.frame, self.RoomsList, self.on_popup_menu)
         self.popup_menu.setup(
             ("#" + _("Join Room"), self.on_popup_join),
             ("#" + _("Leave Room"), self.on_popup_leave),

--- a/pynicotine/gtkgui/roomlist.py
+++ b/pynicotine/gtkgui/roomlist.py
@@ -255,10 +255,10 @@ class RoomList:
             self.popup_room = room
             self.on_popup_join()
 
-    def on_popup_menu(self, widget):
+    def on_popup_menu(self, menu, widget):
 
         if self.room_model is None:
-            return False
+            return True
 
         room = self.get_selected_room(widget)
 
@@ -273,16 +273,13 @@ class RoomList:
         self.popup_room = room
         prooms_enabled = True
 
-        actions = self.popup_menu.get_actions()
+        actions = menu.get_actions()
 
         actions[_("Join Room")].set_enabled(act[0])
         actions[_("Leave Room")].set_enabled(act[1])
 
         actions[_("Disown Private Room")].set_enabled(self.is_private_room_owned(self.popup_room))
         actions[_("Cancel Room Membership")].set_enabled((prooms_enabled and self.is_private_room_member(self.popup_room)))
-
-        self.popup_menu.popup()
-        return True
 
     def on_popup_join(self, *args):
         self.frame.np.queue.append(slskmessages.JoinRoom(self.popup_room))

--- a/pynicotine/gtkgui/search.py
+++ b/pynicotine/gtkgui/search.py
@@ -410,7 +410,7 @@ class Search:
             (">" + _("User(s)"), self.popup_menu_users)
         )
 
-        self.tab_menu = PopupMenu(self.frame, None, self.on_tab_popup)
+        self.tab_menu = PopupMenu(self.frame)
         self.tab_menu.setup(
             ("#" + _("Copy Search Term"), self.on_copy_search_term),
             ("", None),
@@ -1041,11 +1041,11 @@ class Search:
 
         return True
 
-    def on_popup_menu(self, *args):
+    def on_popup_menu(self, menu, widget):
 
         self.select_results()
 
-        actions = self.popup_menu.get_actions()
+        actions = menu.get_actions()
         users = len(self.selected_users) > 0
         files = len(self.selected_results) > 0
 
@@ -1070,10 +1070,7 @@ class Search:
 
                 break
 
-        self.popup_menu.set_num_selected_files(self.selected_files_count)
-
-        self.popup_menu.popup()
-        return True
+        menu.set_num_selected_files(self.selected_files_count)
 
     def on_browse_folder(self, *args):
 
@@ -1364,10 +1361,6 @@ class Search:
             self.FilterLabel.set_text(_("Result Filters"))
 
         self.FilterLabel.set_tooltip_text("%d active filter(s)" % count)
-
-    def on_tab_popup(self, *args):
-        self.tab_menu.popup()
-        return True
 
     def on_clear(self, *args):
 

--- a/pynicotine/gtkgui/settingswindow.py
+++ b/pynicotine/gtkgui/settingswindow.py
@@ -201,7 +201,7 @@ class DownloadsFrame(BuildFrame):
         self.downloadfilters = []
 
         cols = initialise_columns(
-            None, self.FilterView, None,
+            None, self.FilterView,
             ["filter", _("Filter"), -1, "text", None],
             ["escaped", _("Escaped"), 40, "toggle", None]
         )
@@ -506,7 +506,7 @@ class SharesFrame(BuildFrame):
 
         self.Shares.set_model(self.shareslist)
         cols = initialise_columns(
-            None, self.Shares, None,
+            None, self.Shares,
             ["virtual_folder", _("Virtual Folder"), 0, "text", None],
             ["folder", _("Folder"), -1, "text", None],
             ["buddies", _("Buddy-only"), 0, "toggle", None],
@@ -949,7 +949,7 @@ class IgnoreListFrame(BuildFrame):
         self.ignored_users = []
         self.ignorelist = Gtk.ListStore(str)
         initialise_columns(
-            None, self.IgnoredUsers, None,
+            None, self.IgnoredUsers,
             ["users", _("Users"), -1, "text", None]
         )
 
@@ -958,7 +958,7 @@ class IgnoreListFrame(BuildFrame):
         self.ignored_ips = {}
         self.ignored_ips_list = Gtk.ListStore(str, str)
         cols = initialise_columns(
-            None, self.IgnoredIPs, None,
+            None, self.IgnoredIPs,
             ["addresses", _("Addresses"), -1, "text", None],
             ["users", _("Users"), -1, "text", None]
         )
@@ -1102,7 +1102,7 @@ class BanListFrame(BuildFrame):
         self.banlist_model = Gtk.ListStore(str)
 
         initialise_columns(
-            None, self.BannedList, None,
+            None, self.BannedList,
             ["users", _("Users"), -1, "text", None]
         )
 
@@ -1112,7 +1112,7 @@ class BanListFrame(BuildFrame):
         self.blocked_list_model = Gtk.ListStore(str, str)
 
         cols = initialise_columns(
-            None, self.BlockedList, None,
+            None, self.BlockedList,
             ["addresses", _("Addresses"), -1, "text", None],
             ["users", _("Users"), -1, "text", None]
         )
@@ -2002,7 +2002,7 @@ class UrlCatchingFrame(BuildFrame):
         self.protocols = {}
 
         cols = initialise_columns(
-            None, self.ProtocolHandlers, None,
+            None, self.ProtocolHandlers,
             ["protocol", _("Protocol"), -1, "text", None],
             ["handler", _("Handler"), -1, "combo", None]
         )
@@ -2145,7 +2145,7 @@ class CensorListFrame(BuildFrame):
         self.censor_list_model = Gtk.ListStore(str)
 
         cols = initialise_columns(
-            None, self.CensorList, None,
+            None, self.CensorList,
             ["pattern", _("Pattern"), -1, "edit", None]
         )
 
@@ -2245,7 +2245,7 @@ class AutoReplaceListFrame(BuildFrame):
         self.replacelist = Gtk.ListStore(str, str)
 
         cols = initialise_columns(
-            None, self.ReplacementList, None,
+            None, self.ReplacementList,
             ["pattern", _("Pattern"), 150, "edit", None],
             ["replacement", _("Replacement"), -1, "edit", None]
         )
@@ -2699,7 +2699,7 @@ class PluginsFrame(BuildFrame):
             container.add(scrolled_window)
 
             cols = initialise_columns(
-                None, self.tw[name], None,
+                None, self.tw[name],
                 [description, description, 150, "edit", None]
             )
 
@@ -2885,7 +2885,7 @@ class PluginsFrame(BuildFrame):
         self.selected_plugin = None
 
         cols = initialise_columns(
-            None, self.PluginTreeView, None,
+            None, self.PluginTreeView,
             ["enabled", _("Enabled"), 0, "toggle", None],
             ["plugins", _("Plugins"), 380, "text", None]
         )
@@ -3107,7 +3107,7 @@ class Settings:
         self.tree["TextToSpeech"] = model.append(row, [_("Text-to-Speech"), "TextToSpeech"])
 
         initialise_columns(
-            None, self.SettingsTreeview, None,
+            None, self.SettingsTreeview,
             ["categories", _("Categories"), -1, "text", None]
         )
 

--- a/pynicotine/gtkgui/transferlist.py
+++ b/pynicotine/gtkgui/transferlist.py
@@ -724,12 +724,12 @@ class TransferList:
     def on_tooltip(self, widget, x, y, keyboard_mode, tooltip):
         return show_file_path_tooltip(widget, x, y, tooltip, 10)
 
-    def on_popup_menu(self, *args):
+    def on_popup_menu(self, menu, widget):
 
         self.select_transfers()
         num_selected_transfers = len(self.selected_transfers)
 
-        actions = self.popup_menu.get_actions()
+        actions = menu.get_actions()
         users = len(self.selected_users) > 0
         files = num_selected_transfers > 0
 
@@ -757,10 +757,7 @@ class TransferList:
         for i in (_("_Retry"), _("Abor_t"), _("_Clear")):
             actions[i].set_enabled(act)
 
-        self.popup_menu.set_num_selected_files(num_selected_transfers)
-
-        self.popup_menu.popup()
-        return True
+        menu.set_num_selected_files(num_selected_transfers)
 
     def on_row_activated(self, treeview, path, column):
 

--- a/pynicotine/gtkgui/transferlist.py
+++ b/pynicotine/gtkgui/transferlist.py
@@ -111,7 +111,7 @@ class TransferList:
 
         self.column_numbers = list(range(self.transfersmodel.get_n_columns()))
         self.cols = cols = initialise_columns(
-            type, widget, self.on_popup_menu,
+            type, widget,
             ["user", _("User"), 200, "text", None],
             ["path", _("Path"), 400, "text", None],
             ["filename", _("Filename"), 400, "text", None],
@@ -150,7 +150,7 @@ class TransferList:
         self.popup_menu_clear = PopupMenu(frame)
         self.ClearTransfers.set_menu_model(self.popup_menu_clear)
 
-        self.popup_menu = PopupMenu(frame)
+        self.popup_menu = PopupMenu(frame, widget, self.on_popup_menu)
         self.popup_menu.setup(
             ("#" + "selected_files", None),
             ("", None),

--- a/pynicotine/gtkgui/userbrowse.py
+++ b/pynicotine/gtkgui/userbrowse.py
@@ -267,9 +267,9 @@ class UserBrowse:
         if self.user != config.sections["server"]["login"]:
             self.on_download_directory()
 
-    def on_folder_popup_menu(self, *args):
+    def on_folder_popup_menu(self, menu, widget):
 
-        actions = self.folder_popup_menu.get_actions()
+        actions = menu.get_actions()
 
         if self.user == config.sections["server"]["login"]:
             for i in (_("_Download Folder"), _("Download Folder _To..."), _("Download _Recursive"), _("Download R_ecursive To..."),
@@ -282,8 +282,6 @@ class UserBrowse:
                 actions[i].set_enabled(self.selected_folder)
 
         self.user_popup.toggle_user_items()
-        self.folder_popup_menu.popup()
-        return True
 
     def select_files(self):
 
@@ -306,12 +304,12 @@ class UserBrowse:
         else:
             self.on_download_files()
 
-    def on_file_popup_menu(self, *args):
+    def on_file_popup_menu(self, menu, widget):
 
         self.select_files()
         num_selected_files = len(self.selected_files)
 
-        actions = self.file_popup_menu.get_actions()
+        actions = menu.get_actions()
 
         if self.user == config.sections["server"]["login"]:
             for i in (_("Download"), _("Upload"), _("Send to _Player"), _("File _Properties"),
@@ -323,11 +321,8 @@ class UserBrowse:
             for i in (_("Download"), _("File _Properties"), _("Copy _File Path"), _("Copy _URL")):
                 actions[i].set_enabled(num_selected_files)
 
-        self.file_popup_menu.set_num_selected_files(num_selected_files)
-
+        menu.set_num_selected_files(num_selected_files)
         self.user_popup.toggle_user_items()
-        self.file_popup_menu.popup()
-        return True
 
     def make_new_model(self, list):
 
@@ -1054,8 +1049,6 @@ class UserBrowse:
 
     def on_tab_popup(self, *args):
         self.user_popup.toggle_user_items()
-        self.user_popup.popup()
-        return True
 
     def on_close(self, *args):
         del self.userbrowses.users[self.user]

--- a/pynicotine/gtkgui/userbrowse.py
+++ b/pynicotine/gtkgui/userbrowse.py
@@ -94,13 +94,13 @@ class UserBrowse:
 
         self.dir_column_numbers = list(range(self.dir_store.get_n_columns()))
         cols = initialise_columns(
-            None, self.FolderTreeView, self.on_folder_popup_menu,
+            None, self.FolderTreeView,
             ["folders", _("Folders"), -1, "text", None]  # 0
         )
 
         cols["folders"].set_sort_column_id(0)
 
-        self.user_popup = popup = PopupMenu(self.frame)
+        self.user_popup = popup = PopupMenu(self.frame, None, self.on_tab_popup)
         popup.setup_user_menu(user, page="userbrowse")
         popup.setup(
             ("", None),
@@ -141,7 +141,7 @@ class UserBrowse:
             ("#" + _("Up_load File(s)"), self.on_upload_files)
         )
 
-        self.folder_popup_menu = PopupMenu(self.frame)
+        self.folder_popup_menu = PopupMenu(self.frame, self.FolderTreeView, self.on_folder_popup_menu)
 
         if user == config.sections["server"]["login"]:
             self.folder_popup_menu.setup(
@@ -189,7 +189,7 @@ class UserBrowse:
 
         self.file_column_numbers = [i for i in range(self.file_store.get_n_columns())]
         cols = initialise_columns(
-            "user_browse", self.FileTreeView, self.on_file_popup_menu,
+            "user_browse", self.FileTreeView,
             ["filename", _("Filename"), 600, "text", None],
             ["size", _("Size"), 100, "number", None],
             ["bitrate", _("Bitrate"), 100, "number", None],
@@ -201,7 +201,7 @@ class UserBrowse:
         cols["length"].set_sort_column_id(6)
         self.file_store.set_sort_column_id(0, Gtk.SortType.ASCENDING)
 
-        self.file_popup_menu = PopupMenu(self.frame)
+        self.file_popup_menu = PopupMenu(self.frame, self.FileTreeView, self.on_file_popup_menu)
 
         if user == config.sections["server"]["login"]:
             self.file_popup_menu.setup(
@@ -238,6 +238,9 @@ class UserBrowse:
         for name, object in self.__dict__.items():
             if isinstance(object, PopupMenu):
                 object.set_user(self.user)
+
+    def set_label(self, label):
+        self.user_popup.set_widget(label)
 
     def update_visuals(self):
 
@@ -1048,6 +1051,11 @@ class UserBrowse:
         command = config.sections["ui"]["filemanager"]
 
         open_file_path(path, command)
+
+    def on_tab_popup(self, *args):
+        self.user_popup.toggle_user_items()
+        self.user_popup.popup()
+        return True
 
     def on_close(self, *args):
         del self.userbrowses.users[self.user]

--- a/pynicotine/gtkgui/userinfo.py
+++ b/pynicotine/gtkgui/userinfo.py
@@ -366,33 +366,28 @@ class UserInfo:
 
     def on_tab_popup(self, *args):
         self.user_popup.toggle_user_items()
-        self.user_popup.popup()
-        return True
 
-    def on_popup_interest_menu(self, widget):
+    def on_popup_interest_menu(self, menu, widget):
 
         model, iterator = widget.get_selection().get_selected()
 
         if iterator is None:
-            return False
+            return True
 
         item = model.get_value(iterator, 0)
 
         if item is None:
-            return False
+            return True
 
-        self.interest_popup_menu.set_user(item)
+        menu.set_user(item)
 
-        actions = self.interest_popup_menu.get_actions()
+        actions = menu.get_actions()
         actions[_("I _Like This")].set_state(
             GLib.Variant.new_boolean(item in config.sections["interests"]["likes"])
         )
         actions[_("I _Dislike This")].set_state(
             GLib.Variant.new_boolean(item in config.sections["interests"]["dislikes"])
         )
-
-        self.interest_popup_menu.popup()
-        return True
 
     def on_like_recommendation(self, action, state):
         self.frame.interests.on_like_recommendation(action, state, self.interest_popup_menu.get_user())
@@ -449,19 +444,16 @@ class UserInfo:
             title="Save as..."
         )
 
-    def on_image_popup_menu(self, *args):
+    def on_image_popup_menu(self, menu, widget):
 
         act = True
 
         if self.image is None or self.image_pixbuf is None:
             act = False
 
-        actions = self.image_menu.get_actions()
+        actions = menu.get_actions()
         for (action_id, action) in actions.items():
             action.set_enabled(act)
-
-        self.image_menu.popup()
-        return True
 
     def on_scroll_event(self, widget, event):
 

--- a/pynicotine/gtkgui/userlist.py
+++ b/pynicotine/gtkgui/userlist.py
@@ -351,29 +351,26 @@ class UserList:
             self.frame.privatechats.send_message(user, show_user=True)
             self.frame.change_main_page("private")
 
-    def on_popup_menu(self, widget, *args):
+    def on_popup_menu(self, menu, widget):
 
         username, trusted, notify, privileged, status = self.get_selected_username_details(widget)
         if username is None:
-            return False
+            return True
 
-        self.popup_menu.set_user(username)
-        self.popup_menu.toggle_user_items()
-        self.popup_menu.populate_private_rooms(self.popup_menu_private_rooms)
+        menu.set_user(username)
+        menu.toggle_user_items()
+        menu.populate_private_rooms(self.popup_menu_private_rooms)
 
-        actions = self.popup_menu.get_actions()
+        actions = menu.get_actions()
 
         actions[_("Private Rooms")].set_enabled(
             status or
-            self.popup_menu.user != config.sections["server"]["login"]
+            menu.user != config.sections["server"]["login"]
         )
 
         actions[_("_Online Notify")].set_state(GLib.Variant.new_boolean(notify))
         actions[_("_Privileged")].set_state(GLib.Variant.new_boolean(privileged))
         actions[_("_Trusted")].set_state(GLib.Variant.new_boolean(trusted))
-
-        self.popup_menu.popup()
-        return True
 
     def get_user_status(self, msg):
 

--- a/pynicotine/gtkgui/userlist.py
+++ b/pynicotine/gtkgui/userlist.py
@@ -75,7 +75,7 @@ class UserList:
 
         self.column_numbers = list(range(self.usersmodel.get_n_columns()))
         self.cols = cols = initialise_columns(
-            "buddy_list", self.UserListTree, self.on_popup_menu,
+            "buddy_list", self.UserListTree,
             ["status", _("Status"), 25, "pixbuf", None],
             ["country", _("Country"), 25, "pixbuf", None],
             ["user", _("User"), 250, "text", None],
@@ -136,7 +136,7 @@ class UserList:
 
         self.popup_menu_private_rooms = PopupMenu(self.frame)
 
-        self.popup_menu = popup = PopupMenu(frame)
+        self.popup_menu = popup = PopupMenu(frame, self.UserListTree, self.on_popup_menu)
         popup.setup_user_menu(page="userlist")
         popup.setup(
             ("", None),
@@ -351,7 +351,7 @@ class UserList:
             self.frame.privatechats.send_message(user, show_user=True)
             self.frame.change_main_page("private")
 
-    def on_popup_menu(self, widget):
+    def on_popup_menu(self, widget, *args):
 
         username, trusted, notify, privileged, status = self.get_selected_username_details(widget)
         if username is None:

--- a/pynicotine/gtkgui/utils.py
+++ b/pynicotine/gtkgui/utils.py
@@ -346,45 +346,6 @@ def censor_chat(message):
 """ Events """
 
 
-event_touch_started = False
-event_time_prev = 0
-
-
-def triggers_context_menu(event):
-    """ Check if a context menu should be allowed to appear """
-
-    global event_touch_started
-    global event_time_prev
-
-    if event.type in (Gdk.EventType.KEY_PRESS, Gdk.EventType.KEY_RELEASE):
-        return True
-
-    elif event.type in (Gdk.EventType.BUTTON_PRESS, Gdk.EventType._2BUTTON_PRESS,
-                        Gdk.EventType._3BUTTON_PRESS, Gdk.EventType.BUTTON_RELEASE):
-        return event.triggers_context_menu()
-
-    elif event.type == Gdk.EventType.TOUCH_BEGIN:
-        event_touch_started = True
-        event_time_prev = event.time
-        return False
-
-    elif not event_touch_started and event.type == Gdk.EventType.TOUCH_END or \
-            event_touch_started and (event.time - event_time_prev) < 300:
-        # Require a 300 ms press before context menu can be revealed
-        event_time_prev = event.time
-        return False
-
-    event_touch_started = False
-    return True
-
-
-def connect_context_menu_event(widget, callback_press, callback_popup):
-
-    widget.connect("button-press-event", callback_press)
-    widget.connect("popup-menu", callback_popup)
-    widget.connect("touch-event", callback_press)
-
-
 def connect_key_press_event(widget, callback):
     """ Use event controller or legacy 'key-press-event', depending on GTK version """
 

--- a/pynicotine/gtkgui/widgets/iconnotebook.py
+++ b/pynicotine/gtkgui/widgets/iconnotebook.py
@@ -27,7 +27,6 @@ from gi.repository import Gtk
 
 from pynicotine.gtkgui.utils import connect_key_press_event
 from pynicotine.gtkgui.utils import get_key_press_event_args
-from pynicotine.gtkgui.utils import triggers_context_menu
 from pynicotine.gtkgui.widgets.messagedialogs import option_dialog
 from pynicotine.gtkgui.widgets.popupmenu import PopupMenu
 from pynicotine.config import config
@@ -356,9 +355,6 @@ class IconNotebook:
 
         # menu for all tabs
         label_tab_menu = ImageLabel(label)
-        label_tab.connect('button_press_event', self.on_tab_click, page)
-        label_tab.connect('popup_menu', self.on_tab_popup, page)
-        label_tab.connect('touch_event', self.on_tab_click, page)
         label_tab.show()
 
         Gtk.Notebook.append_page_menu(self.notebook, page, label_tab, label_tab_menu)
@@ -406,19 +402,6 @@ class IconNotebook:
     def on_tab_popup(self, widget, page):
         # Dummy implementation
         pass
-
-    def on_tab_click(self, widget, event, page):
-
-        if triggers_context_menu(event):
-            return self.on_tab_popup(widget, page)
-
-        elif event.button == 2:
-            # Middle click
-            tab_label, menu_label = self.get_labels(page)
-            tab_label.onclose(widget)
-            return True
-
-        return False
 
     def set_status_image(self, page, status):
 

--- a/pynicotine/gtkgui/widgets/treeview.py
+++ b/pynicotine/gtkgui/widgets/treeview.py
@@ -287,12 +287,11 @@ def save_columns(treeview_name, columns, subpage=None):
         column_config[treeview_name] = saved_columns
 
 
-def press_header(widget, *args):
+def press_header(menu, widget):
 
     treeview = widget.get_parent()
     columns = treeview.get_columns()
     visible_columns = [column for column in columns if column.get_visible()]
-    menu = args[-1]
     menu.clear()
     actions = menu.get_actions()
     pos = 1
@@ -317,9 +316,6 @@ def press_header(widget, *args):
         actions[title].connect("activate", header_toggle, treeview, columns, pos - 1)
         pos += 1
 
-    menu.popup()
-    return True
-
 
 def header_toggle(action, state, treeview, columns, index):
 
@@ -328,14 +324,12 @@ def header_toggle(action, state, treeview, columns, index):
     set_last_column_autosize(treeview)
 
 
-def set_treeview_selected_row(treeview, event):
+def set_treeview_selected_row(treeview, x, y):
     """ Handles row selection when right-clicking in a treeview """
 
-    if event is None:
-        return
-
-    pathinfo = treeview.get_path_at_pos(event.x, event.y)
+    pathinfo = treeview.get_path_at_pos(x, y)
     selection = treeview.get_selection()
+    print(selection.count_selected_rows())
 
     if pathinfo is not None:
         path, col, cell_x, cell_y = pathinfo

--- a/pynicotine/gtkgui/wishlist.py
+++ b/pynicotine/gtkgui/wishlist.py
@@ -53,7 +53,7 @@ class WishList:
 
         self.column_numbers = list(range(self.store.get_n_columns()))
         cols = initialise_columns(
-            None, self.WishlistView, None,
+            None, self.WishlistView,
             ["wishes", _("Wishes"), -1, "text", None]
         )
 


### PR DESCRIPTION
GTK 4 removed `button-press-event` and `touch-event`, which are currently used for our context menus. To prepare for this change, move as much context menu logic as possible into PopupMenu to make future changes easier, and replace `touch-event` with GtkGestureLongPress.