### PR TITLE
Implement initial support for GTK 4

### DIFF
--- a/nicotine
+++ b/nicotine
@@ -83,6 +83,7 @@ def check_arguments():
 
     # Disables critical error dialog; used for integration tests
     parser.add_argument("--ci-mode", action="store_true", help=argparse.SUPPRESS)
+    parser.add_argument("--gtk4-unstable", action="store_true", help=argparse.SUPPRESS)
 
     args = parser.parse_args()
     trayicon = None
@@ -99,7 +100,7 @@ def check_arguments():
     if args.disable_trayicon:
         trayicon = False
 
-    return trayicon, args.headless, args.hidden, args.bindip, args.port, args.ci_mode, args.rescan
+    return trayicon, args.headless, args.hidden, args.bindip, args.port, args.ci_mode, args.rescan, args.gtk4_unstable
 
 
 def check_core_dependencies():
@@ -128,7 +129,7 @@ You should install Python %(min_version)s or newer.""") % {
     return None
 
 
-def check_gui_dependencies():
+def check_gui_dependencies(use_gtk4=False):
 
     # Require GTK+ >= 3.18
     try:
@@ -139,7 +140,7 @@ def check_gui_dependencies():
 
     else:
         try:
-            gi.require_version('Gtk', '3.0')
+            gi.require_version('Gtk', '4.0' if use_gtk4 else '3.0')
 
         except ValueError as e:
             return _("""You are using an unsupported version of GTK.
@@ -227,7 +228,7 @@ binary package and what you try to run Nicotine+ with).""")
     rename_process(b'nicotine')
     apply_translation()
 
-    trayicon, headless, hidden, bindip, port, ci_mode, rescan = check_arguments()
+    trayicon, headless, hidden, bindip, port, ci_mode, rescan, gtk4_unstable = check_arguments()
     error = check_core_dependencies()
 
     if error:
@@ -245,7 +246,7 @@ binary package and what you try to run Nicotine+ with).""")
     if headless:
         return run_headless(network_processor)
 
-    error = check_gui_dependencies()
+    error = check_gui_dependencies(gtk4_unstable)
 
     if error:
         print(error)

--- a/pynicotine/gtkgui/chatrooms.py
+++ b/pynicotine/gtkgui/chatrooms.py
@@ -514,8 +514,7 @@ class ChatRoom:
             (">" + _("Private Rooms"), self.popup_menu_private_rooms)
         )
 
-        self.activitylogpopupmenu = PopupMenu(self.frame, self.RoomLog, self.on_popup_activity_log_menu)
-        self.activitylogpopupmenu.setup(
+        PopupMenu(self.frame, self.RoomLog).setup(
             ("#" + _("Find..."), self.on_find_activity_log),
             ("", None),
             ("#" + _("Copy"), self.on_copy_activity_log),
@@ -526,8 +525,7 @@ class ChatRoom:
             ("#" + _("_Leave Room"), self.on_leave)
         )
 
-        self.roomlogpopmenu = PopupMenu(self.frame, self.ChatScroll, self.on_popup_room_log_menu)
-        self.roomlogpopmenu.setup(
+        PopupMenu(self.frame, self.ChatScroll).setup(
             ("#" + _("Find..."), self.on_find_room_log),
             ("", None),
             ("#" + _("Copy"), self.on_copy_room_log),
@@ -540,7 +538,7 @@ class ChatRoom:
             ("#" + _("_Leave Room"), self.on_leave)
         )
 
-        self.tab_menu = PopupMenu(self.frame, None, self.on_tab_popup)
+        self.tab_menu = PopupMenu(self.frame)
         self.tab_menu.setup(
             ("#" + _("_Leave Room"), self.on_leave)
         )
@@ -684,10 +682,6 @@ class ChatRoom:
 
         return model.get_value(iterator, 2)
 
-    def on_tab_popup(self, *args):
-        self.tab_menu.popup()
-        return True
-
     def on_row_activated(self, treeview, path, column):
 
         user = self.get_selected_username(treeview)
@@ -696,15 +690,13 @@ class ChatRoom:
             self.frame.privatechats.send_message(user, show_user=True)
             self.frame.change_main_page("private")
 
-    def on_popup_menu(self, widget):
+    def on_popup_menu(self, menu, treeview):
 
-        user = self.get_selected_username(widget)
+        user = self.get_selected_username(treeview)
         if user is None:
-            return False
+            return True
 
         self.populate_user_menu(user)
-        self.popup_menu.popup()
-        return True
 
     def on_show_room_wall(self, *args):
         self.room_wall.show()
@@ -1158,14 +1150,6 @@ class ChatRoom:
 
         if self.room not in config.sections["logging"]["rooms"]:
             config.sections["logging"]["rooms"].append(self.room)
-
-    def on_popup_room_log_menu(self, *args):
-        self.roomlogpopmenu.popup()
-        return True
-
-    def on_popup_activity_log_menu(self, *args):
-        self.activitylogpopupmenu.popup()
-        return True
 
     def on_copy_all_activity_log(self, *args):
         copy_all_text(self.RoomLog, self.frame.clipboard)

--- a/pynicotine/gtkgui/downloads.py
+++ b/pynicotine/gtkgui/downloads.py
@@ -31,7 +31,7 @@ from gi.repository import Gtk
 from pynicotine.config import config
 from pynicotine.gtkgui.transferlist import TransferList
 from pynicotine.gtkgui.utils import open_file_path
-from pynicotine.gtkgui.widgets.messagedialogs import option_dialog
+from pynicotine.gtkgui.widgets.dialogs import option_dialog
 from pynicotine.logfacility import log
 
 

--- a/pynicotine/gtkgui/fastconfigure.py
+++ b/pynicotine/gtkgui/fastconfigure.py
@@ -52,7 +52,7 @@ class FastConfigureAssistant(object):
 
         self.column_numbers = list(range(self.sharelist.get_n_columns()))
         initialise_columns(
-            None, self.shareddirectoriestree, None,
+            None, self.shareddirectoriestree,
             ["virtual_folder", _("Virtual Folder"), 0, "text", None],
             ["folder", _("Folder"), 0, "text", None]
         )

--- a/pynicotine/gtkgui/fastconfigure.py
+++ b/pynicotine/gtkgui/fastconfigure.py
@@ -28,8 +28,9 @@ from pynicotine.gtkgui.utils import load_ui_elements
 from pynicotine.gtkgui.utils import open_uri
 from pynicotine.gtkgui.widgets.filechooser import choose_dir
 from pynicotine.gtkgui.widgets.filechooser import FileChooserButton
-from pynicotine.gtkgui.widgets.messagedialogs import entry_dialog
-from pynicotine.gtkgui.widgets.messagedialogs import message_dialog
+from pynicotine.gtkgui.widgets.dialogs import entry_dialog
+from pynicotine.gtkgui.widgets.dialogs import message_dialog
+from pynicotine.gtkgui.widgets.dialogs import set_dialog_properties
 from pynicotine.gtkgui.widgets.treeview import initialise_columns
 
 
@@ -40,11 +41,22 @@ class FastConfigureAssistant(object):
         self.frame = frame
 
         load_ui_elements(self, os.path.join(self.frame.gui_dir, "ui", "dialogs", "fastconfigure.ui"))
-        self.FastConfigureDialog.set_transient_for(self.frame.MainWindow)
+        set_dialog_properties(self.FastConfigureDialog, frame.MainWindow, type_hint="dialog")
+
+        for page in (self.welcomepage, self.userpasspage, self.portpage, self.sharepage, self.summarypage):
+            self.FastConfigureDialog.append_page(page)
+
+        self.FastConfigureDialog.set_page_type(self.welcomepage, Gtk.AssistantPageType.CUSTOM)
+        self.FastConfigureDialog.set_page_type(self.summarypage, Gtk.AssistantPageType.SUMMARY)
+
+        # Page specific, sharepage
+        if Gtk.get_major_version() == 4:
+            self.shareddirectories.set_has_frame(True)
+        else:
+            self.shareddirectories.set_shadow_type(Gtk.ShadowType.IN)
 
         self.downloaddir = FileChooserButton(self.downloaddir, self.FastConfigureDialog, "folder")
 
-        # Page specific, sharepage
         self.sharelist = Gtk.ListStore(
             str,
             str
@@ -152,6 +164,9 @@ class FastConfigureAssistant(object):
                 return
 
             iterator = self.sharelist.iter_next(iterator)
+
+        if Gtk.get_major_version() == 4:
+            self.sharelist.insert_with_valuesv = self.sharelist.insert_with_values
 
         self.sharelist.insert_with_valuesv(-1, self.column_numbers, [virtual_name, path])
 

--- a/pynicotine/gtkgui/fileproperties.py
+++ b/pynicotine/gtkgui/fileproperties.py
@@ -22,8 +22,10 @@
 import os
 
 from gi.repository import Gdk
+from gi.repository import Gtk
 
 from pynicotine.gtkgui.utils import load_ui_elements
+from pynicotine.gtkgui.widgets.dialogs import generic_dialog
 
 
 class FileProperties:
@@ -35,7 +37,13 @@ class FileProperties:
 
         load_ui_elements(self, os.path.join(self.frame.gui_dir, "ui", "dialogs", "fileproperties.ui"))
 
-        self.FilePropertiesDialog.set_transient_for(self.frame.MainWindow)
+        self.FilePropertiesDialog = generic_dialog(
+            parent=frame.MainWindow,
+            content_box=self.Main,
+            title=_("File Properties"),
+            width=600,
+            height=0
+        )
 
         self.current_index = 0
 
@@ -146,6 +154,8 @@ class FileProperties:
 
         self.update_current_file()
         self.FilePropertiesDialog.present_with_time(Gdk.CURRENT_TIME)
-        self.FilePropertiesDialog.get_window().set_functions(
-            Gdk.WMFunction.RESIZE | Gdk.WMFunction.MOVE | Gdk.WMFunction.CLOSE
-        )
+
+        if Gtk.get_major_version() == 3:
+            self.FilePropertiesDialog.get_window().set_functions(
+                Gdk.WMFunction.RESIZE | Gdk.WMFunction.MOVE | Gdk.WMFunction.CLOSE
+            )

--- a/pynicotine/gtkgui/frame.py
+++ b/pynicotine/gtkgui/frame.py
@@ -385,10 +385,6 @@ class NicotineFrame:
         if Gtk.get_major_version() == 3 and self.MainWindow.get_urgency_hint():
             self.MainWindow.set_urgency_hint(False)
 
-    def cancel(self, popup, *args):
-        print(args)
-        del popup
-
     def save_window_state(self):
 
         if Gtk.get_major_version() == 4:
@@ -639,19 +635,19 @@ class NicotineFrame:
 
         self.UserBrowseCombo.set_sensitive(status)
 
-        """if self.current_tab_label == self.UserBrowseTabLabel:
-            GLib.idle_add(self.UserBrowseEntry.grab_focus)"""
+        if Gtk.get_major_version() == 3 and self.current_tab_label == self.UserBrowseTabLabel:
+            GLib.idle_add(self.UserBrowseEntry.grab_focus)
 
         self.UserInfoCombo.set_sensitive(status)
 
-        """if self.current_tab_label == self.UserInfoTabLabel:
-            GLib.idle_add(self.UserInfoEntry.grab_focus)"""
+        if Gtk.get_major_version() == 3 and self.current_tab_label == self.UserInfoTabLabel:
+            GLib.idle_add(self.UserInfoEntry.grab_focus)
 
         self.UserSearchCombo.set_sensitive(status)
         self.SearchCombo.set_sensitive(status)
 
-        """if self.current_tab_label == self.SearchTabLabel:
-            GLib.idle_add(self.SearchEntry.grab_focus)"""
+        if Gtk.get_major_version() == 3 and self.current_tab_label == self.SearchTabLabel:
+            GLib.idle_add(self.SearchEntry.grab_focus)
 
         self.interests.SimilarUsersButton.set_sensitive(status)
         self.interests.GlobalRecommendationsButton.set_sensitive(status)

--- a/pynicotine/gtkgui/frame.py
+++ b/pynicotine/gtkgui/frame.py
@@ -61,11 +61,13 @@ from pynicotine.gtkgui.utils import load_ui_elements
 from pynicotine.gtkgui.utils import open_file_path
 from pynicotine.gtkgui.utils import open_log
 from pynicotine.gtkgui.utils import open_uri
+from pynicotine.gtkgui.utils import parse_accelerator
 from pynicotine.gtkgui.utils import scroll_bottom
 from pynicotine.gtkgui.widgets.filechooser import choose_file
 from pynicotine.gtkgui.widgets.iconnotebook import ImageLabel
-from pynicotine.gtkgui.widgets.messagedialogs import message_dialog
-from pynicotine.gtkgui.widgets.messagedialogs import option_dialog
+from pynicotine.gtkgui.widgets.dialogs import message_dialog
+from pynicotine.gtkgui.widgets.dialogs import option_dialog
+from pynicotine.gtkgui.widgets.dialogs import set_dialog_properties
 from pynicotine.gtkgui.widgets.popupmenu import PopupMenu
 from pynicotine.gtkgui.widgets.textentry import clear_entry
 from pynicotine.gtkgui.widgets.textentry import TextSearchBar
@@ -89,7 +91,6 @@ class NicotineFrame:
 
         self.application = application
         self.np = network_processor
-        self.clipboard = Gtk.Clipboard.get(Gdk.SELECTION_CLIPBOARD)
         self.gui_dir = os.path.dirname(os.path.realpath(__file__))
         self.ci_mode = ci_mode
         self.current_page_id = "Default"
@@ -100,6 +101,11 @@ class NicotineFrame:
         self.bindip = bindip
         self.port = port
         utils.NICOTINE = self
+
+        if Gtk.get_major_version() == 4:
+            self.clipboard = Gdk.Display.get_default().get_clipboard()
+        else:
+            self.clipboard = Gtk.Clipboard.get(Gdk.SELECTION_CLIPBOARD)
 
         # Initialize these windows/dialogs later when necessary
         self.fastconfigure = None
@@ -168,31 +174,53 @@ class NicotineFrame:
         # Set up event controllers
         self.key_controller = connect_key_press_event(self.MainWindow, self.on_key_press_event)
 
+        if Gtk.get_major_version() == 4:
+            self.MainWindow.connect("close-request", self.on_delete_event)
+        else:
+            self.MainWindow.connect("delete-event", self.on_delete_event)
+
         try:
-            self.motion_controller = Gtk.EventControllerMotion.new(self.MainWindow)
+            if Gtk.get_major_version() == 4:
+                self.focus_controller = Gtk.EventControllerFocus()
+                self.motion_controller = Gtk.EventControllerMotion()
+                self.MainWindow.add_controller(self.focus_controller)
+                self.MainWindow.add_controller(self.motion_controller)
+
+                self.focus_controller.connect("enter", self.on_focus_in_event)
+            else:
+                self.focus_controller = Gtk.EventControllerKey.new(self.MainWindow)
+                self.motion_controller = Gtk.EventControllerMotion.new(self.MainWindow)
+
+                self.focus_controller.connect("focus-in", self.on_focus_in_event)
+
             self.motion_controller.connect("motion", self.on_disable_auto_away)
 
         except AttributeError:
             # GTK <3.24
+            self.MainWindow.connect("focus-in-event", self.on_focus_in_event)
             self.MainWindow.connect("motion-notify-event", self.on_disable_auto_away)
 
         # Handle Ctrl+C and "kill" exit gracefully
         for signal_type in (signal.SIGINT, signal.SIGTERM):
             signal.signal(signal_type, self.on_quit)
 
-        self.MainWindow.resize(
-            config.sections["ui"]["width"],
-            config.sections["ui"]["height"]
-        )
+        width = config.sections["ui"]["width"]
+        height = config.sections["ui"]["height"]
 
-        xpos = config.sections["ui"]["xposition"]
-        ypos = config.sections["ui"]["yposition"]
-
-        # According to the pygtk doc this will be ignored my many window managers since the move takes place before we do a show()
-        if min(xpos, ypos) < 0:
-            self.MainWindow.set_position(Gtk.WindowPosition.CENTER)
+        if Gtk.get_major_version() == 4:
+            self.MainWindow.set_default_size(width, height)
         else:
-            self.MainWindow.move(xpos, ypos)
+            self.MainWindow.resize(width, height)
+
+        if Gtk.get_major_version() == 3:
+            xpos = config.sections["ui"]["xposition"]
+            ypos = config.sections["ui"]["yposition"]
+
+            # According to the pygtk doc this will be ignored my many window managers since the move takes place before we do a show()
+            if min(xpos, ypos) < 0:
+                self.MainWindow.set_position(Gtk.WindowPosition.CENTER)
+            else:
+                self.MainWindow.move(xpos, ypos)
 
         if config.sections["ui"]["maximized"]:
             self.MainWindow.maximize()
@@ -277,6 +305,17 @@ class NicotineFrame:
         # Text Search
         TextSearchBar(self.LogWindow, self.LogSearchBar, self.LogSearchEntry)
 
+        if Gtk.get_major_version() == 4:
+            self.MainPaned.set_property("resize-start-child", True)
+            self.MainPaned.set_property("shrink-start-child", False)
+            self.MainPaned.set_property("resize-end-child", False)
+            self.MainPaned.set_property("shrink-end-child", False)
+        else:
+            self.MainPaned.child_set_property(self.NotebooksPane, "resize", True)
+            self.MainPaned.child_set_property(self.NotebooksPane, "shrink", False)
+            self.MainPaned.child_set_property(self.DebugLog, "resize", False)
+            self.MainPaned.child_set_property(self.DebugLog, "shrink", False)
+
         """ Scanning """
 
         # Deactivate public shares related menu entries if we don't use them
@@ -338,12 +377,12 @@ class NicotineFrame:
 
     """ Window State """
 
-    def on_focus_in(self, widget, event):
+    def on_focus_in_event(self, *args):
 
         self.chatrooms.clear_notifications()
         self.privatechats.clear_notifications()
 
-        if self.MainWindow.get_urgency_hint():
+        if Gtk.get_major_version() == 3 and self.MainWindow.get_urgency_hint():
             self.MainWindow.set_urgency_hint(False)
 
     def cancel(self, popup, *args):
@@ -352,14 +391,17 @@ class NicotineFrame:
 
     def save_window_state(self):
 
-        width, height = self.MainWindow.get_size()
-        xpos, ypos = self.MainWindow.get_position()
+        if Gtk.get_major_version() == 4:
+            width, height = self.MainWindow.get_default_size()
+        else:
+            width, height = self.MainWindow.get_size()
+            xpos, ypos = self.MainWindow.get_position()
+
+            config.sections["ui"]["xposition"] = xpos
+            config.sections["ui"]["yposition"] = ypos
 
         config.sections["ui"]["height"] = height
         config.sections["ui"]["width"] = width
-
-        config.sections["ui"]["xposition"] = xpos
-        config.sections["ui"]["yposition"] = ypos
 
         config.sections["ui"]["maximized"] = self.MainWindow.is_maximized()
         config.sections["ui"]["last_tab_id"] = self.MainNotebook.get_current_page()
@@ -507,26 +549,38 @@ class NicotineFrame:
 
         """ Load local app and tray icons, if available """
 
-        icon_theme = Gtk.IconTheme.get_default()
+        if Gtk.get_major_version() == 4:
+            icon_theme = Gtk.IconTheme.get_for_display(Gdk.Display.get_default())
+            icon_theme.append_search_path = icon_theme.add_search_path
+        else:
+            icon_theme = Gtk.IconTheme.get_default()
 
         # Support running from folder, as well as macOS and Windows
-        icon_theme.append_search_path(os.path.join(self.gui_dir, "icons"))
+        path = os.path.join(self.gui_dir, "icons")
+        icon_theme.append_search_path(path)
 
         # Support Python venv
-        icon_theme.append_search_path(os.path.join(sys.prefix, "share", "icons", "hicolor", "scalable", "apps"))
+        path = os.path.join(sys.prefix, "share", "icons", "hicolor", "scalable", "apps")
+        icon_theme.append_search_path(path)
 
     def update_visuals(self):
 
         if not hasattr(self, "global_css_provider"):
 
-            screen = Gdk.Screen.get_default()
             self.global_css_provider = Gtk.CssProvider()
             self.global_css_provider.load_from_data(
-                b".toolbar { border-bottom: 1px solid @borders; }"
+                b".tab-toolbar { border-bottom: 1px solid @borders; }"
             )
-            Gtk.StyleContext.add_provider_for_screen(
-                screen, self.global_css_provider, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION
-            )
+            if Gtk.get_major_version() == 4:
+                display = Gdk.Display.get_default()
+                Gtk.StyleContext.add_provider_for_display(
+                    display, self.global_css_provider, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION
+                )
+            else:
+                screen = Gdk.Screen.get_default()
+                Gtk.StyleContext.add_provider_for_screen(
+                    screen, self.global_css_provider, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION
+                )
 
         for widget in list(self.__dict__.values()):
             update_widget_visuals(widget)
@@ -585,19 +639,19 @@ class NicotineFrame:
 
         self.UserBrowseCombo.set_sensitive(status)
 
-        if self.current_tab_label == self.UserBrowseTabLabel:
-            GLib.idle_add(self.UserBrowseEntry.grab_focus)
+        """if self.current_tab_label == self.UserBrowseTabLabel:
+            GLib.idle_add(self.UserBrowseEntry.grab_focus)"""
 
         self.UserInfoCombo.set_sensitive(status)
 
-        if self.current_tab_label == self.UserInfoTabLabel:
-            GLib.idle_add(self.UserInfoEntry.grab_focus)
+        """if self.current_tab_label == self.UserInfoTabLabel:
+            GLib.idle_add(self.UserInfoEntry.grab_focus)"""
 
         self.UserSearchCombo.set_sensitive(status)
         self.SearchCombo.set_sensitive(status)
 
-        if self.current_tab_label == self.SearchTabLabel:
-            GLib.idle_add(self.SearchEntry.grab_focus)
+        """if self.current_tab_label == self.SearchTabLabel:
+            GLib.idle_add(self.SearchEntry.grab_focus)"""
 
         self.interests.SimilarUsersButton.set_sensitive(status)
         self.interests.GlobalRecommendationsButton.set_sensitive(status)
@@ -857,7 +911,11 @@ class NicotineFrame:
         self.application.set_menubar(builder.get_object("menubar"))
 
     def on_menu(self, *args):
-        self.HeaderMenu.set_active(not self.HeaderMenu.get_active())
+
+        if Gtk.get_major_version() == 4:
+            self.HeaderMenu.popup()
+        else:
+            self.HeaderMenu.set_active(not self.HeaderMenu.get_active())
 
     # File
 
@@ -1009,21 +1067,38 @@ class NicotineFrame:
 
         mode = self.verify_buddy_list_mode(mode)
 
-        if self.userlist.Main in self.NotebooksPane.get_children():
+        if Gtk.get_major_version() == 4:
+            note_children = self.NotebooksPane
+            chat_children = self.ChatroomsPane
+            buddy_children = self.userlistvbox
+        else:
+            note_children = self.NotebooksPane.get_children()
+            chat_children = self.ChatroomsPane.get_children()
+            buddy_children = self.userlistvbox.get_children()
+
+        if self.userlist.Main in note_children:
 
             if mode == "always":
                 return
 
-            self.NotebooksPane.remove(self.userlist.Main)
+            if Gtk.get_major_version() == 4:
+                self.NotebooksPane.set_end_child(Gtk.Box())
+                self.NotebooksPane.get_end_child().hide()
+            else:
+                self.NotebooksPane.remove(self.userlist.Main)
 
-        elif self.userlist.Main in self.ChatroomsPane.get_children():
+        elif self.userlist.Main in chat_children:
 
             if mode == "chatrooms":
                 return
 
-            self.ChatroomsPane.remove(self.userlist.Main)
+            if Gtk.get_major_version() == 4:
+                self.ChatroomsPane.set_end_child(Gtk.Box())
+                self.ChatroomsPane.get_end_child().hide()
+            else:
+                self.ChatroomsPane.remove(self.userlist.Main)
 
-        elif self.userlist.Main in self.userlistvbox.get_children():
+        elif self.userlist.Main in buddy_children:
 
             if mode == "tab":
                 return
@@ -1033,23 +1108,35 @@ class NicotineFrame:
 
         if mode == "always":
 
-            if self.userlist.Main not in self.NotebooksPane.get_children():
-                self.NotebooksPane.pack2(self.userlist.Main, False, True)
+            if self.userlist.Main not in note_children:
+                if Gtk.get_major_version() == 4:
+                    self.NotebooksPane.set_end_child(self.userlist.Main)
+                    self.NotebooksPane.set_property("resize-end-child", False)
+                else:
+                    self.NotebooksPane.pack2(self.userlist.Main, False, True)
 
             self.userlist.BuddiesToolbar.show()
             self.userlist.UserLabel.hide()
 
         elif mode == "chatrooms":
 
-            if self.userlist.Main not in self.ChatroomsPane.get_children():
-                self.ChatroomsPane.pack2(self.userlist.Main, False, True)
+            if self.userlist.Main not in chat_children:
+                if Gtk.get_major_version() == 4:
+                    self.ChatroomsPane.set_end_child(self.userlist.Main)
+                    self.ChatroomsPane.set_property("resize-end-child", False)
+                else:
+                    self.ChatroomsPane.pack2(self.userlist.Main, False, True)
 
             self.userlist.BuddiesToolbar.show()
             self.userlist.UserLabel.hide()
 
         elif mode == "tab":
 
-            self.userlistvbox.add(self.userlist.Main)
+            if Gtk.get_major_version() == 4:
+                self.userlistvbox.append(self.userlist.Main)
+            else:
+                self.userlistvbox.add(self.userlist.Main)
+
             self.show_tab(self.userlistvbox)
 
             self.userlist.BuddiesToolbar.hide()
@@ -1148,7 +1235,7 @@ class NicotineFrame:
 
         if not hasattr(self, "KeyboardShortcutsDialog"):
             load_ui_elements(self, os.path.join(self.gui_dir, "ui", "dialogs", "shortcuts.ui"))
-            self.KeyboardShortcutsDialog.set_transient_for(self.MainWindow)
+            set_dialog_properties(self.KeyboardShortcutsDialog, self.MainWindow, quit_callback=self.on_hide)
 
         self.KeyboardShortcutsDialog.present_with_time(Gdk.CURRENT_TIME)
 
@@ -1219,18 +1306,25 @@ class NicotineFrame:
     def on_about(self, *args):
 
         load_ui_elements(self, os.path.join(self.gui_dir, "ui", "dialogs", "about.ui"))
+        set_dialog_properties(self.AboutDialog, self.MainWindow)
 
         # Override link handler with our own
         self.AboutDialog.connect("activate-link", self.on_about_uri)
-        self.AboutDialog.connect("response", lambda x, y: x.destroy())
 
         if self.images["n"]:
             self.AboutDialog.set_logo(self.images["n"])
         else:
             self.AboutDialog.set_logo_icon_name(GLib.get_prgname())
 
-        self.AboutDialog.set_transient_for(self.MainWindow)
-        self.AboutDialog.set_version(config.version)
+        if Gtk.get_major_version() == 4:
+            self.AboutDialog.connect("close-request", lambda x: x.destroy())
+        else:
+            self.AboutDialog.connect("response", lambda x, y: x.destroy())
+
+        self.AboutDialog.set_version(
+            config.version + "  •  GTK %s.%s.%s" %
+            (Gtk.get_major_version(), Gtk.get_minor_version(), Gtk.get_micro_version())
+        )
 
         self.AboutDialog.present_with_time(Gdk.CURRENT_TIME)
 
@@ -1254,12 +1348,27 @@ class NicotineFrame:
         if menu_parent is not None:
             menu_parent.remove(self.HeaderMenu)
 
-        end_widget = getattr(self, page_id + "End")
-        end_widget.add(self.HeaderMenu)
-
         header_bar = getattr(self, "Header" + page_id)
-        header_bar.set_title(GLib.get_application_name())
+        end_widget = getattr(self, page_id + "End")
 
+        if Gtk.get_major_version() == 4:
+            self.HeaderMenu.set_icon_name("open-menu-symbolic")
+            end_widget.append(self.HeaderMenu)
+
+            header_bar.set_show_title_buttons(True)
+
+        else:
+            self.HeaderMenu.set_image(self.HeaderMenuIcon)
+            end_widget.add(self.HeaderMenu)
+
+            if page_id == "Default":
+                header_bar.set_has_subtitle(False)
+
+            header_bar.set_title(GLib.get_application_name())
+            header_bar.set_show_close_button(True)
+
+        header_bar.remove(end_widget)
+        header_bar.pack_end(end_widget)
         self.MainWindow.set_titlebar(header_bar)
 
     def set_toolbar(self, page_id):
@@ -1283,20 +1392,28 @@ class NicotineFrame:
 
         title_widget = getattr(self, page_id + "Title")
         title_widget.set_hexpand(True)
-        header_bar.set_custom_title(None)
-        toolbar_contents.add(title_widget)
 
         try:
             start_widget = getattr(self, page_id + "Start")
             header_bar.remove(start_widget)
-            toolbar_contents.add(start_widget)
 
         except AttributeError:
             # No start widget
-            pass
+            start_widget = None
 
         end_widget = getattr(self, page_id + "End")
         header_bar.remove(end_widget)
+
+        if Gtk.get_major_version() == 4:
+            header_bar.set_title_widget(None)
+            toolbar_contents.add = toolbar_contents.append
+        else:
+            header_bar.set_custom_title(None)
+
+        if start_widget:
+            toolbar_contents.add(start_widget)
+
+        toolbar_contents.add(title_widget)
         toolbar_contents.add(end_widget)
 
         toolbar.show()
@@ -1325,7 +1442,12 @@ class NicotineFrame:
         title_widget = getattr(self, self.current_page_id + "Title")
         title_widget.set_hexpand(False)
         toolbar_contents.remove(title_widget)
-        header_bar.set_custom_title(title_widget)
+
+        if Gtk.get_major_version() == 4:
+            header_bar.set_title_widget(title_widget)
+            header_bar.add = header_bar.pack_start
+        else:
+            header_bar.set_custom_title(title_widget)
 
         try:
             start_widget = getattr(self, self.current_page_id + "Start")
@@ -1377,9 +1499,15 @@ class NicotineFrame:
         }
 
         # Initialize tabs labels
-        for page in self.MainNotebook.get_children():
+        for i in range(self.MainNotebook.get_n_pages()):
+            page = self.MainNotebook.get_nth_page(i)
             tab_label = self.MainNotebook.get_tab_label(page)
-            tab_label_id = Gtk.Buildable.get_name(tab_label)
+
+            if Gtk.get_major_version() == 4:
+                tab_label_id = Gtk.Buildable.get_buildable_id(tab_label)
+            else:
+                tab_label_id = Gtk.Buildable.get_name(tab_label)
+
             tab_text, tab_icon_name = tab_data[tab_label]
 
             # Initialize the image label
@@ -1429,13 +1557,25 @@ class NicotineFrame:
         # Hide widgets on previous page for a performance boost
         current_page = notebook.get_nth_page(notebook.get_current_page())
 
-        for child in current_page.get_children():
+        if Gtk.get_major_version() == 4:
+            children = current_page
+        else:
+            children = current_page.get_children()
+
+        for child in children:
             child.hide()
 
-        for child in page.get_children():
+        if Gtk.get_major_version() == 4:
+            children = page
+        else:
+            children = page.get_children()
+
+        for child in children:
             child.show()
 
-        GLib.idle_add(notebook.grab_focus)
+        if Gtk.get_major_version() == 3:
+            # Currently broken in GTK 4
+            GLib.idle_add(notebook.grab_focus)
 
         tab_label = notebook.get_tab_label(page)
         self.current_tab_label = tab_label
@@ -1469,7 +1609,10 @@ class NicotineFrame:
 
         elif tab_label == self.SearchTabLabel:
             self.set_active_header_bar("Search")
-            GLib.idle_add(self.SearchEntry.grab_focus)
+
+            if Gtk.get_major_version() == 3:
+                # Currently broken in GTK 4
+                GLib.idle_add(self.SearchEntry.grab_focus)
 
         elif tab_label == self.UserInfoTabLabel:
             self.set_active_header_bar("UserInfo")
@@ -1517,7 +1660,7 @@ class NicotineFrame:
         keyval, keycode, state = get_key_press_event_args(*args)
         self.on_disable_auto_away()
 
-        if state & (Gdk.ModifierType.MOD1_MASK | Gtk.accelerator_parse("<Primary>")[1]) != Gdk.ModifierType.MOD1_MASK:
+        if state & parse_accelerator("<Primary>")[2]:
             return False
 
         for i in range(1, 10):
@@ -1619,7 +1762,11 @@ class NicotineFrame:
         else:
             expand = True
 
-        self.MainNotebook.child_set_property(tab_box, "tab-expand", expand)
+        if Gtk.get_major_version() == 4:
+            self.MainNotebook.get_page(tab_box).set_property("tab_expand", expand)
+        else:
+            self.MainNotebook.child_set_property(tab_box, "tab-expand", expand)
+
         tab_label.set_centered(expand)
 
     def get_tab_position(self, string):
@@ -1651,10 +1798,11 @@ class NicotineFrame:
 
         for i in range(self.MainNotebook.get_n_pages()):
             tab_box = self.MainNotebook.get_nth_page(i)
-            tab_label = self.MainNotebook.get_tab_label(tab_box)
-
             self.set_tab_expand(tab_box)
-            tab_label.set_angle(ui["labelmain"])
+
+            if Gtk.get_major_version() == 3:
+                tab_label = self.MainNotebook.get_tab_label(tab_box)
+                tab_label.set_angle(ui["labelmain"])
 
         # Other notebooks
         self.chatrooms.set_tab_pos(self.get_tab_position(ui["tabrooms"]))
@@ -1909,7 +2057,7 @@ class NicotineFrame:
             log.add(_("Can't create directory '%(folder)s', reported error: %(error)s"), {'folder': sharesdir, 'error': msg})
 
         choose_file(
-            parent=self.MainWindow.get_toplevel(),
+            parent=self.MainWindow,
             callback=self.on_load_from_disk_selected,
             initialdir=sharesdir,
             multiple=True
@@ -2399,7 +2547,7 @@ class NicotineFrame:
             if self.MainWindow.get_property("visible"):
                 self.MainWindow.hide()
 
-    def on_delete_event(self, widget, event):
+    def on_delete_event(self, *args):
 
         if not config.sections["ui"]["exitdialog"]:
             self.save_state()
@@ -2421,7 +2569,7 @@ class NicotineFrame:
 
         return True
 
-    def on_hide(self, widget, event):
+    def on_hide(self, widget, *args):
         widget.hide()
         return True
 
@@ -2482,4 +2630,6 @@ class Application(Gtk.Application):
         # Show the window of the running Nicotine+ instance
         window = self.get_active_window()
         window.present_with_time(Gdk.CURRENT_TIME)
-        window.deiconify()
+
+        if Gtk.get_major_version() == 3:
+            window.deiconify()

--- a/pynicotine/gtkgui/frame.py
+++ b/pynicotine/gtkgui/frame.py
@@ -262,8 +262,7 @@ class NicotineFrame:
         """ Log """
 
         # Popup menu on the log windows
-        self.logpopupmenu = PopupMenu(self, self.LogWindow, self.on_popup_log_menu)
-        self.logpopupmenu.setup(
+        PopupMenu(self, self.LogWindow).setup(
             ("#" + _("Find..."), self.on_find_log_window),
             ("", None),
             ("#" + _("Copy"), self.on_copy_log_window),
@@ -346,6 +345,10 @@ class NicotineFrame:
 
         if self.MainWindow.get_urgency_hint():
             self.MainWindow.set_urgency_hint(False)
+
+    def cancel(self, popup, *args):
+        print(args)
+        del popup
 
     def save_window_state(self):
 
@@ -1395,7 +1398,7 @@ class NicotineFrame:
             tab_label.show()
 
             # Set the menu to hide the tab
-            popup = PopupMenu(self, tab_label, self.on_tab_popup)
+            popup = PopupMenu(self, tab_label)
             popup.setup(("#" + hide_tab_template % {"tab": tab_text}, self.hide_tab, (tab_label, page)))
 
     def request_tab_icon(self, tab_label, status=1):
@@ -1604,10 +1607,6 @@ class NicotineFrame:
         self.MainNotebook.set_tab_reorderable(tab_box, config.sections["ui"]["tab_reorderable"])
 
         del self.hidden_tabs[tab_box]
-
-    def on_tab_popup(self, widget, *args):
-        menu = args[-1]
-        menu.popup()
 
     def set_tab_expand(self, tab_box):
 
@@ -2061,10 +2060,6 @@ class NicotineFrame:
         append_line(self.LogWindow, msg, scroll=should_scroll, find_urls=False)
 
         return False
-
-    def on_popup_log_menu(self, *args):
-        self.logpopupmenu.popup()
-        return True
 
     def on_find_log_window(self, *args):
         self.LogSearchBar.set_search_mode(True)

--- a/pynicotine/gtkgui/icons/away.svg
+++ b/pynicotine/gtkgui/icons/away.svg
@@ -1,1 +1,1 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 10 10"><circle cx="5" cy="5" r="5" fill="#e0c314"/></svg>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16"><circle cx="8" cy="8" r="5" fill="#e0c314"/></svg>

--- a/pynicotine/gtkgui/icons/hilite.svg
+++ b/pynicotine/gtkgui/icons/hilite.svg
@@ -1,1 +1,1 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 8 8"><circle r="4" cy="4" cx="4" fill="#3d73b9"/></svg>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16"><circle r="4" cy="8" cx="8" fill="#3d73b9"/></svg>

--- a/pynicotine/gtkgui/icons/hilite3.svg
+++ b/pynicotine/gtkgui/icons/hilite3.svg
@@ -1,1 +1,1 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 8 8"><ellipse cy="3.9999981" cx="3.9999967" rx="3.2251966" ry="3.225198" fill="none" stroke="#3d73b9" stroke-width="1.5496"/></svg>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16"><ellipse cy="8" cx="8" rx="3.2251966" ry="3.225198" fill="none" stroke="#3d73b9" stroke-width="1.5496"/></svg>

--- a/pynicotine/gtkgui/icons/offline.svg
+++ b/pynicotine/gtkgui/icons/offline.svg
@@ -1,1 +1,1 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 10 10"><circle cx="5" cy="5" r="5" fill="#da4453"/></svg>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16"><circle cx="8" cy="8" r="5" fill="#da4453"/></svg>

--- a/pynicotine/gtkgui/icons/online.svg
+++ b/pynicotine/gtkgui/icons/online.svg
@@ -1,1 +1,1 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 10 10"><circle cx="5" cy="5" r="5" fill="#1abd5f"/></svg>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16"><circle cx="8" cy="8" r="5" fill="#1abd5f"/></svg>

--- a/pynicotine/gtkgui/interests.py
+++ b/pynicotine/gtkgui/interests.py
@@ -376,37 +376,31 @@ class Interests:
 
         return model.get_value(iterator, column)
 
-    def on_popup_til_menu(self, widget):
+    def on_popup_til_menu(self, menu, widget):
 
         item = self.get_selected_item(widget, column=0)
         if item is None:
-            return False
+            return True
 
-        self.til_popup_menu.set_user(item)
+        menu.set_user(item)
 
-        self.til_popup_menu.popup()
-        return True
-
-    def on_popup_tidl_menu(self, widget):
+    def on_popup_tidl_menu(self, menu, widget):
 
         item = self.get_selected_item(widget, column=0)
         if item is None:
-            return False
+            return True
 
-        self.tidl_popup_menu.set_user(item)
+        menu.set_user(item)
 
-        self.tidl_popup_menu.popup()
-        return True
-
-    def on_popup_r_menu(self, widget):
+    def on_popup_r_menu(self, menu, widget):
 
         item = self.get_selected_item(widget, column=1)
         if item is None:
-            return False
+            return True
 
-        self.r_popup_menu.set_user(item)
+        menu.set_user(item)
 
-        actions = self.r_popup_menu.get_actions()
+        actions = menu.get_actions()
         actions[_("I _Like This")].set_state(
             GLib.Variant.new_boolean(item in config.sections["interests"]["likes"])
         )
@@ -414,20 +408,14 @@ class Interests:
             GLib.Variant.new_boolean(item in config.sections["interests"]["dislikes"])
         )
 
-        self.r_popup_menu.popup()
-        return True
-
-    def on_popup_ru_menu(self, widget):
+    def on_popup_ru_menu(self, menu, widget):
 
         user = self.get_selected_item(widget, column=1)
         if user is None:
-            return False
+            return True
 
-        self.ru_popup_menu.set_user(user)
-        self.ru_popup_menu.toggle_user_items()
-
-        self.ru_popup_menu.popup()
-        return True
+        menu.set_user(user)
+        menu.toggle_user_items()
 
     def on_ru_row_activated(self, treeview, path, column):
 

--- a/pynicotine/gtkgui/interests.py
+++ b/pynicotine/gtkgui/interests.py
@@ -42,7 +42,18 @@ class Interests:
         self.frame = frame
 
         load_ui_elements(self, os.path.join(self.frame.gui_dir, "ui", "interests.ui"))
-        self.frame.interestsvbox.add(self.Main)
+
+        if Gtk.get_major_version() == 4:
+            self.InterestsPaned.set_property("resize-start-child", False)
+            self.InterestsPanedSecond.set_property("resize-start-child", True)
+            self.InterestsPanedSecond.set_property("resize-end-child", False)
+            self.frame.interestsvbox.append(self.Main)
+
+        else:
+            self.InterestsPaned.child_set_property(self.LikesDislikes, "resize", False)
+            self.InterestsPanedSecond.child_set_property(self.RecommendationsVbox, "resize", True)
+            self.InterestsPanedSecond.child_set_property(self.SimilarUsers, "resize", False)
+            self.frame.interestsvbox.add(self.Main)
 
         self.likes = {}
         self.likes_model = Gtk.ListStore(str)
@@ -135,6 +146,13 @@ class Interests:
 
         self.RecommendationUsersList.set_model(self.recommendation_users_model)
         self.recommendation_users_model.set_sort_column_id(1, Gtk.SortType.ASCENDING)
+
+        if Gtk.get_major_version() == 4:
+            self.likes_model.insert_with_valuesv = self.likes_model.insert_with_values
+            self.dislikes_model.insert_with_valuesv = self.dislikes_model.insert_with_values
+            self.recommendations_model.insert_with_valuesv = self.recommendations_model.insert_with_values
+            self.unrecommendations_model.insert_with_valuesv = self.unrecommendations_model.insert_with_values
+            self.recommendation_users_model.insert_with_valuesv = self.recommendation_users_model.insert_with_values
 
         for thing in config.sections["interests"]["likes"]:
             if thing and isinstance(thing, str):

--- a/pynicotine/gtkgui/interests.py
+++ b/pynicotine/gtkgui/interests.py
@@ -50,7 +50,7 @@ class Interests:
 
         self.likes_column_numbers = list(range(self.likes_model.get_n_columns()))
         cols = initialise_columns(
-            None, self.LikesList, self.on_popup_til_menu,
+            None, self.LikesList,
             ["i_like", _("I Like"), -1, "text", None]
         )
 
@@ -63,7 +63,7 @@ class Interests:
 
         self.dislikes_column_numbers = list(range(self.dislikes_model.get_n_columns()))
         cols = initialise_columns(
-            None, self.DislikesList, self.on_popup_tidl_menu,
+            None, self.DislikesList,
             ["i_dislike", _("I Dislike"), -1, "text", None]
         )
 
@@ -78,7 +78,7 @@ class Interests:
 
         self.recommendations_column_numbers = list(range(self.recommendations_model.get_n_columns()))
         cols = initialise_columns(
-            None, self.RecommendationsList, self.on_popup_r_menu,
+            None, self.RecommendationsList,
             ["rating", _("Rating"), 0, "number", None],
             ["item", _("Item"), -1, "text", None]
         )
@@ -96,7 +96,7 @@ class Interests:
 
         self.unrecommendations_column_numbers = list(range(self.unrecommendations_model.get_n_columns()))
         cols = initialise_columns(
-            None, self.UnrecommendationsList, self.on_popup_ru_menu,
+            None, self.UnrecommendationsList,
             ["rating", _("Rating"), 0, "number", None],
             ["item", _("Item"), -1, "text", None]
         )
@@ -119,7 +119,7 @@ class Interests:
 
         self.recommendation_users_column_numbers = list(range(self.recommendation_users_model.get_n_columns()))
         cols = initialise_columns(
-            None, self.RecommendationUsersList, self.on_popup_ru_menu,
+            None, self.RecommendationUsersList,
             ["status", _("Status"), 25, "pixbuf", None],
             ["user", _("User"), 100, "text", None],
             ["speed", _("Speed"), 100, "text", None],
@@ -146,7 +146,7 @@ class Interests:
 
         """ Popup """
 
-        self.til_popup_menu = popup = PopupMenu(self.frame)
+        self.til_popup_menu = popup = PopupMenu(self.frame, self.LikesList, self.on_popup_til_menu)
         popup.setup(
             ("#" + _("_Remove Item"), self.on_remove_thing_i_like),
             ("#" + _("Re_commendations for Item"), self.on_recommend_item),
@@ -154,14 +154,14 @@ class Interests:
             ("#" + _("_Search for Item"), self.on_til_recommend_search)
         )
 
-        self.tidl_popup_menu = popup = PopupMenu(self.frame)
+        self.tidl_popup_menu = popup = PopupMenu(self.frame, self.DislikesList, self.on_popup_tidl_menu)
         popup.setup(
             ("#" + _("_Remove Item"), self.on_remove_thing_i_dislike),
             ("", None),
             ("#" + _("_Search for Item"), self.on_tidl_recommend_search)
         )
 
-        self.r_popup_menu = popup = PopupMenu(self.frame)
+        self.r_popup_menu = popup = PopupMenu(self.frame, self.RecommendationsList, self.on_popup_r_menu)
         popup.setup(
             ("$" + _("I _Like This"), self.on_like_recommendation),
             ("$" + _("I _Dislike This"), self.on_dislike_recommendation),
@@ -170,7 +170,7 @@ class Interests:
             ("#" + _("_Search for Item"), self.on_r_recommend_search)
         )
 
-        self.ru_popup_menu = popup = PopupMenu(self.frame)
+        self.ru_popup_menu = popup = PopupMenu(self.frame, self.RecommendationUsersList, self.on_popup_ru_menu)
         popup.setup_user_menu()
 
         self.update_visuals()

--- a/pynicotine/gtkgui/notifications.py
+++ b/pynicotine/gtkgui/notifications.py
@@ -26,6 +26,7 @@ from ctypes import Structure, sizeof
 from gi.repository import Gdk
 from gi.repository import Gio
 from gi.repository import GLib
+from gi.repository import Gtk
 
 from pynicotine.config import config
 from pynicotine.logfacility import log
@@ -61,7 +62,7 @@ class Notifications:
                 self.frame.hilites[location].append(user)
                 self.frame.tray_icon.set_image()
 
-        if config.sections["ui"]["urgencyhint"] and \
+        if Gtk.get_major_version() == 3 and config.sections["ui"]["urgencyhint"] and \
                 not self.frame.MainWindow.is_active():
             self.frame.MainWindow.set_urgency_hint(True)
 

--- a/pynicotine/gtkgui/privatechat.py
+++ b/pynicotine/gtkgui/privatechat.py
@@ -314,7 +314,7 @@ class PrivateChat:
         self.Log.set_active(config.sections["logging"]["privatechat"])
 
         tab_label, menu_label = self.chats.get_labels(self.Main)
-        self.popup_menu_user = popup = PopupMenu(self.frame, tab_label, self.on_tab_popup)
+        self.popup_menu_user = popup = PopupMenu(self.frame, tab_label, self.on_popup_menu)
         popup.setup_user_menu(user, page="privatechat")
         popup.setup(
             ("", None),
@@ -322,7 +322,7 @@ class PrivateChat:
             ("#" + _("_Close Tab"), self.on_close)
         )
 
-        self.popup_menu = popup = PopupMenu(self.frame, self.ChatScroll, self.on_popup_menu)
+        popup = PopupMenu(self.frame, self.ChatScroll, self.on_popup_menu)
         popup.setup(
             ("#" + _("Find..."), self.on_find_chat_log),
             ("", None),
@@ -394,15 +394,8 @@ class PrivateChat:
     def set_label(self, label):
         self.popup_menu_user.set_widget(label)
 
-    def on_tab_popup(self, *args):
+    def on_popup_menu(self, menu, widget):
         self.popup_menu_user.toggle_user_items()
-        self.popup_menu_user.popup()
-        return True
-
-    def on_popup_menu(self, *args):
-        self.popup_menu_user.toggle_user_items()
-        self.popup_menu.popup()
-        return True
 
     def on_find_chat_log(self, *args):
         self.SearchBar.set_search_mode(True)

--- a/pynicotine/gtkgui/roomlist.py
+++ b/pynicotine/gtkgui/roomlist.py
@@ -52,7 +52,7 @@ class RoomList:
 
         self.column_numbers = list(range(self.room_model.get_n_columns()))
         self.cols = initialise_columns(
-            None, self.RoomsList, self.on_popup_menu,
+            None, self.RoomsList,
             ["room", _("Room"), 260, "text", self.room_status],
             ["users", _("Users"), 100, "number", self.room_status]
         )
@@ -60,7 +60,7 @@ class RoomList:
         self.cols["users"].set_sort_column_id(1)
 
         self.popup_room = None
-        self.popup_menu = PopupMenu(self.frame)
+        self.popup_menu = PopupMenu(self.frame, self.RoomsList, self.on_popup_menu)
         self.popup_menu.setup(
             ("#" + _("Join Room"), self.on_popup_join),
             ("#" + _("Leave Room"), self.on_popup_leave),

--- a/pynicotine/gtkgui/roomlist.py
+++ b/pynicotine/gtkgui/roomlist.py
@@ -80,7 +80,11 @@ class RoomList:
         self.AcceptPrivateRoom.connect("toggled", self.on_toggle_accept_private_room)
 
         frame.RoomList.connect("clicked", self.show)
-        self.RoomListPopover.set_relative_to(frame.RoomList)
+
+        if Gtk.get_major_version() == 4:
+            self.RoomListPopover.set_parent(frame.RoomList)
+        else:
+            self.RoomListPopover.set_relative_to(frame.RoomList)
 
     def get_selected_room(self, treeview):
 
@@ -157,6 +161,9 @@ class RoomList:
     def set_room_list(self, rooms, owned_rooms, other_private_rooms):
 
         self.room_model.clear()
+
+        if Gtk.get_major_version() == 4:
+            self.room_model.insert_with_valuesv = self.room_model.insert_with_values
 
         for room, users in rooms:
             self.room_model.insert_with_valuesv(-1, self.column_numbers, [room, users, 0])

--- a/pynicotine/gtkgui/roomlist.py
+++ b/pynicotine/gtkgui/roomlist.py
@@ -255,10 +255,10 @@ class RoomList:
             self.popup_room = room
             self.on_popup_join()
 
-    def on_popup_menu(self, widget):
+    def on_popup_menu(self, menu, widget):
 
         if self.room_model is None:
-            return False
+            return True
 
         room = self.get_selected_room(widget)
 
@@ -273,16 +273,13 @@ class RoomList:
         self.popup_room = room
         prooms_enabled = True
 
-        actions = self.popup_menu.get_actions()
+        actions = menu.get_actions()
 
         actions[_("Join Room")].set_enabled(act[0])
         actions[_("Leave Room")].set_enabled(act[1])
 
         actions[_("Disown Private Room")].set_enabled(self.is_private_room_owned(self.popup_room))
         actions[_("Cancel Room Membership")].set_enabled((prooms_enabled and self.is_private_room_member(self.popup_room)))
-
-        self.popup_menu.popup()
-        return True
 
     def on_popup_join(self, *args):
         self.frame.np.queue.append(slskmessages.JoinRoom(self.popup_room))

--- a/pynicotine/gtkgui/roomlist.py
+++ b/pynicotine/gtkgui/roomlist.py
@@ -48,6 +48,11 @@ class RoomList:
 
         load_ui_elements(self, os.path.join(self.frame.gui_dir, "ui", "popovers", "roomlist.ui"))
 
+        if Gtk.get_major_version() == 4:
+            self.RoomsListScrolledWindow.set_has_frame(True)
+        else:
+            self.RoomsListScrolledWindow.set_shadow_type(Gtk.ShadowType.IN)
+
         self.room_model = Gtk.ListStore(str, int, int)
 
         self.column_numbers = list(range(self.room_model.get_n_columns()))

--- a/pynicotine/gtkgui/roomwall.py
+++ b/pynicotine/gtkgui/roomwall.py
@@ -19,11 +19,13 @@
 import os
 
 from gi.repository import Gdk
+from gi.repository import Gtk
 
 from pynicotine import slskmessages
 from pynicotine.config import config
 from pynicotine.gtkgui.utils import append_line
 from pynicotine.gtkgui.utils import load_ui_elements
+from pynicotine.gtkgui.widgets.dialogs import generic_dialog
 from pynicotine.gtkgui.widgets.theme import update_widget_visuals
 
 
@@ -35,7 +37,20 @@ class RoomWall:
         self.room = room
 
         load_ui_elements(self, os.path.join(self.frame.gui_dir, "ui", "dialogs", "roomwall.ui"))
-        self.RoomWallDialog.set_transient_for(frame.MainWindow)
+
+        self.RoomWallDialog = generic_dialog(
+            parent=frame.MainWindow,
+            content_box=self.Main,
+            quit_callback=self.hide,
+            title=_("Room Wall"),
+            width=800,
+            height=600
+        )
+
+        if Gtk.get_major_version() == 4:
+            self.RoomWallListWindow.set_has_frame(True)
+        else:
+            self.RoomWallListWindow.set_shadow_type(Gtk.ShadowType.IN)
 
     def on_set_room_wall_message(self, *args):
 
@@ -77,9 +92,11 @@ class RoomWall:
                 self.RoomWallEntry.select_region(0, -1)
 
         self.RoomWallDialog.present_with_time(Gdk.CURRENT_TIME)
-        self.RoomWallDialog.get_window().set_functions(
-            Gdk.WMFunction.RESIZE | Gdk.WMFunction.MOVE | Gdk.WMFunction.CLOSE
-        )
+
+        if Gtk.get_major_version == 3:
+            self.RoomWallDialog.get_window().set_functions(
+                Gdk.WMFunction.RESIZE | Gdk.WMFunction.MOVE | Gdk.WMFunction.CLOSE
+            )
 
 
 class Tickers:

--- a/pynicotine/gtkgui/search.py
+++ b/pynicotine/gtkgui/search.py
@@ -410,7 +410,7 @@ class Search:
             (">" + _("User(s)"), self.popup_menu_users)
         )
 
-        self.tab_menu = PopupMenu(self.frame, None, self.on_tab_popup)
+        self.tab_menu = PopupMenu(self.frame)
         self.tab_menu.setup(
             ("#" + _("Copy Search Term"), self.on_copy_search_term),
             ("", None),
@@ -1041,11 +1041,11 @@ class Search:
 
         return True
 
-    def on_popup_menu(self, *args):
+    def on_popup_menu(self, menu, widget):
 
         self.select_results()
 
-        actions = self.popup_menu.get_actions()
+        actions = menu.get_actions()
         users = len(self.selected_users) > 0
         files = len(self.selected_results) > 0
 
@@ -1070,10 +1070,7 @@ class Search:
 
                 break
 
-        self.popup_menu.set_num_selected_files(self.selected_files_count)
-
-        self.popup_menu.popup()
-        return True
+        menu.set_num_selected_files(self.selected_files_count)
 
     def on_browse_folder(self, *args):
 
@@ -1364,10 +1361,6 @@ class Search:
             self.FilterLabel.set_text(_("Result Filters"))
 
         self.FilterLabel.set_tooltip_text("%d active filter(s)" % count)
-
-    def on_tab_popup(self, *args):
-        self.tab_menu.popup()
-        return True
 
     def on_clear(self, *args):
 

--- a/pynicotine/gtkgui/search.py
+++ b/pynicotine/gtkgui/search.py
@@ -40,6 +40,7 @@ from pynicotine.gtkgui.utils import connect_key_press_event
 from pynicotine.gtkgui.utils import copy_file_url
 from pynicotine.gtkgui.utils import get_key_press_event_args
 from pynicotine.gtkgui.utils import load_ui_elements
+from pynicotine.gtkgui.utils import parse_accelerator
 from pynicotine.gtkgui.widgets.filechooser import choose_dir
 from pynicotine.gtkgui.widgets.iconnotebook import IconNotebook
 from pynicotine.gtkgui.widgets.popupmenu import PopupMenu
@@ -78,7 +79,6 @@ class Searches(IconNotebook):
             notebookraw=self.frame.SearchNotebookRaw
         )
 
-        self.popup_enable()
         self.load_config()
 
         self.wish_list = WishList(frame, self)
@@ -291,6 +291,11 @@ class Search:
         # Build the window
         load_ui_elements(self, os.path.join(self.frame.gui_dir, "ui", "search.ui"))
         self.key_controller = connect_key_press_event(self.ResultsList, self.on_key_press_event)
+
+        if Gtk.get_major_version() == 4:
+            self.ToggleButton.set_icon_name("view-list-symbolic")
+        else:
+            self.ToggleButton.set_image(Gtk.Image.new_from_icon_name("view-list-symbolic", Gtk.IconSize.BUTTON))
 
         self.text = text
         self.searchterm_words_include = [p for p in text.lower().split() if not p.startswith('-')]
@@ -1030,10 +1035,9 @@ class Search:
         keyval, keycode, state = get_key_press_event_args(*args)
         self.select_results()
 
-        key, codes, mods = Gtk.accelerator_parse_with_keycode("<Primary>c")
+        key, codes, mods = parse_accelerator("<Primary>c")
 
-        if state & mods and \
-                keycode in codes:
+        if state & mods and keycode in codes:
             self.on_copy_file_path()
         else:
             # No key match, continue event
@@ -1250,10 +1254,18 @@ class Search:
 
         if active:
             self.ResultsList.expand_all()
-            self.expand.set_from_icon_name("go-up-symbolic", Gtk.IconSize.BUTTON)
+
+            if Gtk.get_major_version() == 4:
+                self.expand.set_from_icon_name("go-up-symbolic")
+            else:
+                self.expand.set_from_icon_name("go-up-symbolic", Gtk.IconSize.BUTTON)
         else:
             collapse_treeview(self.ResultsList, self.ResultGrouping.get_active_id())
-            self.expand.set_from_icon_name("go-down-symbolic", Gtk.IconSize.BUTTON)
+
+            if Gtk.get_major_version() == 4:
+                self.expand.set_from_icon_name("go-down-symbolic")
+            else:
+                self.expand.set_from_icon_name("go-down-symbolic", Gtk.IconSize.BUTTON)
 
         config.sections["searches"]["expand_searches"] = active
 
@@ -1343,7 +1355,11 @@ class Search:
 
         if not hasattr(self, "AboutSearchFiltersPopover"):
             load_ui_elements(self, os.path.join(self.frame.gui_dir, "ui", "popovers", "searchfilters.ui"))
-            self.AboutSearchFiltersPopover.set_relative_to(self.ShowChatHelp)
+
+            if Gtk.get_major_version() == 4:
+                self.AboutSearchFiltersPopover.set_parent(self.ShowChatHelp)
+            else:
+                self.AboutSearchFiltersPopover.set_relative_to(self.ShowChatHelp)
 
         try:
             self.AboutSearchFiltersPopover.popup()

--- a/pynicotine/gtkgui/settingswindow.py
+++ b/pynicotine/gtkgui/settingswindow.py
@@ -201,7 +201,7 @@ class DownloadsFrame(BuildFrame):
         self.downloadfilters = []
 
         cols = initialise_columns(
-            None, self.FilterView, None,
+            None, self.FilterView,
             ["filter", _("Filter"), -1, "text", None],
             ["escaped", _("Escaped"), 40, "toggle", None]
         )
@@ -506,7 +506,7 @@ class SharesFrame(BuildFrame):
 
         self.Shares.set_model(self.shareslist)
         cols = initialise_columns(
-            None, self.Shares, None,
+            None, self.Shares,
             ["virtual_folder", _("Virtual Folder"), 0, "text", None],
             ["folder", _("Folder"), -1, "text", None],
             ["buddies", _("Buddy-only"), 0, "toggle", None],
@@ -949,7 +949,7 @@ class IgnoreListFrame(BuildFrame):
         self.ignored_users = []
         self.ignorelist = Gtk.ListStore(str)
         initialise_columns(
-            None, self.IgnoredUsers, None,
+            None, self.IgnoredUsers,
             ["users", _("Users"), -1, "text", None]
         )
 
@@ -958,7 +958,7 @@ class IgnoreListFrame(BuildFrame):
         self.ignored_ips = {}
         self.ignored_ips_list = Gtk.ListStore(str, str)
         cols = initialise_columns(
-            None, self.IgnoredIPs, None,
+            None, self.IgnoredIPs,
             ["addresses", _("Addresses"), -1, "text", None],
             ["users", _("Users"), -1, "text", None]
         )
@@ -1102,7 +1102,7 @@ class BanListFrame(BuildFrame):
         self.banlist_model = Gtk.ListStore(str)
 
         initialise_columns(
-            None, self.BannedList, None,
+            None, self.BannedList,
             ["users", _("Users"), -1, "text", None]
         )
 
@@ -1112,7 +1112,7 @@ class BanListFrame(BuildFrame):
         self.blocked_list_model = Gtk.ListStore(str, str)
 
         cols = initialise_columns(
-            None, self.BlockedList, None,
+            None, self.BlockedList,
             ["addresses", _("Addresses"), -1, "text", None],
             ["users", _("Users"), -1, "text", None]
         )
@@ -2002,7 +2002,7 @@ class UrlCatchingFrame(BuildFrame):
         self.protocols = {}
 
         cols = initialise_columns(
-            None, self.ProtocolHandlers, None,
+            None, self.ProtocolHandlers,
             ["protocol", _("Protocol"), -1, "text", None],
             ["handler", _("Handler"), -1, "combo", None]
         )
@@ -2145,7 +2145,7 @@ class CensorListFrame(BuildFrame):
         self.censor_list_model = Gtk.ListStore(str)
 
         cols = initialise_columns(
-            None, self.CensorList, None,
+            None, self.CensorList,
             ["pattern", _("Pattern"), -1, "edit", None]
         )
 
@@ -2245,7 +2245,7 @@ class AutoReplaceListFrame(BuildFrame):
         self.replacelist = Gtk.ListStore(str, str)
 
         cols = initialise_columns(
-            None, self.ReplacementList, None,
+            None, self.ReplacementList,
             ["pattern", _("Pattern"), 150, "edit", None],
             ["replacement", _("Replacement"), -1, "edit", None]
         )
@@ -2699,7 +2699,7 @@ class PluginsFrame(BuildFrame):
             container.add(scrolled_window)
 
             cols = initialise_columns(
-                None, self.tw[name], None,
+                None, self.tw[name],
                 [description, description, 150, "edit", None]
             )
 
@@ -2885,7 +2885,7 @@ class PluginsFrame(BuildFrame):
         self.selected_plugin = None
 
         cols = initialise_columns(
-            None, self.PluginTreeView, None,
+            None, self.PluginTreeView,
             ["enabled", _("Enabled"), 0, "toggle", None],
             ["plugins", _("Plugins"), 380, "text", None]
         )
@@ -3107,7 +3107,7 @@ class Settings:
         self.tree["TextToSpeech"] = model.append(row, [_("Text-to-Speech"), "TextToSpeech"])
 
         initialise_columns(
-            None, self.SettingsTreeview, None,
+            None, self.SettingsTreeview,
             ["categories", _("Categories"), -1, "text", None]
         )
 

--- a/pynicotine/gtkgui/statistics.py
+++ b/pynicotine/gtkgui/statistics.py
@@ -23,7 +23,8 @@ from gi.repository import Gtk
 
 from pynicotine.config import config
 from pynicotine.gtkgui.utils import load_ui_elements
-from pynicotine.gtkgui.widgets.messagedialogs import option_dialog
+from pynicotine.gtkgui.widgets.dialogs import generic_dialog
+from pynicotine.gtkgui.widgets.dialogs import option_dialog
 from pynicotine.utils import human_size
 
 
@@ -34,7 +35,14 @@ class Statistics:
         self.frame = frame
 
         load_ui_elements(self, os.path.join(self.frame.gui_dir, "ui", "dialogs", "statistics.ui"))
-        self.StatisticsDialog.set_transient_for(frame.MainWindow)
+
+        self.StatisticsDialog = generic_dialog(
+            parent=frame.MainWindow,
+            content_box=self.Main,
+            quit_callback=self.hide,
+            title=_("Transfer Statistics"),
+            width=450
+        )
 
         # Initialize stats
         for stat_id in config.defaults["statistics"]:
@@ -77,6 +85,8 @@ class Statistics:
     def show(self):
 
         self.StatisticsDialog.present_with_time(Gdk.CURRENT_TIME)
-        self.StatisticsDialog.get_window().set_functions(
-            Gdk.WMFunction.RESIZE | Gdk.WMFunction.MOVE | Gdk.WMFunction.CLOSE
-        )
+
+        if Gtk.get_major_version() == 3:
+            self.StatisticsDialog.get_window().set_functions(
+                Gdk.WMFunction.RESIZE | Gdk.WMFunction.MOVE | Gdk.WMFunction.CLOSE
+            )

--- a/pynicotine/gtkgui/transferlist.py
+++ b/pynicotine/gtkgui/transferlist.py
@@ -724,12 +724,12 @@ class TransferList:
     def on_tooltip(self, widget, x, y, keyboard_mode, tooltip):
         return show_file_path_tooltip(widget, x, y, tooltip, 10)
 
-    def on_popup_menu(self, *args):
+    def on_popup_menu(self, menu, widget):
 
         self.select_transfers()
         num_selected_transfers = len(self.selected_transfers)
 
-        actions = self.popup_menu.get_actions()
+        actions = menu.get_actions()
         users = len(self.selected_users) > 0
         files = num_selected_transfers > 0
 
@@ -757,10 +757,7 @@ class TransferList:
         for i in (_("_Retry"), _("Abor_t"), _("_Clear")):
             actions[i].set_enabled(act)
 
-        self.popup_menu.set_num_selected_files(num_selected_transfers)
-
-        self.popup_menu.popup()
-        return True
+        menu.set_num_selected_files(num_selected_transfers)
 
     def on_row_activated(self, treeview, path, column):
 

--- a/pynicotine/gtkgui/transferlist.py
+++ b/pynicotine/gtkgui/transferlist.py
@@ -36,6 +36,7 @@ from pynicotine.gtkgui.utils import connect_key_press_event
 from pynicotine.gtkgui.utils import copy_file_url
 from pynicotine.gtkgui.utils import get_key_press_event_args
 from pynicotine.gtkgui.utils import load_ui_elements
+from pynicotine.gtkgui.utils import parse_accelerator
 from pynicotine.gtkgui.widgets.popupmenu import PopupMenu
 from pynicotine.gtkgui.widgets.theme import update_widget_visuals
 from pynicotine.gtkgui.widgets.treeview import collapse_treeview
@@ -56,7 +57,22 @@ class TransferList:
         self.type = type
 
         load_ui_elements(self, os.path.join(frame.gui_dir, "ui", type + "s.ui"))
-        getattr(frame, type + "svbox").add(self.Main)
+
+        self.ActionBar.remove(self.End)
+        self.ActionBar.pack_end(self.End)
+
+        if Gtk.get_major_version() == 4:
+            getattr(frame, type + "svbox").append(self.Main)
+            getattr(frame, "ToggleButton%ss" % self.type.title()).set_icon_name("view-list-symbolic")
+
+            self.ClearTransfers.set_has_frame(False)
+            self.ClearTransfers.set_label(self.ClearTransfersLabel.get_first_child().get_text())
+        else:
+            getattr(frame, type + "svbox").add(self.Main)
+            getattr(frame, "ToggleButton%ss" % self.type.title()).set_image(Gtk.Image.new_from_icon_name("view-list-symbolic", Gtk.IconSize.BUTTON))
+
+            self.ClearTransfers.add(self.ClearTransfersLabel)
+
         self.widget = widget = getattr(self, type.title() + "List")
         self.key_controller = connect_key_press_event(widget, self.on_key_press_event)
 
@@ -108,6 +124,9 @@ class TransferList:
             GObject.TYPE_UINT64,   # (17) queue position
             GObject.TYPE_PYOBJECT  # (18) transfer object
         )
+
+        if Gtk.get_major_version() == 4:
+            self.transfersmodel.insert_with_valuesv = self.transfersmodel.insert_with_values
 
         self.column_numbers = list(range(self.transfersmodel.get_n_columns()))
         self.cols = cols = initialise_columns(
@@ -701,11 +720,17 @@ class TransferList:
         expanded = widget.get_active()
 
         if expanded:
+            icon_name = "go-up-symbolic"
             self.widget.expand_all()
-            expand_button_icon.set_from_icon_name("go-up-symbolic", Gtk.IconSize.BUTTON)
+
         else:
+            icon_name = "go-down-symbolic"
             collapse_treeview(self.widget, self.tree_users)
-            expand_button_icon.set_from_icon_name("go-down-symbolic", Gtk.IconSize.BUTTON)
+
+        if Gtk.get_major_version() == 4:
+            expand_button_icon.set_from_icon_name(icon_name)
+        else:
+            expand_button_icon.set_from_icon_name(icon_name, Gtk.IconSize.BUTTON)
 
         config.sections["transfers"]["%ssexpanded" % self.type] = expanded
         config.write_configuration()
@@ -799,17 +824,17 @@ class TransferList:
         keyval, keycode, state = get_key_press_event_args(*args)
         self.select_transfers()
 
-        if keycode in Gtk.accelerator_parse_with_keycode("t")[1]:
+        if keycode in parse_accelerator("t")[1]:
             self.abort_transfers()
 
-        elif keycode in Gtk.accelerator_parse_with_keycode("r")[1]:
+        elif keycode in parse_accelerator("r")[1]:
             self.retry_transfers()
 
-        elif state & Gtk.accelerator_parse("<Primary>")[1] and \
-                keycode in Gtk.accelerator_parse_with_keycode("c")[1]:
+        elif state & parse_accelerator("<Primary>")[2] and \
+                keycode in parse_accelerator("c")[1]:
             self.on_copy_file_path()
 
-        elif keycode in Gtk.accelerator_parse_with_keycode("Delete")[1]:
+        elif keycode in parse_accelerator("Delete")[1]:
             self.abort_transfers(clear=True)
 
         else:

--- a/pynicotine/gtkgui/transferlist.py
+++ b/pynicotine/gtkgui/transferlist.py
@@ -111,7 +111,7 @@ class TransferList:
 
         self.column_numbers = list(range(self.transfersmodel.get_n_columns()))
         self.cols = cols = initialise_columns(
-            type, widget, self.on_popup_menu,
+            type, widget,
             ["user", _("User"), 200, "text", None],
             ["path", _("Path"), 400, "text", None],
             ["filename", _("Filename"), 400, "text", None],
@@ -150,7 +150,7 @@ class TransferList:
         self.popup_menu_clear = PopupMenu(frame)
         self.ClearTransfers.set_menu_model(self.popup_menu_clear)
 
-        self.popup_menu = PopupMenu(frame)
+        self.popup_menu = PopupMenu(frame, widget, self.on_popup_menu)
         self.popup_menu.setup(
             ("#" + "selected_files", None),
             ("", None),

--- a/pynicotine/gtkgui/ui/chatrooms.ui
+++ b/pynicotine/gtkgui/ui/chatrooms.ui
@@ -8,16 +8,16 @@
         <property name="visible">0</property>
         <property name="orientation">vertical</property>
         <child>
-          <object class="GtkPaned">
+          <object class="GtkPaned" id="ChatPaned">
             <property name="visible">1</property>
             <property name="can-focus">1</property>
             <child>
-              <object class="GtkPaned">
+              <object class="GtkPaned" id="ChatPanedSecond">
                 <property name="visible">1</property>
                 <property name="can-focus">1</property>
                 <property name="orientation">vertical</property>
                 <child>
-                  <object class="GtkBox">
+                  <object class="GtkBox" id="ActivityView">
                     <property name="visible">1</property>
                     <property name="orientation">vertical</property>
                     <child>
@@ -62,12 +62,9 @@
                       </object>
                     </child>
                   </object>
-                  <packing>
-                    <property name="resize">0</property>
-                  </packing>
                 </child>
                 <child>
-                  <object class="GtkBox">
+                  <object class="GtkBox" id="ChatView">
                     <property name="visible">1</property>
                     <property name="orientation">vertical</property>
                     <child>
@@ -123,7 +120,6 @@
                           <object class="GtkEntry" id="ChatEntry">
                             <property name="visible">1</property>
                             <property name="can-focus">1</property>
-                            <property name="has-focus">1</property>
                             <property name="hexpand">1</property>
                             <property name="width-chars">5</property>
                           </object>
@@ -185,18 +181,11 @@
                       </object>
                     </child>
                   </object>
-                  <packing>
-                    <property name="shrink">0</property>
-                  </packing>
                 </child>
               </object>
-              <packing>
-                <property name="resize">1</property>
-                <property name="shrink">0</property>
-              </packing>
             </child>
             <child>
-              <object class="GtkBox">
+              <object class="GtkBox" id="UserView">
                 <property name="visible">1</property>
                 <property name="orientation">vertical</property>
                 <child>
@@ -293,10 +282,6 @@
                   </object>
                 </child>
               </object>
-              <packing>
-                <property name="resize">0</property>
-                <property name="shrink">1</property>
-              </packing>
             </child>
           </object>
         </child>

--- a/pynicotine/gtkgui/ui/dialogs/about.ui
+++ b/pynicotine/gtkgui/ui/dialogs/about.ui
@@ -3,7 +3,6 @@
   <requires lib="gtk+" version="3.18"/>
   <object class="GtkAboutDialog" id="AboutDialog">
     <property name="modal">1</property>
-    <property name="window-position">center-on-parent</property>
     <property name="comments" translatable="yes">Graphical client for the Soulseek file sharing network</property>
     <property name="website">https://nicotine-plus.org</property>
     <property name="copyright">© 2001-2003 PySoulSeek Contributors

--- a/pynicotine/gtkgui/ui/dialogs/fastconfigure.ui
+++ b/pynicotine/gtkgui/ui/dialogs/fastconfigure.ui
@@ -3,399 +3,380 @@
   <requires lib="gtk+" version="3.18"/>
   <object class="GtkAssistant" id="FastConfigureDialog">
     <property name="modal">1</property>
-    <property name="window-position">center-on-parent</property>
     <property name="default-width">800</property>
     <property name="default-height">450</property>
-    <property name="type-hint">dialog</property>
     <signal name="apply" handler="on_apply" swapped="no"/>
     <signal name="cancel" handler="on_close" swapped="no"/>
     <signal name="close" handler="on_close" swapped="no"/>
     <signal name="prepare" handler="on_prepare" swapped="no"/>
+  </object>
+  <object class="GtkBox" id="welcomepage">
+    <property name="visible">1</property>
+    <property name="halign">center</property>
+    <property name="valign">center</property>
+    <property name="margin-start">12</property>
+    <property name="margin-end">12</property>
+    <property name="margin-bottom">12</property>
+    <property name="orientation">vertical</property>
+    <property name="spacing">24</property>
     <child>
-      <object class="GtkBox" id="welcomepage">
+      <object class="GtkImage">
         <property name="visible">1</property>
         <property name="halign">center</property>
-        <property name="valign">center</property>
-        <property name="margin-start">12</property>
-        <property name="margin-end">12</property>
-        <property name="margin-bottom">12</property>
-        <property name="orientation">vertical</property>
-        <property name="spacing">24</property>
-        <child>
-          <object class="GtkImage">
-            <property name="visible">1</property>
-            <property name="halign">center</property>
-            <property name="icon-name">org.nicotine_plus.Nicotine</property>
-            <property name="pixel-size">128</property>
-          </object>
-        </child>
-        <child>
-          <object class="GtkBox">
-            <property name="visible">1</property>
-            <property name="orientation">vertical</property>
-            <property name="spacing">18</property>
-            <child>
-              <object class="GtkLabel">
-                <property name="visible">1</property>
-                <property name="label" translatable="yes">Welcome to Nicotine+</property>
-                <property name="justify">center</property>
-                <property name="wrap">1</property>
-                <attributes>
-                  <attribute name="weight" value="ultrabold"/>
-                  <attribute name="size" value="20000"/>
-                </attributes>
-              </object>
-            </child>
-            <child>
-              <object class="GtkLabel">
-                <property name="visible">1</property>
-                <property name="label" translatable="yes">Graphical client for the Soulseek peer-to-peer file sharing network</property>
-                <property name="justify">center</property>
-                <property name="wrap">1</property>
-                <property name="width-chars">36</property>
-                <property name="max-width-chars">60</property>
-              </object>
-            </child>
-          </object>
-        </child>
-        <child>
-          <object class="GtkButton">
-            <property name="visible">1</property>
-            <property name="width-request">96</property>
-            <property name="halign">center</property>
-            <property name="margin-top">6</property>
-            <property name="label" translatable="yes">Set Up...</property>
-            <signal name="clicked" handler="on_set_up" swapped="no"/>
-            <style>
-              <class name="circular"/>
-            </style>
-          </object>
-        </child>
-      </object>
-      <packing>
-        <property name="page-type">custom</property>
-      </packing>
-    </child>
-    <child>
-      <object class="GtkBox" id="userpasspage">
-        <property name="visible">1</property>
-        <property name="halign">center</property>
-        <property name="valign">center</property>
-        <property name="margin-start">12</property>
-        <property name="margin-end">12</property>
-        <property name="margin-top">6</property>
-        <property name="margin-bottom">6</property>
-        <property name="orientation">vertical</property>
-        <property name="spacing">30</property>
-        <child>
-          <object class="GtkLabel">
-            <property name="visible">1</property>
-            <property name="label" translatable="yes">To create a new user, fill in the username and password you want. If you already have a Soulseek account, fill in your chosen details.</property>
-            <property name="justify">center</property>
-            <property name="wrap">1</property>
-            <property name="width-chars">36</property>
-            <property name="max-width-chars">60</property>
-          </object>
-        </child>
-        <child>
-          <object class="GtkLabel">
-            <property name="visible">1</property>
-            <property name="label" translatable="yes">Please keep in mind that more common usernames may be taken. If you&apos;re unable to connect, you can change your username in the preferences later.</property>
-            <property name="justify">center</property>
-            <property name="wrap">1</property>
-            <property name="width-chars">36</property>
-            <property name="max-width-chars">60</property>
-          </object>
-        </child>
-        <child>
-          <object class="GtkFlowBox">
-            <property name="visible">1</property>
-            <property name="column-spacing">10</property>
-            <property name="row-spacing">10</property>
-            <property name="max-children-per-line">2</property>
-            <property name="selection-mode">none</property>
-            <child>
-              <object class="GtkFlowBoxChild">
-                <property name="visible">1</property>
-                <property name="can-focus">0</property>
-                <child>
-                  <object class="GtkBox">
-                    <property name="visible">1</property>
-                    <property name="orientation">vertical</property>
-                    <property name="spacing">10</property>
-                    <property name="hexpand">1</property>
-                    <child>
-                      <object class="GtkLabel">
-                        <property name="visible">1</property>
-                        <property name="halign">start</property>
-                        <property name="label" translatable="yes">Username</property>
-                        <attributes>
-                          <attribute name="weight" value="bold"/>
-                        </attributes>
-                      </object>
-                    </child>
-                    <child>
-                      <object class="GtkEntry" id="username">
-                        <property name="visible">1</property>
-                        <property name="can-focus">1</property>
-                        <property name="width-chars">20</property>
-                        <signal name="changed" handler="on_entry_changed" swapped="no"/>
-                      </object>
-                    </child>
-                  </object>
-                </child>
-              </object>
-            </child>
-            <child>
-              <object class="GtkFlowBoxChild">
-                <property name="visible">1</property>
-                <property name="can-focus">0</property>
-                <child>
-                  <object class="GtkBox">
-                    <property name="visible">1</property>
-                    <property name="orientation">vertical</property>
-                    <property name="spacing">10</property>
-                    <property name="hexpand">1</property>
-                    <child>
-                      <object class="GtkLabel">
-                        <property name="visible">1</property>
-                        <property name="halign">start</property>
-                        <property name="label" translatable="yes">Password</property>
-                        <attributes>
-                          <attribute name="weight" value="bold"/>
-                        </attributes>
-                      </object>
-                    </child>
-                    <child>
-                      <object class="GtkEntry" id="password">
-                        <property name="visible">1</property>
-                        <property name="can-focus">1</property>
-                        <property name="visibility">0</property>
-                        <property name="width-chars">20</property>
-                        <signal name="changed" handler="on_entry_changed" swapped="no"/>
-                      </object>
-                    </child>
-                  </object>
-                </child>
-              </object>
-            </child>
-          </object>
-        </child>
+        <property name="icon-name">org.nicotine_plus.Nicotine</property>
+        <property name="pixel-size">128</property>
       </object>
     </child>
     <child>
-      <object class="GtkBox" id="portpage">
+      <object class="GtkBox">
         <property name="visible">1</property>
-        <property name="halign">center</property>
-        <property name="valign">center</property>
-        <property name="margin-start">12</property>
-        <property name="margin-end">12</property>
-        <property name="margin-top">6</property>
-        <property name="margin-bottom">6</property>
         <property name="orientation">vertical</property>
-        <property name="spacing">24</property>
+        <property name="spacing">18</property>
         <child>
           <object class="GtkLabel">
             <property name="visible">1</property>
-            <property name="label" translatable="yes">Nicotine+ uses peer-to-peer networking to connect to other users. An open listening port is crucial to allow users to connect to you without trouble.</property>
-            <property name="justify">center</property>
-            <property name="wrap">1</property>
-            <property name="width-chars">36</property>
-            <property name="max-width-chars">60</property>
-          </object>
-        </child>
-        <child>
-          <object class="GtkLabel">
-            <property name="visible">1</property>
-            <property name="label" translatable="yes">The default listening port should work fine in most cases. If you need to use a different port, you can change it in the preferences later.</property>
-            <property name="justify">center</property>
-            <property name="wrap">1</property>
-            <property name="width-chars">36</property>
-            <property name="max-width-chars">60</property>
-          </object>
-        </child>
-        <child>
-          <object class="GtkLabel">
-            <property name="visible">1</property>
-            <property name="label" translatable="yes">Nicotine+ will still work to some degree if your port is closed. However, do keep in mind that you won&apos;t be able to connect to users whose port is also closed.</property>
-            <property name="justify">center</property>
-            <property name="wrap">1</property>
-            <property name="width-chars">36</property>
-            <property name="max-width-chars">60</property>
-          </object>
-        </child>
-        <child>
-          <object class="GtkButton" id="checkmyport">
-            <property name="label" translatable="yes">Check Port Status</property>
-            <property name="visible">1</property>
-            <property name="can-focus">1</property>
-            <property name="receives-default">1</property>
-            <property name="halign">center</property>
-            <signal name="clicked" handler="on_check_port_status" swapped="no"/>
-          </object>
-        </child>
-      </object>
-    </child>
-    <child>
-      <object class="GtkBox" id="sharepage">
-        <property name="visible">1</property>
-        <property name="valign">center</property>
-        <property name="margin-start">18</property>
-        <property name="margin-end">18</property>
-        <property name="margin-top">6</property>
-        <property name="margin-bottom">6</property>
-        <property name="orientation">vertical</property>
-        <property name="spacing">30</property>
-        <child>
-          <object class="GtkBox">
-            <property name="visible">1</property>
-            <property name="orientation">vertical</property>
-            <property name="halign">center</property>
-            <property name="spacing">15</property>
-            <child>
-              <object class="GtkLabel">
-                <property name="visible">1</property>
-                <property name="label" translatable="yes">Download Files to Folder</property>
-                <attributes>
-                  <attribute name="weight" value="bold"/>
-                </attributes>
-              </object>
-            </child>
-            <child>
-              <object class="GtkButton" id="downloaddir">
-                <property name="visible">1</property>
-                <property name="hexpand">1</property>
-              </object>
-            </child>
-          </object>
-        </child>
-        <child>
-          <object class="GtkBox">
-            <property name="visible">1</property>
-            <property name="orientation">vertical</property>
-            <property name="spacing">15</property>
-            <child>
-              <object class="GtkLabel">
-                <property name="visible">1</property>
-                <property name="label" translatable="yes">Share Folders</property>
-                <attributes>
-                  <attribute name="weight" value="bold"/>
-                </attributes>
-              </object>
-            </child>
-            <child>
-              <object class="GtkLabel">
-                <property name="visible">1</property>
-                <property name="label" translatable="yes">Users on the Soulseek network will be able to download files from folders you share.</property>
-                <property name="justify">center</property>
-                <property name="wrap">1</property>
-                <property name="width-chars">36</property>
-                <property name="max-width-chars">60</property>
-              </object>
-            </child>
-            <child>
-              <object class="GtkScrolledWindow">
-                <property name="visible">1</property>
-                <property name="can-focus">1</property>
-                <property name="height-request">150</property>
-                <property name="shadow-type">in</property>
-                <child>
-                  <object class="GtkTreeView" id="shareddirectoriestree">
-                    <property name="visible">1</property>
-                    <property name="can-focus">1</property>
-                    <property name="rubber-banding">1</property>
-                    <child internal-child="selection">
-                      <object class="GtkTreeSelection">
-                        <property name="mode">multiple</property>
-                      </object>
-                    </child>
-                  </object>
-                </child>
-              </object>
-            </child>
-            <child>
-              <object class="GtkBox">
-                <property name="visible">1</property>
-                <property name="halign">center</property>
-                <property name="spacing">12</property>
-                <child>
-                  <object class="GtkButton" id="addshare">
-                    <property name="label" translatable="yes">Add</property>
-                    <property name="visible">1</property>
-                    <property name="can-focus">1</property>
-                    <property name="receives-default">1</property>
-                    <signal name="clicked" handler="on_add_share" swapped="no"/>
-                  </object>
-                </child>
-                <child>
-                  <object class="GtkButton" id="removeshares">
-                    <property name="label" translatable="yes">Remove</property>
-                    <property name="visible">1</property>
-                    <property name="can-focus">1</property>
-                    <property name="receives-default">1</property>
-                    <signal name="clicked" handler="on_remove_share" swapped="no"/>
-                  </object>
-                </child>
-              </object>
-            </child>
-          </object>
-        </child>
-      </object>
-    </child>
-    <child>
-      <object class="GtkBox" id="summarypage">
-        <property name="visible">1</property>
-        <property name="halign">center</property>
-        <property name="valign">center</property>
-        <property name="margin-start">12</property>
-        <property name="margin-end">12</property>
-        <property name="margin-top">6</property>
-        <property name="margin-bottom">6</property>
-        <property name="orientation">vertical</property>
-        <property name="spacing">24</property>
-        <child>
-          <object class="GtkLabel">
-            <property name="visible">1</property>
-            <property name="label" translatable="yes">You are ready to use Nicotine+!</property>
+            <property name="label" translatable="yes">Welcome to Nicotine+</property>
             <property name="justify">center</property>
             <property name="wrap">1</property>
             <attributes>
               <attribute name="weight" value="ultrabold"/>
-              <attribute name="size" value="18000"/>
+              <attribute name="size" value="20000"/>
             </attributes>
           </object>
         </child>
         <child>
-          <object class="GtkBox">
+          <object class="GtkLabel">
             <property name="visible">1</property>
-            <property name="orientation">vertical</property>
-            <property name="spacing">18</property>
+            <property name="label" translatable="yes">Graphical client for the Soulseek peer-to-peer file sharing network</property>
+            <property name="justify">center</property>
+            <property name="wrap">1</property>
+            <property name="width-chars">36</property>
+            <property name="max-width-chars">60</property>
+          </object>
+        </child>
+      </object>
+    </child>
+    <child>
+      <object class="GtkButton">
+        <property name="visible">1</property>
+        <property name="width-request">96</property>
+        <property name="halign">center</property>
+        <property name="margin-top">6</property>
+        <property name="label" translatable="yes">Set Up...</property>
+        <signal name="clicked" handler="on_set_up" swapped="no"/>
+        <style>
+          <class name="circular"/>
+        </style>
+      </object>
+    </child>
+  </object>
+  <object class="GtkBox" id="userpasspage">
+    <property name="visible">1</property>
+    <property name="halign">center</property>
+    <property name="valign">center</property>
+    <property name="margin-start">12</property>
+    <property name="margin-end">12</property>
+    <property name="margin-top">6</property>
+    <property name="margin-bottom">6</property>
+    <property name="orientation">vertical</property>
+    <property name="spacing">30</property>
+    <child>
+      <object class="GtkLabel">
+        <property name="visible">1</property>
+        <property name="label" translatable="yes">To create a new user, fill in the username and password you want. If you already have a Soulseek account, fill in your chosen details.</property>
+        <property name="justify">center</property>
+        <property name="wrap">1</property>
+        <property name="width-chars">36</property>
+        <property name="max-width-chars">60</property>
+      </object>
+    </child>
+    <child>
+      <object class="GtkLabel">
+        <property name="visible">1</property>
+        <property name="label" translatable="yes">Please keep in mind that more common usernames may be taken. If you&apos;re unable to connect, you can change your username in the preferences later.</property>
+        <property name="justify">center</property>
+        <property name="wrap">1</property>
+        <property name="width-chars">36</property>
+        <property name="max-width-chars">60</property>
+      </object>
+    </child>
+    <child>
+      <object class="GtkFlowBox">
+        <property name="visible">1</property>
+        <property name="column-spacing">10</property>
+        <property name="row-spacing">10</property>
+        <property name="max-children-per-line">2</property>
+        <property name="selection-mode">none</property>
+        <child>
+          <object class="GtkFlowBoxChild">
+            <property name="visible">1</property>
+            <property name="can-focus">1</property>
             <child>
-              <object class="GtkLabel">
+              <object class="GtkBox">
                 <property name="visible">1</property>
-                <property name="label" translatable="yes">Transfer speeds depend on the users you are downloading from. Some users will be fast while others will be slow.</property>
-                <property name="justify">fill</property>
-                <property name="wrap">1</property>
-                <property name="width-chars">32</property>
-                <property name="max-width-chars">60</property>
+                <property name="orientation">vertical</property>
+                <property name="spacing">10</property>
+                <property name="hexpand">1</property>
+                <child>
+                  <object class="GtkLabel">
+                    <property name="visible">1</property>
+                    <property name="halign">start</property>
+                    <property name="label" translatable="yes">Username</property>
+                    <attributes>
+                      <attribute name="weight" value="bold"/>
+                    </attributes>
+                  </object>
+                </child>
+                <child>
+                  <object class="GtkEntry" id="username">
+                    <property name="visible">1</property>
+                    <property name="can-focus">1</property>
+                    <property name="width-chars">20</property>
+                    <signal name="changed" handler="on_entry_changed" swapped="no"/>
+                  </object>
+                </child>
               </object>
             </child>
+          </object>
+        </child>
+        <child>
+          <object class="GtkFlowBoxChild">
+            <property name="visible">1</property>
+            <property name="can-focus">1</property>
             <child>
-              <object class="GtkLabel" id="labelnoshare">
+              <object class="GtkBox">
                 <property name="visible">1</property>
-                <property name="label" translatable="yes">Sharing files is crucial for the health of the Soulseek network. Many people will ban you if you download from them without sharing anything yourself.</property>
-                <property name="justify">fill</property>
-                <property name="wrap">1</property>
-                <property name="width-chars">32</property>
-                <property name="max-width-chars">60</property>
+                <property name="orientation">vertical</property>
+                <property name="spacing">10</property>
+                <property name="hexpand">1</property>
+                <child>
+                  <object class="GtkLabel">
+                    <property name="visible">1</property>
+                    <property name="halign">start</property>
+                    <property name="label" translatable="yes">Password</property>
+                    <attributes>
+                      <attribute name="weight" value="bold"/>
+                    </attributes>
+                  </object>
+                </child>
+                <child>
+                  <object class="GtkEntry" id="password">
+                    <property name="visible">1</property>
+                    <property name="can-focus">1</property>
+                    <property name="visibility">0</property>
+                    <property name="width-chars">20</property>
+                    <signal name="changed" handler="on_entry_changed" swapped="no"/>
+                  </object>
+                </child>
               </object>
             </child>
           </object>
         </child>
       </object>
-      <packing>
-        <property name="page-type">summary</property>
-      </packing>
+    </child>
+  </object>
+  <object class="GtkBox" id="portpage">
+    <property name="visible">1</property>
+    <property name="halign">center</property>
+    <property name="valign">center</property>
+    <property name="margin-start">12</property>
+    <property name="margin-end">12</property>
+    <property name="margin-top">6</property>
+    <property name="margin-bottom">6</property>
+    <property name="orientation">vertical</property>
+    <property name="spacing">24</property>
+    <child>
+      <object class="GtkLabel">
+        <property name="visible">1</property>
+        <property name="label" translatable="yes">Nicotine+ uses peer-to-peer networking to connect to other users. An open listening port is crucial to allow users to connect to you without trouble.</property>
+        <property name="justify">center</property>
+        <property name="wrap">1</property>
+        <property name="width-chars">36</property>
+        <property name="max-width-chars">60</property>
+      </object>
+    </child>
+    <child>
+      <object class="GtkLabel">
+        <property name="visible">1</property>
+        <property name="label" translatable="yes">The default listening port should work fine in most cases. If you need to use a different port, you can change it in the preferences later.</property>
+        <property name="justify">center</property>
+        <property name="wrap">1</property>
+        <property name="width-chars">36</property>
+        <property name="max-width-chars">60</property>
+      </object>
+    </child>
+    <child>
+      <object class="GtkLabel">
+        <property name="visible">1</property>
+        <property name="label" translatable="yes">Nicotine+ will still work to some degree if your port is closed. However, do keep in mind that you won&apos;t be able to connect to users whose port is also closed.</property>
+        <property name="justify">center</property>
+        <property name="wrap">1</property>
+        <property name="width-chars">36</property>
+        <property name="max-width-chars">60</property>
+      </object>
+    </child>
+    <child>
+      <object class="GtkButton" id="checkmyport">
+        <property name="label" translatable="yes">Check Port Status</property>
+        <property name="visible">1</property>
+        <property name="can-focus">1</property>
+        <property name="receives-default">1</property>
+        <property name="halign">center</property>
+        <signal name="clicked" handler="on_check_port_status" swapped="no"/>
+      </object>
+    </child>
+  </object>
+  <object class="GtkBox" id="sharepage">
+    <property name="visible">1</property>
+    <property name="valign">center</property>
+    <property name="margin-start">18</property>
+    <property name="margin-end">18</property>
+    <property name="margin-top">6</property>
+    <property name="margin-bottom">6</property>
+    <property name="orientation">vertical</property>
+    <property name="spacing">30</property>
+    <child>
+      <object class="GtkBox">
+        <property name="visible">1</property>
+        <property name="orientation">vertical</property>
+        <property name="halign">center</property>
+        <property name="spacing">15</property>
+        <child>
+          <object class="GtkLabel">
+            <property name="visible">1</property>
+            <property name="label" translatable="yes">Download Files to Folder</property>
+            <attributes>
+              <attribute name="weight" value="bold"/>
+            </attributes>
+          </object>
+        </child>
+        <child>
+          <object class="GtkButton" id="downloaddir">
+            <property name="visible">1</property>
+            <property name="hexpand">1</property>
+          </object>
+        </child>
+      </object>
+    </child>
+    <child>
+      <object class="GtkBox">
+        <property name="visible">1</property>
+        <property name="orientation">vertical</property>
+        <property name="spacing">15</property>
+        <child>
+          <object class="GtkLabel">
+            <property name="visible">1</property>
+            <property name="label" translatable="yes">Share Folders</property>
+            <attributes>
+              <attribute name="weight" value="bold"/>
+            </attributes>
+          </object>
+        </child>
+        <child>
+          <object class="GtkLabel">
+            <property name="visible">1</property>
+            <property name="label" translatable="yes">Users on the Soulseek network will be able to download files from folders you share.</property>
+            <property name="justify">center</property>
+            <property name="wrap">1</property>
+            <property name="width-chars">36</property>
+            <property name="max-width-chars">60</property>
+          </object>
+        </child>
+        <child>
+          <object class="GtkScrolledWindow" id="shareddirectories">
+            <property name="visible">1</property>
+            <property name="can-focus">1</property>
+            <property name="height-request">150</property>
+            <child>
+              <object class="GtkTreeView" id="shareddirectoriestree">
+                <property name="visible">1</property>
+                <property name="can-focus">1</property>
+                <property name="rubber-banding">1</property>
+                <child internal-child="selection">
+                  <object class="GtkTreeSelection">
+                    <property name="mode">multiple</property>
+                  </object>
+                </child>
+              </object>
+            </child>
+          </object>
+        </child>
+        <child>
+          <object class="GtkBox">
+            <property name="visible">1</property>
+            <property name="halign">center</property>
+            <property name="spacing">12</property>
+            <child>
+              <object class="GtkButton" id="addshare">
+                <property name="label" translatable="yes">Add</property>
+                <property name="visible">1</property>
+                <property name="can-focus">1</property>
+                <property name="receives-default">1</property>
+                <signal name="clicked" handler="on_add_share" swapped="no"/>
+              </object>
+            </child>
+            <child>
+              <object class="GtkButton" id="removeshares">
+                <property name="label" translatable="yes">Remove</property>
+                <property name="visible">1</property>
+                <property name="can-focus">1</property>
+                <property name="receives-default">1</property>
+                <signal name="clicked" handler="on_remove_share" swapped="no"/>
+              </object>
+            </child>
+          </object>
+        </child>
+      </object>
+    </child>
+  </object>
+  <object class="GtkBox" id="summarypage">
+    <property name="visible">1</property>
+    <property name="halign">center</property>
+    <property name="valign">center</property>
+    <property name="margin-start">12</property>
+    <property name="margin-end">12</property>
+    <property name="margin-top">6</property>
+    <property name="margin-bottom">6</property>
+    <property name="orientation">vertical</property>
+    <property name="spacing">24</property>
+    <child>
+      <object class="GtkLabel">
+        <property name="visible">1</property>
+        <property name="label" translatable="yes">You are ready to use Nicotine+!</property>
+        <property name="justify">center</property>
+        <property name="wrap">1</property>
+        <attributes>
+          <attribute name="weight" value="ultrabold"/>
+          <attribute name="size" value="18000"/>
+        </attributes>
+      </object>
+    </child>
+    <child>
+      <object class="GtkBox">
+        <property name="visible">1</property>
+        <property name="orientation">vertical</property>
+        <property name="spacing">18</property>
+        <child>
+          <object class="GtkLabel">
+            <property name="visible">1</property>
+            <property name="label" translatable="yes">Transfer speeds depend on the users you are downloading from. Some users will be fast while others will be slow.</property>
+            <property name="justify">fill</property>
+            <property name="wrap">1</property>
+            <property name="width-chars">32</property>
+            <property name="max-width-chars">60</property>
+          </object>
+        </child>
+        <child>
+          <object class="GtkLabel" id="labelnoshare">
+            <property name="visible">1</property>
+            <property name="label" translatable="yes">Sharing files is crucial for the health of the Soulseek network. Many people will ban you if you download from them without sharing anything yourself.</property>
+            <property name="justify">fill</property>
+            <property name="wrap">1</property>
+            <property name="width-chars">32</property>
+            <property name="max-width-chars">60</property>
+          </object>
+        </child>
+      </object>
     </child>
   </object>
 </interface>

--- a/pynicotine/gtkgui/ui/dialogs/fileproperties.ui
+++ b/pynicotine/gtkgui/ui/dialogs/fileproperties.ui
@@ -1,372 +1,312 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <interface>
   <requires lib="gtk+" version="3.18"/>
-  <object class="GtkDialog" id="FilePropertiesDialog">
-    <property name="title" translatable="yes">File Properties</property>
-    <property name="modal">1</property>
-    <property name="default-width">600</property>
-    <property name="window-position">center-on-parent</property>
-    <property name="type-hint">normal</property>
-    <child internal-child="vbox">
-      <object class="GtkBox">
+  <object class="GtkBox" id="Main">
+    <property name="visible">1</property>
+    <property name="orientation">vertical</property>
+    <property name="margin-start">18</property>
+    <property name="margin-end">18</property>
+    <property name="margin-top">18</property>
+    <property name="margin-bottom">18</property>
+    <child>
+      <object class="GtkFlowBox">
         <property name="visible">1</property>
-        <property name="orientation">vertical</property>
-        <property name="margin-start">18</property>
-        <property name="margin-end">18</property>
-        <property name="margin-top">18</property>
-        <property name="margin-bottom">18</property>
+        <property name="row-spacing">6</property>
+        <property name="column-spacing">6</property>
+        <property name="min-children-per-line">2</property>
+        <property name="max-children-per-line">2</property>
+        <property name="selection-mode">none</property>
         <child>
-          <object class="GtkGrid">
+          <object class="GtkLabel" id="filename_label">
             <property name="visible">1</property>
-            <property name="row-spacing">10</property>
-            <property name="column-spacing">6</property>
-            <child>
-              <object class="GtkLabel" id="filename_label">
-                <property name="visible">1</property>
-                <property name="can-focus">1</property>
-                <property name="label" translatable="yes">File Name</property>
-                <property name="selectable">1</property>
-                <property name="xalign">1</property>
-                <style>
-                  <class name="dim-label"/>
-                </style>
-              </object>
-              <packing>
-                <property name="left-attach">0</property>
-                <property name="top-attach">0</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkLabel" id="filename_value">
-                <property name="visible">1</property>
-                <property name="can-focus">1</property>
-                <property name="hexpand">1</property>
-                <property name="selectable">1</property>
-                <property name="ellipsize">end</property>
-                <property name="max-width-chars">48</property>
-                <property name="xalign">0</property>
-              </object>
-              <packing>
-                <property name="left-attach">1</property>
-                <property name="top-attach">0</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkLabel" id="folder_label">
-                <property name="visible">1</property>
-                <property name="can-focus">1</property>
-                <property name="label" translatable="yes">Folder</property>
-                <property name="selectable">1</property>
-                <property name="xalign">1</property>
-                <style>
-                  <class name="dim-label"/>
-                </style>
-              </object>
-              <packing>
-                <property name="left-attach">0</property>
-                <property name="top-attach">1</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkLabel" id="folder_value">
-                <property name="visible">1</property>
-                <property name="can-focus">1</property>
-                <property name="hexpand">1</property>
-                <property name="selectable">1</property>
-                <property name="ellipsize">end</property>
-                <property name="max-width-chars">48</property>
-                <property name="xalign">0</property>
-              </object>
-              <packing>
-                <property name="left-attach">1</property>
-                <property name="top-attach">1</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkLabel" id="filesize_label">
-                <property name="visible">1</property>
-                <property name="can-focus">1</property>
-                <property name="label" translatable="yes">File Size</property>
-                <property name="selectable">1</property>
-                <property name="xalign">1</property>
-                <style>
-                  <class name="dim-label"/>
-                </style>
-              </object>
-              <packing>
-                <property name="left-attach">0</property>
-                <property name="top-attach">2</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkLabel" id="filesize_value">
-                <property name="visible">1</property>
-                <property name="can-focus">1</property>
-                <property name="hexpand">1</property>
-                <property name="selectable">1</property>
-                <property name="ellipsize">end</property>
-                <property name="max-width-chars">48</property>
-                <property name="xalign">0</property>
-              </object>
-              <packing>
-                <property name="left-attach">1</property>
-                <property name="top-attach">2</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkLabel" id="empty_1">
-                <property name="visible">1</property>
-              </object>
-              <packing>
-                <property name="left-attach">0</property>
-                <property name="top-attach">3</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkLabel" id="length_label">
-                <property name="visible">1</property>
-                <property name="can-focus">1</property>
-                <property name="label" translatable="yes">Length</property>
-                <property name="selectable">1</property>
-                <property name="xalign">1</property>
-                <style>
-                  <class name="dim-label"/>
-                </style>
-              </object>
-              <packing>
-                <property name="left-attach">0</property>
-                <property name="top-attach">4</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkLabel" id="length_value">
-                <property name="visible">1</property>
-                <property name="can-focus">1</property>
-                <property name="hexpand">1</property>
-                <property name="selectable">1</property>
-                <property name="ellipsize">end</property>
-                <property name="max-width-chars">48</property>
-                <property name="xalign">0</property>
-              </object>
-              <packing>
-                <property name="left-attach">1</property>
-                <property name="top-attach">4</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkLabel" id="bitrate_label">
-                <property name="visible">1</property>
-                <property name="can-focus">1</property>
-                <property name="label" translatable="yes">Bitrate</property>
-                <property name="selectable">1</property>
-                <property name="xalign">1</property>
-                <style>
-                  <class name="dim-label"/>
-                </style>
-              </object>
-              <packing>
-                <property name="left-attach">0</property>
-                <property name="top-attach">5</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkLabel" id="bitrate_value">
-                <property name="visible">1</property>
-                <property name="can-focus">1</property>
-                <property name="hexpand">1</property>
-                <property name="selectable">1</property>
-                <property name="ellipsize">end</property>
-                <property name="max-width-chars">48</property>
-                <property name="xalign">0</property>
-              </object>
-              <packing>
-                <property name="left-attach">1</property>
-                <property name="top-attach">5</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkLabel">
-                <property name="visible">1</property>
-              </object>
-              <packing>
-                <property name="left-attach">0</property>
-                <property name="top-attach">6</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkLabel" id="username_label">
-                <property name="visible">1</property>
-                <property name="can-focus">1</property>
-                <property name="label" translatable="yes">Username</property>
-                <property name="selectable">1</property>
-                <property name="xalign">1</property>
-                <style>
-                  <class name="dim-label"/>
-                </style>
-              </object>
-              <packing>
-                <property name="left-attach">0</property>
-                <property name="top-attach">7</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkLabel" id="username_value">
-                <property name="visible">1</property>
-                <property name="can-focus">1</property>
-                <property name="hexpand">1</property>
-                <property name="selectable">1</property>
-                <property name="ellipsize">end</property>
-                <property name="max-width-chars">48</property>
-                <property name="xalign">0</property>
-              </object>
-              <packing>
-                <property name="left-attach">1</property>
-                <property name="top-attach">7</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkLabel" id="immediate_label">
-                <property name="visible">1</property>
-                <property name="can-focus">1</property>
-                <property name="label" translatable="yes">Immediate Download</property>
-                <property name="selectable">1</property>
-                <property name="xalign">1</property>
-                <style>
-                  <class name="dim-label"/>
-                </style>
-              </object>
-              <packing>
-                <property name="left-attach">0</property>
-                <property name="top-attach">8</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkLabel" id="immediate_value">
-                <property name="visible">1</property>
-                <property name="can-focus">1</property>
-                <property name="hexpand">1</property>
-                <property name="selectable">1</property>
-                <property name="ellipsize">end</property>
-                <property name="max-width-chars">48</property>
-                <property name="xalign">0</property>
-              </object>
-              <packing>
-                <property name="left-attach">1</property>
-                <property name="top-attach">8</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkLabel" id="queue_label">
-                <property name="visible">1</property>
-                <property name="can-focus">1</property>
-                <property name="label" translatable="yes">In Queue</property>
-                <property name="selectable">1</property>
-                <property name="xalign">1</property>
-                <style>
-                  <class name="dim-label"/>
-                </style>
-              </object>
-              <packing>
-                <property name="left-attach">0</property>
-                <property name="top-attach">9</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkLabel" id="queue_value">
-                <property name="visible">1</property>
-                <property name="can-focus">1</property>
-                <property name="hexpand">1</property>
-                <property name="selectable">1</property>
-                <property name="ellipsize">end</property>
-                <property name="max-width-chars">48</property>
-                <property name="xalign">0</property>
-              </object>
-              <packing>
-                <property name="left-attach">1</property>
-                <property name="top-attach">9</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkLabel" id="speed_label">
-                <property name="visible">1</property>
-                <property name="can-focus">1</property>
-                <property name="label" translatable="yes">Last Speed</property>
-                <property name="selectable">1</property>
-                <property name="xalign">1</property>
-                <style>
-                  <class name="dim-label"/>
-                </style>
-              </object>
-              <packing>
-                <property name="left-attach">0</property>
-                <property name="top-attach">10</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkLabel" id="speed_value">
-                <property name="visible">1</property>
-                <property name="can-focus">1</property>
-                <property name="hexpand">1</property>
-                <property name="selectable">1</property>
-                <property name="ellipsize">end</property>
-                <property name="max-width-chars">48</property>
-                <property name="xalign">0</property>
-              </object>
-              <packing>
-                <property name="left-attach">1</property>
-                <property name="top-attach">10</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkLabel" id="country_label">
-                <property name="visible">1</property>
-                <property name="can-focus">1</property>
-                <property name="label" translatable="yes">Country</property>
-                <property name="selectable">1</property>
-                <property name="xalign">1</property>
-                <style>
-                  <class name="dim-label"/>
-                </style>
-              </object>
-              <packing>
-                <property name="left-attach">0</property>
-                <property name="top-attach">11</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkLabel" id="country_value">
-                <property name="visible">1</property>
-                <property name="can-focus">1</property>
-                <property name="hexpand">1</property>
-                <property name="selectable">1</property>
-                <property name="ellipsize">end</property>
-                <property name="max-width-chars">48</property>
-                <property name="xalign">0</property>
-              </object>
-              <packing>
-                <property name="left-attach">1</property>
-                <property name="top-attach">11</property>
-              </packing>
-            </child>
+            <property name="can-focus">1</property>
+            <property name="label" translatable="yes">File Name</property>
+            <property name="selectable">1</property>
+            <property name="xalign">1</property>
+            <style>
+              <class name="dim-label"/>
+            </style>
           </object>
         </child>
         <child>
-          <object class="GtkBox">
+          <object class="GtkLabel" id="filename_value">
             <property name="visible">1</property>
-            <property name="margin-top">18</property>
-            <property name="spacing">5</property>
-            <property name="valign">end</property>
-            <property name="vexpand">1</property>
+            <property name="can-focus">1</property>
+            <property name="hexpand">1</property>
+            <property name="selectable">1</property>
+            <property name="ellipsize">end</property>
+            <property name="max-width-chars">48</property>
+            <property name="xalign">0</property>
+          </object>
+        </child>
+        <child>
+          <object class="GtkLabel" id="folder_label">
+            <property name="visible">1</property>
+            <property name="can-focus">1</property>
+            <property name="label" translatable="yes">Folder</property>
+            <property name="selectable">1</property>
+            <property name="xalign">1</property>
+            <style>
+              <class name="dim-label"/>
+            </style>
+          </object>
+        </child>
+        <child>
+          <object class="GtkLabel" id="folder_value">
+            <property name="visible">1</property>
+            <property name="can-focus">1</property>
+            <property name="hexpand">1</property>
+            <property name="selectable">1</property>
+            <property name="ellipsize">end</property>
+            <property name="max-width-chars">48</property>
+            <property name="xalign">0</property>
+          </object>
+        </child>
+        <child>
+          <object class="GtkLabel" id="filesize_label">
+            <property name="visible">1</property>
+            <property name="can-focus">1</property>
+            <property name="label" translatable="yes">File Size</property>
+            <property name="selectable">1</property>
+            <property name="xalign">1</property>
+            <style>
+              <class name="dim-label"/>
+            </style>
+          </object>
+        </child>
+        <child>
+          <object class="GtkLabel" id="filesize_value">
+            <property name="visible">1</property>
+            <property name="can-focus">1</property>
+            <property name="hexpand">1</property>
+            <property name="selectable">1</property>
+            <property name="ellipsize">end</property>
+            <property name="max-width-chars">48</property>
+            <property name="xalign">0</property>
+          </object>
+        </child>
+        <child>
+          <object class="GtkLabel" id="empty_1">
+            <property name="visible">1</property>
+          </object>
+        </child>
+        <child>
+          <object class="GtkLabel" id="empty_2">
+            <property name="visible">1</property>
+          </object>
+        </child>
+        <child>
+          <object class="GtkLabel" id="length_label">
+            <property name="visible">1</property>
+            <property name="can-focus">1</property>
+            <property name="label" translatable="yes">Length</property>
+            <property name="selectable">1</property>
+            <property name="xalign">1</property>
+            <style>
+              <class name="dim-label"/>
+            </style>
+          </object>
+        </child>
+        <child>
+          <object class="GtkLabel" id="length_value">
+            <property name="visible">1</property>
+            <property name="can-focus">1</property>
+            <property name="hexpand">1</property>
+            <property name="selectable">1</property>
+            <property name="ellipsize">end</property>
+            <property name="max-width-chars">48</property>
+            <property name="xalign">0</property>
+          </object>
+        </child>
+        <child>
+          <object class="GtkLabel" id="bitrate_label">
+            <property name="visible">1</property>
+            <property name="can-focus">1</property>
+            <property name="label" translatable="yes">Bitrate</property>
+            <property name="selectable">1</property>
+            <property name="xalign">1</property>
+            <style>
+              <class name="dim-label"/>
+            </style>
+          </object>
+        </child>
+        <child>
+          <object class="GtkLabel" id="bitrate_value">
+            <property name="visible">1</property>
+            <property name="can-focus">1</property>
+            <property name="hexpand">1</property>
+            <property name="selectable">1</property>
+            <property name="ellipsize">end</property>
+            <property name="max-width-chars">48</property>
+            <property name="xalign">0</property>
+          </object>
+        </child>
+        <child>
+          <object class="GtkLabel">
+            <property name="visible">1</property>
+          </object>
+        </child>
+        <child>
+          <object class="GtkLabel">
+            <property name="visible">1</property>
+          </object>
+        </child>
+        <child>
+          <object class="GtkLabel" id="username_label">
+            <property name="visible">1</property>
+            <property name="can-focus">1</property>
+            <property name="label" translatable="yes">Username</property>
+            <property name="selectable">1</property>
+            <property name="xalign">1</property>
+            <style>
+              <class name="dim-label"/>
+            </style>
+          </object>
+        </child>
+        <child>
+          <object class="GtkLabel" id="username_value">
+            <property name="visible">1</property>
+            <property name="can-focus">1</property>
+            <property name="hexpand">1</property>
+            <property name="selectable">1</property>
+            <property name="ellipsize">end</property>
+            <property name="max-width-chars">48</property>
+            <property name="xalign">0</property>
+          </object>
+        </child>
+        <child>
+          <object class="GtkLabel" id="immediate_label">
+            <property name="visible">1</property>
+            <property name="can-focus">1</property>
+            <property name="label" translatable="yes">Immediate Download</property>
+            <property name="selectable">1</property>
+            <property name="xalign">1</property>
+            <style>
+              <class name="dim-label"/>
+            </style>
+          </object>
+        </child>
+        <child>
+          <object class="GtkLabel" id="immediate_value">
+            <property name="visible">1</property>
+            <property name="can-focus">1</property>
+            <property name="hexpand">1</property>
+            <property name="selectable">1</property>
+            <property name="ellipsize">end</property>
+            <property name="max-width-chars">48</property>
+            <property name="xalign">0</property>
+          </object>
+        </child>
+        <child>
+          <object class="GtkLabel" id="queue_label">
+            <property name="visible">1</property>
+            <property name="can-focus">1</property>
+            <property name="label" translatable="yes">In Queue</property>
+            <property name="selectable">1</property>
+            <property name="xalign">1</property>
+            <style>
+              <class name="dim-label"/>
+            </style>
+          </object>
+        </child>
+        <child>
+          <object class="GtkLabel" id="queue_value">
+            <property name="visible">1</property>
+            <property name="can-focus">1</property>
+            <property name="hexpand">1</property>
+            <property name="selectable">1</property>
+            <property name="ellipsize">end</property>
+            <property name="max-width-chars">48</property>
+            <property name="xalign">0</property>
+          </object>
+        </child>
+        <child>
+          <object class="GtkLabel" id="speed_label">
+            <property name="visible">1</property>
+            <property name="can-focus">1</property>
+            <property name="label" translatable="yes">Last Speed</property>
+            <property name="selectable">1</property>
+            <property name="xalign">1</property>
+            <style>
+              <class name="dim-label"/>
+            </style>
+          </object>
+        </child>
+        <child>
+          <object class="GtkLabel" id="speed_value">
+            <property name="visible">1</property>
+            <property name="can-focus">1</property>
+            <property name="hexpand">1</property>
+            <property name="selectable">1</property>
+            <property name="ellipsize">end</property>
+            <property name="max-width-chars">48</property>
+            <property name="xalign">0</property>
+          </object>
+        </child>
+        <child>
+          <object class="GtkLabel" id="country_label">
+            <property name="visible">1</property>
+            <property name="can-focus">1</property>
+            <property name="label" translatable="yes">Country</property>
+            <property name="selectable">1</property>
+            <property name="xalign">1</property>
+            <style>
+              <class name="dim-label"/>
+            </style>
+          </object>
+        </child>
+        <child>
+          <object class="GtkLabel" id="country_value">
+            <property name="visible">1</property>
+            <property name="can-focus">1</property>
+            <property name="hexpand">1</property>
+            <property name="selectable">1</property>
+            <property name="ellipsize">end</property>
+            <property name="max-width-chars">48</property>
+            <property name="xalign">0</property>
+          </object>
+        </child>
+      </object>
+    </child>
+    <child>
+      <object class="GtkBox">
+        <property name="visible">1</property>
+        <property name="margin-top">18</property>
+        <property name="spacing">5</property>
+        <property name="valign">end</property>
+        <property name="vexpand">1</property>
+        <child>
+          <object class="GtkButton" id="download">
+            <property name="visible">1</property>
+            <property name="can-focus">1</property>
+            <property name="tooltip-text" translatable="yes">Download file</property>
+            <signal name="clicked" handler="on_download_item" swapped="no"/>
             <child>
-              <object class="GtkButton" id="download">
+              <object class="GtkImage">
+                <property name="visible">1</property>
+                <property name="icon-name">document-save-symbolic</property>
+              </object>
+            </child>
+            <style>
+              <class name="image-button"/>
+            </style>
+          </object>
+        </child>
+        <child>
+          <object class="GtkBox" id="navigation_buttons">
+            <property name="visible">1</property>
+            <property name="halign">end</property>
+            <property name="hexpand">1</property>
+            <child>
+              <object class="GtkButton" id="previous">
                 <property name="visible">1</property>
                 <property name="can-focus">1</property>
-                <property name="tooltip-text" translatable="yes">Download file</property>
-                <signal name="clicked" handler="on_download_item" swapped="no"/>
+                <property name="tooltip-text" translatable="yes">Previous file</property>
+                <signal name="clicked" handler="on_previous" swapped="no"/>
                 <child>
                   <object class="GtkImage">
                     <property name="visible">1</property>
-                    <property name="icon-name">document-save-symbolic</property>
+                    <property name="icon-name">go-previous-symbolic</property>
                   </object>
                 </child>
                 <style>
@@ -375,54 +315,25 @@
               </object>
             </child>
             <child>
-              <object class="GtkBox" id="navigation_buttons">
+              <object class="GtkButton" id="next">
                 <property name="visible">1</property>
-                <property name="halign">end</property>
-                <property name="hexpand">1</property>
+                <property name="can-focus">1</property>
+                <property name="tooltip-text" translatable="yes">Next file</property>
+                <signal name="clicked" handler="on_next" swapped="no"/>
                 <child>
-                  <object class="GtkButton" id="previous">
+                  <object class="GtkImage">
                     <property name="visible">1</property>
-                    <property name="can-focus">1</property>
-                    <property name="tooltip-text" translatable="yes">Previous file</property>
-                    <signal name="clicked" handler="on_previous" swapped="no"/>
-                    <child>
-                      <object class="GtkImage">
-                        <property name="visible">1</property>
-                        <property name="icon-name">go-previous-symbolic</property>
-                      </object>
-                    </child>
-                    <style>
-                      <class name="image-button"/>
-                    </style>
-                  </object>
-                </child>
-                <child>
-                  <object class="GtkButton" id="next">
-                    <property name="visible">1</property>
-                    <property name="can-focus">1</property>
-                    <property name="tooltip-text" translatable="yes">Next file</property>
-                    <signal name="clicked" handler="on_next" swapped="no"/>
-                    <child>
-                      <object class="GtkImage">
-                        <property name="visible">1</property>
-                        <property name="icon-name">go-next-symbolic</property>
-                      </object>
-                    </child>
-                    <style>
-                      <class name="image-button"/>
-                    </style>
+                    <property name="icon-name">go-next-symbolic</property>
                   </object>
                 </child>
                 <style>
-                  <class name="linked"/>
+                  <class name="image-button"/>
                 </style>
               </object>
             </child>
-          </object>
-        </child>
-        <child internal-child="action_area">
-          <object class="GtkBox">
-            <property name="visible">0</property>
+            <style>
+              <class name="linked"/>
+            </style>
           </object>
         </child>
       </object>

--- a/pynicotine/gtkgui/ui/dialogs/roomwall.ui
+++ b/pynicotine/gtkgui/ui/dialogs/roomwall.ui
@@ -1,80 +1,63 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <interface>
   <requires lib="gtk+" version="3.18"/>
-  <object class="GtkDialog" id="RoomWallDialog">
-    <property name="title" translatable="yes">Room Wall</property>
-    <property name="modal">1</property>
-    <property name="window-position">center-on-parent</property>
-    <property name="default-width">800</property>
-    <property name="default-height">600</property>
-    <property name="type-hint">normal</property>
-    <signal name="delete-event" handler="hide" swapped="no"/>
-    <child internal-child="vbox">
-      <object class="GtkBox">
+  <object class="GtkBox" id="Main">
+    <property name="visible">1</property>
+    <property name="orientation">vertical</property>
+    <child>
+      <object class="GtkLabel">
         <property name="visible">1</property>
-        <property name="orientation">vertical</property>
+        <property name="halign">start</property>
+        <property name="margin-start">10</property>
+        <property name="margin-end">10</property>
+        <property name="margin-top">13</property>
+        <property name="margin-bottom">13</property>
+        <property name="label" translatable="yes">The room wall feature allows users in a room to specify a unique message to display to others.</property>
+        <property name="justify">fill</property>
+        <property name="wrap">1</property>
+      </object>
+    </child>
+    <child>
+      <object class="GtkScrolledWindow" id="RoomWallListWindow">
+        <property name="visible">1</property>
+        <property name="can-focus">1</property>
+        <property name="vexpand">1</property>
+        <property name="margin-start">10</property>
+        <property name="margin-end">10</property>
         <child>
-          <object class="GtkLabel">
-            <property name="visible">1</property>
-            <property name="halign">start</property>
-            <property name="margin-start">10</property>
-            <property name="margin-end">10</property>
-            <property name="margin-top">13</property>
-            <property name="margin-bottom">13</property>
-            <property name="label" translatable="yes">The room wall feature allows users in a room to specify a unique message to display to others.</property>
-            <property name="justify">fill</property>
-            <property name="wrap">1</property>
-          </object>
-        </child>
-        <child>
-          <object class="GtkScrolledWindow" id="RoomWallListWindow">
+          <object class="GtkTextView" id="RoomWallList">
             <property name="visible">1</property>
             <property name="can-focus">1</property>
-            <property name="vexpand">1</property>
-            <property name="margin-start">10</property>
-            <property name="margin-end">10</property>
-            <property name="shadow-type">in</property>
-            <child>
-              <object class="GtkTextView" id="RoomWallList">
-                <property name="visible">1</property>
-                <property name="can-focus">1</property>
-                <property name="editable">0</property>
-                <property name="wrap-mode">word-char</property>
-                <property name="cursor-visible">0</property>
-                <property name="pixels-above-lines">4</property>
-                <property name="pixels-below-lines">4</property>
-                <property name="left-margin">10</property>
-                <property name="right-margin">10</property>
-                <property name="top-margin">5</property>
-                <property name="bottom-margin">5</property>
-              </object>
-            </child>
+            <property name="editable">0</property>
+            <property name="wrap-mode">word-char</property>
+            <property name="cursor-visible">0</property>
+            <property name="pixels-above-lines">4</property>
+            <property name="pixels-below-lines">4</property>
+            <property name="left-margin">10</property>
+            <property name="right-margin">10</property>
+            <property name="top-margin">5</property>
+            <property name="bottom-margin">5</property>
           </object>
         </child>
+      </object>
+    </child>
+    <child>
+      <object class="GtkBox">
+        <property name="visible">1</property>
+        <property name="margin-start">10</property>
+        <property name="margin-end">10</property>
+        <property name="margin-top">10</property>
+        <property name="margin-bottom">10</property>
+        <property name="spacing">10</property>
         <child>
-          <object class="GtkBox">
+          <object class="GtkEntry" id="RoomWallEntry">
             <property name="visible">1</property>
-            <property name="margin-start">10</property>
-            <property name="margin-end">10</property>
-            <property name="margin-top">10</property>
-            <property name="margin-bottom">10</property>
-            <property name="spacing">10</property>
-            <child>
-              <object class="GtkEntry" id="RoomWallEntry">
-                <property name="visible">1</property>
-                <property name="can-focus">1</property>
-                <property name="hexpand">1</property>
-                <property name="placeholder-text" translatable="yes">Set wall message...</property>
-                <property name="primary-icon-name">user-available-symbolic</property>
-                <signal name="activate" handler="on_set_room_wall_message" swapped="no"/>
-                <signal name="icon-press" handler="on_set_room_wall_message" swapped="no"/>
-              </object>
-            </child>
-          </object>
-        </child>
-        <child internal-child="action_area">
-          <object class="GtkBox">
-            <property name="visible">0</property>
+            <property name="can-focus">1</property>
+            <property name="hexpand">1</property>
+            <property name="placeholder-text" translatable="yes">Set wall message...</property>
+            <property name="primary-icon-name">user-available-symbolic</property>
+            <signal name="activate" handler="on_set_room_wall_message" swapped="no"/>
+            <signal name="icon-press" handler="on_set_room_wall_message" swapped="no"/>
           </object>
         </child>
       </object>

--- a/pynicotine/gtkgui/ui/dialogs/shortcuts.ui
+++ b/pynicotine/gtkgui/ui/dialogs/shortcuts.ui
@@ -3,8 +3,6 @@
   <requires lib="gtk+" version="3.20"/>
   <object class="GtkShortcutsWindow" id="KeyboardShortcutsDialog">
     <property name="modal">1</property>
-    <property name="window-position">center-on-parent</property>
-    <signal name="delete-event" handler="on_hide" swapped="no"/>
     <child>
       <object class="GtkShortcutsSection">
         <property name="visible">1</property>

--- a/pynicotine/gtkgui/ui/dialogs/statistics.ui
+++ b/pynicotine/gtkgui/ui/dialogs/statistics.ui
@@ -1,495 +1,392 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <interface>
   <requires lib="gtk+" version="3.18"/>
-  <object class="GtkDialog" id="StatisticsDialog">
-    <property name="title" translatable="yes">Transfer Statistics</property>
-    <property name="modal">1</property>
-    <property name="default-width">450</property>
-    <property name="window-position">center-on-parent</property>
-    <property name="type-hint">normal</property>
-    <signal name="delete-event" handler="hide" swapped="no"/>
-    <child internal-child="vbox">
-      <object class="GtkBox">
+  <object class="GtkBox" id="Main">
+    <property name="visible">1</property>
+    <property name="orientation">vertical</property>
+    <property name="margin-start">18</property>
+    <property name="margin-end">18</property>
+    <property name="margin-top">18</property>
+    <property name="margin-bottom">18</property>
+    <child>
+      <object class="GtkFlowBox">
         <property name="visible">1</property>
-        <property name="orientation">vertical</property>
-        <property name="margin-start">18</property>
-        <property name="margin-end">18</property>
-        <property name="margin-top">18</property>
-        <property name="margin-bottom">18</property>
+        <property name="row-spacing">6</property>
+        <property name="column-spacing">6</property>
+        <property name="homogeneous">1</property>
+        <property name="min-children-per-line">2</property>
+        <property name="max-children-per-line">2</property>
+        <property name="selection-mode">none</property>
         <child>
-          <object class="GtkGrid">
+          <object class="GtkLabel">
             <property name="visible">1</property>
-            <property name="row-spacing">10</property>
-            <property name="column-spacing">6</property>
-            <property name="column-homogeneous">1</property>
-            <child>
-              <object class="GtkLabel">
-                <property name="visible">1</property>
-                <property name="can-focus">1</property>
-                <property name="label" translatable="yes">Current Session</property>
-                <property name="selectable">1</property>
-                <property name="xalign">0</property>
-                <attributes>
-                  <attribute name="weight" value="bold"/>
-                </attributes>
-              </object>
-              <packing>
-                <property name="left-attach">0</property>
-                <property name="top-attach">0</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkLabel">
-                <property name="visible">1</property>
-                <property name="can-focus">1</property>
-                <property name="label" translatable="yes">Started Downloads</property>
-                <property name="selectable">1</property>
-                <property name="xalign">1</property>
-                <style>
-                  <class name="dim-label"/>
-                </style>
-              </object>
-              <packing>
-                <property name="left-attach">0</property>
-                <property name="top-attach">1</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkLabel" id="started_downloads_session">
-                <property name="visible">1</property>
-                <property name="can-focus">1</property>
-                <property name="hexpand">1</property>
-                <property name="selectable">1</property>
-                <property name="ellipsize">end</property>
-                <property name="max-width-chars">48</property>
-                <property name="xalign">0</property>
-              </object>
-              <packing>
-                <property name="left-attach">1</property>
-                <property name="top-attach">1</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkLabel">
-                <property name="visible">1</property>
-                <property name="can-focus">1</property>
-                <property name="label" translatable="yes">Completed Downloads</property>
-                <property name="selectable">1</property>
-                <property name="xalign">1</property>
-                <style>
-                  <class name="dim-label"/>
-                </style>
-              </object>
-              <packing>
-                <property name="left-attach">0</property>
-                <property name="top-attach">2</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkLabel" id="completed_downloads_session">
-                <property name="visible">1</property>
-                <property name="can-focus">1</property>
-                <property name="hexpand">1</property>
-                <property name="selectable">1</property>
-                <property name="ellipsize">end</property>
-                <property name="max-width-chars">48</property>
-                <property name="xalign">0</property>
-              </object>
-              <packing>
-                <property name="left-attach">1</property>
-                <property name="top-attach">2</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkLabel">
-                <property name="visible">1</property>
-                <property name="can-focus">1</property>
-                <property name="label" translatable="yes">Downloaded Size</property>
-                <property name="selectable">1</property>
-                <property name="xalign">1</property>
-                <style>
-                  <class name="dim-label"/>
-                </style>
-              </object>
-              <packing>
-                <property name="left-attach">0</property>
-                <property name="top-attach">3</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkLabel" id="downloaded_size_session">
-                <property name="visible">1</property>
-                <property name="can-focus">1</property>
-                <property name="hexpand">1</property>
-                <property name="selectable">1</property>
-                <property name="ellipsize">end</property>
-                <property name="max-width-chars">48</property>
-                <property name="xalign">0</property>
-              </object>
-              <packing>
-                <property name="left-attach">1</property>
-                <property name="top-attach">3</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkLabel">
-                <property name="visible">1</property>
-              </object>
-              <packing>
-                <property name="left-attach">0</property>
-                <property name="top-attach">4</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkLabel">
-                <property name="visible">1</property>
-                <property name="can-focus">1</property>
-                <property name="label" translatable="yes">Started Uploads</property>
-                <property name="selectable">1</property>
-                <property name="xalign">1</property>
-                <style>
-                  <class name="dim-label"/>
-                </style>
-              </object>
-              <packing>
-                <property name="left-attach">0</property>
-                <property name="top-attach">5</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkLabel" id="started_uploads_session">
-                <property name="visible">1</property>
-                <property name="can-focus">1</property>
-                <property name="hexpand">1</property>
-                <property name="selectable">1</property>
-                <property name="ellipsize">end</property>
-                <property name="max-width-chars">48</property>
-                <property name="xalign">0</property>
-              </object>
-              <packing>
-                <property name="left-attach">1</property>
-                <property name="top-attach">5</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkLabel">
-                <property name="visible">1</property>
-                <property name="can-focus">1</property>
-                <property name="label" translatable="yes">Completed Uploads</property>
-                <property name="selectable">1</property>
-                <property name="xalign">1</property>
-                <style>
-                  <class name="dim-label"/>
-                </style>
-              </object>
-              <packing>
-                <property name="left-attach">0</property>
-                <property name="top-attach">6</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkLabel" id="completed_uploads_session">
-                <property name="visible">1</property>
-                <property name="can-focus">1</property>
-                <property name="hexpand">1</property>
-                <property name="selectable">1</property>
-                <property name="ellipsize">end</property>
-                <property name="max-width-chars">48</property>
-                <property name="xalign">0</property>
-              </object>
-              <packing>
-                <property name="left-attach">1</property>
-                <property name="top-attach">6</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkLabel">
-                <property name="visible">1</property>
-                <property name="can-focus">1</property>
-                <property name="label" translatable="yes">Uploaded Size</property>
-                <property name="selectable">1</property>
-                <property name="xalign">1</property>
-                <style>
-                  <class name="dim-label"/>
-                </style>
-              </object>
-              <packing>
-                <property name="left-attach">0</property>
-                <property name="top-attach">7</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkLabel" id="uploaded_size_session">
-                <property name="visible">1</property>
-                <property name="can-focus">1</property>
-                <property name="hexpand">1</property>
-                <property name="selectable">1</property>
-                <property name="ellipsize">end</property>
-                <property name="max-width-chars">48</property>
-                <property name="xalign">0</property>
-              </object>
-              <packing>
-                <property name="left-attach">1</property>
-                <property name="top-attach">7</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkLabel">
-                <property name="visible">1</property>
-              </object>
-              <packing>
-                <property name="left-attach">0</property>
-                <property name="top-attach">8</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkLabel">
-                <property name="visible">1</property>
-                <property name="can-focus">1</property>
-                <property name="label" translatable="yes">Total</property>
-                <property name="selectable">1</property>
-                <property name="xalign">0</property>
-                <attributes>
-                  <attribute name="weight" value="bold"/>
-                </attributes>
-              </object>
-              <packing>
-                <property name="left-attach">0</property>
-                <property name="top-attach">9</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkLabel">
-                <property name="visible">1</property>
-                <property name="can-focus">1</property>
-                <property name="label" translatable="yes">Started Downloads</property>
-                <property name="selectable">1</property>
-                <property name="xalign">1</property>
-                <style>
-                  <class name="dim-label"/>
-                </style>
-              </object>
-              <packing>
-                <property name="left-attach">0</property>
-                <property name="top-attach">10</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkLabel" id="started_downloads_total">
-                <property name="visible">1</property>
-                <property name="can-focus">1</property>
-                <property name="hexpand">1</property>
-                <property name="selectable">1</property>
-                <property name="ellipsize">end</property>
-                <property name="max-width-chars">48</property>
-                <property name="xalign">0</property>
-              </object>
-              <packing>
-                <property name="left-attach">1</property>
-                <property name="top-attach">10</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkLabel">
-                <property name="visible">1</property>
-                <property name="can-focus">1</property>
-                <property name="label" translatable="yes">Completed Downloads</property>
-                <property name="selectable">1</property>
-                <property name="xalign">1</property>
-                <style>
-                  <class name="dim-label"/>
-                </style>
-              </object>
-              <packing>
-                <property name="left-attach">0</property>
-                <property name="top-attach">11</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkLabel" id="completed_downloads_total">
-                <property name="visible">1</property>
-                <property name="can-focus">1</property>
-                <property name="hexpand">1</property>
-                <property name="selectable">1</property>
-                <property name="ellipsize">end</property>
-                <property name="max-width-chars">48</property>
-                <property name="xalign">0</property>
-              </object>
-              <packing>
-                <property name="left-attach">1</property>
-                <property name="top-attach">11</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkLabel">
-                <property name="visible">1</property>
-                <property name="can-focus">1</property>
-                <property name="label" translatable="yes">Downloaded Size</property>
-                <property name="selectable">1</property>
-                <property name="xalign">1</property>
-                <style>
-                  <class name="dim-label"/>
-                </style>
-              </object>
-              <packing>
-                <property name="left-attach">0</property>
-                <property name="top-attach">12</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkLabel" id="downloaded_size_total">
-                <property name="visible">1</property>
-                <property name="can-focus">1</property>
-                <property name="hexpand">1</property>
-                <property name="selectable">1</property>
-                <property name="ellipsize">end</property>
-                <property name="max-width-chars">48</property>
-                <property name="xalign">0</property>
-              </object>
-              <packing>
-                <property name="left-attach">1</property>
-                <property name="top-attach">12</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkLabel">
-                <property name="visible">1</property>
-              </object>
-              <packing>
-                <property name="left-attach">0</property>
-                <property name="top-attach">13</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkLabel">
-                <property name="visible">1</property>
-                <property name="can-focus">1</property>
-                <property name="label" translatable="yes">Started Uploads</property>
-                <property name="selectable">1</property>
-                <property name="xalign">1</property>
-                <style>
-                  <class name="dim-label"/>
-                </style>
-              </object>
-              <packing>
-                <property name="left-attach">0</property>
-                <property name="top-attach">14</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkLabel" id="started_uploads_total">
-                <property name="visible">1</property>
-                <property name="can-focus">1</property>
-                <property name="hexpand">1</property>
-                <property name="selectable">1</property>
-                <property name="ellipsize">end</property>
-                <property name="max-width-chars">48</property>
-                <property name="xalign">0</property>
-              </object>
-              <packing>
-                <property name="left-attach">1</property>
-                <property name="top-attach">14</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkLabel">
-                <property name="visible">1</property>
-                <property name="can-focus">1</property>
-                <property name="label" translatable="yes">Completed Uploads</property>
-                <property name="selectable">1</property>
-                <property name="xalign">1</property>
-                <style>
-                  <class name="dim-label"/>
-                </style>
-              </object>
-              <packing>
-                <property name="left-attach">0</property>
-                <property name="top-attach">15</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkLabel" id="completed_uploads_total">
-                <property name="visible">1</property>
-                <property name="can-focus">1</property>
-                <property name="hexpand">1</property>
-                <property name="selectable">1</property>
-                <property name="ellipsize">end</property>
-                <property name="max-width-chars">48</property>
-                <property name="xalign">0</property>
-              </object>
-              <packing>
-                <property name="left-attach">1</property>
-                <property name="top-attach">15</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkLabel">
-                <property name="visible">1</property>
-                <property name="can-focus">1</property>
-                <property name="label" translatable="yes">Uploaded Size</property>
-                <property name="selectable">1</property>
-                <property name="xalign">1</property>
-                <style>
-                  <class name="dim-label"/>
-                </style>
-              </object>
-              <packing>
-                <property name="left-attach">0</property>
-                <property name="top-attach">16</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkLabel" id="uploaded_size_total">
-                <property name="visible">1</property>
-                <property name="can-focus">1</property>
-                <property name="hexpand">1</property>
-                <property name="selectable">1</property>
-                <property name="ellipsize">end</property>
-                <property name="max-width-chars">48</property>
-                <property name="xalign">0</property>
-              </object>
-              <packing>
-                <property name="left-attach">1</property>
-                <property name="top-attach">16</property>
-              </packing>
-            </child>
+            <property name="can-focus">1</property>
+            <property name="label" translatable="yes">Current Session</property>
+            <property name="selectable">1</property>
+            <property name="xalign">0</property>
+            <attributes>
+              <attribute name="weight" value="bold"/>
+            </attributes>
           </object>
         </child>
         <child>
-          <object class="GtkBox">
+          <object class="GtkLabel">
             <property name="visible">1</property>
-            <property name="margin-top">26</property>
+          </object>
+        </child>
+        <child>
+          <object class="GtkLabel">
+            <property name="visible">1</property>
+            <property name="can-focus">1</property>
+            <property name="label" translatable="yes">Started Downloads</property>
+            <property name="selectable">1</property>
+            <property name="xalign">1</property>
+            <style>
+              <class name="dim-label"/>
+            </style>
+          </object>
+        </child>
+        <child>
+          <object class="GtkLabel" id="started_downloads_session">
+            <property name="visible">1</property>
+            <property name="can-focus">1</property>
+            <property name="hexpand">1</property>
+            <property name="selectable">1</property>
+            <property name="ellipsize">end</property>
+            <property name="max-width-chars">48</property>
+            <property name="xalign">0</property>
+          </object>
+        </child>
+        <child>
+          <object class="GtkLabel">
+            <property name="visible">1</property>
+            <property name="can-focus">1</property>
+            <property name="label" translatable="yes">Completed Downloads</property>
+            <property name="selectable">1</property>
+            <property name="xalign">1</property>
+            <style>
+              <class name="dim-label"/>
+            </style>
+          </object>
+        </child>
+        <child>
+          <object class="GtkLabel" id="completed_downloads_session">
+            <property name="visible">1</property>
+            <property name="can-focus">1</property>
+            <property name="hexpand">1</property>
+            <property name="selectable">1</property>
+            <property name="ellipsize">end</property>
+            <property name="max-width-chars">48</property>
+            <property name="xalign">0</property>
+          </object>
+        </child>
+        <child>
+          <object class="GtkLabel">
+            <property name="visible">1</property>
+            <property name="can-focus">1</property>
+            <property name="label" translatable="yes">Downloaded Size</property>
+            <property name="selectable">1</property>
+            <property name="xalign">1</property>
+            <style>
+              <class name="dim-label"/>
+            </style>
+          </object>
+        </child>
+        <child>
+          <object class="GtkLabel" id="downloaded_size_session">
+            <property name="visible">1</property>
+            <property name="can-focus">1</property>
+            <property name="hexpand">1</property>
+            <property name="selectable">1</property>
+            <property name="ellipsize">end</property>
+            <property name="max-width-chars">48</property>
+            <property name="xalign">0</property>
+          </object>
+        </child>
+        <child>
+          <object class="GtkLabel">
+            <property name="visible">1</property>
+          </object>
+        </child>
+        <child>
+          <object class="GtkLabel">
+            <property name="visible">1</property>
+          </object>
+        </child>
+        <child>
+          <object class="GtkLabel">
+            <property name="visible">1</property>
+            <property name="can-focus">1</property>
+            <property name="label" translatable="yes">Started Uploads</property>
+            <property name="selectable">1</property>
+            <property name="xalign">1</property>
+            <style>
+              <class name="dim-label"/>
+            </style>
+          </object>
+        </child>
+        <child>
+          <object class="GtkLabel" id="started_uploads_session">
+            <property name="visible">1</property>
+            <property name="can-focus">1</property>
+            <property name="hexpand">1</property>
+            <property name="selectable">1</property>
+            <property name="ellipsize">end</property>
+            <property name="max-width-chars">48</property>
+            <property name="xalign">0</property>
+          </object>
+        </child>
+        <child>
+          <object class="GtkLabel">
+            <property name="visible">1</property>
+            <property name="can-focus">1</property>
+            <property name="label" translatable="yes">Completed Uploads</property>
+            <property name="selectable">1</property>
+            <property name="xalign">1</property>
+            <style>
+              <class name="dim-label"/>
+            </style>
+          </object>
+        </child>
+        <child>
+          <object class="GtkLabel" id="completed_uploads_session">
+            <property name="visible">1</property>
+            <property name="can-focus">1</property>
+            <property name="hexpand">1</property>
+            <property name="selectable">1</property>
+            <property name="ellipsize">end</property>
+            <property name="max-width-chars">48</property>
+            <property name="xalign">0</property>
+          </object>
+        </child>
+        <child>
+          <object class="GtkLabel">
+            <property name="visible">1</property>
+            <property name="can-focus">1</property>
+            <property name="label" translatable="yes">Uploaded Size</property>
+            <property name="selectable">1</property>
+            <property name="xalign">1</property>
+            <style>
+              <class name="dim-label"/>
+            </style>
+          </object>
+        </child>
+        <child>
+          <object class="GtkLabel" id="uploaded_size_session">
+            <property name="visible">1</property>
+            <property name="can-focus">1</property>
+            <property name="hexpand">1</property>
+            <property name="selectable">1</property>
+            <property name="ellipsize">end</property>
+            <property name="max-width-chars">48</property>
+            <property name="xalign">0</property>
+          </object>
+        </child>
+        <child>
+          <object class="GtkLabel">
+            <property name="visible">1</property>
+          </object>
+        </child>
+        <child>
+          <object class="GtkLabel">
+            <property name="visible">1</property>
+          </object>
+        </child>
+        <child>
+          <object class="GtkLabel">
+            <property name="visible">1</property>
+            <property name="can-focus">1</property>
+            <property name="label" translatable="yes">Total</property>
+            <property name="selectable">1</property>
+            <property name="xalign">0</property>
+            <attributes>
+              <attribute name="weight" value="bold"/>
+            </attributes>
+          </object>
+        </child>
+        <child>
+          <object class="GtkLabel">
+            <property name="visible">1</property>
+          </object>
+        </child>
+        <child>
+          <object class="GtkLabel">
+            <property name="visible">1</property>
+            <property name="can-focus">1</property>
+            <property name="label" translatable="yes">Started Downloads</property>
+            <property name="selectable">1</property>
+            <property name="xalign">1</property>
+            <style>
+              <class name="dim-label"/>
+            </style>
+          </object>
+        </child>
+        <child>
+          <object class="GtkLabel" id="started_downloads_total">
+            <property name="visible">1</property>
+            <property name="can-focus">1</property>
+            <property name="hexpand">1</property>
+            <property name="selectable">1</property>
+            <property name="ellipsize">end</property>
+            <property name="max-width-chars">48</property>
+            <property name="xalign">0</property>
+          </object>
+        </child>
+        <child>
+          <object class="GtkLabel">
+            <property name="visible">1</property>
+            <property name="can-focus">1</property>
+            <property name="label" translatable="yes">Completed Downloads</property>
+            <property name="selectable">1</property>
+            <property name="xalign">1</property>
+            <style>
+              <class name="dim-label"/>
+            </style>
+          </object>
+        </child>
+        <child>
+          <object class="GtkLabel" id="completed_downloads_total">
+            <property name="visible">1</property>
+            <property name="can-focus">1</property>
+            <property name="hexpand">1</property>
+            <property name="selectable">1</property>
+            <property name="ellipsize">end</property>
+            <property name="max-width-chars">48</property>
+            <property name="xalign">0</property>
+          </object>
+        </child>
+        <child>
+          <object class="GtkLabel">
+            <property name="visible">1</property>
+            <property name="can-focus">1</property>
+            <property name="label" translatable="yes">Downloaded Size</property>
+            <property name="selectable">1</property>
+            <property name="xalign">1</property>
+            <style>
+              <class name="dim-label"/>
+            </style>
+          </object>
+        </child>
+        <child>
+          <object class="GtkLabel" id="downloaded_size_total">
+            <property name="visible">1</property>
+            <property name="can-focus">1</property>
+            <property name="hexpand">1</property>
+            <property name="selectable">1</property>
+            <property name="ellipsize">end</property>
+            <property name="max-width-chars">48</property>
+            <property name="xalign">0</property>
+          </object>
+        </child>
+        <child>
+          <object class="GtkLabel">
+            <property name="visible">1</property>
+          </object>
+        </child>
+        <child>
+          <object class="GtkLabel">
+            <property name="visible">1</property>
+          </object>
+        </child>
+        <child>
+          <object class="GtkLabel">
+            <property name="visible">1</property>
+            <property name="can-focus">1</property>
+            <property name="label" translatable="yes">Started Uploads</property>
+            <property name="selectable">1</property>
+            <property name="xalign">1</property>
+            <style>
+              <class name="dim-label"/>
+            </style>
+          </object>
+        </child>
+        <child>
+          <object class="GtkLabel" id="started_uploads_total">
+            <property name="visible">1</property>
+            <property name="can-focus">1</property>
+            <property name="hexpand">1</property>
+            <property name="selectable">1</property>
+            <property name="ellipsize">end</property>
+            <property name="max-width-chars">48</property>
+            <property name="xalign">0</property>
+          </object>
+        </child>
+        <child>
+          <object class="GtkLabel">
+            <property name="visible">1</property>
+            <property name="can-focus">1</property>
+            <property name="label" translatable="yes">Completed Uploads</property>
+            <property name="selectable">1</property>
+            <property name="xalign">1</property>
+            <style>
+              <class name="dim-label"/>
+            </style>
+          </object>
+        </child>
+        <child>
+          <object class="GtkLabel" id="completed_uploads_total">
+            <property name="visible">1</property>
+            <property name="can-focus">1</property>
+            <property name="hexpand">1</property>
+            <property name="selectable">1</property>
+            <property name="ellipsize">end</property>
+            <property name="max-width-chars">48</property>
+            <property name="xalign">0</property>
+          </object>
+        </child>
+        <child>
+          <object class="GtkLabel">
+            <property name="visible">1</property>
+            <property name="can-focus">1</property>
+            <property name="label" translatable="yes">Uploaded Size</property>
+            <property name="selectable">1</property>
+            <property name="xalign">1</property>
+            <style>
+              <class name="dim-label"/>
+            </style>
+          </object>
+        </child>
+        <child>
+          <object class="GtkLabel" id="uploaded_size_total">
+            <property name="visible">1</property>
+            <property name="can-focus">1</property>
+            <property name="hexpand">1</property>
+            <property name="selectable">1</property>
+            <property name="ellipsize">end</property>
+            <property name="max-width-chars">48</property>
+            <property name="xalign">0</property>
+          </object>
+        </child>
+      </object>
+    </child>
+    <child>
+      <object class="GtkBox">
+        <property name="visible">1</property>
+        <property name="margin-top">26</property>
+        <child>
+          <object class="GtkButton">
+            <property name="visible">1</property>
+            <property name="can-focus">1</property>
+            <signal name="clicked" handler="on_reset_statistics" swapped="no"/>
             <child>
-              <object class="GtkButton">
+              <object class="GtkBox">
                 <property name="visible">1</property>
-                <property name="can-focus">1</property>
-                <signal name="clicked" handler="on_reset_statistics" swapped="no"/>
+                <property name="spacing">5</property>
                 <child>
-                  <object class="GtkBox">
+                  <object class="GtkImage">
                     <property name="visible">1</property>
-                    <property name="spacing">5</property>
-                    <child>
-                      <object class="GtkImage">
-                        <property name="visible">1</property>
-                        <property name="icon-name">edit-clear-symbolic</property>
-                      </object>
-                    </child>
-                    <child>
-                      <object class="GtkLabel">
-                        <property name="visible">1</property>
-                        <property name="label" translatable="yes">_Reset Statistics...</property>
-                        <property name="use-underline">1</property>
-                      </object>
-                    </child>
+                    <property name="icon-name">edit-clear-symbolic</property>
+                  </object>
+                </child>
+                <child>
+                  <object class="GtkLabel">
+                    <property name="visible">1</property>
+                    <property name="label" translatable="yes">_Reset Statistics...</property>
+                    <property name="use-underline">1</property>
                   </object>
                 </child>
               </object>
             </child>
-          </object>
-        </child>
-        <child internal-child="action_area">
-          <object class="GtkBox">
-            <property name="visible">0</property>
           </object>
         </child>
       </object>

--- a/pynicotine/gtkgui/ui/dialogs/wishlist.ui
+++ b/pynicotine/gtkgui/ui/dialogs/wishlist.ui
@@ -1,136 +1,119 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <interface>
   <requires lib="gtk+" version="3.18"/>
-  <object class="GtkDialog" id="WishListDialog">
-    <property name="title" translatable="yes">Search Wishlist</property>
-    <property name="modal">1</property>
-    <property name="window-position">center-on-parent</property>
-    <property name="default-width">600</property>
-    <property name="default-height">600</property>
-    <property name="type-hint">normal</property>
-    <signal name="delete-event" handler="quit" swapped="no"/>
-    <child internal-child="vbox">
-      <object class="GtkBox">
+  <object class="GtkBox" id="Main">
+    <property name="visible">1</property>
+    <property name="orientation">vertical</property>
+    <child>
+      <object class="GtkLabel">
         <property name="visible">1</property>
-        <property name="orientation">vertical</property>
+        <property name="halign">start</property>
+        <property name="margin-start">10</property>
+        <property name="margin-end">10</property>
+        <property name="margin-top">13</property>
+        <property name="margin-bottom">13</property>
+        <property name="label" translatable="yes">Wishlist items are auto-searched at regular intervals, useful for discovering uncommon files.</property>
+        <property name="justify">fill</property>
+        <property name="wrap">1</property>
+      </object>
+    </child>
+    <child>
+      <object class="GtkScrolledWindow" id="WishlistScrolledWindow">
+        <property name="visible">1</property>
+        <property name="margin-start">10</property>
+        <property name="margin-end">10</property>
+        <property name="vexpand">1</property>
         <child>
-          <object class="GtkLabel">
+          <object class="GtkTreeView" id="WishlistView">
             <property name="visible">1</property>
-            <property name="halign">start</property>
-            <property name="margin-start">10</property>
-            <property name="margin-end">10</property>
-            <property name="margin-top">13</property>
-            <property name="margin-bottom">13</property>
-            <property name="label" translatable="yes">Wishlist items are auto-searched at regular intervals, useful for discovering uncommon files.</property>
-            <property name="justify">fill</property>
-            <property name="wrap">1</property>
+            <property name="can-focus">1</property>
+            <property name="rubber-banding">1</property>
+            <child internal-child="selection">
+              <object class="GtkTreeSelection">
+                <property name="mode">multiple</property>
+              </object>
+            </child>
           </object>
         </child>
+      </object>
+    </child>
+    <child>
+      <object class="GtkBox">
+        <property name="visible">1</property>
+        <property name="margin-start">10</property>
+        <property name="margin-end">10</property>
+        <property name="margin-top">10</property>
+        <property name="margin-bottom">10</property>
+        <property name="spacing">10</property>
         <child>
-          <object class="GtkScrolledWindow">
+          <object class="GtkBox">
             <property name="visible">1</property>
-            <property name="margin-start">10</property>
-            <property name="margin-end">10</property>
-            <property name="shadow-type">in</property>
-            <property name="vexpand">1</property>
+            <property name="hexpand">1</property>
+            <property name="spacing">10</property>
             <child>
-              <object class="GtkTreeView" id="WishlistView">
+              <object class="GtkEntry" id="AddWishEntry">
                 <property name="visible">1</property>
                 <property name="can-focus">1</property>
-                <property name="rubber-banding">1</property>
-                <child internal-child="selection">
-                  <object class="GtkTreeSelection">
-                    <property name="mode">multiple</property>
-                  </object>
-                </child>
+                <property name="hexpand">1</property>
+                <property name="margin-end">20</property>
+                <property name="placeholder-text" translatable="yes">Add search term...</property>
+                <property name="primary-icon-name">bookmark-new-symbolic</property>
+                <signal name="activate" handler="on_add_wish" swapped="no"/>
+                <signal name="icon-press" handler="on_add_wish" swapped="no"/>
               </object>
             </child>
           </object>
         </child>
         <child>
-          <object class="GtkBox">
+          <object class="GtkButton">
             <property name="visible">1</property>
-            <property name="margin-start">10</property>
-            <property name="margin-end">10</property>
-            <property name="margin-top">10</property>
-            <property name="margin-bottom">10</property>
-            <property name="spacing">10</property>
+            <property name="can-focus">1</property>
+            <signal name="clicked" handler="on_remove_wish" swapped="no"/>
             <child>
               <object class="GtkBox">
                 <property name="visible">1</property>
-                <property name="hexpand">1</property>
-                <property name="spacing">10</property>
+                <property name="spacing">5</property>
                 <child>
-                  <object class="GtkEntry" id="AddWishEntry">
+                  <object class="GtkImage">
                     <property name="visible">1</property>
-                    <property name="can-focus">1</property>
-                    <property name="hexpand">1</property>
-                    <property name="margin-end">20</property>
-                    <property name="placeholder-text" translatable="yes">Add search term...</property>
-                    <property name="primary-icon-name">bookmark-new-symbolic</property>
-                    <signal name="activate" handler="on_add_wish" swapped="no"/>
-                    <signal name="icon-press" handler="on_add_wish" swapped="no"/>
+                    <property name="icon-name">edit-clear-symbolic</property>
                   </object>
                 </child>
-              </object>
-            </child>
-            <child>
-              <object class="GtkButton">
-                <property name="visible">1</property>
-                <property name="can-focus">1</property>
-                <signal name="clicked" handler="on_remove_wish" swapped="no"/>
                 <child>
-                  <object class="GtkBox">
+                  <object class="GtkLabel">
                     <property name="visible">1</property>
-                    <property name="spacing">5</property>
-                    <child>
-                      <object class="GtkImage">
-                        <property name="visible">1</property>
-                        <property name="icon-name">edit-clear-symbolic</property>
-                      </object>
-                    </child>
-                    <child>
-                      <object class="GtkLabel">
-                        <property name="visible">1</property>
-                        <property name="label" translatable="yes">_Remove</property>
-                        <property name="use-underline">1</property>
-                      </object>
-                    </child>
-                  </object>
-                </child>
-              </object>
-            </child>
-            <child>
-              <object class="GtkButton">
-                <property name="visible">1</property>
-                <property name="can-focus">1</property>
-                <signal name="clicked" handler="on_clear_wishlist" swapped="no"/>
-                <child>
-                  <object class="GtkBox">
-                    <property name="visible">1</property>
-                    <property name="spacing">5</property>
-                    <child>
-                      <object class="GtkImage">
-                        <property name="visible">1</property>
-                        <property name="icon-name">edit-clear-symbolic</property>
-                      </object>
-                    </child>
-                    <child>
-                      <object class="GtkLabel">
-                        <property name="visible">1</property>
-                        <property name="label" translatable="yes">_Clear All...</property>
-                        <property name="use-underline">1</property>
-                      </object>
-                    </child>
+                    <property name="label" translatable="yes">_Remove</property>
+                    <property name="use-underline">1</property>
                   </object>
                 </child>
               </object>
             </child>
           </object>
         </child>
-        <child internal-child="action_area">
-          <object class="GtkBox">
-            <property name="visible">0</property>
+        <child>
+          <object class="GtkButton">
+            <property name="visible">1</property>
+            <property name="can-focus">1</property>
+            <signal name="clicked" handler="on_clear_wishlist" swapped="no"/>
+            <child>
+              <object class="GtkBox">
+                <property name="visible">1</property>
+                <property name="spacing">5</property>
+                <child>
+                  <object class="GtkImage">
+                    <property name="visible">1</property>
+                    <property name="icon-name">edit-clear-symbolic</property>
+                  </object>
+                </child>
+                <child>
+                  <object class="GtkLabel">
+                    <property name="visible">1</property>
+                    <property name="label" translatable="yes">_Clear All...</property>
+                    <property name="use-underline">1</property>
+                  </object>
+                </child>
+              </object>
+            </child>
           </object>
         </child>
       </object>

--- a/pynicotine/gtkgui/ui/downloads.ui
+++ b/pynicotine/gtkgui/ui/downloads.ui
@@ -32,15 +32,13 @@
     <child>
       <object class="GtkRevealer" id="DownloadButtons">
         <property name="visible">1</property>
-        <property name="can-focus">0</property>
         <property name="transition-type">slide-up</property>
         <child>
-          <object class="GtkActionBar">
+          <object class="GtkActionBar" id="ActionBar">
             <property name="visible">1</property>
             <child>
               <object class="GtkBox">
                 <property name="visible">1</property>
-                <property name="hexpand">1</property>
                 <property name="spacing">6</property>
                 <child>
                   <object class="GtkButton">
@@ -129,7 +127,7 @@
               </object>
             </child>
             <child>
-              <object class="GtkBox">
+              <object class="GtkBox" id="End">
                 <property name="visible">1</property>
                 <property name="spacing">6</property>
                 <child>
@@ -167,25 +165,7 @@
                     <property name="visible">1</property>
                     <property name="can-focus">1</property>
                     <property name="direction">up</property>
-                    <child>
-                      <object class="GtkBox">
-                        <property name="visible">1</property>
-                        <property name="spacing">6</property>
-                        <child>
-                          <object class="GtkLabel">
-                            <property name="visible">1</property>
-                            <property name="label" translatable="yes">Clear Downloads...</property>
-                            <property name="tooltip-text">Clear every download marked with a specific status.</property>
-                          </object>
-                        </child>
-                        <child>
-                          <object class="GtkImage">
-                            <property name="visible">1</property>
-                            <property name="icon-name">pan-up-symbolic</property>
-                          </object>
-                        </child>
-                      </object>
-                    </child>
+                    <property name="tooltip-text">Clear every download marked with a specific status.</property>
                     <style>
                       <class name="flat"/>
                     </style>
@@ -195,6 +175,22 @@
             </child>
           </object>
         </child>
+      </object>
+    </child>
+  </object>
+  <object class="GtkBox" id="ClearTransfersLabel">
+    <property name="visible">1</property>
+    <property name="spacing">6</property>
+    <child>
+      <object class="GtkLabel">
+        <property name="visible">1</property>
+        <property name="label" translatable="yes">Clear Downloads...</property>
+      </object>
+    </child>
+    <child>
+      <object class="GtkImage">
+        <property name="visible">1</property>
+        <property name="icon-name">pan-up-symbolic</property>
       </object>
     </child>
   </object>

--- a/pynicotine/gtkgui/ui/interests.ui
+++ b/pynicotine/gtkgui/ui/interests.ui
@@ -5,12 +5,12 @@
     <property name="visible">1</property>
     <property name="spacing">6</property>
     <child>
-      <object class="GtkPaned">
+      <object class="GtkPaned" id="InterestsPaned">
         <property name="visible">1</property>
         <property name="can-focus">1</property>
         <property name="hexpand">1</property>
         <child>
-          <object class="GtkBox">
+          <object class="GtkBox" id="LikesDislikes">
             <property name="width-request">240</property>
             <property name="visible">1</property>
             <property name="orientation">vertical</property>
@@ -118,12 +118,9 @@
               </object>
             </child>
           </object>
-          <packing>
-            <property name="resize">0</property>
-          </packing>
         </child>
         <child>
-          <object class="GtkPaned">
+          <object class="GtkPaned" id="InterestsPanedSecond">
             <property name="visible">1</property>
             <property name="can-focus">1</property>
             <child>
@@ -265,12 +262,9 @@
                   </object>
                 </child>
               </object>
-              <packing>
-                <property name="resize">1</property>
-              </packing>
             </child>
             <child>
-              <object class="GtkBox">
+              <object class="GtkBox" id="SimilarUsers">
                 <property name="width-request">280</property>
                 <property name="visible">1</property>
                 <property name="orientation">vertical</property>
@@ -334,9 +328,6 @@
                   </object>
                 </child>
               </object>
-              <packing>
-                <property name="resize">0</property>
-              </packing>
             </child>
           </object>
         </child>

--- a/pynicotine/gtkgui/ui/mainwindow.ui
+++ b/pynicotine/gtkgui/ui/mainwindow.ui
@@ -1,21 +1,17 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <interface>
   <requires lib="gtk+" version="3.18"/>
+  <object class="GtkImage" id="HeaderMenuIcon">
+    <property name="visible">1</property>
+    <property name="icon-name">open-menu-symbolic</property>
+  </object>
   <object class="GtkMenuButton" id="HeaderMenu">
     <property name="visible">1</property>
     <property name="tooltip-text" translatable="yes">Menu</property>
-    <child>
-      <object class="GtkImage">
-        <property name="visible">1</property>
-        <property name="icon-name">open-menu-symbolic</property>
-      </object>
-    </child>
   </object>
   <object class="GtkHeaderBar" id="HeaderDefault">
     <property name="visible">1</property>
     <property name="height-request">42</property>
-    <property name="has-subtitle">0</property>
-    <property name="show-close-button">1</property>
     <child>
       <object class="GtkBox" id="DefaultEnd">
         <property name="visible">1</property>
@@ -36,15 +32,11 @@
           </object>
         </child>
       </object>
-      <packing>
-        <property name="pack-type">end</property>
-      </packing>
     </child>
   </object>
   <object class="GtkHeaderBar" id="HeaderSearch">
     <property name="visible">1</property>
     <property name="height-request">42</property>
-    <property name="show-close-button">1</property>
     <child type="title">
       <object class="GtkBox" id="SearchTitle">
         <property name="visible">1</property>
@@ -178,15 +170,11 @@
           </object>
         </child>
       </object>
-      <packing>
-        <property name="pack-type">end</property>
-      </packing>
     </child>
   </object>
   <object class="GtkHeaderBar" id="HeaderDownloads">
     <property name="visible">1</property>
     <property name="height-request">42</property>
-    <property name="show-close-button">1</property>
     <child type="title">
       <object class="GtkBox" id="DownloadsTitle">
         <property name="visible">1</property>
@@ -306,12 +294,6 @@
               </object>
             </child>
             <child>
-              <object class="GtkImage" id="DownloadGroupingIcon">
-                <property name="visible">1</property>
-                <property name="icon-name">view-list-symbolic</property>
-              </object>
-            </child>
-            <child>
               <object class="GtkComboBoxText" id="ToggleTreeDownloads">
                 <property name="visible">1</property>
                 <property name="has-entry">1</property>
@@ -327,9 +309,7 @@
                   </object>
                 </child>
                 <child internal-child="button">
-                  <object class="GtkButton">
-                    <property name="image">DownloadGroupingIcon</property>
-                  </object>
+                  <object class="GtkButton" id="ToggleButtonDownloads"/>
                 </child>
               </object>
             </child>
@@ -353,15 +333,11 @@
           </object>
         </child>
       </object>
-      <packing>
-        <property name="pack-type">end</property>
-      </packing>
     </child>
   </object>
   <object class="GtkHeaderBar" id="HeaderUploads">
     <property name="visible">1</property>
     <property name="height-request">42</property>
-    <property name="show-close-button">1</property>
     <child type="title">
       <object class="GtkBox" id="UploadsTitle">
         <property name="visible">1</property>
@@ -481,12 +457,6 @@
               </object>
             </child>
             <child>
-              <object class="GtkImage" id="UploadGroupingIcon">
-                <property name="visible">1</property>
-                <property name="icon-name">view-list-symbolic</property>
-              </object>
-            </child>
-            <child>
               <object class="GtkComboBoxText" id="ToggleTreeUploads">
                 <property name="visible">1</property>
                 <property name="has-entry">1</property>
@@ -502,9 +472,7 @@
                   </object>
                 </child>
                 <child internal-child="button">
-                  <object class="GtkButton">
-                    <property name="image">UploadGroupingIcon</property>
-                  </object>
+                  <object class="GtkButton" id="ToggleButtonUploads"/>
                 </child>
               </object>
             </child>
@@ -528,15 +496,11 @@
           </object>
         </child>
       </object>
-      <packing>
-        <property name="pack-type">end</property>
-      </packing>
     </child>
   </object>
   <object class="GtkHeaderBar" id="HeaderPrivateChat">
     <property name="visible">1</property>
     <property name="height-request">42</property>
-    <property name="show-close-button">1</property>
     <child type="title">
       <object class="GtkBox" id="PrivateChatTitle">
         <property name="visible">1</property>
@@ -586,15 +550,11 @@
           </object>
         </child>
       </object>
-      <packing>
-        <property name="pack-type">end</property>
-      </packing>
     </child>
   </object>
   <object class="GtkHeaderBar" id="HeaderUserInfo">
     <property name="visible">1</property>
     <property name="height-request">42</property>
-    <property name="show-close-button">1</property>
     <child type="title">
       <object class="GtkBox" id="UserInfoTitle">
         <property name="visible">1</property>
@@ -644,15 +604,11 @@
           </object>
         </child>
       </object>
-      <packing>
-        <property name="pack-type">end</property>
-      </packing>
     </child>
   </object>
   <object class="GtkHeaderBar" id="HeaderUserBrowse">
     <property name="visible">1</property>
     <property name="height-request">42</property>
-    <property name="show-close-button">1</property>
     <child>
       <object class="GtkBox" id="UserBrowseStart">
         <property name="visible">1</property>
@@ -734,15 +690,11 @@
           </object>
         </child>
       </object>
-      <packing>
-        <property name="pack-type">end</property>
-      </packing>
     </child>
   </object>
   <object class="GtkHeaderBar" id="HeaderUserList">
     <property name="visible">1</property>
     <property name="height-request">42</property>
-    <property name="show-close-button">1</property>
     <child type="title">
       <object class="GtkBox" id="UserListTitle">
         <property name="visible">1</property>
@@ -783,15 +735,11 @@
           </object>
         </child>
       </object>
-      <packing>
-        <property name="pack-type">end</property>
-      </packing>
     </child>
   </object>
   <object class="GtkHeaderBar" id="HeaderChatrooms">
     <property name="visible">1</property>
     <property name="height-request">42</property>
-    <property name="show-close-button">1</property>
     <child type="title">
       <object class="GtkBox" id="ChatroomsTitle">
         <property name="visible">1</property>
@@ -869,20 +817,15 @@
           </object>
         </child>
       </object>
-      <packing>
-        <property name="pack-type">end</property>
-      </packing>
     </child>
   </object>
   <object class="GtkApplicationWindow" id="MainWindow">
-    <signal name="delete-event" handler="on_delete_event" swapped="no"/>
-    <signal name="focus-in-event" handler="on_focus_in" swapped="no"/>
     <child>
       <object class="GtkBox" id="MainContent">
         <property name="visible">1</property>
         <property name="orientation">vertical</property>
         <child>
-          <object class="GtkPaned">
+          <object class="GtkPaned" id="MainPaned">
             <property name="visible">1</property>
             <property name="can-focus">1</property>
             <property name="orientation">vertical</property>
@@ -922,7 +865,7 @@
                                   </object>
                                 </child>
                                 <style>
-                                  <class name="toolbar"/>
+                                  <class name="tab-toolbar"/>
                                 </style>
                               </object>
                             </child>
@@ -966,7 +909,7 @@
                                   </object>
                                 </child>
                                 <style>
-                                  <class name="toolbar"/>
+                                  <class name="tab-toolbar"/>
                                 </style>
                               </object>
                             </child>
@@ -1003,7 +946,7 @@
                                   </object>
                                 </child>
                                 <style>
-                                  <class name="toolbar"/>
+                                  <class name="tab-toolbar"/>
                                 </style>
                               </object>
                             </child>
@@ -1040,7 +983,7 @@
                                   </object>
                                 </child>
                                 <style>
-                                  <class name="toolbar"/>
+                                  <class name="tab-toolbar"/>
                                 </style>
                               </object>
                             </child>
@@ -1084,7 +1027,7 @@
                                   </object>
                                 </child>
                                 <style>
-                                  <class name="toolbar"/>
+                                  <class name="tab-toolbar"/>
                                 </style>
                               </object>
                             </child>
@@ -1128,7 +1071,7 @@
                                   </object>
                                 </child>
                                 <style>
-                                  <class name="toolbar"/>
+                                  <class name="tab-toolbar"/>
                                 </style>
                               </object>
                             </child>
@@ -1172,7 +1115,7 @@
                                   </object>
                                 </child>
                                 <style>
-                                  <class name="toolbar"/>
+                                  <class name="tab-toolbar"/>
                                 </style>
                               </object>
                             </child>
@@ -1209,7 +1152,7 @@
                                   </object>
                                 </child>
                                 <style>
-                                  <class name="toolbar"/>
+                                  <class name="tab-toolbar"/>
                                 </style>
                               </object>
                             </child>
@@ -1224,9 +1167,6 @@
                                     <property name="show-border">0</property>
                                     <property name="scrollable">1</property>
                                   </object>
-                                  <packing>
-                                    <property name="resize">1</property>
-                                  </packing>
                                 </child>
                               </object>
                             </child>
@@ -1253,10 +1193,6 @@
                   </object>
                 </child>
               </object>
-              <packing>
-                <property name="resize">1</property>
-                <property name="shrink">0</property>
-              </packing>
             </child>
             <!-- Log Window -->
             <child>
@@ -1266,7 +1202,6 @@
                 <child>
                   <object class="GtkRevealer" id="DebugButtons">
                     <property name="visible">1</property>
-                    <property name="can-focus">0</property>
                     <property name="transition-type">slide-up</property>
                     <child>
                       <object class="GtkFlowBox">
@@ -1453,10 +1388,6 @@
                   </object>
                 </child>
               </object>
-              <packing>
-                <property name="resize">0</property>
-                <property name="shrink">0</property>
-              </packing>
             </child>
           </object>
         </child>
@@ -1487,6 +1418,7 @@
             </child>
             <child>
               <object class="GtkProgressBar" id="SharesProgress">
+                <property name="visible">0</property>
                 <property name="valign">center</property>
                 <property name="pulse-step">0.10000000149</property>
                 <property name="text" translatable="yes">Scanning Shares</property>
@@ -1495,6 +1427,7 @@
             </child>
             <child>
               <object class="GtkProgressBar" id="BuddySharesProgress">
+                <property name="visible">0</property>
                 <property name="valign">center</property>
                 <property name="pulse-step">0.10000000149</property>
                 <property name="margin-start">18</property>

--- a/pynicotine/gtkgui/ui/popovers/chatroomcommands.ui
+++ b/pynicotine/gtkgui/ui/popovers/chatroomcommands.ui
@@ -17,14 +17,17 @@
               </object>
             </child>
             <child>
-              <object class="GtkGrid">
+              <object class="GtkFlowBox">
                 <property name="visible">1</property>
                 <property name="margin-start">14</property>
                 <property name="margin-end">14</property>
                 <property name="margin-top">14</property>
                 <property name="margin-bottom">14</property>
-                <property name="row-spacing">10</property>
+                <property name="row-spacing">6</property>
                 <property name="column-spacing">15</property>
+                <property name="min-children-per-line">2</property>
+                <property name="max-children-per-line">2</property>
+                <property name="selection-mode">none</property>
                 <child>
                   <object class="GtkLabel">
                     <property name="visible">1</property>
@@ -35,10 +38,11 @@
                       <attribute name="weight" value="bold"/>
                     </attributes>
                   </object>
-                  <packing>
-                    <property name="left-attach">0</property>
-                    <property name="top-attach">0</property>
-                  </packing>
+                </child>
+                <child>
+                  <object class="GtkLabel">
+                    <property name="visible">1</property>
+                  </object>
                 </child>
                 <child>
                   <object class="GtkLabel">
@@ -50,10 +54,6 @@
                       <attribute name="style" value="italic"/>
                     </attributes>
                   </object>
-                  <packing>
-                    <property name="left-attach">0</property>
-                    <property name="top-attach">1</property>
-                  </packing>
                 </child>
                 <child>
                   <object class="GtkLabel">
@@ -62,10 +62,6 @@
                     <property name="label" translatable="yes">Join room &apos;room&apos;</property>
                     <property name="selectable">1</property>
                   </object>
-                  <packing>
-                    <property name="left-attach">1</property>
-                    <property name="top-attach">1</property>
-                  </packing>
                 </child>
                 <child>
                   <object class="GtkLabel">
@@ -77,10 +73,6 @@
                       <attribute name="style" value="italic"/>
                     </attributes>
                   </object>
-                  <packing>
-                    <property name="left-attach">0</property>
-                    <property name="top-attach">2</property>
-                  </packing>
                 </child>
                 <child>
                   <object class="GtkLabel">
@@ -89,10 +81,6 @@
                     <property name="label" translatable="yes">Leave room &apos;room&apos;</property>
                     <property name="selectable">1</property>
                   </object>
-                  <packing>
-                    <property name="left-attach">1</property>
-                    <property name="top-attach">2</property>
-                  </packing>
                 </child>
                 <child>
                   <object class="GtkLabel">
@@ -104,10 +92,6 @@
                       <attribute name="style" value="italic"/>
                     </attributes>
                   </object>
-                  <packing>
-                    <property name="left-attach">0</property>
-                    <property name="top-attach">3</property>
-                  </packing>
                 </child>
                 <child>
                   <object class="GtkLabel">
@@ -116,10 +100,6 @@
                     <property name="label" translatable="yes">Clear the chat window</property>
                     <property name="selectable">1</property>
                   </object>
-                  <packing>
-                    <property name="left-attach">1</property>
-                    <property name="top-attach">3</property>
-                  </packing>
                 </child>
                 <child>
                   <object class="GtkLabel">
@@ -131,10 +111,6 @@
                       <attribute name="style" value="italic"/>
                     </attributes>
                   </object>
-                  <packing>
-                    <property name="left-attach">0</property>
-                    <property name="top-attach">4</property>
-                  </packing>
                 </child>
                 <child>
                   <object class="GtkLabel">
@@ -143,10 +119,6 @@
                     <property name="label" translatable="yes">Set your personal ticker</property>
                     <property name="selectable">1</property>
                   </object>
-                  <packing>
-                    <property name="left-attach">1</property>
-                    <property name="top-attach">4</property>
-                  </packing>
                 </child>
                 <child>
                   <object class="GtkLabel">
@@ -158,10 +130,6 @@
                       <attribute name="style" value="italic"/>
                     </attributes>
                   </object>
-                  <packing>
-                    <property name="left-attach">0</property>
-                    <property name="top-attach">5</property>
-                  </packing>
                 </child>
                 <child>
                   <object class="GtkLabel">
@@ -170,10 +138,6 @@
                     <property name="label" translatable="yes">Show all the tickers</property>
                     <property name="selectable">1</property>
                   </object>
-                  <packing>
-                    <property name="left-attach">1</property>
-                    <property name="top-attach">5</property>
-                  </packing>
                 </child>
                 <child>
                   <object class="GtkLabel">
@@ -185,10 +149,6 @@
                       <attribute name="style" value="italic"/>
                     </attributes>
                   </object>
-                  <packing>
-                    <property name="left-attach">0</property>
-                    <property name="top-attach">6</property>
-                  </packing>
                 </child>
                 <child>
                   <object class="GtkLabel">
@@ -197,19 +157,16 @@
                     <property name="label" translatable="yes">Say something in the third-person</property>
                     <property name="selectable">1</property>
                   </object>
-                  <packing>
-                    <property name="left-attach">1</property>
-                    <property name="top-attach">6</property>
-                  </packing>
                 </child>
                 <child>
                   <object class="GtkLabel">
                     <property name="visible">1</property>
                   </object>
-                  <packing>
-                    <property name="left-attach">0</property>
-                    <property name="top-attach">5</property>
-                  </packing>
+                </child>
+                <child>
+                  <object class="GtkLabel">
+                    <property name="visible">1</property>
+                  </object>
                 </child>
                 <child>
                   <object class="GtkLabel">
@@ -221,10 +178,6 @@
                       <attribute name="style" value="italic"/>
                     </attributes>
                   </object>
-                  <packing>
-                    <property name="left-attach">0</property>
-                    <property name="top-attach">7</property>
-                  </packing>
                 </child>
                 <child>
                   <object class="GtkLabel">
@@ -233,10 +186,6 @@
                     <property name="label" translatable="yes">Display the Now Playing script&apos;s output</property>
                     <property name="selectable">1</property>
                   </object>
-                  <packing>
-                    <property name="left-attach">1</property>
-                    <property name="top-attach">7</property>
-                  </packing>
                 </child>
                 <child>
                   <object class="GtkLabel">
@@ -248,10 +197,6 @@
                       <attribute name="style" value="italic"/>
                     </attributes>
                   </object>
-                  <packing>
-                    <property name="left-attach">0</property>
-                    <property name="top-attach">8</property>
-                  </packing>
                 </child>
                 <child>
                   <object class="GtkLabel">
@@ -260,10 +205,6 @@
                     <property name="label" translatable="yes">Toggles your away status</property>
                     <property name="selectable">1</property>
                   </object>
-                  <packing>
-                    <property name="left-attach">1</property>
-                    <property name="top-attach">8</property>
-                  </packing>
                 </child>
                 <child>
                   <object class="GtkLabel">
@@ -275,10 +216,6 @@
                       <attribute name="style" value="italic"/>
                     </attributes>
                   </object>
-                  <packing>
-                    <property name="left-attach">0</property>
-                    <property name="top-attach">9</property>
-                  </packing>
                 </child>
                 <child>
                   <object class="GtkLabel">
@@ -287,10 +224,6 @@
                     <property name="label" translatable="yes">Rescan shares</property>
                     <property name="selectable">1</property>
                   </object>
-                  <packing>
-                    <property name="left-attach">1</property>
-                    <property name="top-attach">9</property>
-                  </packing>
                 </child>
                 <child>
                   <object class="GtkLabel">
@@ -302,10 +235,6 @@
                       <attribute name="style" value="italic"/>
                     </attributes>
                   </object>
-                  <packing>
-                    <property name="left-attach">0</property>
-                    <property name="top-attach">10</property>
-                  </packing>
                 </child>
                 <child>
                   <object class="GtkLabel">
@@ -314,19 +243,16 @@
                     <property name="label" translatable="yes">Quit Nicotine+</property>
                     <property name="selectable">1</property>
                   </object>
-                  <packing>
-                    <property name="left-attach">1</property>
-                    <property name="top-attach">10</property>
-                  </packing>
                 </child>
                 <child>
                   <object class="GtkLabel">
                     <property name="visible">1</property>
                   </object>
-                  <packing>
-                    <property name="left-attach">0</property>
-                    <property name="top-attach">11</property>
-                  </packing>
+                </child>
+                <child>
+                  <object class="GtkLabel">
+                    <property name="visible">1</property>
+                  </object>
                 </child>
                 <child>
                   <object class="GtkLabel">
@@ -338,10 +264,11 @@
                       <attribute name="weight" value="bold"/>
                     </attributes>
                   </object>
-                  <packing>
-                    <property name="left-attach">0</property>
-                    <property name="top-attach">12</property>
-                  </packing>
+                </child>
+                <child>
+                  <object class="GtkLabel">
+                    <property name="visible">1</property>
+                  </object>
                 </child>
                 <child>
                   <object class="GtkLabel">
@@ -353,10 +280,6 @@
                       <attribute name="style" value="italic"/>
                     </attributes>
                   </object>
-                  <packing>
-                    <property name="left-attach">0</property>
-                    <property name="top-attach">13</property>
-                  </packing>
                 </child>
                 <child>
                   <object class="GtkLabel">
@@ -365,10 +288,6 @@
                     <property name="label" translatable="yes">Add user &apos;user&apos; to your user list</property>
                     <property name="selectable">1</property>
                   </object>
-                  <packing>
-                    <property name="left-attach">1</property>
-                    <property name="top-attach">13</property>
-                  </packing>
                 </child>
                 <child>
                   <object class="GtkLabel">
@@ -380,10 +299,6 @@
                       <attribute name="style" value="italic"/>
                     </attributes>
                   </object>
-                  <packing>
-                    <property name="left-attach">0</property>
-                    <property name="top-attach">14</property>
-                  </packing>
                 </child>
                 <child>
                   <object class="GtkLabel">
@@ -392,10 +307,6 @@
                     <property name="label" translatable="yes">Remove user &apos;user&apos; from your user list</property>
                     <property name="selectable">1</property>
                   </object>
-                  <packing>
-                    <property name="left-attach">1</property>
-                    <property name="top-attach">14</property>
-                  </packing>
                 </child>
                 <child>
                   <object class="GtkLabel">
@@ -407,10 +318,6 @@
                       <attribute name="style" value="italic"/>
                     </attributes>
                   </object>
-                  <packing>
-                    <property name="left-attach">0</property>
-                    <property name="top-attach">15</property>
-                  </packing>
                 </child>
                 <child>
                   <object class="GtkLabel">
@@ -419,10 +326,6 @@
                     <property name="label" translatable="yes">Add user &apos;user&apos; to your ban list</property>
                     <property name="selectable">1</property>
                   </object>
-                  <packing>
-                    <property name="left-attach">1</property>
-                    <property name="top-attach">15</property>
-                  </packing>
                 </child>
                 <child>
                   <object class="GtkLabel">
@@ -434,10 +337,6 @@
                       <attribute name="style" value="italic"/>
                     </attributes>
                   </object>
-                  <packing>
-                    <property name="left-attach">0</property>
-                    <property name="top-attach">16</property>
-                  </packing>
                 </child>
                 <child>
                   <object class="GtkLabel">
@@ -446,10 +345,6 @@
                     <property name="label" translatable="yes">Remove user &apos;user&apos; from your ban list</property>
                     <property name="selectable">1</property>
                   </object>
-                  <packing>
-                    <property name="left-attach">1</property>
-                    <property name="top-attach">16</property>
-                  </packing>
                 </child>
                 <child>
                   <object class="GtkLabel">
@@ -461,10 +356,6 @@
                       <attribute name="style" value="italic"/>
                     </attributes>
                   </object>
-                  <packing>
-                    <property name="left-attach">0</property>
-                    <property name="top-attach">17</property>
-                  </packing>
                 </child>
                 <child>
                   <object class="GtkLabel">
@@ -473,10 +364,6 @@
                     <property name="label" translatable="yes">Add user &apos;user&apos; to your ignore list</property>
                     <property name="selectable">1</property>
                   </object>
-                  <packing>
-                    <property name="left-attach">1</property>
-                    <property name="top-attach">17</property>
-                  </packing>
                 </child>
                 <child>
                   <object class="GtkLabel">
@@ -488,10 +375,6 @@
                       <attribute name="style" value="italic"/>
                     </attributes>
                   </object>
-                  <packing>
-                    <property name="left-attach">0</property>
-                    <property name="top-attach">18</property>
-                  </packing>
                 </child>
                 <child>
                   <object class="GtkLabel">
@@ -500,10 +383,6 @@
                     <property name="label" translatable="yes">Remove user &apos;user&apos; from your ignore list</property>
                     <property name="selectable">1</property>
                   </object>
-                  <packing>
-                    <property name="left-attach">1</property>
-                    <property name="top-attach">18</property>
-                  </packing>
                 </child>
                 <child>
                   <object class="GtkLabel">
@@ -515,10 +394,6 @@
                       <attribute name="style" value="italic"/>
                     </attributes>
                   </object>
-                  <packing>
-                    <property name="left-attach">0</property>
-                    <property name="top-attach">19</property>
-                  </packing>
                 </child>
                 <child>
                   <object class="GtkLabel">
@@ -527,10 +402,6 @@
                     <property name="label" translatable="yes">Browse files of user &apos;user&apos;</property>
                     <property name="selectable">1</property>
                   </object>
-                  <packing>
-                    <property name="left-attach">1</property>
-                    <property name="top-attach">19</property>
-                  </packing>
                 </child>
                 <child>
                   <object class="GtkLabel">
@@ -542,10 +413,6 @@
                       <attribute name="style" value="italic"/>
                     </attributes>
                   </object>
-                  <packing>
-                    <property name="left-attach">0</property>
-                    <property name="top-attach">20</property>
-                  </packing>
                 </child>
                 <child>
                   <object class="GtkLabel">
@@ -554,10 +421,6 @@
                     <property name="label" translatable="yes">Request user info for user &apos;user&apos;</property>
                     <property name="selectable">1</property>
                   </object>
-                  <packing>
-                    <property name="left-attach">1</property>
-                    <property name="top-attach">20</property>
-                  </packing>
                 </child>
                 <child>
                   <object class="GtkLabel">
@@ -569,10 +432,6 @@
                       <attribute name="style" value="italic"/>
                     </attributes>
                   </object>
-                  <packing>
-                    <property name="left-attach">0</property>
-                    <property name="top-attach">21</property>
-                  </packing>
                 </child>
                 <child>
                   <object class="GtkLabel">
@@ -581,19 +440,16 @@
                     <property name="label" translatable="yes">Show IP for user &apos;user&apos;</property>
                     <property name="selectable">1</property>
                   </object>
-                  <packing>
-                    <property name="left-attach">1</property>
-                    <property name="top-attach">21</property>
-                  </packing>
                 </child>
                 <child>
                   <object class="GtkLabel">
                     <property name="visible">1</property>
                   </object>
-                  <packing>
-                    <property name="left-attach">0</property>
-                    <property name="top-attach">22</property>
-                  </packing>
+                </child>
+                <child>
+                  <object class="GtkLabel">
+                    <property name="visible">1</property>
+                  </object>
                 </child>
                 <child>
                   <object class="GtkLabel">
@@ -605,10 +461,11 @@
                       <attribute name="weight" value="bold"/>
                     </attributes>
                   </object>
-                  <packing>
-                    <property name="left-attach">0</property>
-                    <property name="top-attach">23</property>
-                  </packing>
+                </child>
+                <child>
+                  <object class="GtkLabel">
+                    <property name="visible">1</property>
+                  </object>
                 </child>
                 <child>
                   <object class="GtkLabel">
@@ -620,10 +477,6 @@
                       <attribute name="style" value="italic"/>
                     </attributes>
                   </object>
-                  <packing>
-                    <property name="left-attach">0</property>
-                    <property name="top-attach">24</property>
-                  </packing>
                 </child>
                 <child>
                   <object class="GtkLabel">
@@ -632,10 +485,6 @@
                     <property name="label" translatable="yes">Add a new alias</property>
                     <property name="selectable">1</property>
                   </object>
-                  <packing>
-                    <property name="left-attach">1</property>
-                    <property name="top-attach">24</property>
-                  </packing>
                 </child>
                 <child>
                   <object class="GtkLabel">
@@ -647,10 +496,6 @@
                       <attribute name="style" value="italic"/>
                     </attributes>
                   </object>
-                  <packing>
-                    <property name="left-attach">0</property>
-                    <property name="top-attach">25</property>
-                  </packing>
                 </child>
                 <child>
                   <object class="GtkLabel">
@@ -659,19 +504,16 @@
                     <property name="label" translatable="yes">Remove an alias</property>
                     <property name="selectable">1</property>
                   </object>
-                  <packing>
-                    <property name="left-attach">1</property>
-                    <property name="top-attach">25</property>
-                  </packing>
                 </child>
                 <child>
                   <object class="GtkLabel">
                     <property name="visible">1</property>
                   </object>
-                  <packing>
-                    <property name="left-attach">0</property>
-                    <property name="top-attach">26</property>
-                  </packing>
+                </child>
+                <child>
+                  <object class="GtkLabel">
+                    <property name="visible">1</property>
+                  </object>
                 </child>
                 <child>
                   <object class="GtkLabel">
@@ -683,10 +525,11 @@
                       <attribute name="weight" value="bold"/>
                     </attributes>
                   </object>
-                  <packing>
-                    <property name="left-attach">0</property>
-                    <property name="top-attach">27</property>
-                  </packing>
+                </child>
+                <child>
+                  <object class="GtkLabel">
+                    <property name="visible">1</property>
+                  </object>
                 </child>
                 <child>
                   <object class="GtkLabel">
@@ -698,10 +541,6 @@
                       <attribute name="style" value="italic"/>
                     </attributes>
                   </object>
-                  <packing>
-                    <property name="left-attach">0</property>
-                    <property name="top-attach">28</property>
-                  </packing>
                 </child>
                 <child>
                   <object class="GtkLabel">
@@ -710,10 +549,6 @@
                     <property name="label" translatable="yes">Start a new search for &apos;query&apos;</property>
                     <property name="selectable">1</property>
                   </object>
-                  <packing>
-                    <property name="left-attach">1</property>
-                    <property name="top-attach">28</property>
-                  </packing>
                 </child>
                 <child>
                   <object class="GtkLabel">
@@ -725,10 +560,6 @@
                       <attribute name="style" value="italic"/>
                     </attributes>
                   </object>
-                  <packing>
-                    <property name="left-attach">0</property>
-                    <property name="top-attach">29</property>
-                  </packing>
                 </child>
                 <child>
                   <object class="GtkLabel">
@@ -737,10 +568,6 @@
                     <property name="label" translatable="yes">Search the joined rooms for &apos;query&apos;</property>
                     <property name="selectable">1</property>
                   </object>
-                  <packing>
-                    <property name="left-attach">1</property>
-                    <property name="top-attach">29</property>
-                  </packing>
                 </child>
                 <child>
                   <object class="GtkLabel">
@@ -752,10 +579,6 @@
                       <attribute name="style" value="italic"/>
                     </attributes>
                   </object>
-                  <packing>
-                    <property name="left-attach">0</property>
-                    <property name="top-attach">30</property>
-                  </packing>
                 </child>
                 <child>
                   <object class="GtkLabel">
@@ -764,10 +587,6 @@
                     <property name="label" translatable="yes">Search the buddy list for &apos;query&apos;</property>
                     <property name="selectable">1</property>
                   </object>
-                  <packing>
-                    <property name="left-attach">1</property>
-                    <property name="top-attach">30</property>
-                  </packing>
                 </child>
                 <child>
                   <object class="GtkLabel">
@@ -779,10 +598,6 @@
                       <attribute name="style" value="italic"/>
                     </attributes>
                   </object>
-                  <packing>
-                    <property name="left-attach">0</property>
-                    <property name="top-attach">31</property>
-                  </packing>
                 </child>
                 <child>
                   <object class="GtkLabel">
@@ -791,19 +606,16 @@
                     <property name="label" translatable="yes">Search a user&apos;s shares for &apos;query&apos;</property>
                     <property name="selectable">1</property>
                   </object>
-                  <packing>
-                    <property name="left-attach">1</property>
-                    <property name="top-attach">31</property>
-                  </packing>
                 </child>
                 <child>
                   <object class="GtkLabel">
                     <property name="visible">1</property>
                   </object>
-                  <packing>
-                    <property name="left-attach">0</property>
-                    <property name="top-attach">32</property>
-                  </packing>
+                </child>
+                <child>
+                  <object class="GtkLabel">
+                    <property name="visible">1</property>
+                  </object>
                 </child>
                 <child>
                   <object class="GtkLabel">
@@ -815,10 +627,11 @@
                       <attribute name="weight" value="bold"/>
                     </attributes>
                   </object>
-                  <packing>
-                    <property name="left-attach">0</property>
-                    <property name="top-attach">33</property>
-                  </packing>
+                </child>
+                <child>
+                  <object class="GtkLabel">
+                    <property name="visible">1</property>
+                  </object>
                 </child>
                 <child>
                   <object class="GtkLabel">
@@ -830,10 +643,6 @@
                       <attribute name="style" value="italic"/>
                     </attributes>
                   </object>
-                  <packing>
-                    <property name="left-attach">0</property>
-                    <property name="top-attach">34</property>
-                  </packing>
                 </child>
                 <child>
                   <object class="GtkLabel">
@@ -842,10 +651,6 @@
                     <property name="label" translatable="yes">Send message &apos;message&apos; to user &apos;user&apos;</property>
                     <property name="selectable">1</property>
                   </object>
-                  <packing>
-                    <property name="left-attach">1</property>
-                    <property name="top-attach">34</property>
-                  </packing>
                 </child>
                 <child>
                   <object class="GtkLabel">
@@ -857,10 +662,6 @@
                       <attribute name="style" value="italic"/>
                     </attributes>
                   </object>
-                  <packing>
-                    <property name="left-attach">0</property>
-                    <property name="top-attach">35</property>
-                  </packing>
                 </child>
                 <child>
                   <object class="GtkLabel">
@@ -869,10 +670,6 @@
                     <property name="label" translatable="yes">Open private chat window for user &apos;user&apos;</property>
                     <property name="selectable">1</property>
                   </object>
-                  <packing>
-                    <property name="left-attach">1</property>
-                    <property name="top-attach">35</property>
-                  </packing>
                 </child>
               </object>
             </child>

--- a/pynicotine/gtkgui/ui/popovers/privatechatcommands.ui
+++ b/pynicotine/gtkgui/ui/popovers/privatechatcommands.ui
@@ -17,14 +17,17 @@
               </object>
             </child>
             <child>
-              <object class="GtkGrid">
+              <object class="GtkFlowBox">
                 <property name="visible">1</property>
                 <property name="margin-start">14</property>
                 <property name="margin-end">14</property>
                 <property name="margin-top">14</property>
                 <property name="margin-bottom">14</property>
-                <property name="row-spacing">10</property>
+                <property name="row-spacing">6</property>
                 <property name="column-spacing">15</property>
+                <property name="min-children-per-line">2</property>
+                <property name="max-children-per-line">2</property>
+                <property name="selection-mode">none</property>
                 <child>
                   <object class="GtkLabel">
                     <property name="visible">1</property>
@@ -35,10 +38,11 @@
                       <attribute name="weight" value="bold"/>
                     </attributes>
                   </object>
-                  <packing>
-                    <property name="left-attach">0</property>
-                    <property name="top-attach">0</property>
-                  </packing>
+                </child>
+                <child>
+                  <object class="GtkLabel">
+                    <property name="visible">1</property>
+                  </object>
                 </child>
                 <child>
                   <object class="GtkLabel">
@@ -50,10 +54,6 @@
                       <attribute name="style" value="italic"/>
                     </attributes>
                   </object>
-                  <packing>
-                    <property name="left-attach">0</property>
-                    <property name="top-attach">1</property>
-                  </packing>
                 </child>
                 <child>
                   <object class="GtkLabel">
@@ -62,10 +62,6 @@
                     <property name="selectable">1</property>
                     <property name="xalign">0</property>
                   </object>
-                  <packing>
-                    <property name="left-attach">1</property>
-                    <property name="top-attach">1</property>
-                  </packing>
                 </child>
                 <child>
                   <object class="GtkLabel">
@@ -77,10 +73,6 @@
                       <attribute name="style" value="italic"/>
                     </attributes>
                   </object>
-                  <packing>
-                    <property name="left-attach">0</property>
-                    <property name="top-attach">2</property>
-                  </packing>
                 </child>
                 <child>
                   <object class="GtkLabel">
@@ -89,10 +81,6 @@
                     <property name="selectable">1</property>
                     <property name="xalign">0</property>
                   </object>
-                  <packing>
-                    <property name="left-attach">1</property>
-                    <property name="top-attach">2</property>
-                  </packing>
                 </child>
                 <child>
                   <object class="GtkLabel">
@@ -104,10 +92,6 @@
                       <attribute name="style" value="italic"/>
                     </attributes>
                   </object>
-                  <packing>
-                    <property name="left-attach">0</property>
-                    <property name="top-attach">3</property>
-                  </packing>
                 </child>
                 <child>
                   <object class="GtkLabel">
@@ -116,10 +100,6 @@
                     <property name="selectable">1</property>
                     <property name="xalign">0</property>
                   </object>
-                  <packing>
-                    <property name="left-attach">1</property>
-                    <property name="top-attach">3</property>
-                  </packing>
                 </child>
                 <child>
                   <object class="GtkLabel">
@@ -131,10 +111,6 @@
                       <attribute name="style" value="italic"/>
                     </attributes>
                   </object>
-                  <packing>
-                    <property name="left-attach">0</property>
-                    <property name="top-attach">4</property>
-                  </packing>
                 </child>
                 <child>
                   <object class="GtkLabel">
@@ -143,10 +119,6 @@
                     <property name="selectable">1</property>
                     <property name="xalign">0</property>
                   </object>
-                  <packing>
-                    <property name="left-attach">1</property>
-                    <property name="top-attach">4</property>
-                  </packing>
                 </child>
                 <child>
                   <object class="GtkLabel">
@@ -158,10 +130,6 @@
                       <attribute name="style" value="italic"/>
                     </attributes>
                   </object>
-                  <packing>
-                    <property name="left-attach">0</property>
-                    <property name="top-attach">5</property>
-                  </packing>
                 </child>
                 <child>
                   <object class="GtkLabel">
@@ -170,10 +138,6 @@
                     <property name="selectable">1</property>
                     <property name="xalign">0</property>
                   </object>
-                  <packing>
-                    <property name="left-attach">1</property>
-                    <property name="top-attach">5</property>
-                  </packing>
                 </child>
                 <child>
                   <object class="GtkLabel">
@@ -185,10 +149,6 @@
                       <attribute name="style" value="italic"/>
                     </attributes>
                   </object>
-                  <packing>
-                    <property name="left-attach">0</property>
-                    <property name="top-attach">6</property>
-                  </packing>
                 </child>
                 <child>
                   <object class="GtkLabel">
@@ -197,10 +157,6 @@
                     <property name="selectable">1</property>
                     <property name="xalign">0</property>
                   </object>
-                  <packing>
-                    <property name="left-attach">1</property>
-                    <property name="top-attach">6</property>
-                  </packing>
                 </child>
                 <child>
                   <object class="GtkLabel">
@@ -212,10 +168,6 @@
                       <attribute name="style" value="italic"/>
                     </attributes>
                   </object>
-                  <packing>
-                    <property name="left-attach">0</property>
-                    <property name="top-attach">7</property>
-                  </packing>
                 </child>
                 <child>
                   <object class="GtkLabel">
@@ -224,10 +176,6 @@
                     <property name="selectable">1</property>
                     <property name="xalign">0</property>
                   </object>
-                  <packing>
-                    <property name="left-attach">1</property>
-                    <property name="top-attach">7</property>
-                  </packing>
                 </child>
                 <child>
                   <object class="GtkLabel">
@@ -239,10 +187,6 @@
                       <attribute name="style" value="italic"/>
                     </attributes>
                   </object>
-                  <packing>
-                    <property name="left-attach">0</property>
-                    <property name="top-attach">8</property>
-                  </packing>
                 </child>
                 <child>
                   <object class="GtkLabel">
@@ -251,19 +195,16 @@
                     <property name="selectable">1</property>
                     <property name="xalign">0</property>
                   </object>
-                  <packing>
-                    <property name="left-attach">1</property>
-                    <property name="top-attach">8</property>
-                  </packing>
                 </child>
                 <child>
                   <object class="GtkLabel">
                     <property name="visible">1</property>
                   </object>
-                  <packing>
-                    <property name="left-attach">0</property>
-                    <property name="top-attach">9</property>
-                  </packing>
+                </child>
+                <child>
+                  <object class="GtkLabel">
+                    <property name="visible">1</property>
+                  </object>
                 </child>
                 <child>
                   <object class="GtkLabel">
@@ -275,10 +216,11 @@
                       <attribute name="weight" value="bold"/>
                     </attributes>
                   </object>
-                  <packing>
-                    <property name="left-attach">0</property>
-                    <property name="top-attach">10</property>
-                  </packing>
+                </child>
+                <child>
+                  <object class="GtkLabel">
+                    <property name="visible">1</property>
+                  </object>
                 </child>
                 <child>
                   <object class="GtkLabel">
@@ -290,10 +232,6 @@
                       <attribute name="style" value="italic"/>
                     </attributes>
                   </object>
-                  <packing>
-                    <property name="left-attach">0</property>
-                    <property name="top-attach">11</property>
-                  </packing>
                 </child>
                 <child>
                   <object class="GtkLabel">
@@ -302,10 +240,6 @@
                     <property name="selectable">1</property>
                     <property name="xalign">0</property>
                   </object>
-                  <packing>
-                    <property name="left-attach">1</property>
-                    <property name="top-attach">11</property>
-                  </packing>
                 </child>
                 <child>
                   <object class="GtkLabel">
@@ -317,10 +251,6 @@
                       <attribute name="style" value="italic"/>
                     </attributes>
                   </object>
-                  <packing>
-                    <property name="left-attach">0</property>
-                    <property name="top-attach">12</property>
-                  </packing>
                 </child>
                 <child>
                   <object class="GtkLabel">
@@ -329,10 +259,6 @@
                     <property name="selectable">1</property>
                     <property name="xalign">0</property>
                   </object>
-                  <packing>
-                    <property name="left-attach">1</property>
-                    <property name="top-attach">12</property>
-                  </packing>
                 </child>
                 <child>
                   <object class="GtkLabel">
@@ -344,10 +270,6 @@
                       <attribute name="style" value="italic"/>
                     </attributes>
                   </object>
-                  <packing>
-                    <property name="left-attach">0</property>
-                    <property name="top-attach">13</property>
-                  </packing>
                 </child>
                 <child>
                   <object class="GtkLabel">
@@ -356,10 +278,6 @@
                     <property name="selectable">1</property>
                     <property name="xalign">0</property>
                   </object>
-                  <packing>
-                    <property name="left-attach">1</property>
-                    <property name="top-attach">13</property>
-                  </packing>
                 </child>
                 <child>
                   <object class="GtkLabel">
@@ -371,10 +289,6 @@
                       <attribute name="style" value="italic"/>
                     </attributes>
                   </object>
-                  <packing>
-                    <property name="left-attach">0</property>
-                    <property name="top-attach">14</property>
-                  </packing>
                 </child>
                 <child>
                   <object class="GtkLabel">
@@ -383,10 +297,6 @@
                     <property name="selectable">1</property>
                     <property name="xalign">0</property>
                   </object>
-                  <packing>
-                    <property name="left-attach">1</property>
-                    <property name="top-attach">14</property>
-                  </packing>
                 </child>
                 <child>
                   <object class="GtkLabel">
@@ -398,10 +308,6 @@
                       <attribute name="style" value="italic"/>
                     </attributes>
                   </object>
-                  <packing>
-                    <property name="left-attach">0</property>
-                    <property name="top-attach">15</property>
-                  </packing>
                 </child>
                 <child>
                   <object class="GtkLabel">
@@ -410,10 +316,6 @@
                     <property name="selectable">1</property>
                     <property name="xalign">0</property>
                   </object>
-                  <packing>
-                    <property name="left-attach">1</property>
-                    <property name="top-attach">15</property>
-                  </packing>
                 </child>
                 <child>
                   <object class="GtkLabel">
@@ -425,10 +327,6 @@
                       <attribute name="style" value="italic"/>
                     </attributes>
                   </object>
-                  <packing>
-                    <property name="left-attach">0</property>
-                    <property name="top-attach">16</property>
-                  </packing>
                 </child>
                 <child>
                   <object class="GtkLabel">
@@ -437,10 +335,6 @@
                     <property name="selectable">1</property>
                     <property name="xalign">0</property>
                   </object>
-                  <packing>
-                    <property name="left-attach">1</property>
-                    <property name="top-attach">16</property>
-                  </packing>
                 </child>
                 <child>
                   <object class="GtkLabel">
@@ -452,10 +346,6 @@
                       <attribute name="style" value="italic"/>
                     </attributes>
                   </object>
-                  <packing>
-                    <property name="left-attach">0</property>
-                    <property name="top-attach">17</property>
-                  </packing>
                 </child>
                 <child>
                   <object class="GtkLabel">
@@ -464,10 +354,6 @@
                     <property name="selectable">1</property>
                     <property name="xalign">0</property>
                   </object>
-                  <packing>
-                    <property name="left-attach">1</property>
-                    <property name="top-attach">17</property>
-                  </packing>
                 </child>
                 <child>
                   <object class="GtkLabel">
@@ -479,10 +365,6 @@
                       <attribute name="style" value="italic"/>
                     </attributes>
                   </object>
-                  <packing>
-                    <property name="left-attach">0</property>
-                    <property name="top-attach">18</property>
-                  </packing>
                 </child>
                 <child>
                   <object class="GtkLabel">
@@ -491,10 +373,6 @@
                     <property name="selectable">1</property>
                     <property name="xalign">0</property>
                   </object>
-                  <packing>
-                    <property name="left-attach">1</property>
-                    <property name="top-attach">18</property>
-                  </packing>
                 </child>
                 <child>
                   <object class="GtkLabel">
@@ -506,10 +384,6 @@
                       <attribute name="style" value="italic"/>
                     </attributes>
                   </object>
-                  <packing>
-                    <property name="left-attach">0</property>
-                    <property name="top-attach">19</property>
-                  </packing>
                 </child>
                 <child>
                   <object class="GtkLabel">
@@ -518,19 +392,16 @@
                     <property name="selectable">1</property>
                     <property name="xalign">0</property>
                   </object>
-                  <packing>
-                    <property name="left-attach">1</property>
-                    <property name="top-attach">19</property>
-                  </packing>
                 </child>
                 <child>
                   <object class="GtkLabel">
                     <property name="visible">1</property>
                   </object>
-                  <packing>
-                    <property name="left-attach">0</property>
-                    <property name="top-attach">20</property>
-                  </packing>
+                </child>
+                <child>
+                  <object class="GtkLabel">
+                    <property name="visible">1</property>
+                  </object>
                 </child>
                 <child>
                   <object class="GtkLabel">
@@ -542,10 +413,11 @@
                       <attribute name="weight" value="bold"/>
                     </attributes>
                   </object>
-                  <packing>
-                    <property name="left-attach">0</property>
-                    <property name="top-attach">21</property>
-                  </packing>
+                </child>
+                <child>
+                  <object class="GtkLabel">
+                    <property name="visible">1</property>
+                  </object>
                 </child>
                 <child>
                   <object class="GtkLabel">
@@ -557,10 +429,6 @@
                       <attribute name="style" value="italic"/>
                     </attributes>
                   </object>
-                  <packing>
-                    <property name="left-attach">0</property>
-                    <property name="top-attach">22</property>
-                  </packing>
                 </child>
                 <child>
                   <object class="GtkLabel">
@@ -569,10 +437,6 @@
                     <property name="selectable">1</property>
                     <property name="xalign">0</property>
                   </object>
-                  <packing>
-                    <property name="left-attach">1</property>
-                    <property name="top-attach">22</property>
-                  </packing>
                 </child>
                 <child>
                   <object class="GtkLabel">
@@ -584,10 +448,6 @@
                       <attribute name="style" value="italic"/>
                     </attributes>
                   </object>
-                  <packing>
-                    <property name="left-attach">0</property>
-                    <property name="top-attach">23</property>
-                  </packing>
                 </child>
                 <child>
                   <object class="GtkLabel">
@@ -596,19 +456,16 @@
                     <property name="selectable">1</property>
                     <property name="xalign">0</property>
                   </object>
-                  <packing>
-                    <property name="left-attach">1</property>
-                    <property name="top-attach">23</property>
-                  </packing>
                 </child>
                 <child>
                   <object class="GtkLabel">
                     <property name="visible">1</property>
                   </object>
-                  <packing>
-                    <property name="left-attach">0</property>
-                    <property name="top-attach">24</property>
-                  </packing>
+                </child>
+                <child>
+                  <object class="GtkLabel">
+                    <property name="visible">1</property>
+                  </object>
                 </child>
                 <child>
                   <object class="GtkLabel">
@@ -620,10 +477,11 @@
                       <attribute name="weight" value="bold"/>
                     </attributes>
                   </object>
-                  <packing>
-                    <property name="left-attach">0</property>
-                    <property name="top-attach">25</property>
-                  </packing>
+                </child>
+                <child>
+                  <object class="GtkLabel">
+                    <property name="visible">1</property>
+                  </object>
                 </child>
                 <child>
                   <object class="GtkLabel">
@@ -635,10 +493,6 @@
                       <attribute name="style" value="italic"/>
                     </attributes>
                   </object>
-                  <packing>
-                    <property name="left-attach">0</property>
-                    <property name="top-attach">26</property>
-                  </packing>
                 </child>
                 <child>
                   <object class="GtkLabel">
@@ -647,10 +501,6 @@
                     <property name="selectable">1</property>
                     <property name="xalign">0</property>
                   </object>
-                  <packing>
-                    <property name="left-attach">1</property>
-                    <property name="top-attach">26</property>
-                  </packing>
                 </child>
                 <child>
                   <object class="GtkLabel">
@@ -662,10 +512,6 @@
                       <attribute name="style" value="italic"/>
                     </attributes>
                   </object>
-                  <packing>
-                    <property name="left-attach">0</property>
-                    <property name="top-attach">27</property>
-                  </packing>
                 </child>
                 <child>
                   <object class="GtkLabel">
@@ -674,10 +520,6 @@
                     <property name="selectable">1</property>
                     <property name="xalign">0</property>
                   </object>
-                  <packing>
-                    <property name="left-attach">1</property>
-                    <property name="top-attach">27</property>
-                  </packing>
                 </child>
                 <child>
                   <object class="GtkLabel">
@@ -689,10 +531,6 @@
                       <attribute name="style" value="italic"/>
                     </attributes>
                   </object>
-                  <packing>
-                    <property name="left-attach">0</property>
-                    <property name="top-attach">28</property>
-                  </packing>
                 </child>
                 <child>
                   <object class="GtkLabel">
@@ -701,10 +539,6 @@
                     <property name="selectable">1</property>
                     <property name="xalign">0</property>
                   </object>
-                  <packing>
-                    <property name="left-attach">1</property>
-                    <property name="top-attach">28</property>
-                  </packing>
                 </child>
                 <child>
                   <object class="GtkLabel">
@@ -716,10 +550,6 @@
                       <attribute name="style" value="italic"/>
                     </attributes>
                   </object>
-                  <packing>
-                    <property name="left-attach">0</property>
-                    <property name="top-attach">29</property>
-                  </packing>
                 </child>
                 <child>
                   <object class="GtkLabel">
@@ -728,19 +558,16 @@
                     <property name="selectable">1</property>
                     <property name="xalign">0</property>
                   </object>
-                  <packing>
-                    <property name="left-attach">1</property>
-                    <property name="top-attach">29</property>
-                  </packing>
                 </child>
                 <child>
                   <object class="GtkLabel">
                     <property name="visible">1</property>
                   </object>
-                  <packing>
-                    <property name="left-attach">0</property>
-                    <property name="top-attach">30</property>
-                  </packing>
+                </child>
+                <child>
+                  <object class="GtkLabel">
+                    <property name="visible">1</property>
+                  </object>
                 </child>
                 <child>
                   <object class="GtkLabel">
@@ -752,10 +579,11 @@
                       <attribute name="weight" value="bold"/>
                     </attributes>
                   </object>
-                  <packing>
-                    <property name="left-attach">0</property>
-                    <property name="top-attach">31</property>
-                  </packing>
+                </child>
+                <child>
+                  <object class="GtkLabel">
+                    <property name="visible">1</property>
+                  </object>
                 </child>
                 <child>
                   <object class="GtkLabel">
@@ -767,10 +595,6 @@
                       <attribute name="style" value="italic"/>
                     </attributes>
                   </object>
-                  <packing>
-                    <property name="left-attach">0</property>
-                    <property name="top-attach">32</property>
-                  </packing>
                 </child>
                 <child>
                   <object class="GtkLabel">
@@ -779,10 +603,6 @@
                     <property name="selectable">1</property>
                     <property name="xalign">0</property>
                   </object>
-                  <packing>
-                    <property name="left-attach">1</property>
-                    <property name="top-attach">32</property>
-                  </packing>
                 </child>
               </object>
             </child>

--- a/pynicotine/gtkgui/ui/popovers/roomlist.ui
+++ b/pynicotine/gtkgui/ui/popovers/roomlist.ui
@@ -2,7 +2,6 @@
 <interface>
   <requires lib="gtk+" version="3.18"/>
   <object class="GtkPopover" id="RoomListPopover">
-    <!--<property name="modal">1</property>-->
     <child>
       <object class="GtkBox">
         <property name="visible">1</property>
@@ -46,12 +45,11 @@
           </object>
         </child>
         <child>
-          <object class="GtkScrolledWindow">
+          <object class="GtkScrolledWindow" id="RoomsListScrolledWindow">
             <property name="visible">1</property>
             <property name="can-focus">1</property>
             <property name="height-request">400</property>
             <property name="width-request">350</property>
-            <!--<property name="shadow-type">in</property>-->
             <child>
               <object class="GtkTreeView" id="RoomsList">
                 <property name="visible">1</property>

--- a/pynicotine/gtkgui/ui/popovers/roomlist.ui
+++ b/pynicotine/gtkgui/ui/popovers/roomlist.ui
@@ -2,7 +2,7 @@
 <interface>
   <requires lib="gtk+" version="3.18"/>
   <object class="GtkPopover" id="RoomListPopover">
-    <property name="modal">1</property>
+    <!--<property name="modal">1</property>-->
     <child>
       <object class="GtkBox">
         <property name="visible">1</property>
@@ -51,7 +51,7 @@
             <property name="can-focus">1</property>
             <property name="height-request">400</property>
             <property name="width-request">350</property>
-            <property name="shadow-type">in</property>
+            <!--<property name="shadow-type">in</property>-->
             <child>
               <object class="GtkTreeView" id="RoomsList">
                 <property name="visible">1</property>

--- a/pynicotine/gtkgui/ui/popovers/searchfilters.ui
+++ b/pynicotine/gtkgui/ui/popovers/searchfilters.ui
@@ -88,7 +88,7 @@
                       <object class="GtkLabel">
                         <property name="visible">1</property>
                         <property name="halign">start</property>
-                        <property name="xpad">10</property>
+                        <property name="margin-start">10</property>
                         <property name="label" translatable="yes">Files and folders containing this text will be shown.</property>
                         <property name="justify">fill</property>
                         <property name="selectable">1</property>
@@ -99,7 +99,7 @@
                       <object class="GtkLabel">
                         <property name="visible">1</property>
                         <property name="halign">start</property>
-                        <property name="xpad">10</property>
+                        <property name="margin-start">10</property>
                         <property name="label" translatable="yes">Case is insensitive, but word order is important: &apos;Spears Brittany&apos; will not show any &apos;Brittany Spears&apos;</property>
                         <property name="justify">fill</property>
                         <property name="selectable">1</property>
@@ -110,7 +110,7 @@
                       <object class="GtkLabel">
                         <property name="visible">1</property>
                         <property name="halign">start</property>
-                        <property name="xpad">10</property>
+                        <property name="margin-start">10</property>
                         <property name="label" translatable="yes">For order-insensitive filtering, as well as filtering several exact phrases, vertical bars can be used to separate phrases and words.
     Example: Spears|Brittany|My beautiful album|hello</property>
                         <property name="justify">fill</property>
@@ -135,7 +135,7 @@
                   <object class="GtkLabel">
                     <property name="visible">1</property>
                     <property name="halign">start</property>
-                    <property name="xpad">10</property>
+                    <property name="margin-start">10</property>
                     <property name="label" translatable="yes">As above, but files and folders are filtered out if the text matches.</property>
                     <property name="justify">fill</property>
                     <property name="selectable">1</property>
@@ -157,7 +157,7 @@
                   <object class="GtkLabel">
                     <property name="visible">1</property>
                     <property name="halign">start</property>
-                    <property name="xpad">10</property>
+                    <property name="margin-start">10</property>
                     <property name="label" translatable="yes">Filters files based upon their file extension.</property>
                     <property name="justify">fill</property>
                     <property name="selectable">1</property>
@@ -168,7 +168,7 @@
                   <object class="GtkLabel">
                     <property name="visible">1</property>
                     <property name="halign">start</property>
-                    <property name="xpad">10</property>
+                    <property name="margin-start">10</property>
                     <property name="label" translatable="yes">Multiple file extensions can be specified, which in turn will broaden the list of results.
     Example: flac|wav|ape</property>
                     <property name="justify">fill</property>
@@ -180,7 +180,7 @@
                   <object class="GtkLabel">
                     <property name="visible">1</property>
                     <property name="halign">start</property>
-                    <property name="xpad">10</property>
+                    <property name="margin-start">10</property>
                     <property name="label" translatable="yes">It is also possible to invert the filter, specifying file extensions you don&apos;t want in your results.
     Example: !mp3|!jpg</property>
                     <property name="justify">fill</property>
@@ -208,7 +208,7 @@
                       <object class="GtkLabel">
                         <property name="visible">1</property>
                         <property name="halign">start</property>
-                        <property name="xpad">10</property>
+                        <property name="margin-start">10</property>
                         <property name="label" translatable="yes">Filters files based upon their file size.</property>
                         <property name="justify">fill</property>
                         <property name="selectable">1</property>
@@ -219,7 +219,7 @@
                       <object class="GtkLabel">
                         <property name="visible">1</property>
                         <property name="halign">start</property>
-                        <property name="xpad">10</property>
+                        <property name="margin-start">10</property>
                         <property name="label" translatable="yes">By default, the unit used is bytes and files greater than or equal to the value will be matched.</property>
                         <property name="justify">fill</property>
                         <property name="selectable">1</property>
@@ -230,7 +230,7 @@
                       <object class="GtkLabel">
                         <property name="visible">1</property>
                         <property name="halign">start</property>
-                        <property name="xpad">10</property>
+                        <property name="margin-start">10</property>
                         <property name="label" translatable="yes">Prepend = to a value to specify an exact match:
     =1024 only matches files that are 1024 bytes in size (i.e. 1 kibibyte).</property>
                         <property name="justify">fill</property>
@@ -242,7 +242,7 @@
                       <object class="GtkLabel">
                         <property name="visible">1</property>
                         <property name="halign">start</property>
-                        <property name="xpad">10</property>
+                        <property name="margin-start">10</property>
                         <property name="label" translatable="yes">Prepend &lt; or &gt; to find files less-/greater than or equal to the value.</property>
                         <property name="justify">fill</property>
                         <property name="selectable">1</property>
@@ -253,7 +253,7 @@
                       <object class="GtkLabel">
                         <property name="visible">1</property>
                         <property name="halign">start</property>
-                        <property name="xpad">10</property>
+                        <property name="margin-start">10</property>
                         <property name="label" translatable="yes">Append b, k, m, or g (alternatively kib, mib, or gib) to specify byte, kibibyte, mebibyte, or gibibyte units:
     &lt;1024k will find files 1024 kibibytes (i.e. 1 mebibyte) or smaller.</property>
                         <property name="justify">fill</property>
@@ -265,7 +265,7 @@
                       <object class="GtkLabel">
                         <property name="visible">1</property>
                         <property name="halign">start</property>
-                        <property name="xpad">10</property>
+                        <property name="margin-start">10</property>
                         <property name="label" translatable="yes">For convenience, the variants kb, mb, and gb for the better-known kilo-, mega-, and gigabyte units can also be used.</property>
                         <property name="justify">fill</property>
                         <property name="selectable">1</property>
@@ -294,7 +294,7 @@
                       <object class="GtkLabel">
                         <property name="visible">1</property>
                         <property name="halign">start</property>
-                        <property name="xpad">10</property>
+                        <property name="margin-start">10</property>
                         <property name="label" translatable="yes">Filters files based upon their bitrate.</property>
                         <property name="justify">fill</property>
                         <property name="selectable">1</property>
@@ -305,7 +305,7 @@
                       <object class="GtkLabel">
                         <property name="visible">1</property>
                         <property name="halign">start</property>
-                        <property name="xpad">10</property>
+                        <property name="margin-start">10</property>
                         <property name="label" translatable="yes">VBR files display their average bitrate and are typically lower in bitrate than a compressed 320 kbps CBR file of the same audio quality.</property>
                         <property name="justify">fill</property>
                         <property name="selectable">1</property>
@@ -316,7 +316,7 @@
                       <object class="GtkLabel">
                         <property name="visible">1</property>
                         <property name="halign">start</property>
-                        <property name="xpad">10</property>
+                        <property name="margin-start">10</property>
                         <property name="label" translatable="yes">Like Size above, =, &lt;, and &gt; can be used.</property>
                         <property name="justify">fill</property>
                         <property name="selectable">1</property>
@@ -340,7 +340,7 @@
                   <object class="GtkLabel">
                     <property name="visible">1</property>
                     <property name="halign">start</property>
-                    <property name="xpad">10</property>
+                    <property name="margin-start">10</property>
                     <property name="label" translatable="yes">Filters files based upon users&apos; countries.</property>
                     <property name="justify">fill</property>
                     <property name="selectable">1</property>
@@ -351,7 +351,7 @@
                   <object class="GtkLabel">
                     <property name="visible">1</property>
                     <property name="halign">start</property>
-                    <property name="xpad">10</property>
+                    <property name="margin-start">10</property>
                     <property name="label" translatable="yes">Uses country codes defined by ISO 3166-2 (see Wikipedia):
     &apos;US&apos; will only return files from users connected via the United States. Similarly, &apos;GB&apos; returns files from users with IPs in the United Kingdom.</property>
                     <property name="justify">fill</property>
@@ -374,7 +374,7 @@
                   <object class="GtkLabel">
                     <property name="visible">1</property>
                     <property name="halign">start</property>
-                    <property name="xpad">10</property>
+                    <property name="margin-start">10</property>
                     <property name="label" translatable="yes">Show only those results from users which have at least one upload slot free. This filter is applied immediately.</property>
                     <property name="justify">fill</property>
                     <property name="selectable">1</property>

--- a/pynicotine/gtkgui/ui/search.ui
+++ b/pynicotine/gtkgui/ui/search.ui
@@ -122,12 +122,6 @@
                   </object>
                 </child>
                 <child>
-                  <object class="GtkImage" id="GroupingIcon">
-                    <property name="visible">1</property>
-                    <property name="icon-name">view-list-symbolic</property>
-                  </object>
-                </child>
-                <child>
                   <object class="GtkComboBoxText" id="ResultGrouping">
                     <property name="visible">1</property>
                     <property name="has-entry">1</property>
@@ -144,9 +138,7 @@
                       </object>
                     </child>
                     <child internal-child="button">
-                      <object class="GtkButton">
-                        <property name="image">GroupingIcon</property>
-                      </object>
+                      <object class="GtkButton" id="ToggleButton"/>
                     </child>
                   </object>
                 </child>
@@ -160,7 +152,6 @@
         <child>
           <object class="GtkRevealer" id="FiltersContainer">
             <property name="visible">1</property>
-            <property name="can-focus">0</property>
             <property name="transition-type">slide-down</property>
             <child>
               <object class="GtkFlowBox">
@@ -174,7 +165,7 @@
                 <child>
                   <object class="GtkFlowBoxChild">
                     <property name="visible">1</property>
-                    <property name="can-focus">0</property>
+                    <property name="can-focus">1</property>
                     <child>
                       <object class="GtkComboBoxText" id="FilterIn">
                         <property name="visible">1</property>
@@ -203,7 +194,7 @@
                 <child>
                   <object class="GtkFlowBoxChild">
                     <property name="visible">1</property>
-                    <property name="can-focus">0</property>
+                    <property name="can-focus">1</property>
                     <child>
                       <object class="GtkComboBoxText" id="FilterOut">
                         <property name="visible">1</property>
@@ -232,7 +223,7 @@
                 <child>
                   <object class="GtkFlowBoxChild">
                     <property name="visible">1</property>
-                    <property name="can-focus">0</property>
+                    <property name="can-focus">1</property>
                     <child>
                       <object class="GtkComboBoxText" id="FilterType">
                         <property name="visible">1</property>
@@ -261,7 +252,7 @@
                 <child>
                   <object class="GtkFlowBoxChild">
                     <property name="visible">1</property>
-                    <property name="can-focus">0</property>
+                    <property name="can-focus">1</property>
                     <child>
                       <object class="GtkComboBoxText" id="FilterSize">
                         <property name="visible">1</property>
@@ -290,7 +281,7 @@
                 <child>
                   <object class="GtkFlowBoxChild">
                     <property name="visible">1</property>
-                    <property name="can-focus">0</property>
+                    <property name="can-focus">1</property>
                     <child>
                       <object class="GtkComboBoxText" id="FilterBitrate">
                         <property name="visible">1</property>
@@ -319,7 +310,7 @@
                 <child>
                   <object class="GtkFlowBoxChild">
                     <property name="visible">1</property>
-                    <property name="can-focus">0</property>
+                    <property name="can-focus">1</property>
                     <child>
                       <object class="GtkBox">
                         <property name="visible">1</property>

--- a/pynicotine/gtkgui/ui/settings/settingswindow.ui
+++ b/pynicotine/gtkgui/ui/settings/settingswindow.ui
@@ -6,7 +6,7 @@
     <property name="can-focus">1</property>
     <property name="vexpand">1</property>
     <child>
-      <object class="GtkScrolledWindow">
+      <object class="GtkScrolledWindow" id="SettingsList">
         <property name="width-request">250</property>
         <property name="visible">1</property>
         <property name="can-focus">1</property>
@@ -24,9 +24,6 @@
           </object>
         </child>
       </object>
-      <packing>
-        <property name="resize">0</property>
-      </packing>
     </child>
     <child>
       <object class="GtkScrolledWindow">

--- a/pynicotine/gtkgui/ui/uploads.ui
+++ b/pynicotine/gtkgui/ui/uploads.ui
@@ -32,15 +32,13 @@
     <child>
       <object class="GtkRevealer" id="UploadButtons">
         <property name="visible">1</property>
-        <property name="can-focus">0</property>
         <property name="transition-type">slide-up</property>
         <child>
-          <object class="GtkActionBar">
+          <object class="GtkActionBar" id="ActionBar">
             <property name="visible">1</property>
             <child>
               <object class="GtkBox">
                 <property name="visible">1</property>
-                <property name="hexpand">1</property>
                 <property name="spacing">6</property>
                 <child>
                   <object class="GtkButton">
@@ -129,7 +127,7 @@
               </object>
             </child>
             <child>
-              <object class="GtkBox">
+              <object class="GtkBox" id="End">
                 <property name="visible">1</property>
                 <property name="spacing">6</property>
                 <child>
@@ -167,25 +165,7 @@
                     <property name="visible">1</property>
                     <property name="can-focus">1</property>
                     <property name="direction">up</property>
-                    <child>
-                      <object class="GtkBox">
-                        <property name="visible">1</property>
-                        <property name="spacing">6</property>
-                        <child>
-                          <object class="GtkLabel">
-                            <property name="visible">1</property>
-                            <property name="label" translatable="yes">Clear Uploads...</property>
-                            <property name="tooltip-text">Clear every upload marked with a specific status.</property>
-                          </object>
-                        </child>
-                        <child>
-                          <object class="GtkImage">
-                            <property name="visible">1</property>
-                            <property name="icon-name">pan-up-symbolic</property>
-                          </object>
-                        </child>
-                      </object>
-                    </child>
+                    <property name="tooltip-text">Clear every upload marked with a specific status.</property>
                     <style>
                       <class name="flat"/>
                     </style>
@@ -195,6 +175,22 @@
             </child>
           </object>
         </child>
+      </object>
+    </child>
+  </object>
+  <object class="GtkBox" id="ClearTransfersLabel">
+    <property name="visible">1</property>
+    <property name="spacing">6</property>
+    <child>
+      <object class="GtkLabel">
+        <property name="visible">1</property>
+        <property name="label" translatable="yes">Clear Uploads...</property>
+      </object>
+    </child>
+    <child>
+      <object class="GtkImage">
+        <property name="visible">1</property>
+        <property name="icon-name">pan-up-symbolic</property>
       </object>
     </child>
   </object>

--- a/pynicotine/gtkgui/ui/userbrowse.ui
+++ b/pynicotine/gtkgui/ui/userbrowse.ui
@@ -10,28 +10,16 @@
         <child>
           <object class="GtkRevealer">
             <property name="visible">1</property>
-            <property name="can-focus">0</property>
             <property name="transition-type">slide-down</property>
             <child>
               <object class="GtkInfoBar" id="InfoBar">
                 <property name="visible">1</property>
-                <child internal-child="content_area">
-                  <object class="GtkBox">
-                    <property name="spacing">16</property>
-                    <child>
-                      <object class="GtkLabel">
-                        <property name="visible">1</property>
-                        <property name="wrap">1</property>
-                      </object>
-                    </child>
-                  </object>
-                </child>
               </object>
             </child>
           </object>
         </child>
         <child>
-          <object class="GtkPaned">
+          <object class="GtkPaned" id="MainPaned">
             <property name="visible">1</property>
             <property name="can-focus">1</property>
             <child>
@@ -232,12 +220,9 @@
                   </object>
                 </child>
               </object>
-              <packing>
-                <property name="resize">1</property>
-              </packing>
             </child>
             <child>
-              <object class="GtkBox">
+              <object class="GtkBox" id="FilePane">
                 <property name="visible">1</property>
                 <property name="orientation">vertical</property>
                 <child>
@@ -263,9 +248,6 @@
                   </object>
                 </child>
               </object>
-              <packing>
-                <property name="resize">1</property>
-              </packing>
             </child>
           </object>
         </child>

--- a/pynicotine/gtkgui/ui/userinfo.ui
+++ b/pynicotine/gtkgui/ui/userinfo.ui
@@ -10,22 +10,10 @@
         <child>
           <object class="GtkRevealer">
             <property name="visible">1</property>
-            <property name="can-focus">0</property>
             <property name="transition-type">slide-down</property>
             <child>
               <object class="GtkInfoBar" id="InfoBar">
                 <property name="visible">1</property>
-                <child internal-child="content_area">
-                  <object class="GtkBox">
-                    <property name="spacing">16</property>
-                    <child>
-                      <object class="GtkLabel">
-                        <property name="visible">1</property>
-                        <property name="wrap">1</property>
-                      </object>
-                    </child>
-                  </object>
-                </child>
               </object>
             </child>
           </object>
@@ -35,7 +23,7 @@
             <property name="visible">1</property>
             <property name="vexpand">1</property>
             <child>
-              <object class="GtkPaned">
+              <object class="GtkPaned" id="MainPaned">
                 <property name="visible">1</property>
                 <property name="can-focus">1</property>
                 <property name="hexpand">1</property>
@@ -195,16 +183,13 @@
                       </object>
                     </child>
                   </object>
-                  <packing>
-                    <property name="resize">0</property>
-                  </packing>
                 </child>
                 <child>
-                  <object class="GtkPaned">
+                  <object class="GtkPaned" id="SecondPaned">
                     <property name="visible">1</property>
                     <property name="can-focus">1</property>
                     <child>
-                      <object class="GtkBox">
+                      <object class="GtkBox" id="Interests">
                         <property name="width-request">300</property>
                         <property name="visible">1</property>
                         <property name="spacing">6</property>
@@ -256,9 +241,6 @@
                           </object>
                         </child>
                       </object>
-                      <packing>
-                        <property name="resize">0</property>
-                      </packing>
                     </child>
                     <child>
                       <object class="GtkBox">
@@ -284,13 +266,12 @@
                           <object class="GtkScrolledWindow">
                             <property name="visible">1</property>
                             <property name="vexpand">1</property>
-                            <signal name="scroll-event" handler="on_scroll_event" swapped="no"/>
+                            <!--<signal name="scroll-event" handler="on_scroll_event" swapped="no"/>-->
                             <child>
                               <object class="GtkViewport">
                                 <property name="visible">1</property>
-                                <property name="shadow-type">none</property>
                                 <child>
-                                  <object class="GtkEventBox" id="UserImage">
+                                  <object class="GtkBox" id="UserImage">
                                     <property name="visible">1</property>
                                     <property name="can-focus">1</property>
                                     <child>

--- a/pynicotine/gtkgui/ui/userinfo.ui
+++ b/pynicotine/gtkgui/ui/userinfo.ui
@@ -266,22 +266,9 @@
                           <object class="GtkScrolledWindow">
                             <property name="visible">1</property>
                             <property name="vexpand">1</property>
-                            <!--<signal name="scroll-event" handler="on_scroll_event" swapped="no"/>-->
                             <child>
-                              <object class="GtkViewport">
+                              <object class="GtkViewport" id="ImageViewport">
                                 <property name="visible">1</property>
-                                <child>
-                                  <object class="GtkBox" id="UserImage">
-                                    <property name="visible">1</property>
-                                    <property name="can-focus">1</property>
-                                    <child>
-                                      <object class="GtkImage" id="image">
-                                        <property name="visible">1</property>
-                                        <property name="icon-name">action-unavailable-symbolic</property>
-                                      </object>
-                                    </child>
-                                  </object>
-                                </child>
                               </object>
                             </child>
                           </object>

--- a/pynicotine/gtkgui/uploads.py
+++ b/pynicotine/gtkgui/uploads.py
@@ -27,7 +27,7 @@ import os
 from pynicotine.config import config
 from pynicotine.gtkgui.transferlist import TransferList
 from pynicotine.gtkgui.utils import open_file_path
-from pynicotine.gtkgui.widgets.messagedialogs import option_dialog
+from pynicotine.gtkgui.widgets.dialogs import option_dialog
 
 
 class Uploads(TransferList):

--- a/pynicotine/gtkgui/userbrowse.py
+++ b/pynicotine/gtkgui/userbrowse.py
@@ -267,9 +267,9 @@ class UserBrowse:
         if self.user != config.sections["server"]["login"]:
             self.on_download_directory()
 
-    def on_folder_popup_menu(self, *args):
+    def on_folder_popup_menu(self, menu, widget):
 
-        actions = self.folder_popup_menu.get_actions()
+        actions = menu.get_actions()
 
         if self.user == config.sections["server"]["login"]:
             for i in (_("_Download Folder"), _("Download Folder _To..."), _("Download _Recursive"), _("Download R_ecursive To..."),
@@ -282,8 +282,6 @@ class UserBrowse:
                 actions[i].set_enabled(self.selected_folder)
 
         self.user_popup.toggle_user_items()
-        self.folder_popup_menu.popup()
-        return True
 
     def select_files(self):
 
@@ -306,12 +304,12 @@ class UserBrowse:
         else:
             self.on_download_files()
 
-    def on_file_popup_menu(self, *args):
+    def on_file_popup_menu(self, menu, widget):
 
         self.select_files()
         num_selected_files = len(self.selected_files)
 
-        actions = self.file_popup_menu.get_actions()
+        actions = menu.get_actions()
 
         if self.user == config.sections["server"]["login"]:
             for i in (_("Download"), _("Upload"), _("Send to _Player"), _("File _Properties"),
@@ -323,11 +321,8 @@ class UserBrowse:
             for i in (_("Download"), _("File _Properties"), _("Copy _File Path"), _("Copy _URL")):
                 actions[i].set_enabled(num_selected_files)
 
-        self.file_popup_menu.set_num_selected_files(num_selected_files)
-
+        menu.set_num_selected_files(num_selected_files)
         self.user_popup.toggle_user_items()
-        self.file_popup_menu.popup()
-        return True
 
     def make_new_model(self, list):
 
@@ -1054,8 +1049,6 @@ class UserBrowse:
 
     def on_tab_popup(self, *args):
         self.user_popup.toggle_user_items()
-        self.user_popup.popup()
-        return True
 
     def on_close(self, *args):
         del self.userbrowses.users[self.user]

--- a/pynicotine/gtkgui/userbrowse.py
+++ b/pynicotine/gtkgui/userbrowse.py
@@ -94,13 +94,13 @@ class UserBrowse:
 
         self.dir_column_numbers = list(range(self.dir_store.get_n_columns()))
         cols = initialise_columns(
-            None, self.FolderTreeView, self.on_folder_popup_menu,
+            None, self.FolderTreeView,
             ["folders", _("Folders"), -1, "text", None]  # 0
         )
 
         cols["folders"].set_sort_column_id(0)
 
-        self.user_popup = popup = PopupMenu(self.frame)
+        self.user_popup = popup = PopupMenu(self.frame, None, self.on_tab_popup)
         popup.setup_user_menu(user, page="userbrowse")
         popup.setup(
             ("", None),
@@ -141,7 +141,7 @@ class UserBrowse:
             ("#" + _("Up_load File(s)"), self.on_upload_files)
         )
 
-        self.folder_popup_menu = PopupMenu(self.frame)
+        self.folder_popup_menu = PopupMenu(self.frame, self.FolderTreeView, self.on_folder_popup_menu)
 
         if user == config.sections["server"]["login"]:
             self.folder_popup_menu.setup(
@@ -189,7 +189,7 @@ class UserBrowse:
 
         self.file_column_numbers = [i for i in range(self.file_store.get_n_columns())]
         cols = initialise_columns(
-            "user_browse", self.FileTreeView, self.on_file_popup_menu,
+            "user_browse", self.FileTreeView,
             ["filename", _("Filename"), 600, "text", None],
             ["size", _("Size"), 100, "number", None],
             ["bitrate", _("Bitrate"), 100, "number", None],
@@ -201,7 +201,7 @@ class UserBrowse:
         cols["length"].set_sort_column_id(6)
         self.file_store.set_sort_column_id(0, Gtk.SortType.ASCENDING)
 
-        self.file_popup_menu = PopupMenu(self.frame)
+        self.file_popup_menu = PopupMenu(self.frame, self.FileTreeView, self.on_file_popup_menu)
 
         if user == config.sections["server"]["login"]:
             self.file_popup_menu.setup(
@@ -238,6 +238,9 @@ class UserBrowse:
         for name, object in self.__dict__.items():
             if isinstance(object, PopupMenu):
                 object.set_user(self.user)
+
+    def set_label(self, label):
+        self.user_popup.set_widget(label)
 
     def update_visuals(self):
 
@@ -1048,6 +1051,11 @@ class UserBrowse:
         command = config.sections["ui"]["filemanager"]
 
         open_file_path(path, command)
+
+    def on_tab_popup(self, *args):
+        self.user_popup.toggle_user_items()
+        self.user_popup.popup()
+        return True
 
     def on_close(self, *args):
         del self.userbrowses.users[self.user]

--- a/pynicotine/gtkgui/userinfo.py
+++ b/pynicotine/gtkgui/userinfo.py
@@ -366,33 +366,28 @@ class UserInfo:
 
     def on_tab_popup(self, *args):
         self.user_popup.toggle_user_items()
-        self.user_popup.popup()
-        return True
 
-    def on_popup_interest_menu(self, widget):
+    def on_popup_interest_menu(self, menu, widget):
 
         model, iterator = widget.get_selection().get_selected()
 
         if iterator is None:
-            return False
+            return True
 
         item = model.get_value(iterator, 0)
 
         if item is None:
-            return False
+            return True
 
-        self.interest_popup_menu.set_user(item)
+        menu.set_user(item)
 
-        actions = self.interest_popup_menu.get_actions()
+        actions = menu.get_actions()
         actions[_("I _Like This")].set_state(
             GLib.Variant.new_boolean(item in config.sections["interests"]["likes"])
         )
         actions[_("I _Dislike This")].set_state(
             GLib.Variant.new_boolean(item in config.sections["interests"]["dislikes"])
         )
-
-        self.interest_popup_menu.popup()
-        return True
 
     def on_like_recommendation(self, action, state):
         self.frame.interests.on_like_recommendation(action, state, self.interest_popup_menu.get_user())
@@ -449,19 +444,16 @@ class UserInfo:
             title="Save as..."
         )
 
-    def on_image_popup_menu(self, *args):
+    def on_image_popup_menu(self, menu, widget):
 
         act = True
 
         if self.image is None or self.image_pixbuf is None:
             act = False
 
-        actions = self.image_menu.get_actions()
+        actions = menu.get_actions()
         for (action_id, action) in actions.items():
             action.set_enabled(act)
-
-        self.image_menu.popup()
-        return True
 
     def on_scroll_event(self, widget, event):
 

--- a/pynicotine/gtkgui/userinfo.py
+++ b/pynicotine/gtkgui/userinfo.py
@@ -60,8 +60,6 @@ class UserTabs(IconNotebook):
             notebookraw=notebookraw
         )
 
-        self.popup_enable()
-
         self.subwindow = subwindow
 
         self.users = {}
@@ -180,6 +178,13 @@ class UserInfo:
         # Build the window
         load_ui_elements(self, os.path.join(self.frame.gui_dir, "ui", "userinfo.ui"))
         self.info_bar = InfoBar(self.InfoBar, Gtk.MessageType.INFO)
+
+        if Gtk.get_major_version() == 4:
+            self.MainPaned.set_property("resize-start-child", False)
+            self.SecondPaned.set_property("resize-start-child", False)
+        else:
+            self.MainPaned.child_set_property(self.InfoVbox, "resize", False)
+            self.SecondPaned.child_set_property(self.Interests, "resize", False)
 
         # Request user status, speed and number of shared files
         self.frame.np.watch_user(user, force_update=True)

--- a/pynicotine/gtkgui/userlist.py
+++ b/pynicotine/gtkgui/userlist.py
@@ -351,29 +351,26 @@ class UserList:
             self.frame.privatechats.send_message(user, show_user=True)
             self.frame.change_main_page("private")
 
-    def on_popup_menu(self, widget, *args):
+    def on_popup_menu(self, menu, widget):
 
         username, trusted, notify, privileged, status = self.get_selected_username_details(widget)
         if username is None:
-            return False
+            return True
 
-        self.popup_menu.set_user(username)
-        self.popup_menu.toggle_user_items()
-        self.popup_menu.populate_private_rooms(self.popup_menu_private_rooms)
+        menu.set_user(username)
+        menu.toggle_user_items()
+        menu.populate_private_rooms(self.popup_menu_private_rooms)
 
-        actions = self.popup_menu.get_actions()
+        actions = menu.get_actions()
 
         actions[_("Private Rooms")].set_enabled(
             status or
-            self.popup_menu.user != config.sections["server"]["login"]
+            menu.user != config.sections["server"]["login"]
         )
 
         actions[_("_Online Notify")].set_state(GLib.Variant.new_boolean(notify))
         actions[_("_Privileged")].set_state(GLib.Variant.new_boolean(privileged))
         actions[_("_Trusted")].set_state(GLib.Variant.new_boolean(trusted))
-
-        self.popup_menu.popup()
-        return True
 
     def get_user_status(self, msg):
 

--- a/pynicotine/gtkgui/userlist.py
+++ b/pynicotine/gtkgui/userlist.py
@@ -75,7 +75,7 @@ class UserList:
 
         self.column_numbers = list(range(self.usersmodel.get_n_columns()))
         self.cols = cols = initialise_columns(
-            "buddy_list", self.UserListTree, self.on_popup_menu,
+            "buddy_list", self.UserListTree,
             ["status", _("Status"), 25, "pixbuf", None],
             ["country", _("Country"), 25, "pixbuf", None],
             ["user", _("User"), 250, "text", None],
@@ -136,7 +136,7 @@ class UserList:
 
         self.popup_menu_private_rooms = PopupMenu(self.frame)
 
-        self.popup_menu = popup = PopupMenu(frame)
+        self.popup_menu = popup = PopupMenu(frame, self.UserListTree, self.on_popup_menu)
         popup.setup_user_menu(page="userlist")
         popup.setup(
             ("", None),
@@ -351,7 +351,7 @@ class UserList:
             self.frame.privatechats.send_message(user, show_user=True)
             self.frame.change_main_page("private")
 
-    def on_popup_menu(self, widget):
+    def on_popup_menu(self, widget, *args):
 
         username, trusted, notify, privileged, status = self.get_selected_username_details(widget)
         if username is None:

--- a/pynicotine/gtkgui/userlist.py
+++ b/pynicotine/gtkgui/userlist.py
@@ -31,7 +31,7 @@ from gi.repository import Gtk
 from pynicotine import slskmessages
 from pynicotine.config import config
 from pynicotine.gtkgui.utils import load_ui_elements
-from pynicotine.gtkgui.widgets.messagedialogs import entry_dialog
+from pynicotine.gtkgui.widgets.dialogs import entry_dialog
 from pynicotine.gtkgui.widgets.popupmenu import PopupMenu
 from pynicotine.gtkgui.widgets.theme import update_widget_visuals
 from pynicotine.gtkgui.widgets.treeview import initialise_columns
@@ -73,6 +73,11 @@ class UserList:
             str                   # (14) country
         )
 
+        if Gtk.get_major_version() == 4:
+            frame.userlistvbox.append(self.Main)
+        else:
+            frame.userlistvbox.add(self.Main)
+
         self.column_numbers = list(range(self.usersmodel.get_n_columns()))
         self.cols = cols = initialise_columns(
             "buddy_list", self.UserListTree,
@@ -87,6 +92,8 @@ class UserList:
             ["last_seen", _("Last seen"), 160, "text", None],
             ["comments", _("Comments"), 400, "edit", None]
         )
+
+        frame.userlistvbox.remove(self.Main)
 
         cols["status"].set_sort_column_id(10)
         cols["country"].set_sort_column_id(14)
@@ -214,6 +221,9 @@ class UserList:
             time_from_epoch,
             country
         ]
+
+        if Gtk.get_major_version() == 4:
+            self.usersmodel.insert_with_valuesv = self.usersmodel.insert_with_values
 
         self.user_iterators[username] = self.usersmodel.insert_with_valuesv(0, self.column_numbers, row)
 

--- a/pynicotine/gtkgui/utils.py
+++ b/pynicotine/gtkgui/utils.py
@@ -346,45 +346,6 @@ def censor_chat(message):
 """ Events """
 
 
-event_touch_started = False
-event_time_prev = 0
-
-
-def triggers_context_menu(event):
-    """ Check if a context menu should be allowed to appear """
-
-    global event_touch_started
-    global event_time_prev
-
-    if event.type in (Gdk.EventType.KEY_PRESS, Gdk.EventType.KEY_RELEASE):
-        return True
-
-    elif event.type in (Gdk.EventType.BUTTON_PRESS, Gdk.EventType._2BUTTON_PRESS,
-                        Gdk.EventType._3BUTTON_PRESS, Gdk.EventType.BUTTON_RELEASE):
-        return event.triggers_context_menu()
-
-    elif event.type == Gdk.EventType.TOUCH_BEGIN:
-        event_touch_started = True
-        event_time_prev = event.time
-        return False
-
-    elif not event_touch_started and event.type == Gdk.EventType.TOUCH_END or \
-            event_touch_started and (event.time - event_time_prev) < 300:
-        # Require a 300 ms press before context menu can be revealed
-        event_time_prev = event.time
-        return False
-
-    event_touch_started = False
-    return True
-
-
-def connect_context_menu_event(widget, callback_press, callback_popup):
-
-    widget.connect("button-press-event", callback_press)
-    widget.connect("popup-menu", callback_popup)
-    widget.connect("touch-event", callback_press)
-
-
 def connect_key_press_event(widget, callback):
     """ Use event controller or legacy 'key-press-event', depending on GTK version """
 

--- a/pynicotine/gtkgui/utils.py
+++ b/pynicotine/gtkgui/utils.py
@@ -47,7 +47,12 @@ NICOTINE = None
 def load_ui_elements(ui_class, filename):
 
     try:
-        builder = Gtk.Builder()
+        if Gtk.get_major_version() == 4:
+            builder = Gtk.Builder(ui_class)
+            Gtk.Buildable.get_name = Gtk.Buildable.get_buildable_id
+        else:
+            builder = Gtk.Builder()
+
         builder.set_translation_domain('nicotine')
         builder.add_from_file(filename)
 
@@ -61,7 +66,8 @@ def load_ui_elements(ui_class, filename):
             except TypeError:
                 pass
 
-        builder.connect_signals(ui_class)
+        if Gtk.get_major_version() == 3:
+            builder.connect_signals(ui_class)
 
     except Exception as e:
         log.add(_("Failed to load ui file %(file)s: %(error)s"), {
@@ -215,7 +221,9 @@ def append_line(textview, line, tag=None, timestamp=None, showstamp=True, timest
         color = config.sections["ui"]["urlcolor"] or None
         tag = buffer.create_tag(foreground=color, underline=Pango.Underline.SINGLE)
         tag.last_event_type = -1
-        tag.connect("event", url_event, url)
+
+        if Gtk.get_major_version() == 3:
+            tag.connect("event", url_event, url)
 
         return tag
 
@@ -350,7 +358,12 @@ def connect_key_press_event(widget, callback):
     """ Use event controller or legacy 'key-press-event', depending on GTK version """
 
     try:
-        controller = Gtk.EventControllerKey.new(widget)
+        if Gtk.get_major_version() == 4:
+            controller = Gtk.EventControllerKey()
+            widget.add_controller(controller)
+        else:
+            controller = Gtk.EventControllerKey.new(widget)
+
         controller.connect("key-pressed", callback)
 
     except AttributeError:
@@ -373,3 +386,13 @@ def get_key_press_event_args(*args):
         state = event.state
 
     return (keyval, keycode, state)
+
+
+def parse_accelerator(accelerator):
+
+    if Gtk.get_major_version() == 4:
+        ok, key, codes, mods = Gtk.accelerator_parse_with_keycode(accelerator)
+    else:
+        key, codes, mods = Gtk.accelerator_parse_with_keycode(accelerator)
+
+    return key, codes, mods

--- a/pynicotine/gtkgui/widgets/dialogs.py
+++ b/pynicotine/gtkgui/widgets/dialogs.py
@@ -20,6 +20,51 @@ from gi.repository import Gdk
 from gi.repository import Gtk
 
 
+""" Dialogs """
+
+
+def generic_dialog(parent=None, content_box=None, quit_callback=None, type_hint="normal", title="Dialog", width=400, height=400, modal=True):
+
+    from pynicotine.config import config
+
+    dialog = Gtk.Dialog(
+        use_header_bar=config.sections["ui"]["header_bar"],
+        title=title,
+        default_width=width,
+        default_height=height
+    )
+
+    if content_box:
+        if Gtk.get_major_version() == 4:
+            dialog.get_content_area().append(content_box)
+        else:
+            dialog.get_content_area().add(content_box)
+
+    set_dialog_properties(dialog, parent, quit_callback, type_hint, modal)
+    return dialog
+
+
+def set_dialog_properties(dialog, parent, quit_callback=None, type_hint="normal", modal=True):
+
+    if Gtk.get_major_version() == 4:
+        if quit_callback:
+            dialog.connect("close-request", quit_callback)
+    else:
+        dialog.set_property("window-position", Gtk.WindowPosition.CENTER_ON_PARENT)
+
+        if quit_callback:
+            dialog.connect("delete-event", quit_callback)
+
+        if type_hint == "normal":
+            dialog.set_type_hint(Gdk.WindowTypeHint.NORMAL)
+
+        elif type_hint == "dialog":
+            dialog.set_type_hint(Gdk.WindowTypeHint.DIALOG)
+
+    dialog.set_modal(modal)
+    dialog.set_transient_for(parent)
+
+
 """ Message Dialogs """
 
 
@@ -38,7 +83,11 @@ def entry_dialog(parent, title, message, callback, callback_data=None, default="
     self.set_destroy_with_parent(True)
     self.set_modal(True)
 
-    label = self.get_message_area().get_children()[-1]
+    if Gtk.get_major_version() == 4:
+        label = self.get_message_area().get_last_child()
+    else:
+        label = self.get_message_area().get_children()[-1]
+
     label.set_selectable(True)
 
     if droplist:
@@ -48,12 +97,21 @@ def entry_dialog(parent, title, message, callback, callback_data=None, default="
         for i in droplist:
             dropdown.append_text(i)
 
-        self.get_message_area().add(dropdown)
+        if Gtk.get_major_version() == 4:
+            self.get_message_area().append(dropdown)
+        else:
+            self.get_message_area().add(dropdown)
+
         dropdown.show()
 
     else:
         entry = Gtk.Entry()
-        self.get_message_area().add(entry)
+
+        if Gtk.get_major_version() == 4:
+            self.get_message_area().append(entry)
+        else:
+            self.get_message_area().add(entry)
+
         entry.show()
 
     self.get_response_value = entry.get_text
@@ -65,7 +123,12 @@ def entry_dialog(parent, title, message, callback, callback_data=None, default="
         self.option = Gtk.CheckButton()
         self.option.set_active(optionvalue)
         self.option.set_label(optionmessage)
-        self.get_message_area().add(self.option)
+
+        if Gtk.get_major_version() == 4:
+            self.get_message_area().append(self.option)
+        else:
+            self.get_message_area().add(self.option)
+
         self.option.show()
 
         self.get_second_response_value = self.option.get_active
@@ -91,7 +154,11 @@ def message_dialog(parent, title, message, callback=None):
     self.set_destroy_with_parent(True)
     self.set_modal(True)
 
-    label = self.get_message_area().get_children()[-1]
+    if Gtk.get_major_version() == 4:
+        label = self.get_message_area().get_last_child()
+    else:
+        label = self.get_message_area().get_children()[-1]
+
     label.set_selectable(True)
 
     self.present_with_time(Gdk.CURRENT_TIME)
@@ -116,13 +183,22 @@ def option_dialog(parent, title, message, callback, callback_data=None,
     self.set_destroy_with_parent(True)
     self.set_modal(True)
 
-    label = self.get_message_area().get_children()[-1]
+    if Gtk.get_major_version() == 4:
+        label = self.get_message_area().get_last_child()
+    else:
+        label = self.get_message_area().get_children()[-1]
+
     label.set_selectable(True)
 
     if checkbox_label:
         self.checkbox = Gtk.CheckButton()
         self.checkbox.set_label(checkbox_label)
-        self.get_message_area().add(self.checkbox)
+
+        if Gtk.get_major_version() == 4:
+            self.get_message_area().append(self.checkbox)
+        else:
+            self.get_message_area().add(self.checkbox)
+
         self.checkbox.show()
 
     if third:

--- a/pynicotine/gtkgui/widgets/filechooser.py
+++ b/pynicotine/gtkgui/widgets/filechooser.py
@@ -191,14 +191,16 @@ def save_file(parent, callback, callback_data=None, initialdir="~", initialfile=
     self.connect("response", _on_selected, callback, callback_data)
     self.set_modal(True)
     self.set_select_multiple(False)
-    self.set_show_hidden(True)
 
-    folder = os.path.expanduser(initialdir)
+    if Gtk.get_major_version() == 3:
+        self.set_show_hidden(True)
 
-    if os.path.isdir(folder):
-        self.set_current_folder(folder)
-    else:
-        self.set_current_folder(os.path.expanduser("~"))
+        folder = os.path.expanduser(initialdir)
+
+        if os.path.isdir(folder):
+            self.set_current_folder(folder)
+        else:
+            self.set_current_folder(os.path.expanduser("~"))
 
     self.set_current_name(initialfile)
 
@@ -222,21 +224,34 @@ class FileChooserButton:
         self.icon = Gtk.Image.new()
 
         if chooser_type == "folder":
-            self.icon.set_from_icon_name("folder-symbolic", Gtk.IconSize.BUTTON)
+            if Gtk.get_major_version() == 4:
+                self.icon.set_from_icon_name("folder-symbolic")
+            else:
+                self.icon.set_from_icon_name("folder-symbolic", Gtk.IconSize.BUTTON)
 
         elif chooser_type == "image":
-            self.icon.set_from_icon_name("image-x-generic-symbolic", Gtk.IconSize.BUTTON)
+            if Gtk.get_major_version() == 4:
+                self.icon.set_from_icon_name("image-x-generic-symbolic")
+            else:
+                self.icon.set_from_icon_name("image-x-generic-symbolic", Gtk.IconSize.BUTTON)
 
         else:
-            self.icon.set_from_icon_name("text-x-generic-symbolic", Gtk.IconSize.BUTTON)
+            if Gtk.get_major_version() == 4:
+                self.icon.set_from_icon_name("text-x-generic-symbolic")
+            else:
+                self.icon.set_from_icon_name("text-x-generic-symbolic", Gtk.IconSize.BUTTON)
 
         self.label = Gtk.Label.new(_("(None)"))
 
-        box.add(self.icon)
-        box.add(self.label)
-
-        self.button.add(box)
-        self.button.show_all()
+        if Gtk.get_major_version() == 4:
+            box.append(self.icon)
+            box.append(self.label)
+            self.button.set_child(box)
+        else:
+            box.add(self.icon)
+            box.add(self.label)
+            self.button.add(box)
+            self.button.show_all()
 
         self.button.connect("clicked", self.open_file_chooser)
 

--- a/pynicotine/gtkgui/widgets/iconnotebook.py
+++ b/pynicotine/gtkgui/widgets/iconnotebook.py
@@ -27,7 +27,6 @@ from gi.repository import Gtk
 
 from pynicotine.gtkgui.utils import connect_key_press_event
 from pynicotine.gtkgui.utils import get_key_press_event_args
-from pynicotine.gtkgui.utils import triggers_context_menu
 from pynicotine.gtkgui.widgets.messagedialogs import option_dialog
 from pynicotine.gtkgui.widgets.popupmenu import PopupMenu
 from pynicotine.config import config
@@ -356,9 +355,6 @@ class IconNotebook:
 
         # menu for all tabs
         label_tab_menu = ImageLabel(label)
-        label_tab.connect('button_press_event', self.on_tab_click, page)
-        label_tab.connect('popup_menu', self.on_tab_popup, page)
-        label_tab.connect('touch_event', self.on_tab_click, page)
         label_tab.show()
 
         Gtk.Notebook.append_page_menu(self.notebook, page, label_tab, label_tab_menu)
@@ -406,19 +402,6 @@ class IconNotebook:
     def on_tab_popup(self, widget, page):
         # Dummy implementation
         pass
-
-    def on_tab_click(self, widget, event, page):
-
-        if triggers_context_menu(event):
-            return self.on_tab_popup(widget, page)
-
-        elif event.button == 2:
-            # Middle click
-            tab_label, menu_label = self.get_labels(page)
-            tab_label.onclose(widget)
-            return True
-
-        return False
 
     def set_status_image(self, page, status):
 

--- a/pynicotine/gtkgui/widgets/iconnotebook.py
+++ b/pynicotine/gtkgui/widgets/iconnotebook.py
@@ -310,26 +310,28 @@ class IconNotebook:
         if Gtk.get_major_version() == 4:
             self.window = self.notebook.get_root()
 
-            self.unread_button = Gtk.Button.new_from_icon_name("emblem-important-symbolic")
+            self.unread_button = Gtk.MenuButton.new()
+            self.unread_button.set_icon_name("emblem-important-symbolic")
             self.unread_button.set_has_frame(False)
         else:
             self.window = self.notebook.get_toplevel()
             self.popup_enable()
 
-            self.unread_button = Gtk.Button.new_from_icon_name("emblem-important-symbolic", Gtk.IconSize.BUTTON)
+            self.unread_button = Gtk.MenuButton.new()
+            self.unread_button.set_image(Gtk.Image.new_from_icon_name("emblem-important-symbolic", Gtk.IconSize.BUTTON))
             self.unread_button.set_relief(Gtk.ReliefStyle.NONE)
 
         self.unread_button.set_tooltip_text(_("Unread Tabs"))
         self.unread_button.set_halign(Gtk.Align.CENTER)
         self.unread_button.set_valign(Gtk.Align.CENTER)
-        self.unread_button.connect("clicked", self.on_unread_notifications_menu)
 
         context = self.unread_button.get_style_context()
         context.add_class("circular")
 
         self.notebook.set_action_widget(self.unread_button, Gtk.PackType.END)
 
-        self.popup_menu_unread = PopupMenu(widget=self.notebook)
+        self.popup_menu_unread = PopupMenu(widget=self.unread_button)
+        self.unread_button.set_menu_model(self.popup_menu_unread)
         self.unread_pages = []
 
         self.angle = angle
@@ -509,6 +511,14 @@ class IconNotebook:
         if image:
             if page not in self.unread_pages:
                 self.unread_pages.append(page)
+                self.popup_menu_unread.clear()
+
+                for page in self.unread_pages:
+                    tab_label, menu_label = self.get_labels(page)
+                    self.popup_menu_unread.setup(
+                        ("#" + tab_label.get_text(), self.set_unread_page, self.page_num(page))
+                    )
+
                 self.unread_button.show()
             return
 
@@ -620,15 +630,3 @@ class IconNotebook:
         # Dismiss tab notification
         self.set_hilite_image(new_page, status=0)
         self.set_text_color(new_page, status=0)
-
-    def on_unread_notifications_menu(self, widget):
-
-        self.popup_menu_unread.clear()
-
-        for page in self.unread_pages:
-            tab_label, menu_label = self.get_labels(page)
-            self.popup_menu_unread.setup(
-                ("#" + tab_label.get_text(), self.set_unread_page, self.page_num(page))
-            )
-
-        self.popup_menu_unread.popup()

--- a/pynicotine/gtkgui/widgets/iconnotebook.py
+++ b/pynicotine/gtkgui/widgets/iconnotebook.py
@@ -67,12 +67,16 @@ class ImageLabel(Gtk.Box):
         if show_status_image:
             self.set_status_image(status_image)
             self.status_image.show()
+        else:
+            self.status_image.hide()
 
         self.hilite_image = Gtk.Image()
         self.hilite_pixbuf = None
 
         if show_hilite_image:
             self.set_hilite_image(hilite_image)
+        else:
+            self.hilite_image.hide()
 
         self._pack_children()
         self._order_children()

--- a/pynicotine/gtkgui/widgets/infobar.py
+++ b/pynicotine/gtkgui/widgets/infobar.py
@@ -16,6 +16,8 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+from gi.repository import Gtk
+
 
 class InfoBar:
     """ Wrapper for setting up a GtkInfoBar """
@@ -27,6 +29,14 @@ class InfoBar:
         self.info_bar.set_show_close_button(True)
         self.info_bar.connect("response", self._hide)
 
+        self.label = Gtk.Label()
+        self.label.set_wrap(True)
+
+        if Gtk.get_major_version() == 4:
+            self.info_bar.add_child(self.label)
+        else:
+            self.info_bar.get_content_area().add(self.label)
+
         self.set_visible(False)
 
     def _hide(self, *args):
@@ -36,8 +46,5 @@ class InfoBar:
         self.info_bar.get_parent().set_reveal_child(visible)
 
     def show_message(self, message):
-
-        label = self.info_bar.get_content_area().get_children()[0]
-        label.set_text(message)
-
+        self.label.set_text(message)
         self.set_visible(True)

--- a/pynicotine/gtkgui/widgets/infobar.py
+++ b/pynicotine/gtkgui/widgets/infobar.py
@@ -30,12 +30,14 @@ class InfoBar:
         self.info_bar.connect("response", self._hide)
 
         self.label = Gtk.Label()
-        self.label.set_wrap(True)
 
         if Gtk.get_major_version() == 4:
+            self.label.set_wrap(True)
             self.info_bar.add_child(self.label)
         else:
+            self.label.set_line_wrap(True)
             self.info_bar.get_content_area().add(self.label)
+            self.label.show()
 
         self.set_visible(False)
 

--- a/pynicotine/gtkgui/widgets/textentry.py
+++ b/pynicotine/gtkgui/widgets/textentry.py
@@ -577,7 +577,14 @@ class TextSearchBar:
 
 def clear_entry(entry):
 
-    completion = entry.get_completion()
-    entry.set_completion(None)
-    entry.set_text("")
-    entry.set_completion(completion)
+    if Gtk.get_major_version() == 4:
+        completion = entry.get_completion()
+        completion.set_minimum_key_length(1)
+        entry.set_text("")
+        completion.set_minimum_key_length(0)
+
+    else:
+        completion = entry.get_completion()
+        entry.set_completion(None)
+        entry.set_text("")
+        entry.set_completion(completion)

--- a/pynicotine/gtkgui/widgets/textentry.py
+++ b/pynicotine/gtkgui/widgets/textentry.py
@@ -27,6 +27,7 @@ from pynicotine.gtkgui.utils import append_line
 from pynicotine.gtkgui.utils import auto_replace
 from pynicotine.gtkgui.utils import connect_key_press_event
 from pynicotine.gtkgui.utils import get_key_press_event_args
+from pynicotine.gtkgui.utils import parse_accelerator
 from pynicotine.logfacility import log
 from pynicotine.utils import add_alias
 from pynicotine.utils import expand_alias
@@ -427,11 +428,11 @@ class ChatEntry:
     def on_key_press_event(self, *args):
 
         keyval, keycode, state = get_key_press_event_args(*args)
-        key, codes, mods = Gtk.accelerator_parse_with_keycode("Tab")
+        key, codes, mods = parse_accelerator("Tab")
 
         if keycode not in codes:
-            key, codes_shift_l, mods = Gtk.accelerator_parse_with_keycode("Shift_L")
-            key, codes_shift_r, mods = Gtk.accelerator_parse_with_keycode("Shift_R")
+            key, codes_shift_l, mods = parse_accelerator("Shift_L")
+            key, codes_shift_r, mods = parse_accelerator("Shift_R")
 
             if keycode not in codes_shift_l and \
                     keycode not in codes_shift_r:
@@ -561,7 +562,7 @@ class TextSearchBar:
     def on_key_press_event(self, *args):
 
         keyval, keycode, state = get_key_press_event_args(*args)
-        key, codes, mods = Gtk.accelerator_parse_with_keycode("<Primary>f")
+        key, codes, mods = parse_accelerator("<Primary>f")
 
         if state & mods and keycode in codes:
             self.show_search_bar()
@@ -571,7 +572,7 @@ class TextSearchBar:
 
     def show_search_bar(self):
         self.search_bar.set_search_mode(True)
-        self.entry.grab_focus_without_selecting()
+        self.entry.grab_focus()
 
 
 def clear_entry(entry):

--- a/pynicotine/gtkgui/widgets/trayicon.py
+++ b/pynicotine/gtkgui/widgets/trayicon.py
@@ -26,7 +26,7 @@ from gi.repository import Gtk
 
 from pynicotine import slskmessages
 from pynicotine.config import config
-from pynicotine.gtkgui.widgets.messagedialogs import entry_dialog
+from pynicotine.gtkgui.widgets.dialogs import entry_dialog
 
 
 """ Status Icon / AppIndicator """
@@ -79,6 +79,9 @@ class TrayIcon:
         return item, handler
 
     def create_menu(self):
+
+        if Gtk.get_major_version() == 4:
+            return
 
         self.tray_popup_menu = Gtk.Menu()
         self.hide_show_item, handler = self.create_item(_("Hide / Show Nicotine+"), self.on_hide_unhide_window)
@@ -281,6 +284,9 @@ class TrayIcon:
 
     def load(self, use_trayicon=None):
 
+        if Gtk.get_major_version() == 4:
+            return
+
         if sys.platform == "darwin":
             # Tray icons don't work as expected on macOS
             return
@@ -403,6 +409,9 @@ class TrayIcon:
 
     def set_away(self, enable):
 
+        if self.trayicon is None:
+            return
+
         if enable:
             self.tray_status["status"] = "away"
         else:
@@ -416,6 +425,9 @@ class TrayIcon:
 
     def set_connected(self, enable):
 
+        if self.trayicon is None:
+            return
+
         if enable:
             self.tray_status["status"] = "connect"
         else:
@@ -424,6 +436,9 @@ class TrayIcon:
         self.set_image()
 
     def set_server_actions_sensitive(self, status):
+
+        if self.trayicon is None:
+            return
 
         for i in (self.disconnect_item, self.away_item, self.send_message_item, self.lookup_ip_item,
                   self.lookup_info_item, self.lookup_shares_item):

--- a/pynicotine/gtkgui/widgets/treeview.py
+++ b/pynicotine/gtkgui/widgets/treeview.py
@@ -287,12 +287,11 @@ def save_columns(treeview_name, columns, subpage=None):
         column_config[treeview_name] = saved_columns
 
 
-def press_header(widget, *args):
+def press_header(menu, widget):
 
     treeview = widget.get_parent()
     columns = treeview.get_columns()
     visible_columns = [column for column in columns if column.get_visible()]
-    menu = args[-1]
     menu.clear()
     actions = menu.get_actions()
     pos = 1
@@ -317,9 +316,6 @@ def press_header(widget, *args):
         actions[title].connect("activate", header_toggle, treeview, columns, pos - 1)
         pos += 1
 
-    menu.popup()
-    return True
-
 
 def header_toggle(action, state, treeview, columns, index):
 
@@ -328,14 +324,12 @@ def header_toggle(action, state, treeview, columns, index):
     set_last_column_autosize(treeview)
 
 
-def set_treeview_selected_row(treeview, event):
+def set_treeview_selected_row(treeview, x, y):
     """ Handles row selection when right-clicking in a treeview """
 
-    if event is None:
-        return
-
-    pathinfo = treeview.get_path_at_pos(event.x, event.y)
+    pathinfo = treeview.get_path_at_pos(x, y)
     selection = treeview.get_selection()
+    print(selection.count_selected_rows())
 
     if pathinfo is not None:
         path, col, cell_x, cell_y = pathinfo

--- a/pynicotine/gtkgui/widgets/treeview.py
+++ b/pynicotine/gtkgui/widgets/treeview.py
@@ -86,9 +86,15 @@ def initialise_columns(treeview_name, treeview, *args):
         if not isinstance(width, int):
             width = 0
 
+        if Gtk.get_major_version() == 4:
+            # GTK 4 rows need more padding to match GTK 3
+            height_padding = 5
+        else:
+            height_padding = 3
+
         if type == "text":
             renderer = Gtk.CellRendererText()
-            renderer.set_padding(10, 3)
+            renderer.set_padding(10, height_padding)
 
             column = Gtk.TreeViewColumn(id, renderer, text=i)
 
@@ -107,13 +113,13 @@ def initialise_columns(treeview_name, treeview, *args):
 
         elif type == "edit":
             renderer = Gtk.CellRendererText()
-            renderer.set_padding(10, 3)
+            renderer.set_padding(10, height_padding)
             renderer.set_property('editable', True)
             column = Gtk.TreeViewColumn(id, renderer, text=i)
 
         elif type == "combo":
             renderer = Gtk.CellRendererCombo()
-            renderer.set_padding(10, 3)
+            renderer.set_padding(10, height_padding)
             renderer.set_property('text-column', 0)
             renderer.set_property('editable', True)
             column = Gtk.TreeViewColumn(id, renderer, text=i)
@@ -234,7 +240,7 @@ def hide_columns(treeview, cols, config):
     for (column_id, column) in cols.items():
         parent = column.get_widget().get_ancestor(Gtk.Button)
         if parent:
-            PopupMenu(None, parent, press_header, window=treeview.get_toplevel())
+            PopupMenu(widget=parent, callback=press_header)
 
         # Read Show / Hide column settings from last session
         if config:

--- a/pynicotine/gtkgui/wishlist.py
+++ b/pynicotine/gtkgui/wishlist.py
@@ -29,7 +29,8 @@ from gi.repository import Gtk
 
 from pynicotine.config import config
 from pynicotine.gtkgui.utils import load_ui_elements
-from pynicotine.gtkgui.widgets.messagedialogs import option_dialog
+from pynicotine.gtkgui.widgets.dialogs import option_dialog
+from pynicotine.gtkgui.widgets.dialogs import generic_dialog
 from pynicotine.gtkgui.widgets.theme import update_widget_visuals
 from pynicotine.gtkgui.widgets.treeview import initialise_columns
 from pynicotine.logfacility import log
@@ -47,9 +48,25 @@ class WishList:
         self.wishes = {}
 
         load_ui_elements(self, os.path.join(self.frame.gui_dir, "ui", "dialogs", "wishlist.ui"))
-        self.WishListDialog.set_transient_for(frame.MainWindow)
+
+        self.WishListDialog = generic_dialog(
+            parent=frame.MainWindow,
+            content_box=self.Main,
+            quit_callback=self.quit,
+            title=_("Search Wishlist"),
+            width=600,
+            height=600
+        )
+
+        if Gtk.get_major_version() == 4:
+            self.WishlistScrolledWindow.set_has_frame(True)
+        else:
+            self.WishlistScrolledWindow.set_shadow_type(Gtk.ShadowType.IN)
 
         self.store = Gtk.ListStore(str)
+
+        if Gtk.get_major_version() == 4:
+            self.store.insert_with_valuesv = self.store.insert_with_values
 
         self.column_numbers = list(range(self.store.get_n_columns()))
         cols = initialise_columns(
@@ -224,9 +241,11 @@ class WishList:
     def show(self, *args):
 
         self.WishListDialog.present_with_time(Gdk.CURRENT_TIME)
-        self.WishListDialog.get_window().set_functions(
-            Gdk.WMFunction.RESIZE | Gdk.WMFunction.MOVE | Gdk.WMFunction.CLOSE
-        )
+
+        if Gtk.get_major_version() == 3:
+            self.WishListDialog.get_window().set_functions(
+                Gdk.WMFunction.RESIZE | Gdk.WMFunction.MOVE | Gdk.WMFunction.CLOSE
+            )
 
     def quit(self, *args):
         self.WishListDialog.hide()

--- a/pynicotine/gtkgui/wishlist.py
+++ b/pynicotine/gtkgui/wishlist.py
@@ -53,7 +53,7 @@ class WishList:
 
         self.column_numbers = list(range(self.store.get_n_columns()))
         cols = initialise_columns(
-            None, self.WishlistView, None,
+            None, self.WishlistView,
             ["wishes", _("Wishes"), -1, "text", None]
         )
 


### PR DESCRIPTION
Replaces #1399

This PR adds code for supporting GTK 4 alongside GTK 3, but does not enable GTK 4 yet. Almost everything is functional, except for the preferences dialog, which has not been ported yet.

List of current issues:
- Context menus behave strangely when attached to GtkTreeView
- 100% CPU usage when attempting to call grab_focus through GLib.idle_add (currently disabled)
- GtkTreeView rubberband selection seems broken
- Tooltips are cut off when GtkPopoverMenuBar is enabled
- Several GTK warnings in terminal (most seem related to GtkEntryCompletion)

List of current limitations:
- No spell checking yet, since support is missing in GTK 4
- No tray icons yet, since AppIndicator is currently missing GTK 4 support
- Tab label rotation no longer supported, Gtk.Label.set_angle has been removed (will most likely drop this feature, since it's not maintained well anyway)