### PR TITLE
Run integration tests with GTK 4

### DIFF
--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -65,14 +65,15 @@ jobs:
     strategy:
       matrix:
         include: [
-          { msystem: MINGW64, arch: x86_64 },
-          { msystem: MINGW32, arch: i686   }
+          { msystem: MINGW64, arch: x86_64, gtk: 3 },
+          { msystem: MINGW32, arch: i686, gtk: 3 }
         ]
     defaults:
       run:
         shell: msys2 {0}
     env:
       ARCH: ${{ matrix.arch }}
+      NICOTINE_GTK_VERSION: ${{ matrix.gtk }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
@@ -111,6 +112,8 @@ jobs:
 
   macos:
     runs-on: macos-10.15
+    env:
+      NICOTINE_GTK_VERSION: 3
     steps:
       - name: Checkout code
         uses: actions/checkout@v2

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -30,7 +30,7 @@ jobs:
         run: |
           python -m flake8
 
-      - name: Unit tests
+      - name: Integration and unit tests
         run: |
           xvfb-run python -m pytest
 
@@ -39,6 +39,11 @@ jobs:
     defaults:
       run:
         shell: msys2 {0}
+    strategy:
+      matrix:
+        gtk: [3, 4]
+    env:
+      NICOTINE_GTK_VERSION: ${{ matrix.gtk }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
@@ -60,12 +65,17 @@ jobs:
         run: |
           flake8
 
-      - name: Unit tests
+      - name: Integration and unit tests
         run: |
           pytest
 
   macos:
     runs-on: macos-latest
+    strategy:
+      matrix:
+        gtk: [3, 4]
+    env:
+      NICOTINE_GTK_VERSION: ${{ matrix.gtk }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
@@ -80,6 +90,6 @@ jobs:
         run: |
           flake8
 
-      - name: Unit tests
+      - name: Integration and unit tests
         run: |
           pytest

--- a/nicotine
+++ b/nicotine
@@ -26,6 +26,7 @@
 
 import argparse
 import importlib.util
+import os
 import sys
 
 
@@ -83,7 +84,6 @@ def check_arguments():
 
     # Disables critical error dialog; used for integration tests
     parser.add_argument("--ci-mode", action="store_true", help=argparse.SUPPRESS)
-    parser.add_argument("--gtk4-unstable", action="store_true", help=argparse.SUPPRESS)
 
     args = parser.parse_args()
     trayicon = None
@@ -100,7 +100,7 @@ def check_arguments():
     if args.disable_trayicon:
         trayicon = False
 
-    return trayicon, args.headless, args.hidden, args.bindip, args.port, args.ci_mode, args.rescan, args.gtk4_unstable
+    return trayicon, args.headless, args.hidden, args.bindip, args.port, args.ci_mode, args.rescan
 
 
 def check_core_dependencies():
@@ -129,7 +129,7 @@ You should install Python %(min_version)s or newer.""") % {
     return None
 
 
-def check_gui_dependencies(use_gtk4=False):
+def check_gui_dependencies():
 
     # Require GTK+ >= 3.18
     try:
@@ -140,7 +140,8 @@ def check_gui_dependencies(use_gtk4=False):
 
     else:
         try:
-            gi.require_version('Gtk', '4.0' if use_gtk4 else '3.0')
+            version = '4.0' if os.getenv("NICOTINE_GTK_VERSION") == '4' else '3.0'
+            gi.require_version('Gtk', version)
 
         except ValueError as e:
             return _("""You are using an unsupported version of GTK.
@@ -230,7 +231,7 @@ binary package and what you try to run Nicotine+ with).""")
     rename_process(b'nicotine')
     apply_translation()
 
-    trayicon, headless, hidden, bindip, port, ci_mode, rescan, gtk4_unstable = check_arguments()
+    trayicon, headless, hidden, bindip, port, ci_mode, rescan = check_arguments()
     error = check_core_dependencies()
 
     if error:
@@ -248,7 +249,7 @@ binary package and what you try to run Nicotine+ with).""")
     if headless:
         return run_headless(network_processor, ci_mode)
 
-    error = check_gui_dependencies(gtk4_unstable)
+    error = check_gui_dependencies()
 
     if error:
         print(error)

--- a/packaging/macos/dependencies-core.sh
+++ b/packaging/macos/dependencies-core.sh
@@ -24,7 +24,7 @@
 brew install \
   adwaita-icon-theme \
   flake8 \
-  gtk+3 \
+  gtk+$NICOTINE_GTK_VERSION
 
 # Install dependencies with pip
 pip3 install \

--- a/packaging/windows/dependencies-core.sh
+++ b/packaging/windows/dependencies-core.sh
@@ -23,7 +23,7 @@
 # Install dependencies from the main MinGW repos
 pacman --noconfirm -S --needed \
   mingw-w64-$ARCH-gspell \
-  mingw-w64-$ARCH-gtk3 \
+  mingw-w64-$ARCH-gtk$NICOTINE_GTK_VERSION \
   mingw-w64-$ARCH-python \
   mingw-w64-$ARCH-python-flake8 \
   mingw-w64-$ARCH-python-pip \

--- a/pynicotine/gtkgui/frame.py
+++ b/pynicotine/gtkgui/frame.py
@@ -147,7 +147,6 @@ class NicotineFrame:
         # Left align window controls on macOS
         if sys.platform == "darwin":
             gtk_settings.set_property("gtk-decoration-layout", "close,minimize,maximize:")
-            gtk_settings.set_property("gtk-key-theme-name", "Mac")
 
         """ Actions and Menu """
 


### PR DESCRIPTION
If you are testing the GTK 4 version of Nicotine+ on GNU/Linux or *BSD, you should now launch it using `NICOTINE_GTK_VERSION=4 nicotine` instead of `nicotine --gtk4-unstable`.