### PR TITLE
Deprecate PMessageUser peer message

### DIFF
--- a/pynicotine/gtkgui/privatechat.py
+++ b/pynicotine/gtkgui/privatechat.py
@@ -533,12 +533,7 @@ class PrivateChat:
         else:
             payload = auto_replace(text)
 
-        if self.PeerPrivateMessages.get_active():
-            # not in the soulseek protocol
-            self.frame.np.send_message_to_peer(self.user, slskmessages.PMessageUser(None, my_username, payload))
-        else:
-            self.frame.np.queue.append(slskmessages.MessageUser(self.user, payload))
-
+        self.frame.np.queue.append(slskmessages.MessageUser(self.user, payload))
         self.frame.np.pluginhandler.outgoing_private_chat_notification(self.user, text)
 
     def update_visuals(self):

--- a/pynicotine/gtkgui/ui/privatechat.ui
+++ b/pynicotine/gtkgui/ui/privatechat.ui
@@ -71,14 +71,6 @@
               </object>
             </child>
             <child>
-              <object class="GtkCheckButton" id="PeerPrivateMessages">
-                <property name="label" translatable="yes">Direct Message</property>
-                <property name="visible">1</property>
-                <property name="can-focus">1</property>
-                <property name="tooltip-text" translatable="yes">Send the private message directly to the user (not supported on most clients)</property>
-              </object>
-            </child>
-            <child>
               <object class="GtkCheckButton" id="Log">
                 <property name="label" translatable="yes">_Log</property>
                 <property name="visible">1</property>

--- a/pynicotine/slskmessages.py
+++ b/pynicotine/slskmessages.py
@@ -2419,6 +2419,7 @@ class PMessageUser(PeerMessage):
     """ Peer code: 22 """
     """ Chat phrase sent to someone or received by us in private.
     This is a Nicotine+ extension to the Soulseek protocol. """
+    """ DEPRECATED """
 
     def __init__(self, conn=None, user=None, msg=None):
         self.conn = conn
@@ -2428,10 +2429,13 @@ class PMessageUser(PeerMessage):
         self.timestamp = None
 
     def make_network_message(self):
-        return (self.pack_object(0)
-                + self.pack_object(0)
-                + self.pack_object(self.user)
-                + self.pack_object(self.msg))
+        msg = bytearray()
+        msg.extend(self.pack_object(0))
+        msg.extend(self.pack_object(0))
+        msg.extend(self.pack_object(self.user))
+        msg.extend(self.pack_object(self.msg))
+
+        return msg
 
     def parse_network_message(self, message):
         pos, self.msgid = self.get_object(message, int)


### PR DESCRIPTION
The Nicotine+-exclusive PMessageUser peer message was added in https://github.com/Nicotine-Plus/nicotine-plus/commit/33a82ecdb3b9dffc533445e0e60a3852a2021018 back in 2007. In my opinion, this was a mistake, as we are not supposed to modify the Soulseek protocol.

Due to the small range of possible recipients for these kind of private messages, remove the option to send them from the GUI.