### PR TITLE
Add option to show locked/privately shared files in search results

### DIFF
--- a/doc/SLSKPROTOCOL.md
+++ b/doc/SLSKPROTOCOL.md
@@ -1,6 +1,6 @@
 # Soulseek Protocol Documentation
 
-Last updated on June 18, 2021
+Last updated on June 20, 2021
 
 As the official Soulseek client and server is proprietary software, this documentation has been compiled thanks to years of reverse engineering efforts. To preserve the health of the Soulseek network, please do not modify the protocol in ways that negatively impact the network.
 
@@ -2679,8 +2679,8 @@ A peer sends this message when it has a file search match. The token/ticket is t
     5.  **bool** <ins>slotfree</ins>
     6.  **int** <ins>avgspeed</ins>
     7.  **off\_t** <ins>queue length</ins>
-    8.  **int** <ins>locked results size</ins> *number of locked results*
-    9.  Iterate for number of locked results
+    8.  **int** <ins>private results size</ins> *number of privately shared results*
+    9.  Iterate for number of privately shared results
         1.  **uchar** 1
         2.  **string** <ins>filename</ins>
         3.  **off\_t** <ins>size</ins>
@@ -2707,16 +2707,16 @@ A peer sends this message when it has a file search match. The token/ticket is t
     6.  **bool** <ins>slotfree</ins>
     7.  **int** <ins>avgspeed</ins>
     8.  **off\_t** <ins>queue length</ins>
-    9.  **int** <ins>locked results size</ins> *number of locked results*
-    10.  Iterate for <ins>number of locked results</ins>
-        1.  **string** <ins>filename</ins>
-        2.  **off\_t** <ins>size</ins>
-        3.  **string** <ins>ext</ins>
-        4.  **int** <ins>number of attributes</ins>
-        5.  Iterate <ins>number of attributes</ins>
-            1.  **int** <ins>place in
-                attributes</ins>
-            2.  **int** <ins>attribute</ins>
+    9.  **int** <ins>private results size</ins> *number of privately shared results*
+    10.  Iterate for <ins>number of privately shared results</ins>
+         1.  **string** <ins>filename</ins>
+         2.  **off\_t** <ins>size</ins>
+         3.  **string** <ins>ext</ins>
+         4.  **int** <ins>number of attributes</ins>
+         5.  Iterate <ins>number of attributes</ins>
+             1.  **int** <ins>place in
+                 attributes</ins>
+             2.  **int** <ins>attribute</ins>
 
 ### Peer Code 15
 

--- a/pynicotine/config.py
+++ b/pynicotine/config.py
@@ -234,7 +234,8 @@ class Config:
                 "search_results": True,
                 "max_displayed_results": 1500,
                 "min_search_chars": 3,
-                "remove_special_chars": True
+                "remove_special_chars": True,
+                "show_private_results": False
             },
 
             "ui": {

--- a/pynicotine/gtkgui/search.py
+++ b/pynicotine/gtkgui/search.py
@@ -541,35 +541,15 @@ class Search:
             else:
                 combobox.prepend_text(text)
 
-    def add_user_results(self, msg, user, country):
-
-        if user in self.users:
-            return
-
-        self.users.add(user)
-
-        counter = len(self.all_data) + 1
-
-        inqueue = msg.inqueue
-        ulspeed = msg.ulspeed
-        h_speed = human_speed(ulspeed)
-
-        if msg.freeulslots:
-            imdl = "Y"
-            inqueue = 0
-        else:
-            imdl = "N"
-
-        color_id = (imdl == "Y" and "search" or "searchq")
-        color = config.sections["ui"][color_id] or None
-
-        h_queue = humanize(inqueue)
+    def add_result_list(self, result_list, counter, user, country, inqueue, ulspeed, h_speed,
+                        imdl, h_queue, color, private=False):
+        """ Adds a list of search results to the treeview. Lists can either contain publicly or
+        privately shared files. """
 
         update_ui = False
         max_results = config.sections["searches"]["max_displayed_results"]
 
-        for result in msg.list:
-
+        for result in result_list:
             if counter > max_results:
                 break
 
@@ -593,6 +573,9 @@ class Search:
             size = result[2]
             h_size = human_size(size)
             h_bitrate, bitrate, h_length, length = get_result_bitrate_length(size, result[4])
+
+            if private:
+                name = "[PRIVATE FILE]  " + name
 
             is_result_visible = self.append(
                 [
@@ -622,6 +605,42 @@ class Search:
                 update_ui = True
 
             counter += 1
+
+        return update_ui, counter
+
+    def add_user_results(self, msg, user, country):
+
+        if user in self.users:
+            return
+
+        self.users.add(user)
+
+        counter = len(self.all_data) + 1
+
+        inqueue = msg.inqueue
+        ulspeed = msg.ulspeed
+        h_speed = human_speed(ulspeed)
+
+        if msg.freeulslots:
+            imdl = "Y"
+            inqueue = 0
+        else:
+            imdl = "N"
+
+        h_queue = humanize(inqueue)
+
+        color_id = (imdl == "Y" and "search" or "searchq")
+        color = config.sections["ui"][color_id] or None
+
+        update_ui, counter = self.add_result_list(
+            msg.list, counter, user, country, inqueue, ulspeed, h_speed, imdl, h_queue, color)
+
+        if config.sections["searches"]["show_private_results"] and msg.privatelist:
+            update_ui_private, counter = self.add_result_list(
+                msg.privatelist, counter, user, country, inqueue, ulspeed, h_speed, imdl, h_queue, color, private=True)
+
+            if not update_ui and update_ui_private:
+                update_ui = True
 
         if update_ui:
             # If this search wasn't initiated by us (e.g. wishlist), and the results aren't spoofed, show tab
@@ -1149,7 +1168,7 @@ class Search:
             bitratestr = model.get_value(iterator, 9)
             length = model.get_value(iterator, 10)
             fn = model.get_value(iterator, 12)
-            directory = fn.rsplit('\\', 1)[0]
+            directory, filename = fn.rsplit('\\', 1)
             cc = model.get_value(iterator, 13)
             country = "%s / %s" % (cc, self.frame.np.geoip.country_code_to_name(cc))
 

--- a/pynicotine/gtkgui/settingswindow.py
+++ b/pynicotine/gtkgui/settingswindow.py
@@ -1877,7 +1877,8 @@ class SearchesFrame(BuildFrame):
                 "search_results": self.ToggleResults,
                 "max_displayed_results": self.MaxDisplayedResults,
                 "min_search_chars": self.MinSearchChars,
-                "remove_special_chars": self.RemoveSpecialChars
+                "remove_special_chars": self.RemoveSpecialChars,
+                "show_private_results": self.ShowPrivateResults
             }
         }
 
@@ -1927,7 +1928,8 @@ class SearchesFrame(BuildFrame):
                 "search_results": self.ToggleResults.get_active(),
                 "max_displayed_results": self.MaxDisplayedResults.get_value_as_int(),
                 "min_search_chars": self.MinSearchChars.get_value_as_int(),
-                "remove_special_chars": self.RemoveSpecialChars.get_active()
+                "remove_special_chars": self.RemoveSpecialChars.get_active(),
+                "show_private_results": self.ShowPrivateResults.get_active()
             }
         }
 

--- a/pynicotine/gtkgui/ui/settings/search.ui
+++ b/pynicotine/gtkgui/ui/settings/search.ui
@@ -154,6 +154,14 @@
           </object>
         </child>
         <child>
+          <object class="GtkCheckButton" id="ShowPrivateResults">
+            <property name="label" translatable="yes">Show privately shared files in search results</property>
+            <property name="visible">1</property>
+            <property name="tooltip_text" translatable="yes">Other clients may offer an option to send privately shared files in response to search requests. Such files are not downloadable unless the uploader gives explicit permission.</property>
+            <property name="use-underline">1</property>
+          </object>
+        </child>
+        <child>
           <object class="GtkFlowBox">
             <property name="visible">1</property>
             <property name="row-spacing">12</property>

--- a/pynicotine/slskmessages.py
+++ b/pynicotine/slskmessages.py
@@ -2229,7 +2229,7 @@ class FileSearchResult(PeerMessage):
     token/ticket is taken from original FileSearch, UserSearch or
     RoomSearch message. """
 
-    __slots__ = ("conn", "user", "geoip", "token", "list", "fileindex", "freeulslots",
+    __slots__ = ("conn", "user", "geoip", "token", "list", "privatelist", "fileindex", "freeulslots",
                  "ulspeed", "inqueue", "fifoqueue", "numresults", "pos")
 
     def __init__(self, conn, user=None, token=None, shares=None, fileindex=None, freeulslots=None,
@@ -2238,13 +2238,13 @@ class FileSearchResult(PeerMessage):
         self.user = user
         self.token = token
         self.list = shares
+        self.privatelist = []
         self.fileindex = fileindex
         self.freeulslots = freeulslots
         self.ulspeed = ulspeed
         self.inqueue = inqueue
         self.fifoqueue = fifoqueue
         self.numresults = numresults
-        self.pos = 0
 
     def parse_network_message(self, message):
         try:
@@ -2255,34 +2255,40 @@ class FileSearchResult(PeerMessage):
                     {'area': 'FileSearchResult', 'exception': error})
             self.list = {}
 
-    def _parse_network_message(self, message):
-        self.pos, self.user = self.get_object(message, str)
-        self.pos, self.token = self.get_object(message, int, self.pos)
-        self.pos, nfiles = self.get_object(message, int, self.pos)
+    def _parse_result_list(self, message, pos):
+        pos, nfiles = self.get_object(message, int, pos)
 
         shares = []
         for _ in range(nfiles):
-            self.pos, code = self.pos + 1, message[self.pos]
-            self.pos, name = self.get_object(message, str, self.pos)
+            pos, code = pos + 1, message[pos]
+            pos, name = self.get_object(message, str, pos)
 
-            self.pos, size = self.get_object(message, int, self.pos, getunsignedlonglong=True)
-            self.pos, ext = self.get_object(message, str, self.pos)
-            self.pos, numattr = self.get_object(message, int, self.pos)
+            pos, size = self.get_object(message, int, pos, getunsignedlonglong=True)
+            pos, ext = self.get_object(message, str, pos)
+            pos, numattr = self.get_object(message, int, pos)
 
             attrs = []
             if numattr:
                 for _ in range(numattr):
-                    self.pos, _attrnum = self.get_object(message, int, self.pos)
-                    self.pos, attr = self.get_object(message, int, self.pos)
+                    pos, _attrnum = self.get_object(message, int, pos)
+                    pos, attr = self.get_object(message, int, pos)
                     attrs.append(attr)
 
             shares.append((code, name.replace('/', '\\'), size, ext, attrs))
 
-        self.list = shares
+        return pos, shares
 
-        self.pos, self.freeulslots = self.pos + 1, message[self.pos]
-        self.pos, self.ulspeed = self.get_object(message, int, self.pos, getsignedint=True)
-        self.pos, self.inqueue = self.get_object(message, int, self.pos, getunsignedlonglong=True)
+    def _parse_network_message(self, message):
+        pos, self.user = self.get_object(message, str)
+        pos, self.token = self.get_object(message, int, pos)
+        pos, self.list = self._parse_result_list(message, pos)
+
+        pos, self.freeulslots = pos + 1, message[pos]
+        pos, self.ulspeed = self.get_object(message, int, pos, getsignedint=True)
+        pos, self.inqueue = self.get_object(message, int, pos, getunsignedlonglong=True)
+
+        if message[pos:]:
+            pos, self.privatelist = self._parse_result_list(message, pos)
 
     def make_network_message(self):
         msg_list = bytearray()


### PR DESCRIPTION
For the sake of transparency, I've added the option to show privately shared/locked files from other clients in search results. Since this is a controversial Soulseek feature, these files will not appear in results unless explicitly enabled in the search preferences.

For more information, see: https://groups.google.com/g/soulseek-discussion/c/vAnknGtihxg/m/pU2ItYSMAQAJ