### PR TITLE
Improve layout of Interests tab

### DIFF
--- a/pynicotine/gtkgui/ui/interests.ui
+++ b/pynicotine/gtkgui/ui/interests.ui
@@ -10,18 +10,17 @@
         <property name="hexpand">1</property>
         <child>
           <object class="GtkBox" id="LikesDislikes">
-            <property name="width-request">240</property>
+            <property name="width-request">200</property>
             <property name="visible">1</property>
             <property name="orientation">vertical</property>
             <child>
               <object class="GtkLabel">
                 <property name="visible">1</property>
-                <property name="xalign">0</property>
                 <property name="margin-start">12</property>
                 <property name="margin-end">12</property>
                 <property name="margin-top">12</property>
                 <property name="margin-bottom">12</property>
-                <property name="label" translatable="yes">My Interests</property>
+                <property name="label" translatable="yes">Edit My Interests</property>
                 <attributes>
                   <attribute name="weight" value="bold"/>
                 </attributes>
@@ -32,6 +31,25 @@
                 <property name="visible">1</property>
                 <property name="orientation">vertical</property>
                 <property name="vexpand">1</property>
+                <child>
+                  <object class="GtkActionBar">
+                    <property name="visible">1</property>
+                    <child type="center">
+                      <object class="GtkEntry" id="AddLikeEntry">
+                        <property name="visible">1</property>
+                        <property name="hexpand">1</property>
+                        <property name="width-chars">15</property>
+                        <property name="placeholder-text" translatable="yes">Add something you like...</property>
+                        <property name="primary-icon-name">non-starred-symbolic</property>
+                        <signal name="activate" handler="on_add_thing_i_like" swapped="no"/>
+                        <signal name="icon-press" handler="on_add_thing_i_like" swapped="no"/>
+                        <style>
+                          <class name="flat"/>
+                        </style>
+                      </object>
+                    </child>
+                  </object>
+                </child>
                 <child>
                   <object class="GtkBox">
                     <property name="visible">1</property>
@@ -53,25 +71,6 @@
                     </child>
                   </object>
                 </child>
-                <child>
-                  <object class="GtkActionBar">
-                    <property name="visible">1</property>
-                    <child type="center">
-                      <object class="GtkEntry" id="AddLikeEntry">
-                        <property name="visible">1</property>
-                        <property name="hexpand">1</property>
-                        <property name="width-chars">15</property>
-                        <property name="placeholder-text" translatable="yes">Add something you like...</property>
-                        <property name="primary-icon-name">non-starred-symbolic</property>
-                        <signal name="activate" handler="on_add_thing_i_like" swapped="no"/>
-                        <signal name="icon-press" handler="on_add_thing_i_like" swapped="no"/>
-                        <style>
-                          <class name="flat"/>
-                        </style>
-                      </object>
-                    </child>
-                  </object>
-                </child>
               </object>
             </child>
             <child>
@@ -80,6 +79,25 @@
                 <property name="margin-top">6</property>
                 <property name="orientation">vertical</property>
                 <property name="vexpand">1</property>
+                <child>
+                  <object class="GtkActionBar">
+                    <property name="visible">1</property>
+                    <child type="center">
+                      <object class="GtkEntry" id="AddDislikeEntry">
+                        <property name="visible">1</property>
+                        <property name="hexpand">1</property>
+                        <property name="width-chars">15</property>
+                        <property name="placeholder-text" translatable="yes">Add something you dislike...</property>
+                        <property name="primary-icon-name">action-unavailable-symbolic</property>
+                        <signal name="activate" handler="on_add_thing_i_dislike" swapped="no"/>
+                        <signal name="icon-press" handler="on_add_thing_i_dislike" swapped="no"/>
+                        <style>
+                          <class name="flat"/>
+                        </style>
+                      </object>
+                    </child>
+                  </object>
+                </child>
                 <child>
                   <object class="GtkBox">
                     <property name="visible">1</property>
@@ -97,25 +115,6 @@
                             </child>
                           </object>
                         </child>
-                      </object>
-                    </child>
-                  </object>
-                </child>
-                <child>
-                  <object class="GtkActionBar">
-                    <property name="visible">1</property>
-                    <child type="center">
-                      <object class="GtkEntry" id="AddDislikeEntry">
-                        <property name="visible">1</property>
-                        <property name="hexpand">1</property>
-                        <property name="width-chars">15</property>
-                        <property name="placeholder-text" translatable="yes">Add something you dislike...</property>
-                        <property name="primary-icon-name">action-unavailable-symbolic</property>
-                        <signal name="activate" handler="on_add_thing_i_dislike" swapped="no"/>
-                        <signal name="icon-press" handler="on_add_thing_i_dislike" swapped="no"/>
-                        <style>
-                          <class name="flat"/>
-                        </style>
                       </object>
                     </child>
                   </object>
@@ -144,9 +143,33 @@
                         <property name="margin-bottom">6</property>
                         <property name="spacing">6</property>
                         <child>
+                          <object class="GtkButton" id="RecommendationsButton">
+                            <property name="visible">1</property>
+                            <signal name="clicked" handler="on_recommendations_clicked" swapped="no"/>
+                            <child>
+                              <object class="GtkBox">
+                                <property name="visible">1</property>
+                                <property name="spacing">6</property>
+                                <child>
+                                  <object class="GtkImage">
+                                    <property name="visible">1</property>
+                                    <property name="icon-name">view-refresh-symbolic</property>
+                                  </object>
+                                </child>
+                                <child>
+                                  <object class="GtkLabel">
+                                    <property name="visible">1</property>
+                                    <property name="label" translatable="yes">_Personal</property>
+                                    <property name="use-underline">1</property>
+                                  </object>
+                                </child>
+                              </object>
+                            </child>
+                          </object>
+                        </child>
+                        <child>
                           <object class="GtkLabel">
                             <property name="visible">1</property>
-                            <property name="xalign">0</property>
                             <property name="hexpand">1</property>
                             <property name="margin-start">6</property>
                             <property name="label" translatable="yes">Recommendations</property>
@@ -173,31 +196,6 @@
                                   <object class="GtkLabel">
                                     <property name="visible">1</property>
                                     <property name="label" translatable="yes">_Global</property>
-                                    <property name="use-underline">1</property>
-                                  </object>
-                                </child>
-                              </object>
-                            </child>
-                          </object>
-                        </child>
-                        <child>
-                          <object class="GtkButton" id="RecommendationsButton">
-                            <property name="visible">1</property>
-                            <signal name="clicked" handler="on_recommendations_clicked" swapped="no"/>
-                            <child>
-                              <object class="GtkBox">
-                                <property name="visible">1</property>
-                                <property name="spacing">6</property>
-                                <child>
-                                  <object class="GtkImage">
-                                    <property name="visible">1</property>
-                                    <property name="icon-name">view-refresh-symbolic</property>
-                                  </object>
-                                </child>
-                                <child>
-                                  <object class="GtkLabel">
-                                    <property name="visible">1</property>
-                                    <property name="label" translatable="yes">_Personal</property>
                                     <property name="use-underline">1</property>
                                   </object>
                                 </child>
@@ -237,7 +235,6 @@
                     <child>
                       <object class="GtkLabel" id="UnrecommendationsLabel">
                         <property name="visible">1</property>
-                        <property name="xalign">0</property>
                         <property name="margin-start">12</property>
                         <property name="margin-end">12</property>
                         <property name="margin-top">12</property>
@@ -275,7 +272,7 @@
             </child>
             <child>
               <object class="GtkBox" id="SimilarUsers">
-                <property name="width-request">280</property>
+                <property name="width-request">240</property>
                 <property name="visible">1</property>
                 <property name="orientation">vertical</property>
                 <child>
@@ -286,18 +283,6 @@
                     <property name="margin-top">6</property>
                     <property name="margin-bottom">6</property>
                     <property name="spacing">6</property>
-                    <child>
-                      <object class="GtkLabel">
-                        <property name="visible">1</property>
-                        <property name="xalign">0</property>
-                        <property name="hexpand">1</property>
-                        <property name="margin-start">6</property>
-                        <property name="label" translatable="yes">Similar Users</property>
-                        <attributes>
-                          <attribute name="weight" value="bold"/>
-                        </attributes>
-                      </object>
-                    </child>
                     <child>
                       <object class="GtkButton" id="SimilarUsersButton">
                         <property name="visible">1</property>
@@ -313,6 +298,17 @@
                           <class name="circular"/>
                           <class name="image-button"/>
                         </style>
+                      </object>
+                    </child>
+                    <child>
+                      <object class="GtkLabel">
+                        <property name="visible">1</property>
+                        <property name="hexpand">1</property>
+                        <property name="margin-start">6</property>
+                        <property name="label" translatable="yes">Similar Users</property>
+                        <attributes>
+                          <attribute name="weight" value="bold"/>
+                        </attributes>
                       </object>
                     </child>
                   </object>


### PR DESCRIPTION
1. Relocate 'Show users with similar interests' button before label so doesn't disappear off the screen on narrow viewports [fixes #1523].
2. Remove all instances of depreciated "xalign" property (note this causes labels to be central which looks okay here)
3. Relocate 'Personal' refresh button before label so doesn't disappear on narrow viewports, helps keep label alignment central.
4. Relocate 'Add something you like...' entry above list to reduce confusion as it was close to the dislikes list before.
5. Relocate 'Add something you dislike...' entry above list to suit new layout.
6. Rename caption for left panel to "Edit My Interests" to make the purpose of the Interests tab more obvious.
7. Reduce width of 'My Interests' and 'Similar Users' boxes by -40px so Recommendations box is still usable on narrow viewport.