### PR TITLE
Add Listenbrainz /now command integration

### DIFF
--- a/po/nicotine.pot
+++ b/po/nicotine.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-09-04 20:37+0300\n"
+"POT-Creation-Date: 2021-09-06 21:13+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -1178,7 +1178,7 @@ msgstr ""
 msgid "You have been added to a private room: %(room)s"
 msgstr ""
 
-#: pynicotine/gtkgui/chatrooms.py:487 pynicotine/gtkgui/interests.py:104
+#: pynicotine/gtkgui/chatrooms.py:487 pynicotine/gtkgui/interests.py:105
 #: pynicotine/gtkgui/transferlist.py:142 pynicotine/gtkgui/userlist.py:78
 msgid "Status"
 msgstr ""
@@ -1190,25 +1190,25 @@ msgstr ""
 msgid "Country"
 msgstr ""
 
-#: pynicotine/gtkgui/chatrooms.py:489 pynicotine/gtkgui/interests.py:105
+#: pynicotine/gtkgui/chatrooms.py:489 pynicotine/gtkgui/interests.py:106
 #: pynicotine/gtkgui/privatechat.py:212 pynicotine/gtkgui/search.py:184
 #: pynicotine/gtkgui/search.py:376 pynicotine/gtkgui/transferlist.py:139
-#: pynicotine/gtkgui/userbrowse.py:260 pynicotine/gtkgui/userbrowse.py:272
-#: pynicotine/gtkgui/userbrowse.py:318 pynicotine/gtkgui/userbrowse.py:331
+#: pynicotine/gtkgui/userbrowse.py:255 pynicotine/gtkgui/userbrowse.py:267
+#: pynicotine/gtkgui/userbrowse.py:313 pynicotine/gtkgui/userbrowse.py:326
 #: pynicotine/gtkgui/userlist.py:80 pynicotine/gtkgui/ui/mainwindow.ui:48
 #: pynicotine/gtkgui/ui/popovers/privatechatcommands.ui:229
 msgid "User"
 msgstr ""
 
-#: pynicotine/gtkgui/chatrooms.py:490 pynicotine/gtkgui/interests.py:106
+#: pynicotine/gtkgui/chatrooms.py:490 pynicotine/gtkgui/interests.py:107
 #: pynicotine/gtkgui/search.py:378 pynicotine/gtkgui/transferlist.py:146
 #: pynicotine/gtkgui/userlist.py:81
 msgid "Speed"
 msgstr ""
 
-#: pynicotine/gtkgui/chatrooms.py:491 pynicotine/gtkgui/interests.py:107
+#: pynicotine/gtkgui/chatrooms.py:491 pynicotine/gtkgui/interests.py:108
 #: pynicotine/gtkgui/userlist.py:82 pynicotine/gtkgui/ui/mainwindow.ui:216
-#: pynicotine/gtkgui/ui/mainwindow.ui:371
+#: pynicotine/gtkgui/ui/mainwindow.ui:370
 msgid "Files"
 msgstr ""
 
@@ -1222,18 +1222,18 @@ msgid "Private Rooms"
 msgstr ""
 
 #: pynicotine/gtkgui/chatrooms.py:522 pynicotine/gtkgui/chatrooms.py:533
-#: pynicotine/gtkgui/frame.py:280 pynicotine/gtkgui/privatechat.py:202
+#: pynicotine/gtkgui/frame.py:285 pynicotine/gtkgui/privatechat.py:202
 msgid "Find..."
 msgstr ""
 
 #: pynicotine/gtkgui/chatrooms.py:524 pynicotine/gtkgui/chatrooms.py:535
-#: pynicotine/gtkgui/frame.py:282 pynicotine/gtkgui/privatechat.py:204
-#: pynicotine/gtkgui/ui/dialogs/shortcuts.ui:190
+#: pynicotine/gtkgui/frame.py:287 pynicotine/gtkgui/privatechat.py:204
+#: pynicotine/gtkgui/ui/dialogs/shortcuts.ui:183
 msgid "Copy"
 msgstr ""
 
 #: pynicotine/gtkgui/chatrooms.py:525 pynicotine/gtkgui/chatrooms.py:536
-#: pynicotine/gtkgui/frame.py:283 pynicotine/gtkgui/privatechat.py:205
+#: pynicotine/gtkgui/frame.py:288 pynicotine/gtkgui/privatechat.py:205
 msgid "Copy All"
 msgstr ""
 
@@ -1392,37 +1392,37 @@ msgstr ""
 msgid "Folder"
 msgstr ""
 
-#: pynicotine/gtkgui/fastconfigure.py:184
-#: pynicotine/gtkgui/fastconfigure.py:203
-#: pynicotine/gtkgui/fastconfigure.py:212
+#: pynicotine/gtkgui/fastconfigure.py:187
+#: pynicotine/gtkgui/fastconfigure.py:206
+#: pynicotine/gtkgui/fastconfigure.py:215
 #: pynicotine/gtkgui/settingswindow.py:716
 #: pynicotine/gtkgui/settingswindow.py:746
 msgid "Unable to Share Folder"
 msgstr ""
 
-#: pynicotine/gtkgui/fastconfigure.py:185
+#: pynicotine/gtkgui/fastconfigure.py:188
 msgid "The chosen virtual name is empty"
 msgstr ""
 
-#: pynicotine/gtkgui/fastconfigure.py:204
+#: pynicotine/gtkgui/fastconfigure.py:207
 msgid "The chosen virtual name already exists"
 msgstr ""
 
-#: pynicotine/gtkgui/fastconfigure.py:213
+#: pynicotine/gtkgui/fastconfigure.py:216
 msgid "The chosen folder is already shared"
 msgstr ""
 
-#: pynicotine/gtkgui/fastconfigure.py:228
+#: pynicotine/gtkgui/fastconfigure.py:231
 msgid "Virtual Name"
 msgstr ""
 
-#: pynicotine/gtkgui/fastconfigure.py:229
+#: pynicotine/gtkgui/fastconfigure.py:232
 #: pynicotine/gtkgui/settingswindow.py:754
 #, python-format
 msgid "Enter virtual name for '%(dir)s':"
 msgstr ""
 
-#: pynicotine/gtkgui/fastconfigure.py:238
+#: pynicotine/gtkgui/fastconfigure.py:241
 #: pynicotine/gtkgui/settingswindow.py:771
 msgid "Add a Shared Folder"
 msgstr ""
@@ -1436,33 +1436,33 @@ msgstr ""
 msgid "File Properties (%(num)i of %(total)i)"
 msgstr ""
 
-#: pynicotine/gtkgui/frame.py:248
+#: pynicotine/gtkgui/frame.py:253
 #, python-format
 msgid "Downloads: %(speed)s"
 msgstr ""
 
-#: pynicotine/gtkgui/frame.py:249
+#: pynicotine/gtkgui/frame.py:254
 #, python-format
 msgid "Uploads: %(speed)s"
 msgstr ""
 
-#: pynicotine/gtkgui/frame.py:285
+#: pynicotine/gtkgui/frame.py:290
 msgid "View Debug Logs"
 msgstr ""
 
-#: pynicotine/gtkgui/frame.py:286
+#: pynicotine/gtkgui/frame.py:291
 msgid "View Transfer Log"
 msgstr ""
 
-#: pynicotine/gtkgui/frame.py:288
+#: pynicotine/gtkgui/frame.py:293
 msgid "Clear Log View"
 msgstr ""
 
-#: pynicotine/gtkgui/frame.py:341
+#: pynicotine/gtkgui/frame.py:346
 msgid "Your config file is corrupt"
 msgstr ""
 
-#: pynicotine/gtkgui/frame.py:342
+#: pynicotine/gtkgui/frame.py:347
 #, python-format
 msgid ""
 "We're sorry, but it seems your configuration file is corrupt. Please "
@@ -1474,18 +1474,18 @@ msgid ""
 "your settings."
 msgstr ""
 
-#: pynicotine/gtkgui/frame.py:477
+#: pynicotine/gtkgui/frame.py:482
 #, python-format
 msgid "Error loading custom icon %(path)s: %(error)s"
 msgstr ""
 
-#: pynicotine/gtkgui/frame.py:547 pynicotine/gtkgui/frame.py:654
+#: pynicotine/gtkgui/frame.py:552 pynicotine/gtkgui/frame.py:659
 #: pynicotine/gtkgui/widgets/iconnotebook.py:442
 #: pynicotine/gtkgui/widgets/treeview.py:484
 msgid "Online"
 msgstr ""
 
-#: pynicotine/gtkgui/frame.py:556 pynicotine/gtkgui/frame.py:657
+#: pynicotine/gtkgui/frame.py:561 pynicotine/gtkgui/frame.py:662
 #: pynicotine/gtkgui/settingswindow.py:1422
 #: pynicotine/gtkgui/widgets/iconnotebook.py:440
 #: pynicotine/gtkgui/widgets/trayicon.py:97
@@ -1494,371 +1494,374 @@ msgstr ""
 msgid "Away"
 msgstr ""
 
-#: pynicotine/gtkgui/frame.py:573 pynicotine/gtkgui/widgets/iconnotebook.py:444
+#: pynicotine/gtkgui/frame.py:578 pynicotine/gtkgui/widgets/iconnotebook.py:444
 #: pynicotine/gtkgui/widgets/treeview.py:486
-#: pynicotine/gtkgui/ui/mainwindow.ui:1500
+#: pynicotine/gtkgui/ui/mainwindow.ui:1493
 msgid "Offline"
 msgstr ""
 
-#: pynicotine/gtkgui/frame.py:587
+#: pynicotine/gtkgui/frame.py:592
 msgid "Invalid Password"
 msgstr ""
 
-#: pynicotine/gtkgui/frame.py:588
+#: pynicotine/gtkgui/frame.py:593
 #, python-format
 msgid "The password you've entered is invalid for user %s"
 msgstr ""
 
-#: pynicotine/gtkgui/frame.py:594
+#: pynicotine/gtkgui/frame.py:599
 msgid "Change Login Details"
 msgstr ""
 
-#: pynicotine/gtkgui/frame.py:948
+#: pynicotine/gtkgui/frame.py:953
 msgid "Error retrieving latest version"
 msgstr ""
 
-#: pynicotine/gtkgui/frame.py:955
+#: pynicotine/gtkgui/frame.py:960
 #, python-format
 msgid "Version %s is available"
 msgstr ""
 
-#: pynicotine/gtkgui/frame.py:958
+#: pynicotine/gtkgui/frame.py:963
 #, python-format
 msgid "released on %s"
 msgstr ""
 
-#: pynicotine/gtkgui/frame.py:963
+#: pynicotine/gtkgui/frame.py:968
 msgid "Out of date"
 msgstr ""
 
-#: pynicotine/gtkgui/frame.py:971 pynicotine/gtkgui/frame.py:979
+#: pynicotine/gtkgui/frame.py:976 pynicotine/gtkgui/frame.py:984
 msgid "Up to date"
 msgstr ""
 
-#: pynicotine/gtkgui/frame.py:972
+#: pynicotine/gtkgui/frame.py:977
 msgid "You appear to be using a development version of Nicotine+."
 msgstr ""
 
-#: pynicotine/gtkgui/frame.py:980
+#: pynicotine/gtkgui/frame.py:985
 msgid "You are using the latest version of Nicotine+."
 msgstr ""
 
-#: pynicotine/gtkgui/frame.py:1251
+#: pynicotine/gtkgui/frame.py:1257
 msgid "_Connect"
 msgstr ""
 
-#: pynicotine/gtkgui/frame.py:1252
+#: pynicotine/gtkgui/frame.py:1258
 msgid "_Disconnect"
 msgstr ""
 
-#: pynicotine/gtkgui/frame.py:1253
+#: pynicotine/gtkgui/frame.py:1259
 msgid "_Away"
 msgstr ""
 
-#: pynicotine/gtkgui/frame.py:1254
+#: pynicotine/gtkgui/frame.py:1260
 msgid "Soulseek _Privileges"
 msgstr ""
 
-#: pynicotine/gtkgui/frame.py:1259 pynicotine/gtkgui/ui/settings/plugin.ui:124
+#: pynicotine/gtkgui/frame.py:1265 pynicotine/gtkgui/ui/settings/plugin.ui:124
 msgid "_Preferences"
 msgstr ""
 
-#: pynicotine/gtkgui/frame.py:1262
+#: pynicotine/gtkgui/frame.py:1268
 msgid "_Quit"
 msgstr ""
 
-#: pynicotine/gtkgui/frame.py:1280
+#: pynicotine/gtkgui/frame.py:1286
 msgid "Prefer Dark _Mode"
 msgstr ""
 
-#: pynicotine/gtkgui/frame.py:1281
+#: pynicotine/gtkgui/frame.py:1287
 msgid "Use _Header Bar"
 msgstr ""
 
-#: pynicotine/gtkgui/frame.py:1282
+#: pynicotine/gtkgui/frame.py:1288
 msgid "Show _Flag Columns in User Lists"
 msgstr ""
 
-#: pynicotine/gtkgui/frame.py:1283
+#: pynicotine/gtkgui/frame.py:1289
 msgid "Show _Buttons in Transfer Tabs"
 msgstr ""
 
-#: pynicotine/gtkgui/frame.py:1285
+#: pynicotine/gtkgui/frame.py:1291
 msgid "Show _Log Pane"
 msgstr ""
 
-#: pynicotine/gtkgui/frame.py:1286
+#: pynicotine/gtkgui/frame.py:1292
 msgid "Show _Debug Log Controls"
 msgstr ""
 
-#: pynicotine/gtkgui/frame.py:1288
+#: pynicotine/gtkgui/frame.py:1294
 msgid "Buddy List in Separate Tab"
 msgstr ""
 
-#: pynicotine/gtkgui/frame.py:1289
+#: pynicotine/gtkgui/frame.py:1295
 msgid "Buddy List in Chat Rooms"
 msgstr ""
 
-#: pynicotine/gtkgui/frame.py:1290
+#: pynicotine/gtkgui/frame.py:1296
 msgid "Buddy List Always Visible"
 msgstr ""
 
-#: pynicotine/gtkgui/frame.py:1298
+#: pynicotine/gtkgui/frame.py:1304
 msgid "_Rescan Public Shares"
 msgstr ""
 
-#: pynicotine/gtkgui/frame.py:1299
+#: pynicotine/gtkgui/frame.py:1305
 msgid "Rescan B_uddy Shares"
 msgstr ""
 
-#: pynicotine/gtkgui/frame.py:1300
+#: pynicotine/gtkgui/frame.py:1306
 msgid "_Configure Shares"
 msgstr ""
 
-#: pynicotine/gtkgui/frame.py:1307
+#: pynicotine/gtkgui/frame.py:1313
 msgid "_Browse Public Shares"
 msgstr ""
 
-#: pynicotine/gtkgui/frame.py:1308
+#: pynicotine/gtkgui/frame.py:1314
 msgid "Bro_wse Buddy Shares"
 msgstr ""
 
-#: pynicotine/gtkgui/frame.py:1324
+#: pynicotine/gtkgui/frame.py:1330
 msgid "_Search Files"
 msgstr ""
 
-#: pynicotine/gtkgui/frame.py:1325
+#: pynicotine/gtkgui/frame.py:1331
 msgid "_Downloads"
 msgstr ""
 
-#: pynicotine/gtkgui/frame.py:1326
+#: pynicotine/gtkgui/frame.py:1332
 msgid "_Uploads"
 msgstr ""
 
-#: pynicotine/gtkgui/frame.py:1327
+#: pynicotine/gtkgui/frame.py:1333
 msgid "User _Browse"
 msgstr ""
 
-#: pynicotine/gtkgui/frame.py:1328
+#: pynicotine/gtkgui/frame.py:1334
 msgid "User I_nfo"
 msgstr ""
 
-#: pynicotine/gtkgui/frame.py:1329
+#: pynicotine/gtkgui/frame.py:1335
 msgid "_Private Chat"
 msgstr ""
 
-#: pynicotine/gtkgui/frame.py:1330
+#: pynicotine/gtkgui/frame.py:1336
 msgid "Buddy _List"
 msgstr ""
 
-#: pynicotine/gtkgui/frame.py:1331
+#: pynicotine/gtkgui/frame.py:1337
 msgid "_Chat Rooms"
 msgstr ""
 
-#: pynicotine/gtkgui/frame.py:1332
+#: pynicotine/gtkgui/frame.py:1338
 msgid "_Interests"
 msgstr ""
 
-#: pynicotine/gtkgui/frame.py:1334
+#: pynicotine/gtkgui/frame.py:1340
 msgid "_Transfer Statistics"
 msgstr ""
 
-#: pynicotine/gtkgui/frame.py:1343
+#: pynicotine/gtkgui/frame.py:1349
 msgid "_Keyboard Shortcuts"
 msgstr ""
 
-#: pynicotine/gtkgui/frame.py:1344
+#: pynicotine/gtkgui/frame.py:1350
 msgid "Report a _Bug"
 msgstr ""
 
-#: pynicotine/gtkgui/frame.py:1345
+#: pynicotine/gtkgui/frame.py:1351
 msgid "_Setup Assistant"
 msgstr ""
 
-#: pynicotine/gtkgui/frame.py:1346
+#: pynicotine/gtkgui/frame.py:1352
 msgid "Check _Latest Version"
 msgstr ""
 
-#: pynicotine/gtkgui/frame.py:1348
+#: pynicotine/gtkgui/frame.py:1354
 msgid "About _Nicotine+"
 msgstr ""
 
-#: pynicotine/gtkgui/frame.py:1360 pynicotine/gtkgui/frame.py:1380
+#: pynicotine/gtkgui/frame.py:1366 pynicotine/gtkgui/frame.py:1386
 msgid "_View"
 msgstr ""
 
-#: pynicotine/gtkgui/frame.py:1361 pynicotine/gtkgui/frame.py:1382
+#: pynicotine/gtkgui/frame.py:1367 pynicotine/gtkgui/frame.py:1388
 msgid "_Modes"
 msgstr ""
 
-#: pynicotine/gtkgui/frame.py:1368 pynicotine/gtkgui/frame.py:1383
+#: pynicotine/gtkgui/frame.py:1374 pynicotine/gtkgui/frame.py:1389
 msgid "_Help"
 msgstr ""
 
-#: pynicotine/gtkgui/frame.py:1379
+#: pynicotine/gtkgui/frame.py:1385
 msgid "_File"
 msgstr ""
 
-#: pynicotine/gtkgui/frame.py:1381
+#: pynicotine/gtkgui/frame.py:1387
 msgid "_Shares"
 msgstr ""
 
-#: pynicotine/gtkgui/frame.py:1556
+#: pynicotine/gtkgui/frame.py:1562
 #, python-format
 msgid "Hide %(tab)s"
 msgstr ""
 
-#: pynicotine/gtkgui/frame.py:1560
+#: pynicotine/gtkgui/frame.py:1566
 msgid "Search Files"
 msgstr ""
 
-#: pynicotine/gtkgui/frame.py:1561 pynicotine/gtkgui/settingswindow.py:3155
+#: pynicotine/gtkgui/frame.py:1567 pynicotine/gtkgui/settingswindow.py:3164
 #: pynicotine/gtkgui/widgets/trayicon.py:90
-#: pynicotine/gtkgui/ui/mainwindow.ui:1212
+#: pynicotine/gtkgui/ui/mainwindow.ui:1205
 #: pynicotine/gtkgui/ui/settings/downloads.ui:27
 msgid "Downloads"
 msgstr ""
 
-#: pynicotine/gtkgui/frame.py:1562 pynicotine/gtkgui/settingswindow.py:3156
+#: pynicotine/gtkgui/frame.py:1568 pynicotine/gtkgui/settingswindow.py:3165
 #: pynicotine/gtkgui/widgets/trayicon.py:91
-#: pynicotine/gtkgui/ui/mainwindow.ui:1225
+#: pynicotine/gtkgui/ui/mainwindow.ui:1218
 #: pynicotine/gtkgui/ui/settings/uploads.ui:48
 msgid "Uploads"
 msgstr ""
 
-#: pynicotine/gtkgui/frame.py:1563
+#: pynicotine/gtkgui/frame.py:1569
 msgid "User Browse"
 msgstr ""
 
-#: pynicotine/gtkgui/frame.py:1564 pynicotine/gtkgui/settingswindow.py:3146
+#: pynicotine/gtkgui/frame.py:1570 pynicotine/gtkgui/settingswindow.py:3155
 msgid "User Info"
 msgstr ""
 
-#: pynicotine/gtkgui/frame.py:1565
+#: pynicotine/gtkgui/frame.py:1571
 #: pynicotine/gtkgui/ui/popovers/chatroomcommands.ui:751
 msgid "Private Chat"
 msgstr ""
 
-#: pynicotine/gtkgui/frame.py:1566 pynicotine/gtkgui/ui/buddylist.ui:19
+#: pynicotine/gtkgui/frame.py:1572 pynicotine/gtkgui/ui/buddylist.ui:19
 msgid "Buddy List"
 msgstr ""
 
-#: pynicotine/gtkgui/frame.py:1567
+#: pynicotine/gtkgui/frame.py:1573
 #: pynicotine/gtkgui/ui/popovers/privatechatcommands.ui:667
 msgid "Chat Rooms"
 msgstr ""
 
-#: pynicotine/gtkgui/frame.py:1568 pynicotine/gtkgui/ui/mainwindow.ui:785
-#: pynicotine/gtkgui/ui/userinfo.ui:320
+#: pynicotine/gtkgui/frame.py:1574 pynicotine/gtkgui/ui/mainwindow.ui:778
 msgid "Interests"
 msgstr ""
 
-#: pynicotine/gtkgui/frame.py:1884 pynicotine/gtkgui/frame.py:1904
+#: pynicotine/gtkgui/frame.py:1891 pynicotine/gtkgui/frame.py:1911
 #: pynicotine/gtkgui/settingswindow.py:1384
 msgid "Left"
 msgstr ""
 
-#: pynicotine/gtkgui/frame.py:1884 pynicotine/gtkgui/frame.py:1907
+#: pynicotine/gtkgui/frame.py:1891 pynicotine/gtkgui/frame.py:1914
 #: pynicotine/gtkgui/settingswindow.py:1384
 msgid "Right"
 msgstr ""
 
-#: pynicotine/gtkgui/frame.py:1898 pynicotine/gtkgui/settingswindow.py:1384
+#: pynicotine/gtkgui/frame.py:1905 pynicotine/gtkgui/settingswindow.py:1384
 msgid "Top"
 msgstr ""
 
-#: pynicotine/gtkgui/frame.py:1901 pynicotine/gtkgui/settingswindow.py:1384
+#: pynicotine/gtkgui/frame.py:1908 pynicotine/gtkgui/settingswindow.py:1384
 msgid "Bottom"
 msgstr ""
 
-#: pynicotine/gtkgui/frame.py:2072 pynicotine/gtkgui/userbrowse.py:582
+#: pynicotine/gtkgui/frame.py:2079 pynicotine/gtkgui/userbrowse.py:587
 #, python-format
 msgid "Can't create directory '%(folder)s', reported error: %(error)s"
 msgstr ""
 
-#: pynicotine/gtkgui/frame.py:2125
+#: pynicotine/gtkgui/frame.py:2084
+msgid "Select a Saved Shares List File"
+msgstr ""
+
+#: pynicotine/gtkgui/frame.py:2133
 msgid "Create New Room?"
 msgstr ""
 
-#: pynicotine/gtkgui/frame.py:2126
+#: pynicotine/gtkgui/frame.py:2134
 #, python-format
 msgid "Are you sure you wish to create a new room \"%s\"?"
 msgstr ""
 
-#: pynicotine/gtkgui/frame.py:2127
+#: pynicotine/gtkgui/frame.py:2135
 msgid "Make room private"
 msgstr ""
 
-#: pynicotine/gtkgui/frame.py:2574
+#: pynicotine/gtkgui/frame.py:2582
 msgid "Critical Error"
 msgstr ""
 
-#: pynicotine/gtkgui/frame.py:2575
+#: pynicotine/gtkgui/frame.py:2583
 msgid ""
 "Nicotine+ has encountered a critical error and needs to exit. Please copy "
 "the following error and include it in a bug report:"
 msgstr ""
 
-#: pynicotine/gtkgui/frame.py:2577
+#: pynicotine/gtkgui/frame.py:2585
 msgid "Copy & Report Bug"
 msgstr ""
 
-#: pynicotine/gtkgui/frame.py:2625
+#: pynicotine/gtkgui/frame.py:2633
 msgid "Close Nicotine+?"
 msgstr ""
 
-#: pynicotine/gtkgui/frame.py:2626
+#: pynicotine/gtkgui/frame.py:2634
 msgid "Are you sure you wish to exit Nicotine+ at this time?"
 msgstr ""
 
-#: pynicotine/gtkgui/frame.py:2627
+#: pynicotine/gtkgui/frame.py:2635
 msgid "Run in Background"
 msgstr ""
 
-#: pynicotine/gtkgui/frame.py:2628
+#: pynicotine/gtkgui/frame.py:2636
 msgid "Remember choice"
 msgstr ""
 
-#: pynicotine/gtkgui/interests.py:53 pynicotine/gtkgui/userinfo.py:181
+#: pynicotine/gtkgui/interests.py:54 pynicotine/gtkgui/userinfo.py:181
 msgid "Likes"
 msgstr ""
 
-#: pynicotine/gtkgui/interests.py:66 pynicotine/gtkgui/userinfo.py:169
+#: pynicotine/gtkgui/interests.py:67 pynicotine/gtkgui/userinfo.py:169
 msgid "Dislikes"
 msgstr ""
 
-#: pynicotine/gtkgui/interests.py:81
+#: pynicotine/gtkgui/interests.py:82
 msgid "Rating"
 msgstr ""
 
-#: pynicotine/gtkgui/interests.py:82
+#: pynicotine/gtkgui/interests.py:83
 msgid "Item"
 msgstr ""
 
-#: pynicotine/gtkgui/interests.py:133 pynicotine/gtkgui/interests.py:141
+#: pynicotine/gtkgui/interests.py:134 pynicotine/gtkgui/interests.py:142
 msgid "_Remove Item"
 msgstr ""
 
-#: pynicotine/gtkgui/interests.py:134
+#: pynicotine/gtkgui/interests.py:135
 msgid "Re_commendations for Item"
 msgstr ""
 
-#: pynicotine/gtkgui/interests.py:136 pynicotine/gtkgui/interests.py:143
-#: pynicotine/gtkgui/interests.py:152 pynicotine/gtkgui/userinfo.py:201
+#: pynicotine/gtkgui/interests.py:137 pynicotine/gtkgui/interests.py:144
+#: pynicotine/gtkgui/interests.py:153 pynicotine/gtkgui/userinfo.py:201
 msgid "_Search for Item"
 msgstr ""
 
-#: pynicotine/gtkgui/interests.py:148 pynicotine/gtkgui/interests.py:345
+#: pynicotine/gtkgui/interests.py:149 pynicotine/gtkgui/interests.py:365
 #: pynicotine/gtkgui/userinfo.py:198 pynicotine/gtkgui/userinfo.py:360
 msgid "I _Like This"
 msgstr ""
 
-#: pynicotine/gtkgui/interests.py:149 pynicotine/gtkgui/interests.py:348
+#: pynicotine/gtkgui/interests.py:150 pynicotine/gtkgui/interests.py:368
 #: pynicotine/gtkgui/userinfo.py:199 pynicotine/gtkgui/userinfo.py:363
 msgid "I _Dislike This"
 msgstr ""
 
-#: pynicotine/gtkgui/interests.py:150
+#: pynicotine/gtkgui/interests.py:151
 msgid "_Recommendations for Item"
 msgstr ""
 
@@ -1878,12 +1881,12 @@ msgid "Unable to show notification popup: %s"
 msgstr ""
 
 #: pynicotine/gtkgui/privatechat.py:196 pynicotine/gtkgui/search.py:432
-#: pynicotine/gtkgui/userbrowse.py:207 pynicotine/gtkgui/userinfo.py:193
+#: pynicotine/gtkgui/userbrowse.py:202 pynicotine/gtkgui/userinfo.py:193
 msgid "Close All Tabs..."
 msgstr ""
 
 #: pynicotine/gtkgui/privatechat.py:197 pynicotine/gtkgui/search.py:433
-#: pynicotine/gtkgui/userbrowse.py:208 pynicotine/gtkgui/userinfo.py:194
+#: pynicotine/gtkgui/userbrowse.py:203 pynicotine/gtkgui/userinfo.py:194
 msgid "_Close Tab"
 msgstr ""
 
@@ -1922,7 +1925,7 @@ msgstr ""
 #: pynicotine/gtkgui/settingswindow.py:1177
 #: pynicotine/gtkgui/settingswindow.py:1189
 #: pynicotine/gtkgui/ui/mainwindow.ui:167
-#: pynicotine/gtkgui/ui/mainwindow.ui:322
+#: pynicotine/gtkgui/ui/mainwindow.ui:321
 #: pynicotine/gtkgui/ui/popovers/chatroomcommands.ui:313
 msgid "Users"
 msgstr ""
@@ -1970,31 +1973,31 @@ msgid "In Queue"
 msgstr ""
 
 #: pynicotine/gtkgui/search.py:381 pynicotine/gtkgui/transferlist.py:141
-#: pynicotine/gtkgui/userbrowse.py:292
+#: pynicotine/gtkgui/userbrowse.py:287
 msgid "Filename"
 msgstr ""
 
 #: pynicotine/gtkgui/search.py:382 pynicotine/gtkgui/transferlist.py:145
-#: pynicotine/gtkgui/userbrowse.py:293
+#: pynicotine/gtkgui/userbrowse.py:288
 msgid "Size"
 msgstr ""
 
-#: pynicotine/gtkgui/search.py:383 pynicotine/gtkgui/settingswindow.py:2513
-#: pynicotine/gtkgui/userbrowse.py:294
+#: pynicotine/gtkgui/search.py:383 pynicotine/gtkgui/settingswindow.py:2521
+#: pynicotine/gtkgui/userbrowse.py:289
 #: pynicotine/gtkgui/ui/dialogs/fileproperties.ui:166
 #: pynicotine/gtkgui/ui/popovers/searchfilters.ui:267
-#: pynicotine/gtkgui/ui/search.ui:275
+#: pynicotine/gtkgui/ui/search.ui:274
 msgid "Bitrate"
 msgstr ""
 
-#: pynicotine/gtkgui/search.py:384 pynicotine/gtkgui/settingswindow.py:2511
-#: pynicotine/gtkgui/userbrowse.py:295
+#: pynicotine/gtkgui/search.py:384 pynicotine/gtkgui/settingswindow.py:2519
+#: pynicotine/gtkgui/userbrowse.py:290
 #: pynicotine/gtkgui/ui/dialogs/fileproperties.ui:131
 msgid "Length"
 msgstr ""
 
 #: pynicotine/gtkgui/search.py:412 pynicotine/gtkgui/search.py:1151
-#: pynicotine/gtkgui/search.py:1165 pynicotine/gtkgui/userbrowse.py:221
+#: pynicotine/gtkgui/search.py:1165 pynicotine/gtkgui/userbrowse.py:216
 msgid "_Download File(s)"
 msgstr ""
 
@@ -2017,26 +2020,26 @@ msgid "_Browse Folder(s)"
 msgstr ""
 
 #: pynicotine/gtkgui/search.py:418 pynicotine/gtkgui/search.py:1151
-#: pynicotine/gtkgui/search.py:1165 pynicotine/gtkgui/userbrowse.py:313
-#: pynicotine/gtkgui/userbrowse.py:326 pynicotine/gtkgui/userbrowse.py:402
-#: pynicotine/gtkgui/userbrowse.py:408
+#: pynicotine/gtkgui/search.py:1165 pynicotine/gtkgui/userbrowse.py:308
+#: pynicotine/gtkgui/userbrowse.py:321 pynicotine/gtkgui/userbrowse.py:398
+#: pynicotine/gtkgui/userbrowse.py:404
 msgid "File _Properties"
 msgstr ""
 
 #: pynicotine/gtkgui/search.py:420 pynicotine/gtkgui/search.py:1156
 #: pynicotine/gtkgui/transferlist.py:190 pynicotine/gtkgui/transferlist.py:767
-#: pynicotine/gtkgui/userbrowse.py:315 pynicotine/gtkgui/userbrowse.py:328
-#: pynicotine/gtkgui/userbrowse.py:403 pynicotine/gtkgui/userbrowse.py:408
+#: pynicotine/gtkgui/userbrowse.py:310 pynicotine/gtkgui/userbrowse.py:323
+#: pynicotine/gtkgui/userbrowse.py:399 pynicotine/gtkgui/userbrowse.py:404
 msgid "Copy _File Path"
 msgstr ""
 
 #: pynicotine/gtkgui/search.py:421 pynicotine/gtkgui/search.py:1152
 #: pynicotine/gtkgui/search.py:1166 pynicotine/gtkgui/transferlist.py:191
-#: pynicotine/gtkgui/transferlist.py:767 pynicotine/gtkgui/userbrowse.py:258
-#: pynicotine/gtkgui/userbrowse.py:270 pynicotine/gtkgui/userbrowse.py:316
-#: pynicotine/gtkgui/userbrowse.py:329 pynicotine/gtkgui/userbrowse.py:364
-#: pynicotine/gtkgui/userbrowse.py:368 pynicotine/gtkgui/userbrowse.py:403
-#: pynicotine/gtkgui/userbrowse.py:408
+#: pynicotine/gtkgui/transferlist.py:767 pynicotine/gtkgui/userbrowse.py:253
+#: pynicotine/gtkgui/userbrowse.py:265 pynicotine/gtkgui/userbrowse.py:311
+#: pynicotine/gtkgui/userbrowse.py:324 pynicotine/gtkgui/userbrowse.py:360
+#: pynicotine/gtkgui/userbrowse.py:364 pynicotine/gtkgui/userbrowse.py:399
+#: pynicotine/gtkgui/userbrowse.py:404
 msgid "Copy _URL"
 msgstr ""
 
@@ -2297,79 +2300,84 @@ msgstr ""
 msgid "Replacement"
 msgstr ""
 
-#: pynicotine/gtkgui/settingswindow.py:2490
+#: pynicotine/gtkgui/settingswindow.py:2494
 msgid "Username;APIKEY:"
 msgstr ""
 
-#: pynicotine/gtkgui/settingswindow.py:2494
+#: pynicotine/gtkgui/settingswindow.py:2498
 msgid "Client name (e.g. amarok, audacious, exaile) or empty for auto:"
 msgstr ""
 
-#: pynicotine/gtkgui/settingswindow.py:2498
-msgid "Command:"
+#: pynicotine/gtkgui/settingswindow.py:2502
+#: pynicotine/gtkgui/ui/settings/network.ui:70
+msgid "Username:"
 msgstr ""
 
 #: pynicotine/gtkgui/settingswindow.py:2506
-#: pynicotine/gtkgui/settingswindow.py:2509
+msgid "Command:"
+msgstr ""
+
+#: pynicotine/gtkgui/settingswindow.py:2514
+#: pynicotine/gtkgui/settingswindow.py:2517
 msgid "Title"
 msgstr ""
 
-#: pynicotine/gtkgui/settingswindow.py:2508
+#: pynicotine/gtkgui/settingswindow.py:2516
 #, python-format
 msgid "Now Playing (typically \"%(artist)s - %(title)s\")"
 msgstr ""
 
-#: pynicotine/gtkgui/settingswindow.py:2509
 #: pynicotine/gtkgui/settingswindow.py:2517
+#: pynicotine/gtkgui/settingswindow.py:2525
 msgid "Artist"
 msgstr ""
 
-#: pynicotine/gtkgui/settingswindow.py:2515
+#: pynicotine/gtkgui/settingswindow.py:2523
 msgid "Comment"
 msgstr ""
 
-#: pynicotine/gtkgui/settingswindow.py:2519
+#: pynicotine/gtkgui/settingswindow.py:2527
 msgid "Album"
 msgstr ""
 
-#: pynicotine/gtkgui/settingswindow.py:2521
+#: pynicotine/gtkgui/settingswindow.py:2529
 msgid "Track Number"
 msgstr ""
 
-#: pynicotine/gtkgui/settingswindow.py:2523
+#: pynicotine/gtkgui/settingswindow.py:2531
 msgid "Year"
 msgstr ""
 
-#: pynicotine/gtkgui/settingswindow.py:2525
+#: pynicotine/gtkgui/settingswindow.py:2533
 msgid "Filename (URI)"
 msgstr ""
 
-#: pynicotine/gtkgui/settingswindow.py:2527
+#: pynicotine/gtkgui/settingswindow.py:2535
 msgid "Program"
 msgstr ""
 
-#: pynicotine/gtkgui/settingswindow.py:2639
+#: pynicotine/gtkgui/settingswindow.py:2647
 #, python-format
 msgid "%s Properties"
 msgstr ""
 
-#: pynicotine/gtkgui/settingswindow.py:2647
-#: pynicotine/gtkgui/settingswindow.py:3114
+#: pynicotine/gtkgui/settingswindow.py:2655
+#: pynicotine/gtkgui/settingswindow.py:3123
 msgid "Cancel"
 msgstr ""
 
-#: pynicotine/gtkgui/settingswindow.py:2647
-#: pynicotine/gtkgui/settingswindow.py:3117
+#: pynicotine/gtkgui/settingswindow.py:2655
+#: pynicotine/gtkgui/settingswindow.py:3126
 msgid "OK"
 msgstr ""
 
-#: pynicotine/gtkgui/settingswindow.py:2726
+#: pynicotine/gtkgui/settingswindow.py:2734
 #: pynicotine/gtkgui/ui/settings/urlcatch.ui:170
 msgid "Add"
 msgstr ""
 
-#: pynicotine/gtkgui/settingswindow.py:2727
-#: pynicotine/gtkgui/ui/dialogs/fastconfigure.ui:323
+#: pynicotine/gtkgui/settingswindow.py:2735
+#: pynicotine/gtkgui/ui/dialogs/fastconfigure.ui:351
 #: pynicotine/gtkgui/ui/settings/autoreplace.ui:115
 #: pynicotine/gtkgui/ui/settings/ban.ui:163
 #: pynicotine/gtkgui/ui/settings/ban.ui:311
@@ -2382,150 +2390,150 @@ msgstr ""
 msgid "Remove"
 msgstr ""
 
-#: pynicotine/gtkgui/settingswindow.py:2942
+#: pynicotine/gtkgui/settingswindow.py:2951
 msgid "Enabled"
 msgstr ""
 
-#: pynicotine/gtkgui/settingswindow.py:2943
-#: pynicotine/gtkgui/settingswindow.py:3150
+#: pynicotine/gtkgui/settingswindow.py:2952
+#: pynicotine/gtkgui/settingswindow.py:3159
 msgid "Plugins"
 msgstr ""
 
-#: pynicotine/gtkgui/settingswindow.py:3017
+#: pynicotine/gtkgui/settingswindow.py:3026
 msgid "Could not enable plugin."
 msgstr ""
 
-#: pynicotine/gtkgui/settingswindow.py:3021
+#: pynicotine/gtkgui/settingswindow.py:3030
 msgid "Could not disable plugin."
 msgstr ""
 
-#: pynicotine/gtkgui/settingswindow.py:3108
+#: pynicotine/gtkgui/settingswindow.py:3117
 #: pynicotine/gtkgui/widgets/trayicon.py:108
 #: pynicotine/gtkgui/ui/dialogs/shortcuts.ui:48
 msgid "Preferences"
 msgstr ""
 
-#: pynicotine/gtkgui/settingswindow.py:3115
+#: pynicotine/gtkgui/settingswindow.py:3124
 msgid "Export"
 msgstr ""
 
-#: pynicotine/gtkgui/settingswindow.py:3116
+#: pynicotine/gtkgui/settingswindow.py:3125
 msgid "Apply"
 msgstr ""
 
-#: pynicotine/gtkgui/settingswindow.py:3144
+#: pynicotine/gtkgui/settingswindow.py:3153
 #: pynicotine/gtkgui/ui/dialogs/shortcuts.ui:15
 msgid "General"
 msgstr ""
 
-#: pynicotine/gtkgui/settingswindow.py:3145
+#: pynicotine/gtkgui/settingswindow.py:3154
 msgid "Network"
 msgstr ""
 
-#: pynicotine/gtkgui/settingswindow.py:3147
+#: pynicotine/gtkgui/settingswindow.py:3156
 #: pynicotine/gtkgui/ui/settings/userinterface.ui:17
 msgid "User Interface"
 msgstr ""
 
-#: pynicotine/gtkgui/settingswindow.py:3148
+#: pynicotine/gtkgui/settingswindow.py:3157
 #: pynicotine/gtkgui/ui/settings/search.ui:42
 msgid "Searches"
 msgstr ""
 
-#: pynicotine/gtkgui/settingswindow.py:3149
+#: pynicotine/gtkgui/settingswindow.py:3158
 #: pynicotine/gtkgui/ui/settings/notifications.ui:16
 msgid "Notifications"
 msgstr ""
 
-#: pynicotine/gtkgui/settingswindow.py:3151
+#: pynicotine/gtkgui/settingswindow.py:3160
 #: pynicotine/gtkgui/ui/settings/log.ui:26
 msgid "Logging"
 msgstr ""
 
-#: pynicotine/gtkgui/settingswindow.py:3153
-#: pynicotine/gtkgui/ui/mainwindow.ui:1290
+#: pynicotine/gtkgui/settingswindow.py:3162
+#: pynicotine/gtkgui/ui/mainwindow.ui:1283
 msgid "Transfers"
 msgstr ""
 
-#: pynicotine/gtkgui/settingswindow.py:3154
-#: pynicotine/gtkgui/ui/dialogs/shortcuts.ui:233
+#: pynicotine/gtkgui/settingswindow.py:3163
+#: pynicotine/gtkgui/ui/dialogs/shortcuts.ui:226
 #: pynicotine/gtkgui/ui/settings/shares.ui:17
 msgid "Shares"
 msgstr ""
 
-#: pynicotine/gtkgui/settingswindow.py:3157
+#: pynicotine/gtkgui/settingswindow.py:3166
 #: pynicotine/gtkgui/ui/settings/ban.ui:16
 msgid "Ban List"
 msgstr ""
 
-#: pynicotine/gtkgui/settingswindow.py:3158
+#: pynicotine/gtkgui/settingswindow.py:3167
 msgid "Events"
 msgstr ""
 
-#: pynicotine/gtkgui/settingswindow.py:3159
+#: pynicotine/gtkgui/settingswindow.py:3168
 #: pynicotine/gtkgui/ui/settings/geoblock.ui:16
 msgid "Geo Block"
 msgstr ""
 
-#: pynicotine/gtkgui/settingswindow.py:3161
-#: pynicotine/gtkgui/ui/mainwindow.ui:1251
+#: pynicotine/gtkgui/settingswindow.py:3170
+#: pynicotine/gtkgui/ui/mainwindow.ui:1244
 msgid "Chat"
 msgstr ""
 
-#: pynicotine/gtkgui/settingswindow.py:3162
+#: pynicotine/gtkgui/settingswindow.py:3171
 #: pynicotine/gtkgui/ui/settings/nowplaying.ui:16
 msgid "Now Playing"
 msgstr ""
 
-#: pynicotine/gtkgui/settingswindow.py:3163
+#: pynicotine/gtkgui/settingswindow.py:3172
 #: pynicotine/gtkgui/ui/settings/away.ui:27
 msgid "Away Mode"
 msgstr ""
 
-#: pynicotine/gtkgui/settingswindow.py:3164
+#: pynicotine/gtkgui/settingswindow.py:3173
 msgid "Ignore List"
 msgstr ""
 
-#: pynicotine/gtkgui/settingswindow.py:3165
+#: pynicotine/gtkgui/settingswindow.py:3174
 #: pynicotine/gtkgui/ui/settings/censor.ui:16
 msgid "Censor List"
 msgstr ""
 
-#: pynicotine/gtkgui/settingswindow.py:3166
+#: pynicotine/gtkgui/settingswindow.py:3175
 #: pynicotine/gtkgui/ui/settings/autoreplace.ui:16
 msgid "Auto-Replace List"
 msgstr ""
 
-#: pynicotine/gtkgui/settingswindow.py:3167
+#: pynicotine/gtkgui/settingswindow.py:3176
 #: pynicotine/gtkgui/ui/settings/urlcatch.ui:16
 msgid "URL Catching"
 msgstr ""
 
-#: pynicotine/gtkgui/settingswindow.py:3168
+#: pynicotine/gtkgui/settingswindow.py:3177
 #: pynicotine/gtkgui/ui/settings/completion.ui:23
 msgid "Completion"
 msgstr ""
 
-#: pynicotine/gtkgui/settingswindow.py:3169
+#: pynicotine/gtkgui/settingswindow.py:3178
 #: pynicotine/gtkgui/ui/settings/tts.ui:16
 msgid "Text-to-Speech"
 msgstr ""
 
-#: pynicotine/gtkgui/settingswindow.py:3173
+#: pynicotine/gtkgui/settingswindow.py:3182
 msgid "Categories"
 msgstr ""
 
-#: pynicotine/gtkgui/settingswindow.py:3486
+#: pynicotine/gtkgui/settingswindow.py:3495
 #, python-format
 msgid "Error backing up config: %s"
 msgstr ""
 
-#: pynicotine/gtkgui/settingswindow.py:3488
+#: pynicotine/gtkgui/settingswindow.py:3497
 #, python-format
 msgid "Config backed up to: %s"
 msgstr ""
 
-#: pynicotine/gtkgui/settingswindow.py:3497
+#: pynicotine/gtkgui/settingswindow.py:3506
 msgid "Pick a File Name for Config Backup"
 msgstr ""
 
@@ -2640,7 +2648,7 @@ msgid "Time Left"
 msgstr ""
 
 #: pynicotine/gtkgui/transferlist.py:187 pynicotine/gtkgui/transferlist.py:766
-#: pynicotine/gtkgui/userbrowse.py:311 pynicotine/gtkgui/userbrowse.py:402
+#: pynicotine/gtkgui/userbrowse.py:306 pynicotine/gtkgui/userbrowse.py:398
 msgid "Send to _Player"
 msgstr ""
 
@@ -2700,115 +2708,115 @@ msgstr ""
 msgid "Are you sure you wish to clear all uploads?"
 msgstr ""
 
-#: pynicotine/gtkgui/userbrowse.py:197
+#: pynicotine/gtkgui/userbrowse.py:192
 #: pynicotine/gtkgui/ui/settings/downloads.ui:188
-#: pynicotine/gtkgui/ui/userbrowse.ui:55
+#: pynicotine/gtkgui/ui/userbrowse.ui:63
 msgid "Folders"
 msgstr ""
 
-#: pynicotine/gtkgui/userbrowse.py:206
+#: pynicotine/gtkgui/userbrowse.py:201
 msgid "_Save Shares List to Disk"
 msgstr ""
 
-#: pynicotine/gtkgui/userbrowse.py:213 pynicotine/gtkgui/userbrowse.py:224
-#: pynicotine/gtkgui/userbrowse.py:247 pynicotine/gtkgui/userbrowse.py:264
-#: pynicotine/gtkgui/userbrowse.py:362 pynicotine/gtkgui/userbrowse.py:367
+#: pynicotine/gtkgui/userbrowse.py:208 pynicotine/gtkgui/userbrowse.py:219
+#: pynicotine/gtkgui/userbrowse.py:242 pynicotine/gtkgui/userbrowse.py:259
+#: pynicotine/gtkgui/userbrowse.py:358 pynicotine/gtkgui/userbrowse.py:363
 msgid "_Download Folder"
 msgstr ""
 
-#: pynicotine/gtkgui/userbrowse.py:214 pynicotine/gtkgui/userbrowse.py:225
-#: pynicotine/gtkgui/userbrowse.py:248 pynicotine/gtkgui/userbrowse.py:265
-#: pynicotine/gtkgui/userbrowse.py:362 pynicotine/gtkgui/userbrowse.py:367
+#: pynicotine/gtkgui/userbrowse.py:209 pynicotine/gtkgui/userbrowse.py:220
+#: pynicotine/gtkgui/userbrowse.py:243 pynicotine/gtkgui/userbrowse.py:260
+#: pynicotine/gtkgui/userbrowse.py:358 pynicotine/gtkgui/userbrowse.py:363
 msgid "Download Folder _To..."
 msgstr ""
 
-#: pynicotine/gtkgui/userbrowse.py:215 pynicotine/gtkgui/userbrowse.py:226
-#: pynicotine/gtkgui/userbrowse.py:249 pynicotine/gtkgui/userbrowse.py:266
-#: pynicotine/gtkgui/userbrowse.py:362 pynicotine/gtkgui/userbrowse.py:367
+#: pynicotine/gtkgui/userbrowse.py:210 pynicotine/gtkgui/userbrowse.py:221
+#: pynicotine/gtkgui/userbrowse.py:244 pynicotine/gtkgui/userbrowse.py:261
+#: pynicotine/gtkgui/userbrowse.py:358 pynicotine/gtkgui/userbrowse.py:363
 msgid "Download _Recursive"
 msgstr ""
 
-#: pynicotine/gtkgui/userbrowse.py:216 pynicotine/gtkgui/userbrowse.py:227
-#: pynicotine/gtkgui/userbrowse.py:250 pynicotine/gtkgui/userbrowse.py:267
-#: pynicotine/gtkgui/userbrowse.py:363 pynicotine/gtkgui/userbrowse.py:368
+#: pynicotine/gtkgui/userbrowse.py:211 pynicotine/gtkgui/userbrowse.py:222
+#: pynicotine/gtkgui/userbrowse.py:245 pynicotine/gtkgui/userbrowse.py:262
+#: pynicotine/gtkgui/userbrowse.py:359 pynicotine/gtkgui/userbrowse.py:364
 msgid "Download R_ecursive To..."
 msgstr ""
 
-#: pynicotine/gtkgui/userbrowse.py:222
+#: pynicotine/gtkgui/userbrowse.py:217
 msgid "Download _To..."
 msgstr ""
 
-#: pynicotine/gtkgui/userbrowse.py:232 pynicotine/gtkgui/userbrowse.py:238
-#: pynicotine/gtkgui/userbrowse.py:252 pynicotine/gtkgui/userbrowse.py:363
+#: pynicotine/gtkgui/userbrowse.py:227 pynicotine/gtkgui/userbrowse.py:233
+#: pynicotine/gtkgui/userbrowse.py:247 pynicotine/gtkgui/userbrowse.py:359
 msgid "Upload Folder To..."
 msgstr ""
 
-#: pynicotine/gtkgui/userbrowse.py:233 pynicotine/gtkgui/userbrowse.py:239
-#: pynicotine/gtkgui/userbrowse.py:253 pynicotine/gtkgui/userbrowse.py:363
+#: pynicotine/gtkgui/userbrowse.py:228 pynicotine/gtkgui/userbrowse.py:234
+#: pynicotine/gtkgui/userbrowse.py:248 pynicotine/gtkgui/userbrowse.py:359
 msgid "Upload Folder Recursive To..."
 msgstr ""
 
-#: pynicotine/gtkgui/userbrowse.py:240
+#: pynicotine/gtkgui/userbrowse.py:235
 msgid "Up_load File(s)"
 msgstr ""
 
-#: pynicotine/gtkgui/userbrowse.py:255 pynicotine/gtkgui/userbrowse.py:312
-#: pynicotine/gtkgui/userbrowse.py:364 pynicotine/gtkgui/userbrowse.py:406
+#: pynicotine/gtkgui/userbrowse.py:250 pynicotine/gtkgui/userbrowse.py:307
+#: pynicotine/gtkgui/userbrowse.py:360 pynicotine/gtkgui/userbrowse.py:402
 msgid "Open in File _Manager"
 msgstr ""
 
-#: pynicotine/gtkgui/userbrowse.py:257 pynicotine/gtkgui/userbrowse.py:269
-#: pynicotine/gtkgui/userbrowse.py:364 pynicotine/gtkgui/userbrowse.py:368
+#: pynicotine/gtkgui/userbrowse.py:252 pynicotine/gtkgui/userbrowse.py:264
+#: pynicotine/gtkgui/userbrowse.py:360 pynicotine/gtkgui/userbrowse.py:364
 msgid "Copy _Folder Path"
 msgstr ""
 
-#: pynicotine/gtkgui/userbrowse.py:308 pynicotine/gtkgui/userbrowse.py:324
-#: pynicotine/gtkgui/userbrowse.py:402 pynicotine/gtkgui/userbrowse.py:408
+#: pynicotine/gtkgui/userbrowse.py:303 pynicotine/gtkgui/userbrowse.py:319
+#: pynicotine/gtkgui/userbrowse.py:398 pynicotine/gtkgui/userbrowse.py:404
 msgid "Download"
 msgstr ""
 
-#: pynicotine/gtkgui/userbrowse.py:309 pynicotine/gtkgui/userbrowse.py:402
+#: pynicotine/gtkgui/userbrowse.py:304 pynicotine/gtkgui/userbrowse.py:398
 msgid "Upload"
 msgstr ""
 
-#: pynicotine/gtkgui/userbrowse.py:568
+#: pynicotine/gtkgui/userbrowse.py:573
 #, python-format
 msgid ""
 "Error while attempting to display folder '%(folder)s', reported error: "
 "%(error)s"
 msgstr ""
 
-#: pynicotine/gtkgui/userbrowse.py:587
+#: pynicotine/gtkgui/userbrowse.py:592
 #, python-format
 msgid "Saved list of shared files for user '%(user)s' to %(dir)s"
 msgstr ""
 
-#: pynicotine/gtkgui/userbrowse.py:591
+#: pynicotine/gtkgui/userbrowse.py:596
 #, python-format
 msgid "Can't save shares, '%(user)s', reported error: %(error)s"
 msgstr ""
 
-#: pynicotine/gtkgui/userbrowse.py:612
+#: pynicotine/gtkgui/userbrowse.py:617
 msgid ""
 "User's list of shared files is empty. Either the user is not sharing "
 "anything, or they are sharing files privately."
 msgstr ""
 
-#: pynicotine/gtkgui/userbrowse.py:621
+#: pynicotine/gtkgui/userbrowse.py:626
 msgid ""
 "Unable to request shared files from user. Either the user is offline, you "
 "both have a closed listening port, or there's a temporary connectivity issue."
 msgstr ""
 
-#: pynicotine/gtkgui/userbrowse.py:856
+#: pynicotine/gtkgui/userbrowse.py:860
 msgid "Upload Folder's Contents"
 msgstr ""
 
-#: pynicotine/gtkgui/userbrowse.py:857 pynicotine/gtkgui/userbrowse.py:928
+#: pynicotine/gtkgui/userbrowse.py:861 pynicotine/gtkgui/userbrowse.py:932
 msgid "Enter the name of a user you wish to upload to:"
 msgstr ""
 
-#: pynicotine/gtkgui/userbrowse.py:927
+#: pynicotine/gtkgui/userbrowse.py:931
 msgid "Upload File(s)"
 msgstr ""
 
@@ -2959,6 +2967,7 @@ msgstr ""
 #: pynicotine/gtkgui/widgets/filechooser.py:114
 #: pynicotine/gtkgui/widgets/filechooser.py:161
 #: pynicotine/gtkgui/widgets/filechooser.py:195
+#: pynicotine/gtkgui/ui/dialogs/fastconfigure.ui:72
 msgid "_Cancel"
 msgstr ""
 
@@ -3228,49 +3237,71 @@ msgstr ""
 msgid "Text-to-speech for message failed: %s"
 msgstr ""
 
-#: pynicotine/nowplaying.py:82
+#: pynicotine/nowplaying.py:84
 msgid ""
 "Could not execute now playing code. Are you sure you picked the right player?"
 msgstr ""
 
-#: pynicotine/nowplaying.py:136
+#: pynicotine/nowplaying.py:138
 msgid "lastfm: Please provide both your lastfm username and API key"
 msgstr ""
 
-#: pynicotine/nowplaying.py:146
+#: pynicotine/nowplaying.py:148
 #, python-format
 msgid "lastfm: Could not connect to audioscrobbler: %(error)s"
 msgstr ""
 
-#: pynicotine/nowplaying.py:157
+#: pynicotine/nowplaying.py:159
 msgid "Last played"
 msgstr ""
 
-#: pynicotine/nowplaying.py:160
+#: pynicotine/nowplaying.py:162
 #, python-format
 msgid "lastfm: Could not get recent track from audioscrobbler: %(error)s"
 msgstr ""
 
-#: pynicotine/nowplaying.py:197
+#: pynicotine/nowplaying.py:199
 msgid "MPRIS: Could not find a suitable MPRIS player."
 msgstr ""
 
-#: pynicotine/nowplaying.py:202
+#: pynicotine/nowplaying.py:204
 #, python-format
 msgid "Found multiple MPRIS players: %(players)s. Using: %(player)s"
 msgstr ""
 
-#: pynicotine/nowplaying.py:205
+#: pynicotine/nowplaying.py:207
 #, python-format
 msgid "Auto-detected MPRIS player: %s."
 msgstr ""
 
-#: pynicotine/nowplaying.py:219
+#: pynicotine/nowplaying.py:221
 #, python-format
 msgid "MPRIS: Something went wrong while querying %(player)s: %(exception)s"
 msgstr ""
 
-#: pynicotine/nowplaying.py:272
+#: pynicotine/nowplaying.py:270
+msgid "listenbrainz: Please provide your listenbrainz username"
+msgstr ""
+
+#: pynicotine/nowplaying.py:279
+#, python-format
+msgid "listenbrainz: Could not connect to listenbrainz: %(error)s"
+msgstr ""
+
+#: pynicotine/nowplaying.py:285
+msgid "listenbrainz: You don't seem to be listening to anything right now"
+msgstr ""
+
+#: pynicotine/nowplaying.py:293
+msgid "Playing now"
+msgstr ""
+
+#: pynicotine/nowplaying.py:297
+#, python-format
+msgid "listenbrainz: Could not get current track from listenbrainz: %(error)s"
+msgstr ""
+
+#: pynicotine/nowplaying.py:310
 #, python-format
 msgid "Executing '%(command)s' failed: %(error)s"
 msgstr ""
@@ -3285,47 +3316,47 @@ msgstr ""
 msgid "Failed to load plugin '%s', could not find it."
 msgstr ""
 
-#: pynicotine/pluginsystem.py:135
+#: pynicotine/pluginsystem.py:138
 #, python-format
 msgid ""
 "Unable to enable plugin %(name)s. Plugin folder name contains invalid "
 "characters: %(characters)s"
 msgstr ""
 
-#: pynicotine/pluginsystem.py:161
+#: pynicotine/pluginsystem.py:164
 #, python-format
 msgid "Enabled plugin %s"
 msgstr ""
 
-#: pynicotine/pluginsystem.py:165
+#: pynicotine/pluginsystem.py:168
 #, python-format
 msgid ""
 "Unable to enable plugin %(module)s\n"
 "%(exc_trace)s"
 msgstr ""
 
-#: pynicotine/pluginsystem.py:189
+#: pynicotine/pluginsystem.py:193
 msgid "Disabled plugin {}"
 msgstr ""
 
-#: pynicotine/pluginsystem.py:205
+#: pynicotine/pluginsystem.py:223
 #, python-format
 msgid ""
 "Unable to fully disable plugin %(module)s\n"
 "%(exc_trace)s"
 msgstr ""
 
-#: pynicotine/pluginsystem.py:268
+#: pynicotine/pluginsystem.py:288
 #, python-format
 msgid "Stored setting '%(name)s' is no longer present in the plugin"
 msgstr ""
 
-#: pynicotine/pluginsystem.py:308 pynicotine/pluginsystem.py:363
+#: pynicotine/pluginsystem.py:328 pynicotine/pluginsystem.py:383
 #, python-format
 msgid "Plugin %(module)s returned something weird, '%(value)s', ignoring"
 msgstr ""
 
-#: pynicotine/pluginsystem.py:316 pynicotine/pluginsystem.py:371
+#: pynicotine/pluginsystem.py:336 pynicotine/pluginsystem.py:391
 #, python-format
 msgid ""
 "Plugin %(module)s failed with error %(errortype)s: %(error)s.\n"
@@ -3788,15 +3819,15 @@ msgstr ""
 msgid "User:"
 msgstr ""
 
-#: pynicotine/gtkgui/ui/buddylist.ui:41 pynicotine/gtkgui/ui/mainwindow.ui:681
+#: pynicotine/gtkgui/ui/buddylist.ui:41 pynicotine/gtkgui/ui/mainwindow.ui:674
 msgid "Add buddy..."
 msgstr ""
 
-#: pynicotine/gtkgui/ui/buddylist.ui:42 pynicotine/gtkgui/ui/mainwindow.ui:682
+#: pynicotine/gtkgui/ui/buddylist.ui:42 pynicotine/gtkgui/ui/mainwindow.ui:675
 msgid "Enter the username of the person you wish to add to your buddy list"
 msgstr ""
 
-#: pynicotine/gtkgui/ui/buddylist.ui:51 pynicotine/gtkgui/ui/mainwindow.ui:698
+#: pynicotine/gtkgui/ui/buddylist.ui:51 pynicotine/gtkgui/ui/mainwindow.ui:691
 msgid "Configure banned users"
 msgstr ""
 
@@ -3824,71 +3855,71 @@ msgstr ""
 msgid "Welcome to Nicotine+"
 msgstr ""
 
-#: pynicotine/gtkgui/ui/dialogs/fastconfigure.ui:67
-msgid "Set Up..."
+#: pynicotine/gtkgui/ui/dialogs/fastconfigure.ui:92
+msgid "_Set Up..."
 msgstr ""
 
-#: pynicotine/gtkgui/ui/dialogs/fastconfigure.ui:91
+#: pynicotine/gtkgui/ui/dialogs/fastconfigure.ui:119
 msgid ""
 "To create a new Soulseek account, fill in your desired username and "
 "password. If you already have an account, fill in your existing login "
 "details."
 msgstr ""
 
-#: pynicotine/gtkgui/ui/dialogs/fastconfigure.ui:101
+#: pynicotine/gtkgui/ui/dialogs/fastconfigure.ui:129
 msgid ""
 "Please keep in mind that more common usernames may be taken. If you're "
 "unable to connect, you can change your username in the preferences later."
 msgstr ""
 
-#: pynicotine/gtkgui/ui/dialogs/fastconfigure.ui:129
+#: pynicotine/gtkgui/ui/dialogs/fastconfigure.ui:157
 #: pynicotine/gtkgui/ui/dialogs/fileproperties.ui:199
 msgid "Username"
 msgstr ""
 
-#: pynicotine/gtkgui/ui/dialogs/fastconfigure.ui:160
+#: pynicotine/gtkgui/ui/dialogs/fastconfigure.ui:188
 msgid "Password"
 msgstr ""
 
-#: pynicotine/gtkgui/ui/dialogs/fastconfigure.ui:194
+#: pynicotine/gtkgui/ui/dialogs/fastconfigure.ui:222
 msgid ""
 "Nicotine+ uses peer-to-peer networking to connect to other users. An open "
 "listening port is crucial to allow users to connect to you without trouble."
 msgstr ""
 
-#: pynicotine/gtkgui/ui/dialogs/fastconfigure.ui:204
+#: pynicotine/gtkgui/ui/dialogs/fastconfigure.ui:232
 msgid ""
 "The default listening port should work fine in most cases. If you need to "
 "use a different port, you can change it in the preferences later."
 msgstr ""
 
-#: pynicotine/gtkgui/ui/dialogs/fastconfigure.ui:214
+#: pynicotine/gtkgui/ui/dialogs/fastconfigure.ui:242
 msgid ""
 "Nicotine+ will still work to some degree if your port is closed. However, do "
 "keep in mind that you won't be able to connect to users whose port is also "
 "closed."
 msgstr ""
 
-#: pynicotine/gtkgui/ui/dialogs/fastconfigure.ui:224
+#: pynicotine/gtkgui/ui/dialogs/fastconfigure.ui:252
 #: pynicotine/gtkgui/ui/settings/network.ui:183
 msgid "Check Port Status"
 msgstr ""
 
-#: pynicotine/gtkgui/ui/dialogs/fastconfigure.ui:248
+#: pynicotine/gtkgui/ui/dialogs/fastconfigure.ui:276
 msgid "Download Files to Folder"
 msgstr ""
 
-#: pynicotine/gtkgui/ui/dialogs/fastconfigure.ui:270
+#: pynicotine/gtkgui/ui/dialogs/fastconfigure.ui:298
 msgid "Share Folders"
 msgstr ""
 
-#: pynicotine/gtkgui/ui/dialogs/fastconfigure.ui:279
+#: pynicotine/gtkgui/ui/dialogs/fastconfigure.ui:307
 msgid ""
 "Users on the Soulseek network will be able to download files from folders "
 "you share."
 msgstr ""
 
-#: pynicotine/gtkgui/ui/dialogs/fastconfigure.ui:316
+#: pynicotine/gtkgui/ui/dialogs/fastconfigure.ui:344
 #: pynicotine/gtkgui/ui/settings/autoreplace.ui:87
 #: pynicotine/gtkgui/ui/settings/ban.ui:135
 #: pynicotine/gtkgui/ui/settings/ban.ui:283
@@ -3900,17 +3931,17 @@ msgstr ""
 msgid "Add..."
 msgstr ""
 
-#: pynicotine/gtkgui/ui/dialogs/fastconfigure.ui:345
+#: pynicotine/gtkgui/ui/dialogs/fastconfigure.ui:373
 msgid "You are ready to use Nicotine+!"
 msgstr ""
 
-#: pynicotine/gtkgui/ui/dialogs/fastconfigure.ui:362
+#: pynicotine/gtkgui/ui/dialogs/fastconfigure.ui:390
 msgid ""
 "Transfer speeds depend on the users you are downloading from. Some users "
 "will be fast while others will be slow."
 msgstr ""
 
-#: pynicotine/gtkgui/ui/dialogs/fastconfigure.ui:372
+#: pynicotine/gtkgui/ui/dialogs/fastconfigure.ui:400
 msgid ""
 "Sharing files is crucial for the health of the Soulseek network. Many people "
 "will ban you if you download from them without sharing anything yourself."
@@ -3965,99 +3996,95 @@ msgid "Show Log Pane"
 msgstr ""
 
 #: pynicotine/gtkgui/ui/dialogs/shortcuts.ui:75
-msgid "Show Room List"
-msgstr ""
-
-#: pynicotine/gtkgui/ui/dialogs/shortcuts.ui:82
 msgid "Show Flag Columns in User Lists"
 msgstr ""
 
-#: pynicotine/gtkgui/ui/dialogs/shortcuts.ui:89
+#: pynicotine/gtkgui/ui/dialogs/shortcuts.ui:82
 msgid "Show Buttons in Transfer Tabs"
 msgstr ""
 
-#: pynicotine/gtkgui/ui/dialogs/shortcuts.ui:97
+#: pynicotine/gtkgui/ui/dialogs/shortcuts.ui:90
 msgid "Menus"
 msgstr ""
 
-#: pynicotine/gtkgui/ui/dialogs/shortcuts.ui:102
+#: pynicotine/gtkgui/ui/dialogs/shortcuts.ui:95
 msgid "Open Main Menu"
 msgstr ""
 
-#: pynicotine/gtkgui/ui/dialogs/shortcuts.ui:109
+#: pynicotine/gtkgui/ui/dialogs/shortcuts.ui:102
 msgid "Open Context Menu"
 msgstr ""
 
-#: pynicotine/gtkgui/ui/dialogs/shortcuts.ui:117
+#: pynicotine/gtkgui/ui/dialogs/shortcuts.ui:110
 #: pynicotine/gtkgui/ui/settings/userinterface.ui:116
 msgid "Tabs"
 msgstr ""
 
-#: pynicotine/gtkgui/ui/dialogs/shortcuts.ui:122
+#: pynicotine/gtkgui/ui/dialogs/shortcuts.ui:115
 msgid "Change Primary Tab"
 msgstr ""
 
-#: pynicotine/gtkgui/ui/dialogs/shortcuts.ui:129
+#: pynicotine/gtkgui/ui/dialogs/shortcuts.ui:122
 msgid "Go to Previous Secondary Tab"
 msgstr ""
 
-#: pynicotine/gtkgui/ui/dialogs/shortcuts.ui:136
+#: pynicotine/gtkgui/ui/dialogs/shortcuts.ui:129
 msgid "Go to Next Secondary Tab"
 msgstr ""
 
-#: pynicotine/gtkgui/ui/dialogs/shortcuts.ui:143
+#: pynicotine/gtkgui/ui/dialogs/shortcuts.ui:136
 msgid "Close Secondary Tab"
 msgstr ""
 
-#: pynicotine/gtkgui/ui/dialogs/shortcuts.ui:151
+#: pynicotine/gtkgui/ui/dialogs/shortcuts.ui:144
 msgid "File Lists"
 msgstr ""
 
-#: pynicotine/gtkgui/ui/dialogs/shortcuts.ui:156
+#: pynicotine/gtkgui/ui/dialogs/shortcuts.ui:149
 msgid "Copy File Path"
 msgstr ""
 
-#: pynicotine/gtkgui/ui/dialogs/shortcuts.ui:163
+#: pynicotine/gtkgui/ui/dialogs/shortcuts.ui:156
 msgid "Retry Transfer"
 msgstr ""
 
-#: pynicotine/gtkgui/ui/dialogs/shortcuts.ui:170
+#: pynicotine/gtkgui/ui/dialogs/shortcuts.ui:163
 msgid "Abort Transfer"
 msgstr ""
 
-#: pynicotine/gtkgui/ui/dialogs/shortcuts.ui:178
+#: pynicotine/gtkgui/ui/dialogs/shortcuts.ui:171
 msgid "Editing"
 msgstr ""
 
-#: pynicotine/gtkgui/ui/dialogs/shortcuts.ui:183
+#: pynicotine/gtkgui/ui/dialogs/shortcuts.ui:176
 msgid "Cut"
 msgstr ""
 
-#: pynicotine/gtkgui/ui/dialogs/shortcuts.ui:197
+#: pynicotine/gtkgui/ui/dialogs/shortcuts.ui:190
 msgid "Paste"
 msgstr ""
 
-#: pynicotine/gtkgui/ui/dialogs/shortcuts.ui:204
+#: pynicotine/gtkgui/ui/dialogs/shortcuts.ui:197
 msgid "Select All"
 msgstr ""
 
-#: pynicotine/gtkgui/ui/dialogs/shortcuts.ui:211
+#: pynicotine/gtkgui/ui/dialogs/shortcuts.ui:204
 msgid "Find"
 msgstr ""
 
-#: pynicotine/gtkgui/ui/dialogs/shortcuts.ui:218
+#: pynicotine/gtkgui/ui/dialogs/shortcuts.ui:211
 msgid "Find Next Match"
 msgstr ""
 
-#: pynicotine/gtkgui/ui/dialogs/shortcuts.ui:225
+#: pynicotine/gtkgui/ui/dialogs/shortcuts.ui:218
 msgid "Find Previous Match"
 msgstr ""
 
-#: pynicotine/gtkgui/ui/dialogs/shortcuts.ui:238
+#: pynicotine/gtkgui/ui/dialogs/shortcuts.ui:231
 msgid "Rescan Public Shares"
 msgstr ""
 
-#: pynicotine/gtkgui/ui/dialogs/shortcuts.ui:245
+#: pynicotine/gtkgui/ui/dialogs/shortcuts.ui:238
 msgid "Rescan Buddy Shares"
 msgstr ""
 
@@ -4168,9 +4195,9 @@ msgstr ""
 msgid "Room..."
 msgstr ""
 
-#: pynicotine/gtkgui/ui/mainwindow.ui:85 pynicotine/gtkgui/ui/mainwindow.ui:477
-#: pynicotine/gtkgui/ui/mainwindow.ui:532
-#: pynicotine/gtkgui/ui/mainwindow.ui:630
+#: pynicotine/gtkgui/ui/mainwindow.ui:85 pynicotine/gtkgui/ui/mainwindow.ui:475
+#: pynicotine/gtkgui/ui/mainwindow.ui:530
+#: pynicotine/gtkgui/ui/mainwindow.ui:597
 msgid "Username..."
 msgstr ""
 
@@ -4189,112 +4216,116 @@ msgid "Configure searches"
 msgstr ""
 
 #: pynicotine/gtkgui/ui/mainwindow.ui:269
-#: pynicotine/gtkgui/ui/mainwindow.ui:424 pynicotine/gtkgui/ui/search.ui:102
-#: pynicotine/gtkgui/ui/userbrowse.ui:193
+#: pynicotine/gtkgui/ui/mainwindow.ui:423 pynicotine/gtkgui/ui/search.ui:102
+#: pynicotine/gtkgui/ui/userbrowse.ui:200
 msgid "Expand / Collapse all"
 msgstr ""
 
-#: pynicotine/gtkgui/ui/mainwindow.ui:281
-#: pynicotine/gtkgui/ui/mainwindow.ui:436
+#: pynicotine/gtkgui/ui/mainwindow.ui:280
+#: pynicotine/gtkgui/ui/mainwindow.ui:434
 msgid "File grouping mode"
 msgstr ""
 
-#: pynicotine/gtkgui/ui/mainwindow.ui:292
+#: pynicotine/gtkgui/ui/mainwindow.ui:291
 msgid "Configure downloads"
 msgstr ""
 
-#: pynicotine/gtkgui/ui/mainwindow.ui:447
+#: pynicotine/gtkgui/ui/mainwindow.ui:445
 msgid "Configure uploads"
 msgstr ""
 
-#: pynicotine/gtkgui/ui/mainwindow.ui:478
+#: pynicotine/gtkgui/ui/mainwindow.ui:476
 msgid "Enter the username of the person you wish to send a message to"
 msgstr ""
 
-#: pynicotine/gtkgui/ui/mainwindow.ui:502
-#: pynicotine/gtkgui/ui/mainwindow.ui:766
+#: pynicotine/gtkgui/ui/mainwindow.ui:500
+#: pynicotine/gtkgui/ui/mainwindow.ui:759
 msgid "Configure logging"
 msgstr ""
 
-#: pynicotine/gtkgui/ui/mainwindow.ui:533
+#: pynicotine/gtkgui/ui/mainwindow.ui:531
 msgid "Enter the username of the person you to receive information about"
 msgstr ""
 
-#: pynicotine/gtkgui/ui/mainwindow.ui:571
+#: pynicotine/gtkgui/ui/mainwindow.ui:569
 msgid "Update I_nfo"
 msgstr ""
 
-#: pynicotine/gtkgui/ui/mainwindow.ui:606
-msgid "Load from _Disk"
-msgstr ""
-
-#: pynicotine/gtkgui/ui/mainwindow.ui:631
+#: pynicotine/gtkgui/ui/mainwindow.ui:598
 msgid "Enter the username of the person whose files you wish to see"
 msgstr ""
 
-#: pynicotine/gtkgui/ui/mainwindow.ui:655
+#: pynicotine/gtkgui/ui/mainwindow.ui:636
+msgid "Opens a local list of shared files that was previously saved to disk"
+msgstr ""
+
+#: pynicotine/gtkgui/ui/mainwindow.ui:637
+msgid "_Open List"
+msgstr ""
+
+#: pynicotine/gtkgui/ui/mainwindow.ui:648
 msgid "Configure shares"
 msgstr ""
 
-#: pynicotine/gtkgui/ui/mainwindow.ui:723
+#: pynicotine/gtkgui/ui/mainwindow.ui:716
 msgid "_Room List"
 msgstr ""
 
-#: pynicotine/gtkgui/ui/mainwindow.ui:743
+#: pynicotine/gtkgui/ui/mainwindow.ui:736
 msgid "Create or join room..."
 msgstr ""
 
-#: pynicotine/gtkgui/ui/mainwindow.ui:744
+#: pynicotine/gtkgui/ui/mainwindow.ui:737
 msgid ""
 "Enter the name of a room you want to join. If the room doesn't exist, it "
 "will be created."
 msgstr ""
 
-#: pynicotine/gtkgui/ui/mainwindow.ui:1196
+#: pynicotine/gtkgui/ui/mainwindow.ui:1189
 msgid "Debug Logging"
 msgstr ""
 
-#: pynicotine/gtkgui/ui/mainwindow.ui:1238
+#: pynicotine/gtkgui/ui/mainwindow.ui:1231
 #: pynicotine/gtkgui/ui/popovers/chatroomcommands.ui:631
 #: pynicotine/gtkgui/ui/popovers/privatechatcommands.ui:547
 msgid "Search"
 msgstr ""
 
-#: pynicotine/gtkgui/ui/mainwindow.ui:1264
-#: pynicotine/gtkgui/ui/mainwindow.ui:1414
+#: pynicotine/gtkgui/ui/mainwindow.ui:1257
+#: pynicotine/gtkgui/ui/mainwindow.ui:1407
 msgid "Connections"
 msgstr ""
 
-#: pynicotine/gtkgui/ui/mainwindow.ui:1277
+#: pynicotine/gtkgui/ui/mainwindow.ui:1270
 #: pynicotine/gtkgui/ui/settings/tts.ui:110
 msgid "Messages"
 msgstr ""
 
-#: pynicotine/gtkgui/ui/mainwindow.ui:1303
+#: pynicotine/gtkgui/ui/mainwindow.ui:1296
 msgid "Miscellaneous"
 msgstr ""
 
-#: pynicotine/gtkgui/ui/mainwindow.ui:1388
+#: pynicotine/gtkgui/ui/mainwindow.ui:1381
 msgid "Scanning Shares"
 msgstr ""
 
-#: pynicotine/gtkgui/ui/mainwindow.ui:1397
+#: pynicotine/gtkgui/ui/mainwindow.ui:1390
 msgid "Scanning Buddy Shares"
 msgstr ""
 
-#: pynicotine/gtkgui/ui/mainwindow.ui:1442
-msgid "Downloading (speed / active downloads)"
+#: pynicotine/gtkgui/ui/mainwindow.ui:1435
+msgid "Downloading (speed / active users)"
 msgstr ""
 
-#: pynicotine/gtkgui/ui/mainwindow.ui:1469
-msgid "Uploading (speed / active uploads)"
+#: pynicotine/gtkgui/ui/mainwindow.ui:1462
+msgid "Uploading (speed / active users)"
 msgstr ""
 
-#: pynicotine/gtkgui/ui/mainwindow.ui:1514
+#: pynicotine/gtkgui/ui/mainwindow.ui:1507
 msgid "Enable alternative download and upload speed limits"
 msgstr ""
 
-#: pynicotine/gtkgui/ui/mainwindow.ui:1532
+#: pynicotine/gtkgui/ui/mainwindow.ui:1525
 msgid "Show log history"
 msgstr ""
 
@@ -4821,15 +4852,15 @@ msgstr ""
 msgid "Results"
 msgstr ""
 
-#: pynicotine/gtkgui/ui/search.ui:118
+#: pynicotine/gtkgui/ui/search.ui:117
 msgid "Result grouping mode"
 msgstr ""
 
-#: pynicotine/gtkgui/ui/search.ui:154
+#: pynicotine/gtkgui/ui/search.ui:153
 msgid "Include text..."
 msgstr ""
 
-#: pynicotine/gtkgui/ui/search.ui:155
+#: pynicotine/gtkgui/ui/search.ui:154
 #: pynicotine/gtkgui/ui/settings/search.ui:198
 msgid ""
 "Filter in results whose file paths contain the specified text. Multiple "
@@ -4837,11 +4868,11 @@ msgid ""
 "phrase two"
 msgstr ""
 
-#: pynicotine/gtkgui/ui/search.ui:184
+#: pynicotine/gtkgui/ui/search.ui:183
 msgid "Exclude text..."
 msgstr ""
 
-#: pynicotine/gtkgui/ui/search.ui:185
+#: pynicotine/gtkgui/ui/search.ui:184
 #: pynicotine/gtkgui/ui/settings/search.ui:225
 msgid ""
 "Filter out results whose file paths contain the specified text. Multiple "
@@ -4849,45 +4880,45 @@ msgid ""
 "phrase two"
 msgstr ""
 
-#: pynicotine/gtkgui/ui/search.ui:214
+#: pynicotine/gtkgui/ui/search.ui:213
 msgid "File type..."
 msgstr ""
 
-#: pynicotine/gtkgui/ui/search.ui:215
+#: pynicotine/gtkgui/ui/search.ui:214
 #: pynicotine/gtkgui/ui/settings/search.ui:255
 msgid "File type, e.g. flac|wav|ape or !mp3|!m4a"
 msgstr ""
 
-#: pynicotine/gtkgui/ui/search.ui:244
+#: pynicotine/gtkgui/ui/search.ui:243
 msgid "File size..."
 msgstr ""
 
-#: pynicotine/gtkgui/ui/search.ui:245
+#: pynicotine/gtkgui/ui/search.ui:244
 msgid "File size"
 msgstr ""
 
-#: pynicotine/gtkgui/ui/search.ui:274
+#: pynicotine/gtkgui/ui/search.ui:273
 msgid "Bitrate..."
 msgstr ""
 
-#: pynicotine/gtkgui/ui/search.ui:308
+#: pynicotine/gtkgui/ui/search.ui:307
 msgid "Country code..."
 msgstr ""
 
-#: pynicotine/gtkgui/ui/search.ui:309
+#: pynicotine/gtkgui/ui/search.ui:308
 #: pynicotine/gtkgui/ui/settings/search.ui:349
 msgid "Country code, e.g. US|GB|ES or !DE|!GB"
 msgstr ""
 
-#: pynicotine/gtkgui/ui/search.ui:326
+#: pynicotine/gtkgui/ui/search.ui:325
 msgid "Free Sl_ot"
 msgstr ""
 
-#: pynicotine/gtkgui/ui/search.ui:339
+#: pynicotine/gtkgui/ui/search.ui:338
 msgid "Clear all active filters"
 msgstr ""
 
-#: pynicotine/gtkgui/ui/search.ui:352
+#: pynicotine/gtkgui/ui/search.ui:351
 msgid "Search result filter help"
 msgstr ""
 
@@ -5319,10 +5350,6 @@ msgid ""
 "username, try choosing another one."
 msgstr ""
 
-#: pynicotine/gtkgui/ui/settings/network.ui:70
-msgid "Username:"
-msgstr ""
-
 #: pynicotine/gtkgui/ui/settings/network.ui:140
 msgid "Connection"
 msgstr ""
@@ -5445,18 +5472,22 @@ msgid "MPRIS (v2)"
 msgstr ""
 
 #: pynicotine/gtkgui/ui/settings/nowplaying.ui:54
+msgid "Listenbrainz"
+msgstr ""
+
+#: pynicotine/gtkgui/ui/settings/nowplaying.ui:62
 msgid "Other"
 msgstr ""
 
-#: pynicotine/gtkgui/ui/settings/nowplaying.ui:106
+#: pynicotine/gtkgui/ui/settings/nowplaying.ui:114
 msgid "Now Playing Format"
 msgstr ""
 
-#: pynicotine/gtkgui/ui/settings/nowplaying.ui:135
+#: pynicotine/gtkgui/ui/settings/nowplaying.ui:143
 msgid "Now Playing message format:"
 msgstr ""
 
-#: pynicotine/gtkgui/ui/settings/nowplaying.ui:186
+#: pynicotine/gtkgui/ui/settings/nowplaying.ui:194
 msgid "Test Configuration"
 msgstr ""
 
@@ -5772,7 +5803,6 @@ msgid "Handler:"
 msgstr ""
 
 #: pynicotine/gtkgui/ui/settings/userinfo.ui:17
-#: pynicotine/gtkgui/ui/userinfo.ui:47
 msgid "Self Description"
 msgstr ""
 
@@ -6042,24 +6072,28 @@ msgstr ""
 msgid "Clear Uploa_ds..."
 msgstr ""
 
-#: pynicotine/gtkgui/ui/userbrowse.ui:103
+#: pynicotine/gtkgui/ui/userbrowse.ui:111
 msgid "Shared"
 msgstr ""
 
-#: pynicotine/gtkgui/ui/userbrowse.ui:158
+#: pynicotine/gtkgui/ui/userbrowse.ui:166
 msgid "Search files and folders (exact match)"
 msgstr ""
 
-#: pynicotine/gtkgui/ui/userbrowse.ui:166
+#: pynicotine/gtkgui/ui/userbrowse.ui:174
 msgid "Save shares list to disk"
 msgstr ""
 
-#: pynicotine/gtkgui/ui/userbrowse.ui:179
+#: pynicotine/gtkgui/ui/userbrowse.ui:187
 msgid "Refresh files"
 msgstr ""
 
+#: pynicotine/gtkgui/ui/userinfo.ui:47
+msgid "User Description"
+msgstr ""
+
 #: pynicotine/gtkgui/ui/userinfo.ui:92
-msgid "Information"
+msgid "User Information"
 msgstr ""
 
 #: pynicotine/gtkgui/ui/userinfo.ui:112
@@ -6082,8 +6116,12 @@ msgstr ""
 msgid "Shared Files"
 msgstr ""
 
+#: pynicotine/gtkgui/ui/userinfo.ui:320
+msgid "User Interests"
+msgstr ""
+
 #: pynicotine/gtkgui/ui/userinfo.ui:382
-msgid "Picture"
+msgid "User Picture"
 msgstr ""
 
 #: pynicotine/gtkgui/ui/userinfo.ui:580

--- a/pynicotine/gtkgui/settingswindow.py
+++ b/pynicotine/gtkgui/settingswindow.py
@@ -2463,6 +2463,8 @@ class NowPlayingFrame(BuildFrame):
             player = "lastfm"
         elif self.NP_mpris.get_active():
             player = "mpris"
+        elif self.NP_listenbrainz.get_active():
+            player = "listenbrainz"
         elif self.NP_other.get_active():
             player = "other"
 
@@ -2478,6 +2480,8 @@ class NowPlayingFrame(BuildFrame):
 
         if player == "lastfm":
             self.NP_lastfm.set_active(True)
+        elif player == 'listenbrainz':
+            self.NP_listenbrainz.set_active(True)
         elif player == "other":
             self.NP_other.set_active(True)
         else:
@@ -2492,6 +2496,10 @@ class NowPlayingFrame(BuildFrame):
         elif self.NP_mpris.get_active():
             self.player_replacers = ["$n", "$p", "$a", "$b", "$t", "$y", "$c", "$r", "$k", "$l", "$f"]
             self.player_input.set_text(_("Client name (e.g. amarok, audacious, exaile) or empty for auto:"))
+
+        elif self.NP_listenbrainz.get_active():
+            self.player_replacers = ["$n", "$t", "$a", "$b"]
+            self.player_input.set_text(_("Username:"))
 
         elif self.NP_other.get_active():
             self.player_replacers = ["$n"]

--- a/pynicotine/gtkgui/ui/settings/nowplaying.ui
+++ b/pynicotine/gtkgui/ui/settings/nowplaying.ui
@@ -50,6 +50,14 @@
               </object>
             </child>
             <child>
+              <object class="GtkRadioButton" id="NP_listenbrainz">
+                <property name="label" translatable="yes">Listenbrainz</property>
+                <property name="visible">1</property>
+                <property name="group">NP_lastfm</property>
+                <signal name="toggled" handler="update_now_playing_info" swapped="no"/>
+              </object>
+            </child>
+            <child>
               <object class="GtkRadioButton" id="NP_other">
                 <property name="label" translatable="yes">Other</property>
                 <property name="visible">1</property>

--- a/pynicotine/nowplaying.py
+++ b/pynicotine/nowplaying.py
@@ -73,6 +73,8 @@ class NowPlaying:
         try:
             if player == "lastfm":
                 result = self.lastfm(command)
+            elif player == 'listenbrainz':
+                result = self.listenbrainz(command)
             elif player == "other":
                 result = self.other(command)
             elif player == "mpris":
@@ -258,6 +260,42 @@ class NowPlaying:
             self.title['nowplaying'] += " - " + self.title['title']
 
         return True
+
+    def listenbrainz(self, username):
+        """ Function to get the currently playing song listenbrainz api """
+
+        import json
+
+        if not username:
+            log.add_important_error(_('listenbrainz: Please provide your listenbrainz username'))
+            return None
+
+        try:
+            response = http_request('https', 'api.listenbrainz.org', f'/1/user/{username}/playing-now',
+                                    headers={'User-Agent': 'Nicotine+'})
+
+        except Exception as error:
+            log.add_important_error(_('listenbrainz: Could not connect to listenbrainz: %(error)s'), {'error': error})
+            return None
+
+        try:
+            json_api = json.loads(response)['payload']
+            if not json_api['playing_now']:
+                log.add_important_error(_('listenbrainz: You don\'t seem to be listening to anything right now'))
+                return None
+            track = json_api['listens'][0]['track_metadata']
+
+            self.title['artist'] = track['artist_name']
+            self.title['title'] = track['track_name']
+            self.title['album'] = track['release_name']
+            self.title['nowplaying'] = '%s: %s - %s - %s' % (
+                _('Playing now'), self.title['artist'], self.title['album'], self.title['title'])
+
+            return True
+        except Exception:
+            log.add_important_error(_('listenbrainz: Could not get current track from listenbrainz: %(error)s'),
+                                    {'error': str(response)})
+        return None
 
     def other(self, command):
 

--- a/pynicotine/nowplaying.py
+++ b/pynicotine/nowplaying.py
@@ -271,7 +271,8 @@ class NowPlaying:
             return None
 
         try:
-            response = http_request('https', 'api.listenbrainz.org', f'/1/user/{username}/playing-now',
+            response = http_request('https', 'api.listenbrainz.org',
+                                    '/1/user/{}/playing-now'.format(username),
                                     headers={'User-Agent': 'Nicotine+'})
 
         except Exception as error:


### PR DESCRIPTION
Add `/now` integration for [Listenbrainz](http://listenbrainz.org/). 

Sadly I cannot test it myself as I cannot run N+ from source atm as outlined in [this comment](https://github.com/Nachtalb/more-upload-stats/issues/1#issuecomment-912893610). **If someone else could take over from here that'd be mighty fine.**

The main integration of getting the song should basically work tho as I have tested it in a small plugin I wrote: https://github.com/Nachtalb/listenbrainz_now/blob/3bc9a23dc7454f04c2d14bf935b7da263fe502a6/listenbrainz_now/__init__.py#L29-L51

I'd still like to contribute as much as possible ^_____^  As soon as I am able to test the stuff myself I'll flood you with PRs or something...

During the po update, I get the following error. As such, I can't update the locals myself. There is a way to get around it, by adding an encoding comment at the top of the files. But then comes the next and the next and so on... I don't know where the problem lies (maybe I am missing some libs?)
```
running update_pot
xgettext: Non-ASCII string at pynicotine/geoip/geoip.py:36.
          Please specify the source encoding through --from-code or through a comment
          as specified in http://www.python.org/peps/pep-0263.html.
```