### PR TITLE
 Show essential Download operations in status bar 

### DIFF
--- a/pynicotine/transfers.py
+++ b/pynicotine/transfers.py
@@ -2323,7 +2323,7 @@ class Transfers:
                     }
                 )
                 log.add(
-                    _("Download stopped: %(file)s from user %(user)s"), {
+                    ("Download stopped: %(file)s from user %(user)s"), {
                         "file": clean_file(transfer.filename.replace('/', '\\').split('\\')[-1]),
                         "user": transfer.user
                     }

--- a/pynicotine/transfers.py
+++ b/pynicotine/transfers.py
@@ -1112,7 +1112,7 @@ class Transfers:
                         )
                         
                         log.add(
-                            _("Download started: %(file)s from user %(user)s"), {
+                            ("Download started: %(file)s from user %(user)s"), {
                                 "file": "%s" % base_name,
                                 "user": i.user
                             }
@@ -1965,7 +1965,7 @@ class Transfers:
         )
 
         log.add(
-            _("Download finished: %(file)s from user %(user)s"), {
+            ("Download finished: %(file)s from user %(user)s"), {
                 'file': basename,
                 'user': i.user
             }


### PR DESCRIPTION
The client feels more responsive to Download 'started' / 'finished' / 'already downloaded' / 'stopped' (includes Resume / Pause / Clear UI actions) when the status bar text is updated with standard log messages. Transfer log functionality is unaffected.