### PR TITLE
Various improvements to plugin system

### DIFF
--- a/pynicotine/plugins/anti_shout/__init__.py
+++ b/pynicotine/plugins/anti_shout/__init__.py
@@ -22,19 +22,24 @@ from pynicotine.pluginsystem import BasePlugin
 
 class Plugin(BasePlugin):
 
-    __name__ = "Anti SHOUT"
-    settings = {
-        'maxscore': 0.6,
-        'minlength': 10,
-    }
-    metasettings = {
-        'maxscore': {
-            'description': 'The maximum ratio capitals/noncapitals before fixing capitalization',
-            'type': 'float', 'minimum': 0, 'maximum': 1, 'stepsize': 0.1},
-        'minlength': {
-            'description': 'Lines shorter than this never not be altered', 'type': 'integer',
-            'minimum': 0},
-    }
+    def __init__(self, *args, **kwargs):
+
+        super().__init__(*args, **kwargs)
+
+        self.settings = {
+            'maxscore': 0.6,
+            'minlength': 10
+        }
+        self.metasettings = {
+            'maxscore': {
+                'description': 'The maximum ratio capitals/noncapitals before fixing capitalization',
+                'type': 'float', 'minimum': 0, 'maximum': 1, 'stepsize': 0.1
+            },
+            'minlength': {
+                'description': 'Lines shorter than this never not be altered', 'type': 'integer',
+                'minimum': 0
+            }
+        }
 
     @staticmethod
     def capitalize(text):

--- a/pynicotine/plugins/examplars/memory_debugger/__init__.py
+++ b/pynicotine/plugins/examplars/memory_debugger/__init__.py
@@ -25,9 +25,9 @@ from pynicotine.pluginsystem import BasePlugin
 
 class Plugin(BasePlugin):
 
-    __name__ = "Memory Debugger"
+    def __init__(self, *args, **kwargs):
 
-    def init(self):
+        super().__init__(*args, **kwargs)
 
         self.log(
             "Tweaking garbage collection. Is it currently turned on? %s\n"
@@ -44,7 +44,7 @@ class Plugin(BasePlugin):
             self.log("Forcing collection of generation %s...", str(i))
             gc.collect(i)
 
-        unclaimed = ['A total of %s objects that could not be freed:' % (len(gc.garbage),)]
+        unclaimed = ['A total of %s objects that could not be freed:' % len(gc.garbage)]
 
         for i in gc.garbage:
             unclaimed.append('%s: %s (%s)' % (type(i), str(i), repr(i)))

--- a/pynicotine/plugins/examplars/preferences/choices.py
+++ b/pynicotine/plugins/examplars/preferences/choices.py
@@ -20,27 +20,33 @@ from pynicotine.pluginsystem import BasePlugin
 
 
 class Plugin(BasePlugin):
+    """ Radio Button/Dropdown Example """
 
-    __name__ = "Radio Button/Dropdown Example"
-    settings = {
-        'player_radio': 2,                # id, starts from 0
-        'player_dropdown': 'Clementine',  # can be either string or id starting from 0
-    }
-    metasettings = {
-        'player_radio': {
-            'description': 'Choose an audio player',
-            'type': 'radio',
-            'options': (
-                'Exaile',
-                'Audacious',
-                'Clementine'
-            )},
-        'player_dropdown': {
-            'description': 'Choose an audio player',
-            'type': 'dropdown',
-            'options': (
-                'Exaile',
-                'Audacious',
-                'Clementine'
-            )}
-    }
+    def __init__(self, *args, **kwargs):
+
+        super().__init__(*args, **kwargs)
+
+        self.settings = {
+            'player_radio': 2,                # id, starts from 0
+            'player_dropdown': 'Clementine'   # can be either string or id starting from 0
+        }
+        self.metasettings = {
+            'player_radio': {
+                'description': 'Choose an audio player',
+                'type': 'radio',
+                'options': (
+                    'Exaile',
+                    'Audacious',
+                    'Clementine'
+                )
+            },
+            'player_dropdown': {
+                'description': 'Choose an audio player',
+                'type': 'dropdown',
+                'options': (
+                    'Exaile',
+                    'Audacious',
+                    'Clementine'
+                )
+            }
+        }

--- a/pynicotine/plugins/examplars/preferences/filechooser.py
+++ b/pynicotine/plugins/examplars/preferences/filechooser.py
@@ -20,24 +20,28 @@ from pynicotine.pluginsystem import BasePlugin
 
 
 class Plugin(BasePlugin):
+    """ File Chooser Example"""
 
-    __name__ = "File Chooser Example"
-    settings = {
-        'file': '/home/example/file.pdf',
-        'folder': '/home/example/folder',
-        'image': '/home/example/image.jpg',
-    }
-    metasettings = {
-        'file': {
-            'description': 'Select a file',
-            'type': 'file',
-            'chooser': 'file'},
-        'folder': {
-            'description': 'Select a folder',
-            'type': 'file',
-            'chooser': 'folder'},
-        'image': {
-            'description': 'Select an image',
-            'type': 'file',
-            'chooser': 'image'},
-    }
+    def __init__(self, *args, **kwargs):
+
+        super().__init__(*args, **kwargs)
+
+        self.settings = {
+            'file': '/home/example/file.pdf',
+            'folder': '/home/example/folder',
+            'image': '/home/example/image.jpg',
+        }
+        self.metasettings = {
+            'file': {
+                'description': 'Select a file',
+                'type': 'file',
+                'chooser': 'file'},
+            'folder': {
+                'description': 'Select a folder',
+                'type': 'file',
+                'chooser': 'folder'},
+            'image': {
+                'description': 'Select an image',
+                'type': 'file',
+                'chooser': 'image'},
+        }

--- a/pynicotine/plugins/leech_detector/__init__.py
+++ b/pynicotine/plugins/leech_detector/__init__.py
@@ -1,5 +1,3 @@
-# pylint: disable=attribute-defined-outside-init
-
 # COPYRIGHT (C) 2020-2021 Nicotine+ Team
 # COPYRIGHT (C) 2011 Quinox <quinox@users.sf.net>
 #
@@ -25,31 +23,39 @@ from pynicotine.pluginsystem import BasePlugin
 
 class Plugin(BasePlugin):
 
-    __name__ = "Leech Detector"
-    settings = {
-        'message': 'Please consider sharing more files before downloading from me. Thanks :)',
-        'num_files': 1,
-        'num_folders': 1,
-        'open_private_chat': True
-    }
-    metasettings = {
-        'message': {
-            'description': 'Message to send to leechers. New lines are sent as separate messages, '
-                           + 'too many lines may get you tempbanned for spam!',
-            'type': 'textview'},
-        'num_files': {
-            'description': 'Least required number of shared files',
-            'type': 'int', 'minimum': 1},
-        'num_folders': {
-            'description': 'Least required number of shared folders',
-            'type': 'int', 'minimum': 1},
-        'open_private_chat': {
-            'description': 'Open private chat tabs when sending messages to leechers',
-            'type': 'bool'},
-    }
+    def __init__(self, *args, **kwargs):
 
-    def init(self):
+        super().__init__(*args, **kwargs)
+
+        self.settings = {
+            'message': 'Please consider sharing more files before downloading from me. Thanks :)',
+            'num_files': 1,
+            'num_folders': 1,
+            'open_private_chat': True
+        }
+        self.metasettings = {
+            'message': {
+                'description': ('Message to send to leechers. New lines are sent as separate messages, '
+                                'too many lines may get you tempbanned for spam!'),
+                'type': 'textview'
+            },
+            'num_files': {
+                'description': 'Least required number of shared files',
+                'type': 'int', 'minimum': 1
+            },
+            'num_folders': {
+                'description': 'Least required number of shared folders',
+                'type': 'int', 'minimum': 1
+            },
+            'open_private_chat': {
+                'description': 'Open private chat tabs when sending messages to leechers',
+                'type': 'bool'
+            }
+        }
+
         self.probed = {}
+
+    def loaded_notification(self):
 
         min_num_files = self.metasettings['num_files']['minimum']
         min_num_folders = self.metasettings['num_folders']['minimum']

--- a/pynicotine/plugins/multipaste/__init__.py
+++ b/pynicotine/plugins/multipaste/__init__.py
@@ -24,15 +24,24 @@ from pynicotine.pluginsystem import returncode
 
 class Plugin(BasePlugin):
 
-    __name__ = "Multi Paste"
-    settings = {
-        'maxpubliclines': 4,
-        'maxprivatelines': 8,
-    }
-    metasettings = {
-        'maxpubliclines': {"description": 'The maximum number of lines that will pasted in public', 'type': 'int'},
-        'maxprivatelines': {"description": 'The maximum number of lines that will be pasted in private', 'type': 'int'},
-    }
+    def __init__(self, *args, **kwargs):
+
+        super().__init__(*args, **kwargs)
+
+        self.settings = {
+            'maxpubliclines': 4,
+            'maxprivatelines': 8
+        }
+        self.metasettings = {
+            'maxpubliclines': {
+                "description": 'The maximum number of lines that will pasted in public',
+                'type': 'int'
+            },
+            'maxprivatelines': {
+                "description": 'The maximum number of lines that will be pasted in private',
+                'type': 'int'
+            }
+        }
 
     def outgoing_private_chat_event(self, user, line):
 

--- a/pynicotine/plugins/now_playing_search/__init__.py
+++ b/pynicotine/plugins/now_playing_search/__init__.py
@@ -23,8 +23,6 @@ from pynicotine.pluginsystem import BasePlugin
 
 class Plugin(BasePlugin):
 
-    __name__ = "Now Playing Search"
-
     def outgoing_global_search_event(self, text):
         return (self.get_np(text),)
 

--- a/pynicotine/plugins/now_playing_sender/__init__.py
+++ b/pynicotine/plugins/now_playing_sender/__init__.py
@@ -1,5 +1,3 @@
-# pylint: disable=attribute-defined-outside-init
-
 # COPYRIGHT (C) 2020-2021 Nicotine+ Team
 #
 # GNU GENERAL PUBLIC LICENSE
@@ -24,15 +22,19 @@ from pynicotine.pluginsystem import BasePlugin
 
 class Plugin(BasePlugin):
 
-    __name__ = "MPRIS Now Playing Sender"
-    settings = {
-        'rooms': ['testroom'],
-    }
-    metasettings = {
-        'rooms': {'description': 'Rooms to broadcast in', 'type': 'list string'},
-    }
+    def __init__(self, *args, **kwargs):
 
-    def init(self):
+        super().__init__(*args, **kwargs)
+
+        self.settings = {
+            'rooms': ['testroom']
+        }
+        self.metasettings = {
+            'rooms': {
+                'description': 'Rooms to broadcast in',
+                'type': 'list string'
+            }
+        }
 
         self.last_song_url = ""
         self.stop = False

--- a/pynicotine/plugins/plugin_debugger/__init__.py
+++ b/pynicotine/plugins/plugin_debugger/__init__.py
@@ -22,10 +22,26 @@ from pynicotine.pluginsystem import BasePlugin
 
 class Plugin(BasePlugin):
 
-    __name__ = "Plugin Debugger"
+    def __init__(self, *args, **kwargs):
+
+        super().__init__(*args, **kwargs)
+
+        self.log('__init__')
 
     def init(self):
-        self.log('init')
+        self.log('Init')
+
+    def disable(self):
+        self.log('Disable')
+
+    def loaded_notification(self):
+        self.log('LoadedNotification')
+
+    def unloaded_notification(self):
+        self.log('UnloadedNotification')
+
+    def shutdown_notification(self):
+        self.log('ShutdownNotification')
 
     def public_room_message_notification(self, room, user, line):
         self.log('PublicRoomMessageNotification, room=%s, user=%s, line=%s', (room, user, line))
@@ -107,6 +123,3 @@ class Plugin(BasePlugin):
     def download_finished_notification(self, user, virtual_path, real_path):
         self.log('DownloadFinishedNotification, user=%s, virtual_path=%s, real_path=%s',
                  (user, virtual_path, real_path))
-
-    def shutdown_notification(self):
-        self.log('ShutdownNotification')

--- a/pynicotine/plugins/reddit/__init__.py
+++ b/pynicotine/plugins/reddit/__init__.py
@@ -38,13 +38,22 @@ from pynicotine.utils import http_request
 
 class Plugin(BasePlugin):
 
-    __name__ = "Reddit"
-    settings = {'reddit_links': 3}
-    metasettings = {'reddit_links': {"description": 'Maximum number of links to provide', 'type': 'integer'}}
+    def __init__(self, *args, **kwargs):
 
-    def init(self):
+        super().__init__(*args, **kwargs)
+
+        self.settings = {
+            'reddit_links': 3
+        }
+        self.metasettings = {
+            'reddit_links': {
+                'description': 'Maximum number of links to provide',
+                'type': 'integer'
+            }
+        }
+
         self.plugin_command = "!reddit"
-        self.responder = ResponseThrottle(self.core, self.__name__)
+        self.responder = ResponseThrottle(self.core, self.human_name)
 
     def incoming_public_chat_notification(self, room, user, line):
         line = line.lower().strip()

--- a/pynicotine/plugins/spamfilter/__init__.py
+++ b/pynicotine/plugins/spamfilter/__init__.py
@@ -24,27 +24,37 @@ from pynicotine.pluginsystem import returncode
 
 class Plugin(BasePlugin):
 
-    __name__ = "Spamfilter"
-    settings = {
-        'minlength': 200,
-        'maxlength': 400,
-        'maxdiffcharacters': 10,
-        'badprivatephrases': ['buy viagra now', 'mybrute.com', 'mybrute.es', '0daymusic.biz']
-    }
-    metasettings = {
-        'minlength': {"description": (
-                      'The minimum length of a line before it\'s considered as ASCII spam'),
-                      'type': 'integer'},
-        'maxdiffcharacters': {"description": (
-                              'The maximum number of different characters that is still considered ASCII spam'),
-                              'type': 'integer'},
-        'maxlength': {"description": 'The maximum length of a line before it\'s considered as spam.',
-                      'type': 'integer'},
-        'badprivatephrases': {"description": 'Filter chat room and private messages containing the following phrases:',
-                              'type': 'list string'},
-    }
+    def __init__(self, *args, **kwargs):
 
-    def init(self):
+        super().__init__(*args, **kwargs)
+
+        self.settings = {
+            'minlength': 200,
+            'maxlength': 400,
+            'maxdiffcharacters': 10,
+            'badprivatephrases': ['buy viagra now', 'mybrute.com', 'mybrute.es', '0daymusic.biz']
+        }
+        self.metasettings = {
+            'minlength': {
+                'description': 'The minimum length of a line before it\'s considered as ASCII spam',
+                'type': 'integer'
+            },
+            'maxdiffcharacters': {
+                'description': 'The maximum number of different characters that is still considered ASCII spam',
+                'type': 'integer'
+            },
+            'maxlength': {
+                'description': 'The maximum length of a line before it\'s considered as spam.',
+                'type': 'integer'
+            },
+            'badprivatephrases': {
+                'description': 'Filter chat room and private messages containing the following phrases:',
+                'type': 'list string'
+            }
+        }
+
+    def loaded_notification(self):
+
         self.log('A line should be at least %s long with a maximum of %s different characters '
                  'before it\'s considered ASCII spam.',
                  (self.settings['minlength'], self.settings['maxdiffcharacters']))

--- a/pynicotine/plugins/testreplier/__init__.py
+++ b/pynicotine/plugins/testreplier/__init__.py
@@ -25,18 +25,21 @@ from pynicotine.pluginsystem import BasePlugin, ResponseThrottle
 
 class Plugin(BasePlugin):
 
-    __name__ = "Test Replier"
-    settings = {
-        'replies': ['Test failed.']
-    }
-    metasettings = {
-        'replies': {
-            'description': 'Replies:',
-            'type': 'list string'}
-    }
+    def __init__(self, *args, **kwargs):
 
-    def init(self):
-        self.throttle = ResponseThrottle(self.core, self.__name__)
+        super().__init__(*args, **kwargs)
+
+        self.settings = {
+            'replies': ['Test failed.']
+        }
+        self.metasettings = {
+            'replies': {
+                'description': 'Replies:',
+                'type': 'list string'
+            }
+        }
+
+        self.throttle = ResponseThrottle(self.core, self.human_name)
 
     def incoming_public_chat_event(self, room, user, line):
 

--- a/pynicotine/plugins/youtube_info/__init__.py
+++ b/pynicotine/plugins/youtube_info/__init__.py
@@ -28,31 +28,37 @@ from pynicotine.utils import humanize
 
 class Plugin(BasePlugin):
 
-    __name__ = 'YouTube Info'
+    def __init__(self, *args, **kwargs):
 
-    settings = {
-        'api_key': '',
-        'color': 'Local',
-        'format': [
-            '* Title: %title%',
-            '* Duration: %duration% - Views: %views%']
-    }
-    metasettings = {
-        'api_key': {
-            'description': 'YouTube Data v3 API key:',
-            'type': 'string'},
-        'color': {
-            'description': 'Message color:',
-            'type': 'dropdown',
-            'options': ('Remote', 'Local', 'Action', 'Hilite')},
-        'format': {
-            'description': 'Message format',
-            'type': 'list string'}
-    }
-    last_video_id = {
-        'private': {},
-        'public': {}
-    }
+        super().__init__(*args, **kwargs)
+
+        self.settings = {
+            'api_key': '',
+            'color': 'Local',
+            'format': [
+                '* Title: %title%',
+                '* Duration: %duration% - Views: %views%']
+        }
+        self.metasettings = {
+            'api_key': {
+                'description': 'YouTube Data v3 API key:',
+                'type': 'string'
+            },
+            'color': {
+                'description': 'Message color:',
+                'type': 'dropdown',
+                'options': ('Remote', 'Local', 'Action', 'Hilite')
+            },
+            'format': {
+                'description': 'Message format',
+                'type': 'list string'
+            }
+        }
+
+        self.last_video_id = {
+            'private': {},
+            'public': {}
+        }
 
     def incoming_public_chat_notification(self, room, user, line):
 


### PR DESCRIPTION
- Remove the `__name__` BasePlugin class attribute. Automatically set `internal_name` (plugin folder name) and `human_name` (human-readable name) attributes when the plugin loads.
- Remove arguments from BasePlugin's `__init__` function, allow plugins to safely use this function if they want. Avoids Pylint's "attribute-defined-outside-init" warning.
- Add new notifications:
  - `loaded_notification`: plugin has finished loading (settings are loaded)
  - `unloaded_notification`: plugin has finished unloading
- Allow unified commands (for both public and private chats) to be defined in the `__commands__` attribute. `__publiccommands__` and `__privatecommands__` can still be used if unified commands aren't desired.

All changes in this PR are backwards compatible.