### PR TITLE
Status bar always shows text

### DIFF
--- a/pynicotine/gtkgui/frame.py
+++ b/pynicotine/gtkgui/frame.py
@@ -730,7 +730,6 @@ class NicotineFrame(UserInterface):
     def set_show_log(self, show):
 
         if show:
-            self.set_status_text("")
             self.DebugLog.show()
             self.log_textview.scroll_bottom()
         else:
@@ -2212,7 +2211,7 @@ class NicotineFrame(UserInterface):
             message_dialog(parent=self.application.get_active_window(), title=title, message=msg)
             return
 
-        if config.sections["logging"]["logcollapsed"]:
+        if level not in ("connection", "message", "miscellaneous"):
             self.set_status_text(msg)
 
         self.log_textview.append_line(msg, find_urls=False)

--- a/pynicotine/gtkgui/frame.py
+++ b/pynicotine/gtkgui/frame.py
@@ -2211,6 +2211,7 @@ class NicotineFrame(UserInterface):
             message_dialog(parent=self.application.get_active_window(), title=title, message=msg)
             return
 
+        # Keep verbose debug messages out of Statusbar to make it more useful
         if level not in ("connection", "message", "miscellaneous"):
             self.set_status_text(msg)
 


### PR DESCRIPTION
... even when the Log Pane is visible (otherwise, this is just wasted space that could be better used).