### PR TITLE
Wishlist: Add Shift+Delete shortcut and Keyboard Accessibility Improvements

### DIFF
--- a/pynicotine/gtkgui/ui/popovers/wishlist.ui
+++ b/pynicotine/gtkgui/ui/popovers/wishlist.ui
@@ -14,7 +14,7 @@
           <object class="GtkLabel">
             <property name="visible">1</property>
             <property name="xalign">0</property>
-            <property name="label" translatable="yes">Wishlist items are auto-searched at regular intervals, useful for discovering uncommon files.</property>
+            <property name="label" translatable="yes">Wishlist items are auto-searched at regular intervals, for discovering uncommon files.</property>
             <property name="max-width-chars">55</property>
             <property name="wrap">1</property>
             <property name="mnemonic_widget">list_view</property>
@@ -24,7 +24,7 @@
           <object class="GtkEntry" id="wish_entry">
             <property name="visible">1</property>
             <property name="hexpand">1</property>
-            <property name="placeholder-text" translatable="yes">Add search term...</property>
+            <property name="placeholder-text" translatable="yes">Add Wish...</property>
             <property name="primary-icon-name">list-add-symbolic</property>
             <signal name="activate" handler="on_add_wish" swapped="no"/>
             <signal name="icon-press" handler="on_add_wish" swapped="no"/>
@@ -77,13 +77,14 @@
                             <child>
                               <object class="GtkImage">
                                 <property name="visible">1</property>
-                                <property name="icon-name">edit-clear-symbolic</property>
+                                <property name="icon-name">list-remove-symbolic</property>
                               </object>
                             </child>
                             <child>
                               <object class="GtkLabel">
                                 <property name="visible">1</property>
-                                <property name="label" translatable="yes">_Remove</property>
+                                <property name="label" translatable="yes">R_emove Wish</property>
+                                <property name="tooltip-text">Shift+Delete</property>
                                 <property name="use-underline">1</property>
                               </object>
                             </child>
@@ -116,7 +117,7 @@
                                 <child>
                                   <object class="GtkLabel">
                                     <property name="visible">1</property>
-                                    <property name="label" translatable="yes">_Clear All...</property>
+                                    <property name="label" translatable="yes">Clear All...</property>
                                     <property name="use-underline">1</property>
                                   </object>
                                 </child>

--- a/pynicotine/gtkgui/wishlist.py
+++ b/pynicotine/gtkgui/wishlist.py
@@ -240,14 +240,15 @@ class WishList(UserInterface):
                 break
 
         if not text:
+            self.list_view.get_selection().unselect_all()
             return
 
         if text in self.wishes:
             # Highlight existing wish row
 
             iterator = self.wishes[text]
-            self.wish_entry.set_text("")
             self.list_view.set_cursor(self.store.get_path(iterator))
+            self.wish_entry.set_text("")
             self.list_view.grab_focus()
             return
 

--- a/pynicotine/gtkgui/wishlist.py
+++ b/pynicotine/gtkgui/wishlist.py
@@ -89,19 +89,13 @@ class WishList(UserInterface):
         if value and not value.isspace():
             self.remove_wish(old_value)
             self.add_wish(value)
-            self.list_view.set_cursor(self.store.get_path(self.wishes[value]))
 
     def on_add_wish(self, *args):
 
         wish = self.wish_entry.get_text()
-
-        if not wish:
-            return None
+        self.wish_entry.set_text("")
 
         self.add_wish(wish)
-
-        self.wish_entry.set_text("")
-        self.list_view.set_cursor(self.store.get_path(self.wishes[wish]))
 
     def on_remove_wish(self, *args):
 
@@ -146,6 +140,7 @@ class WishList(UserInterface):
 
         if wish not in self.wishes:
             self.wishes[wish] = self.store.insert_with_valuesv(-1, self.column_numbers, [wish])
+            self.list_view.set_cursor(self.store.get_path(self.wishes[wish]))
 
         self.searches.searches[search_id] = {"id": search_id, "term": wish, "tab": None, "mode": "wishlist",
                                              "ignore": True}
@@ -237,7 +232,7 @@ class WishList(UserInterface):
 
         text = self.searches.notebook.get_tab_label(page).full_text
 
-        if text.startswith("(Wish) "):
+        if text.startswith("(Wish) "):  # ToDo: get search tab tooltip text instead
             text = text[7:]
 
         if text in self.wishes:
@@ -247,10 +242,9 @@ class WishList(UserInterface):
             self.wish_entry.set_text("")
             self.list_view.set_cursor(self.store.get_path(iterator))
             self.list_view.grab_focus()
+            return
 
-        else:
-            # Pre-fill text field with search term from active search tab
-
-            self.list_view.get_selection().unselect_all()
-            self.wish_entry.set_text(text)
-            self.wish_entry.grab_focus()
+        # Pre-fill text field with search term from active search tab
+        self.list_view.get_selection().unselect_all()
+        self.wish_entry.set_text(text)
+        self.wish_entry.grab_focus()

--- a/pynicotine/gtkgui/wishlist.py
+++ b/pynicotine/gtkgui/wishlist.py
@@ -68,6 +68,8 @@ class WishList(UserInterface):
             render.connect('edited', self.cell_edited_callback, self.list_view, 0)
 
         setup_accelerator("<Shift>Delete", self.main, self.on_remove_wish_accelerator)
+        setup_accelerator("<Shift>Delete", self.wish_entry, self.on_remove_wish_accelerator)
+        setup_accelerator("<Shift>Tab", self.list_view, self.on_list_focus_entry_accelerator)  # skip column header
 
         if Gtk.get_major_version() == 4:
             button = frame.WishList.get_first_child()
@@ -107,6 +109,7 @@ class WishList(UserInterface):
             self.remove_wish(wish)
 
         self.list_view.get_selection().unselect_all()
+        self.wish_entry.grab_focus()
 
     def on_remove_wish_accelerator(self, *args):
         """ Shift+Delete: Remove Wish """
@@ -121,6 +124,8 @@ class WishList(UserInterface):
         if response_id == Gtk.ResponseType.OK:
             for wish in self.wishes.copy():
                 self.remove_wish(wish)
+
+        self.wish_entry.grab_focus()
 
     def on_clear_wishlist(self, *args):
 
@@ -222,6 +227,10 @@ class WishList(UserInterface):
 
         for widget in list(self.__dict__.values()):
             update_widget_visuals(widget)
+
+    def on_list_focus_entry_accelerator(self, *args):
+        self.wish_entry.grab_focus()
+        return True
 
     def on_show(self, *args):
 

--- a/pynicotine/gtkgui/wishlist.py
+++ b/pynicotine/gtkgui/wishlist.py
@@ -115,7 +115,7 @@ class WishList(UserInterface):
         self.list_view.get_selection().unselect_all()
 
     def on_remove_wish_accelerator(self, *args):
-        """ Delete: Remove Wish """
+        """ Shift+Delete: Remove Wish """
 
         self.on_remove_wish()
         return True

--- a/pynicotine/gtkgui/wishlist.py
+++ b/pynicotine/gtkgui/wishlist.py
@@ -230,10 +230,17 @@ class WishList(UserInterface):
         if page is None:
             return
 
-        text = self.searches.notebook.get_tab_label(page).full_text
+        text = None
 
-        if text.startswith("(Wish) "):  # ToDo: get search tab tooltip text instead
-            text = text[7:]
+        for search in self.searches.searches.values():
+            tab = search.get("tab")
+
+            if tab is not None and tab.Main == page:
+                text = tab.text
+                break
+
+        if not text:
+            return
 
         if text in self.wishes:
             # Highlight existing wish row


### PR DESCRIPTION
... also fixed UI bugs:

- Fixed: Items starting with `"(Wish) "` appear in the TextEntry when opening the Wishlist popover.

- Fixed: Irrelevant listitem selected after deleting an item.

- Fixed: Incorrect listitem selected after renaming an item.

- Fixed: Incorrect or none highlighted listitem when adding a new Wish.

- Fixed: Existing wish not highlighted if it's (Wish) tab is open.

- Fixed: Shift+Tab key navigation trapped on column header when moving focus between widgets. 
...

...and in wishlist.ui minor UI bugs and accessibility improvements:

- Added: ToolTop for Shift+Delete on the Remove Wish button.

- Fixed: Resolved mnemonic conflict with _Result Filters that meant shortcut had to be pressed twice to Remove item.

- Changed: Duplicate icon used for both buttons, changed to match same in Search Files and label to "Remove Wish"

- Changed: Label string too long causing ugly wrapped text, removed unnecessary word "useful".

- Changed: placeholder text to "Add Wish..." because "Add search term..." was ambiguous with main search entry.

- Removed: Alt+_C mnemonic from risky Clear All button because this is too similar to Copy.