### PR TITLE
Leech Detector: Reduce aggressiveness

### DIFF
--- a/pynicotine/plugins/leech_detector/PLUGININFO
+++ b/pynicotine/plugins/leech_detector/PLUGININFO
@@ -1,4 +1,4 @@
-Version = "2021-07-24r00"
+Version = "2021-10-27r00"
 Authors = ['Nicotine+ Team']
 Name = "Leech Detector"
-Description = "Detects when leechers are downloading, and sends them a message"
+Description = "Detects when leechers are downloading, and sends them a message after a file is leeched."

--- a/pynicotine/plugins/leech_detector/__init__.py
+++ b/pynicotine/plugins/leech_detector/__init__.py
@@ -107,7 +107,7 @@ class Plugin(BasePlugin):
             return
 
         if stats['files'] == 0 and stats['dirs'] == 0:
-            ## ToDo: Implement alternate fallback method (num_files | num_folders) from Browse Shares (Issue #1565) ##
+            # ToDo: Implement alternate fallback method (num_files | num_folders) from Browse Shares (Issue #1565) #
             self.log("User %s seems to have zero files and no public shared folder, the server could be wrong.", user)
             self.probed[user] = 'zero'
             return
@@ -132,4 +132,4 @@ class Plugin(BasePlugin):
         for line in self.settings['message'].splitlines():
             self.send_private(user, line, show_ui=self.settings['open_private_chat'], switch_page=False)
 
-        self.log("Leecher %s doesn't share enough files, sent complaint.", user)
+        self.log("Leecher %s doesn't share enough files, complaint message sent.", user)

--- a/pynicotine/plugins/leech_detector/__init__.py
+++ b/pynicotine/plugins/leech_detector/__init__.py
@@ -109,8 +109,6 @@ class Plugin(BasePlugin):
         if stats['files'] == 0 and stats['dirs'] == 0:
             # ToDo: Implement alternate fallback method (num_files | num_folders) from Browse Shares (Issue #1565) #
             self.log("User %s seems to have zero files and no public shared folder, the server could be wrong.", user)
-            self.probed[user] = 'zero'
-            return
 
         self.log("Leecher %s detected, only sharing %s files in %s folders.", (user, stats['files'], stats['dirs']))
         self.probed[user] = 'leecher'

--- a/pynicotine/plugins/leech_detector/__init__.py
+++ b/pynicotine/plugins/leech_detector/__init__.py
@@ -84,7 +84,7 @@ class Plugin(BasePlugin):
 
         self.probed[user] = 'requesting'
         self.core.queue.append(slskmessages.GetUserStats(user))
-        self.log("Requesting statistics for new user %s...", user)
+        self.log("Requesting statistics for new user %s…", user)
 
     def user_stats_notification(self, user, stats):
 

--- a/pynicotine/plugins/leech_detector/__init__.py
+++ b/pynicotine/plugins/leech_detector/__init__.py
@@ -28,27 +28,27 @@ class Plugin(BasePlugin):
         super().__init__(*args, **kwargs)
 
         self.settings = {
-            'message': 'Please consider sharing more files before downloading from me. Thanks :)',
+            'message': 'Please consider sharing more files if you would like to download from me again. Thanks :)',
             'num_files': 1,
             'num_folders': 1,
             'open_private_chat': True
         }
         self.metasettings = {
             'message': {
-                'description': ('Message to send to leechers. New lines are sent as separate messages, '
-                                'too many lines may get you tempbanned for spam!'),
+                'description': ('Private chat message to send to leechers. Each line is sent as a separate message, '
+                                'too many message lines may get you temporarily banned for spam!'),
                 'type': 'textview'
             },
             'num_files': {
-                'description': 'Least required number of shared files',
+                'description': 'Require users to have a minimum number of shared files:',
                 'type': 'int', 'minimum': 1
             },
             'num_folders': {
-                'description': 'Least required number of shared folders',
+                'description': 'Require users to have a minimum number of shared folders:',
                 'type': 'int', 'minimum': 1
             },
             'open_private_chat': {
-                'description': 'Open private chat tabs when sending messages to leechers',
+                'description': 'Open chat tabs when sending private messages to leechers',
                 'type': 'bool'
             }
         }
@@ -66,14 +66,25 @@ class Plugin(BasePlugin):
         if self.settings['num_folders'] < min_num_folders:
             self.settings['num_folders'] = min_num_folders
 
+        if self.settings['message']:
+            str_log_start = "complain to leecher"
+        else:
+            str_log_start = "log leecher"
+
+        self.log(
+            "Ready to %ss, require users have a minimum of %d files in %d shared public folders.",
+            (str_log_start, self.settings['num_files'], self.settings['num_folders'])
+        )
+
     def upload_queued_notification(self, user, virtual_path, real_path):
 
         if user in self.probed:
+            # We already have stats for this user.
             return
 
         self.probed[user] = 'requesting'
         self.core.queue.append(slskmessages.GetUserStats(user))
-        self.log('New user %s, requesting information...', user)
+        self.log("Requesting statistics for new user %s...", user)
 
     def user_stats_notification(self, user, stats):
 
@@ -81,28 +92,44 @@ class Plugin(BasePlugin):
             # We did not trigger this notification
             return
 
-        status = self.probed[user]
-
-        if status != 'requesting':
+        if self.probed[user] != 'requesting':
             # We already dealt with this user.
+            return
+
+        if stats['files'] >= self.settings['num_files'] and stats['dirs'] >= self.settings['num_folders']:
+            self.log("User %s is okay, sharing %s files in %s folders.", (user, stats['files'], stats['dirs']))
+            self.probed[user] = 'okay'
+            return
+
+        if user in (i[0] for i in self.config.sections["server"]["userlist"]):
+            self.log("Buddy %s is only sharing %s files in %s folders.", (user, stats['files'], stats['dirs']))
+            self.probed[user] = 'buddy'
+            return
+
+        if stats['files'] == 0 and stats['dirs'] == 0:
+            ## ToDo: Implement alternate fallback method (num_files | num_folders) from Browse Shares (Issue #1565) ##
+            self.log("User %s seems to have zero files and no public shared folder, the server could be wrong.", user)
+            self.probed[user] = 'zero'
+            return
+
+        self.log("Leecher %s detected, only sharing %s files in %s folders.", (user, stats['files'], stats['dirs']))
+        self.probed[user] = 'leecher'
+
+    def upload_finished_notification(self, user, *_):
+
+        if user not in self.probed:
+            return
+
+        if self.probed[user] != 'leecher':
             return
 
         self.probed[user] = 'processed'
 
-        if stats['files'] >= self.settings['num_files'] and stats['dirs'] >= self.settings['num_folders']:
-            self.log('User %s is okay, sharing %s files and %s folders', (user, stats['files'], stats['dirs']))
-            return
-
         if not self.settings['message']:
-            self.log("User %s doesn't share enough files, but no complaint message is specified.", user)
+            self.log("Leecher %s doesn't share enough files, but no complaint message is specified.", user)
             return
-
-        show_ui = False
-
-        if self.settings['open_private_chat']:
-            show_ui = True
 
         for line in self.settings['message'].splitlines():
-            self.send_private(user, line, show_ui=show_ui, switch_page=False)
+            self.send_private(user, line, show_ui=self.settings['open_private_chat'], switch_page=False)
 
-        self.log("User %s doesn't share enough files, sent complaint.", user)
+        self.log("Leecher %s doesn't share enough files, sent complaint.", user)


### PR DESCRIPTION
- Added: Wait until after a successful download before sending complaint, to avoid ["stern" popup notifications](https://github.com/nicotine-plus/nicotine-plus/issues/1589).
- Added: Allow buddies to leech without complaining to them.
- Added: Init log message on plugin loading to identify the active settings and minimum file/folder count requirements.
- Added: Log the actual file/folder count of leechers for improved logging.
- Added: Log users with zero statistics with a warning that the server could be wrong, and prepare handling for alternate fallback count method to be implemented, see #1565.
- Changed: Settings window strings with abbreviations, ambiguous or unclear terminology.
- Changed: Default complaint message, as appropriate to plugin behaviour.
- Removed: Pointless 'status' and 'show_ui' local variables