### PR TITLE
Browse Shares: Simplify accelerator functions

### DIFF
--- a/pynicotine/gtkgui/userbrowse.py
+++ b/pynicotine/gtkgui/userbrowse.py
@@ -867,16 +867,11 @@ class UserBrowse(UserInterface):
         return True
 
     def on_folder_open_manager_accelerator(self, *args):
-        """ Ctrl+Alt+Enter: Open folder in File Manager...
-                            Download Folder Into...    """
+        """ Ctrl+Alt+Enter: Open folder in File Manager... """
 
         if self.user == config.sections["server"]["login"]:
             self.on_file_manager()
-
-        elif len(self.file_store) >= 1:  # [user is not self]
-            self.on_download_directory_to()  # same as Ctrl+Enter
-
-        return True
+            return True
 
     """ Key Bindings (FileTreeView) """
 

--- a/pynicotine/gtkgui/userbrowse.py
+++ b/pynicotine/gtkgui/userbrowse.py
@@ -968,9 +968,6 @@ class UserBrowse(UserInterface):
         elif self.num_selected_files >= 1:  # [user is not self]
             self.on_file_properties()  # same as Alt+Enter
 
-        elif self.num_selected_files <= 0:
-            self.on_folder_transfer_to_accelerator()
-
         return True
 
     def on_file_properties_accelerator(self, *args):

--- a/pynicotine/gtkgui/userbrowse.py
+++ b/pynicotine/gtkgui/userbrowse.py
@@ -862,7 +862,7 @@ class UserBrowse(UserInterface):
             return True
 
         if len(self.file_store) <= 0:
-            # risk of accidental recursive download
+            # don't risk accidental recursive download
             self.on_folder_expand_sub_accelerator()
             return True
 
@@ -872,9 +872,6 @@ class UserBrowse(UserInterface):
     def on_folder_open_manager_accelerator(self, *args):
         """ Ctrl+Alt+Enter: Open folder in File Manager...
                             Download Folder Into...    """
-
-        if len(self.file_store) <= 0:
-            self.on_folder_expand_sub_accelerator()
 
         if self.user == config.sections["server"]["login"]:
             self.on_file_manager()
@@ -890,8 +887,7 @@ class UserBrowse(UserInterface):
         """ Left: focus back parent folder (left arrow) """
 
         if self.FileScrolledWindow.get_hadjustment().get_value() > 0.0:
-            # Allow horizontal scrolling
-            return False
+            return False  # allow horizontal scrolling
 
         self.FolderTreeView.grab_focus()
         return True
@@ -979,7 +975,7 @@ class UserBrowse(UserInterface):
             self.on_file_manager()
 
         elif self.num_selected_files >= 1:  # [user is not self]
-            self.on_file_properties()
+            self.on_file_properties()  # same as Alt+Enter
 
         elif self.num_selected_files <= 0:
             self.on_folder_transfer_to_accelerator()
@@ -991,10 +987,6 @@ class UserBrowse(UserInterface):
 
         if len(self.file_store) <= 0:
             self.FolderTreeView.grab_focus()  # avoid nav trap
-
-        if self.user == config.sections["server"]["login"]:
-            if self.num_selected_files <= 0:
-                self.on_file_manager()
 
         if self.num_selected_files >= 1:
             self.on_file_properties()

--- a/pynicotine/gtkgui/userbrowse.py
+++ b/pynicotine/gtkgui/userbrowse.py
@@ -844,11 +844,8 @@ class UserBrowse(UserInterface):
             else:
                 self.on_upload_directory_recursive_to()
 
-        else:
-            if len(self.file_store) >= 1:
-                self.on_download_directory_to()
-            else:
-                self.on_download_directory_recursive_to()
+        elif len(self.file_store) >= 1:
+            self.on_download_directory_to()
 
         return True
 
@@ -907,18 +904,17 @@ class UserBrowse(UserInterface):
             self.FolderTreeView.grab_focus()
             return True
 
-        if self.num_selected_files >= 1:
-            self.select_files()
-
-            if self.user == config.sections["server"]["login"]:
-                self.on_upload_files()
-                return True
-
-            self.on_download_files_to()  # (prompt, Single or Multi-selection)
+        if self.num_selected_files <= 0:  # do folder instead
+            self.on_folder_transfer_to_accelerator()
             return True
 
-        # Do folder instead
-        self.on_folder_transfer_to_accelerator()
+        self.select_files()
+
+        if self.user == config.sections["server"]["login"]:
+            self.on_upload_files()
+            return True
+
+        self.on_download_files_to()  # (with prompt, Single or Multi-selection)
         return True
 
     def on_file_transfer_accelerator(self, *args):

--- a/pynicotine/gtkgui/userbrowse.py
+++ b/pynicotine/gtkgui/userbrowse.py
@@ -219,7 +219,6 @@ class UserBrowse(UserInterface):
         setup_accelerator("<Shift><Primary>Return", self.FolderTreeView, self.on_folder_transfer_accelerator)  # no prmt
 
         setup_accelerator("<Primary><Alt>Return", self.FolderTreeView, self.on_folder_open_manager_accelerator)
-        setup_accelerator("<Alt>Return", self.FolderTreeView, self.on_folder_open_manager_accelerator)
 
         self.dir_column_numbers = list(range(self.dir_store.get_n_columns()))
         cols = initialise_columns(
@@ -872,7 +871,7 @@ class UserBrowse(UserInterface):
 
     def on_folder_open_manager_accelerator(self, *args):
         """ Ctrl+Alt+Enter: Open folder in File Manager...
-            (or Alt+Enter)  Download Folder Into...    """
+                            Download Folder Into...    """
 
         if len(self.file_store) <= 0:
             self.on_folder_expand_sub_accelerator()
@@ -881,7 +880,7 @@ class UserBrowse(UserInterface):
             self.on_file_manager()
 
         elif len(self.file_store) >= 1:  # [user is not self]
-            self.on_download_directory_to()
+            self.on_download_directory_to()  # same as Ctrl+Enter
 
         return True
 

--- a/pynicotine/gtkgui/userbrowse.py
+++ b/pynicotine/gtkgui/userbrowse.py
@@ -814,9 +814,11 @@ class UserBrowse(UserInterface):
     def on_folder_open_manager_accelerator(self, *args):
         """ Ctrl+Alt+Enter: Open folder in File Manager... """
 
-        if self.user == config.sections["server"]["login"]:
-            self.on_file_manager()
-            return True
+        if self.user != config.sections["server"]["login"]:
+            return False
+
+        self.on_file_manager()
+        return True
 
     """ Key Bindings (FileTreeView) """
 
@@ -901,17 +903,13 @@ class UserBrowse(UserInterface):
         return True
 
     def on_file_open_manager_accelerator(self, *args):
-        """ Ctrl+Alt+Enter: Open in File Manager
-                            Download Folder Into...     """
+        """ Ctrl+Alt+Enter: Open in File Manager """
 
-        if len(self.file_store) <= 0:
-            self.FolderTreeView.grab_focus()  # avoid nav trap
-
-        elif self.user == config.sections["server"]["login"]:
+        if self.user == config.sections["server"]["login"]:
             self.on_file_manager()
 
-        elif self.num_selected_files >= 1:  # [user is not self]
-            self.on_file_properties()  # same as Alt+Enter
+        else:  # [user is not self]
+            self.on_file_properties_accelerator()  # same as Alt+Enter
 
         return True
 


### PR DESCRIPTION
- Fixed: Alt+Enter currently has three completely different actions depending on what's focused. _Now there is only two._
- Removed: Ctrl+Enter to download folder recursively when folder contains zero files.
- Removed: Ctrl+Alt+Enter to download folder, because this is only for self browse local folder with Open in File Manager.
- Removed: Ctrl+Alt+Enter to download file, because this is only for self browse local file with Open in File Manager.
- Removed: Ctrl+Alt+Enter to open File Properties, because this function is not expected when Ctrl is pressed.