### PR TITLE
utils.py: Days and Years in human_length

### DIFF
--- a/pynicotine/utils.py
+++ b/pynicotine/utils.py
@@ -251,23 +251,25 @@ def make_version(version):
     return (major << 24) + (minor << 16) + (patch << 8) + stable
 
 
-def human_length(seconds):
+def human_length(seconds, long=False):
 
     minutes, seconds = divmod(seconds, 60)
     hours, minutes = divmod(minutes, 60)
     days, hours = divmod(hours, 24)
     years, days = divmod(days, 365)
 
-    if years > 1:
+    if long and years > 1:
         ret = '%i years' % (years)
-    elif years > 0:
+    elif long and years > 0:
         ret = '%i year %i days' % (years, days)
-    elif days > 1:
+    elif long and days > 1:
         ret = '%i days %i hours' % (days, hours)
-    elif days > 0:
+    elif long and days > 0:
         ret = '%i day %ih %im' % (days, hours, minutes)
+    elif days > 0:
+        ret = '%i:%02i:%02i:%02i' % (days, hours, minutes, seconds)
     elif hours > 0:
-        ret = '%02i:%02i:%02i' % (hours, minutes, seconds)
+        ret = '%i:%02i:%02i' % (hours, minutes, seconds)
     else:
         ret = '%i:%02i' % (minutes, seconds)
 

--- a/pynicotine/utils.py
+++ b/pynicotine/utils.py
@@ -244,7 +244,7 @@ def make_version(version):
     stable = 1
 
     if "dev" in version or "rc" in version:
-        # Example: 2.0.1.dev1
+        # Example: 3.2.0.dev1
         # A dev version will be one less than a stable version
         stable = 0
 
@@ -256,11 +256,18 @@ def human_length(seconds):
     minutes, seconds = divmod(seconds, 60)
     hours, minutes = divmod(minutes, 60)
     days, hours = divmod(hours, 24)
+    years, days = divmod(days, 365)
 
-    if days > 0:
-        ret = '%i:%02i:%02i:%02i' % (days, hours, minutes, seconds)
+    if years > 1:
+        ret = '%i years' % (years)
+    elif years > 0:
+        ret = '%i year %i days' % (years, days)
+    elif days > 1:
+        ret = '%i days %i hours' % (days, hours)
+    elif days > 0:
+        ret = '%i day %ih %im' % (days, hours, minutes)
     elif hours > 0:
-        ret = '%i:%02i:%02i' % (hours, minutes, seconds)
+        ret = '%02i:%02i:%02i' % (hours, minutes, seconds)
     else:
         ret = '%i:%02i' % (minutes, seconds)
 


### PR DESCRIPTION
- Added: Long string format for length more than 24 Hours... 'D:HH:MM:SS' -> '% day %h %m'
- Added: Long string format for length more than 48 Hours... 'D:HH:MM:SS' -> '% days % hours'
- Added: Long string format number of Years if length is more than 365 Days - > '% year % days'
- Added: Long string format without Days if length is more than 2 Years -> '% years'

Long display format option with `long=True` argument if length is 1 Day or more, otherwise the output of the function is the same as it was before.

_Edit: Thank you for the below suggestions which have now been implemented._