### PR TITLE
Log History Pane: Interface terminology of Debug Logging

### DIFF
--- a/pynicotine/gtkgui/frame.py
+++ b/pynicotine/gtkgui/frame.py
@@ -112,15 +112,17 @@ class NicotineFrame(UserInterface):
 
         # Popup menu on the log windows
         PopupMenu(self, self.LogWindow, self.on_popup_menu_log).setup(
-            ("#" + _("Find…"), self.on_find_log_window),
             ("", None),
-            ("#" + _("Copy"), self.log_textview.on_copy_text),
-            ("#" + _("Copy All"), self.log_textview.on_copy_all_text),
+            ("#" + _("_Find…"), self.on_find_log_window),
             ("", None),
-            ("#" + _("View Debug Logs"), self.on_view_debug_logs),
-            ("#" + _("View Transfer Log"), self.on_view_transfer_log),
+            ("#" + _("_Copy"), self.log_textview.on_copy_text),
+            ("#" + _("Copy _All"), self.log_textview.on_copy_all_text),
             ("", None),
-            ("#" + _("Clear Log View"), self.log_textview.on_clear_all_text)
+            ("#" + _("_Open Log _Files"), self.on_view_debug_logs),
+            ("#" + _("Open _Transfer Log"), self.on_view_transfer_log),
+            ("", None),
+            ("#" + _("Clear Log View"), self.log_textview.on_clear_all_text),
+            ("$" + _("Show _Log Pane Controls"), "win.showdebug")
         )
 
         # Text Search
@@ -1021,8 +1023,8 @@ class NicotineFrame(UserInterface):
             ("$" + _("Prefer Dark _Mode"), "win.preferdarkmode"),
             ("$" + _("Use _Header Bar"), "win.showheaderbar"),
             ("", None),
-            ("$" + _("Show _Log Pane"), "win.showlog"),
-            ("$" + _("Show _Debug Log Controls"), "win.showdebug"),
+            ("$" + _("Show _Log History Pane"), "win.showlog"),
+            ("$" + _("Show _Log Pane Controls"), "win.showdebug"),
             ("", None),
             ("O" + _("Buddy List in Separate Tab"), "win.togglebuddylist", "tab"),
             ("O" + _("Buddy List in Chat Rooms"), "win.togglebuddylist", "chatrooms"),
@@ -1840,7 +1842,7 @@ class NicotineFrame(UserInterface):
 
     def on_popup_menu_log(self, menu, textview):
         actions = menu.get_actions()
-        actions[_("Copy")].set_enabled(self.log_textview.get_has_selection())
+        actions[_("_Copy")].set_enabled(self.log_textview.get_has_selection())
 
     def on_find_log_window(self, *args):
         self.LogSearchBar.set_search_mode(True)

--- a/pynicotine/gtkgui/frame.py
+++ b/pynicotine/gtkgui/frame.py
@@ -110,6 +110,9 @@ class NicotineFrame(UserInterface):
 
         self.log_textview = TextView(self.LogWindow)
 
+        # Popup sub menu in the View menu and on the Log History pane
+        self.create_log_catagories_menu()
+
         # Popup menu on the log windows
         PopupMenu(self, self.LogWindow, self.on_popup_menu_log).setup(
             ("", None),
@@ -118,11 +121,12 @@ class NicotineFrame(UserInterface):
             ("#" + _("_Copy"), self.log_textview.on_copy_text),
             ("#" + _("Copy _All"), self.log_textview.on_copy_all_text),
             ("", None),
+            (">" + _("_Log Categories"), self.popup_menu_log_categories),
+            ("", None),
             ("#" + _("_Open Log _Files"), self.on_view_debug_logs),
             ("#" + _("Open _Transfer Log"), self.on_view_transfer_log),
             ("", None),
             ("#" + _("Clear Log View"), self.log_textview.on_clear_all_text),
-            ("$" + _("Show _Log Pane Controls"), "win.showdebug")
         )
 
         # Text Search
@@ -1024,7 +1028,7 @@ class NicotineFrame(UserInterface):
             ("$" + _("Use _Header Bar"), "win.showheaderbar"),
             ("", None),
             ("$" + _("Show _Log History Pane"), "win.showlog"),
-            ("$" + _("Show _Log Pane Controls"), "win.showdebug"),
+            (">" + _("L_og Categories"), self.popup_menu_log_categories),
             ("", None),
             ("O" + _("Buddy List in Separate Tab"), "win.togglebuddylist", "tab"),
             ("O" + _("Buddy List in Chat Rooms"), "win.togglebuddylist", "chatrooms"),
@@ -1032,6 +1036,22 @@ class NicotineFrame(UserInterface):
         )
 
         return menu
+
+    def create_log_catagories_menu(self):
+
+        # Popup sub menu in the View menu and on the Log History pane
+        self.popup_menu_log_categories = PopupMenu(self.LogWindow)
+        self.popup_menu_log_categories.setup(
+            ("$" + _("Downloads"), "app.debugdownloads"),
+            ("$" + _("Uploads"), "app.debuguploads"),
+            ("$" + _("Search"), "app.debugsearches"),
+            ("$" + _("Chat"), "app.debugchat"),
+            ("", None),
+            ("$" + _("Transfers (debug)"), "app.debugtransfers"),
+            ("$" + _("Connections (debug)"), "app.debugconnections"),
+            ("$" + _("Protocol (debug)"), "app.debugmessages"),
+            ("$" + _("Miscellaneous (debug)"), "app.debugmiscellaneous"),
+        )
 
     def add_configure_shares_section(self, menu):
 
@@ -1843,6 +1863,9 @@ class NicotineFrame(UserInterface):
     def on_popup_menu_log(self, menu, textview):
         actions = menu.get_actions()
         actions[_("_Copy")].set_enabled(self.log_textview.get_has_selection())
+
+    def on_popup_menu_log_categories(self, menu, textview):
+        actions = menu.get_actions()
 
     def on_find_log_window(self, *args):
         self.LogSearchBar.set_search_mode(True)

--- a/pynicotine/gtkgui/ui/mainwindow.ui
+++ b/pynicotine/gtkgui/ui/mainwindow.ui
@@ -1586,7 +1586,7 @@
                                     <child>
                                       <object class="GtkLabel">
                                         <property name="visible">1</property>
-                                        <property name="label" translatable="yes">Debug Logging</property>
+                                        <property name="label" translatable="yes">Log History</property>
                                         <property name="xalign">0</property>
                                         <property name="margin-end">12</property>
                                         <attributes>
@@ -1618,6 +1618,19 @@
                                         <property name="label" translatable="yes">Uploads</property>
                                         <property name="visible">1</property>
                                         <property name="action-name">app.debuguploads</property>
+                                      </object>
+                                    </child>
+                                  </object>
+                                </child>
+                                <child>
+                                  <object class="GtkFlowBoxChild">
+                                    <property name="visible">1</property>
+                                    <property name="focusable">0</property>
+                                    <child>
+                                      <object class="GtkCheckButton">
+                                        <property name="label" translatable="yes">Transfers</property>
+                                        <property name="visible">1</property>
+                                        <property name="action-name">app.debugtransfers</property>
                                       </object>
                                     </child>
                                   </object>
@@ -1667,7 +1680,7 @@
                                     <property name="focusable">0</property>
                                     <child>
                                       <object class="GtkCheckButton">
-                                        <property name="label" translatable="yes">Messages</property>
+                                        <property name="label" translatable="yes">Protocol</property>
                                         <property name="visible">1</property>
                                         <property name="action-name">app.debugmessages</property>
                                       </object>
@@ -1680,20 +1693,7 @@
                                     <property name="focusable">0</property>
                                     <child>
                                       <object class="GtkCheckButton">
-                                        <property name="label" translatable="yes">Transfers</property>
-                                        <property name="visible">1</property>
-                                        <property name="action-name">app.debugtransfers</property>
-                                      </object>
-                                    </child>
-                                  </object>
-                                </child>
-                                <child>
-                                  <object class="GtkFlowBoxChild">
-                                    <property name="visible">1</property>
-                                    <property name="focusable">0</property>
-                                    <child>
-                                      <object class="GtkCheckButton">
-                                        <property name="label" translatable="yes">Miscellaneous</property>
+                                        <property name="label" translatable="yes">Debug</property>
                                         <property name="visible">1</property>
                                         <property name="action-name">app.debugmiscellaneous</property>
                                       </object>
@@ -1913,7 +1913,7 @@
                 <child>
                   <object class="GtkToggleButton">
                     <property name="visible">1</property>
-                    <property name="tooltip-text" translatable="yes">Show log history</property>
+                    <property name="tooltip-text" translatable="yes">Show Log History</property>
                     <property name="action-name">win.showlog</property>
                     <child>
                       <object class="GtkImage">


### PR DESCRIPTION
- Changed: The term 'Debug Logging' is not appropriate, since the 'Log History' Pane is an integral part of the application's interface.
- Changed: Log category label 'Miscellaneous' -> 'Debug', because this is where debug log messages appear.
- Changed: Log category label 'Messages' -> 'Protocol', because it was ambiguous with Chats.
- Changed: The visual order of the categories, to group together the 3 categories that are excluded from the Statusbar.
- Changed: 'Show Log Pane' -> 'Show Log History Pane' in accordance with the correct terminology used elsewhere.
- Changed: 'Show Debug Log Controls' -> 'Show _Log Pane Controls'  because not every category is for debugging.
- Changed: 'View' -> 'Open' log File because this was ambiguous as to how to view the debug log category in the Pane.
- Added: 'Show_Log Pane Controls' toggle open in the popover context menu, to make the log categories easier to find.
- Fixed: Missing mnemonics in Log History Pane popover context menu.