### PR TITLE
Browse Shares: Multi-selection counters for Files

### DIFF
--- a/pynicotine/gtkgui/userbrowse.py
+++ b/pynicotine/gtkgui/userbrowse.py
@@ -451,8 +451,9 @@ class UserBrowse(UserInterface):
 
             str_length = " " + human_length(selected_length)
 
-            self.frame.set_status_text(_("Selected: %s files (%s total%s)")
-                                        % (str(self.num_selected_files), human_size(self.selected_size), str_length)
+            self.frame.set_status_text(
+                _("Selected: %s files (%s total%s)")
+                 % (str(self.num_selected_files), human_size(self.selected_size), str_length)
             )
 
         if self.num_selected_files == 1:
@@ -464,8 +465,9 @@ class UserBrowse(UserInterface):
             if file_bitrate:
                 file_bitrate = "[" + file_bitrate + " Kbps]"
 
-            self.frame.set_status_text(_("Selected file") + " (%(size)s%(length)s): %(name)s %(rate)s"
-                % {'size': file_hsize, 'length': str_length, 'name': file_name, 'rate': file_bitrate}
+            self.frame.set_status_text(
+                _("Selected file") + " (%(size)s%(length)s): %(name)s %(rate)s"
+                 % {'size': file_hsize, 'length': str_length, 'name': file_name, 'rate': file_bitrate}
             )
 
     def on_file_row_activated(self, treeview, path, column):
@@ -680,11 +682,7 @@ class UserBrowse(UserInterface):
 
         self.frame.set_status_text(
             _("Browsing %s files (%s total %s) in folder: %s")
-            % (str(len(files)),
-               human_size(dir_size),
-               str_length,
-               self.user + "\\" + directory + "\\"
-            )
+             % (str(len(files)), human_size(dir_size), str_length, self.user + "\\" + directory + "\\")
         )
 
     def on_save_accelerator(self, *args):

--- a/pynicotine/gtkgui/userbrowse.py
+++ b/pynicotine/gtkgui/userbrowse.py
@@ -453,7 +453,7 @@ class UserBrowse(UserInterface):
 
             self.frame.set_status_text(
                 _("Selected: %s files (%s total%s)")
-                 % (str(self.num_selected_files), human_size(self.selected_size), str_length)
+                % (str(self.num_selected_files), human_size(self.selected_size), str_length)
             )
 
         if self.num_selected_files == 1:
@@ -467,7 +467,7 @@ class UserBrowse(UserInterface):
 
             self.frame.set_status_text(
                 _("Selected file") + " (%(size)s%(length)s): %(name)s %(rate)s"
-                 % {'size': file_hsize, 'length': str_length, 'name': file_name, 'rate': file_bitrate}
+                % {'size': file_hsize, 'length': str_length, 'name': file_name, 'rate': file_bitrate}
             )
 
     def on_file_row_activated(self, treeview, path, column):
@@ -682,7 +682,7 @@ class UserBrowse(UserInterface):
 
         self.frame.set_status_text(
             _("Browsing %s files (%s total %s) in folder: %s")
-             % (str(len(files)), human_size(dir_size), str_length, self.user + "\\" + directory + "\\")
+            % (str(len(files)), human_size(dir_size), str_length, self.user + "\\" + directory + "\\")
         )
 
     def on_save_accelerator(self, *args):

--- a/pynicotine/gtkgui/userbrowse.py
+++ b/pynicotine/gtkgui/userbrowse.py
@@ -831,6 +831,10 @@ class UserBrowse(UserInterface):
             Shift+Right (Gtk) | "+" (Gtk) |    """
 
         path, _focus_column = self.FolderTreeView.get_cursor()
+
+        if path is None:
+            return False
+
         expandable = self.FolderTreeView.expand_row(path, False)
 
         if not expandable and len(self.file_store) > 0:
@@ -843,6 +847,9 @@ class UserBrowse(UserInterface):
 
         path, _focus_column = self.FolderTreeView.get_cursor()
 
+        if path is None:
+            return False
+
         self.FolderTreeView.collapse_row(path)  # show 2nd level
         self.FolderTreeView.expand_row(path, False)
         return True
@@ -851,6 +858,10 @@ class UserBrowse(UserInterface):
         """ =equal: expand only (dont move focus)   """
 
         path, _focus_column = self.FolderTreeView.get_cursor()
+
+        if path is None:
+            return False
+
         self.FolderTreeView.expand_row(path, False)
         return True
 

--- a/pynicotine/gtkgui/userbrowse.py
+++ b/pynicotine/gtkgui/userbrowse.py
@@ -449,7 +449,7 @@ class UserBrowse(UserInterface):
         if self.num_selected_files >= 2:
             # Display total size and length for multi-selection
 
-            str_length = " " + human_length(selected_length)
+            str_length = " " + human_length(selected_length, long=True)
 
             self.frame.set_status_text(
                 _("Selected: %s files (%s total%s)")
@@ -678,7 +678,7 @@ class UserBrowse(UserInterface):
         if dir_length == 0:
             str_length = "data"
         else:
-            str_length = human_length(dir_length)
+            str_length = human_length(dir_length, long=True)
 
         self.frame.set_status_text(
             _("Browsing %s files (%s total %s) in folder: %s")


### PR DESCRIPTION
STATUS: recent code refactoring in master makes this version of userbrowse.py non-functional.

Main purpose of this PR is to borrow the Linter. This is a non-urgent work in progress and intended for 3.2.1, unless you are keen to do the implement the new features for file counting and Statusbar etc.

- Fixed: Crash when pressing an accelerator key on an empty TreeView model, user offline etc.
- Added: Counter for the total number of files when browsing a user's share, required for future improvements to the Leech Detector plugin, helps with #1565
- Added: Tooltip text to display the total number of Shared Files, because this statistic is not displayed anywhere else within the interface, nor was is available anywhere programmatically for use in external modules.
- Added: Statusbar implementation to display File and Folder names and properties (including total number, size and length of audio files) - [PR in Draft]
- ToDo: Remove any unnecessary or obsolete calls to select_files() and review stability benchmark for UX benefits vs performance of iterating the data store.