### PR TITLE
Access the Log Categories from View menu

### DIFF
--- a/pynicotine/gtkgui/frame.py
+++ b/pynicotine/gtkgui/frame.py
@@ -990,7 +990,8 @@ class NicotineFrame(UserInterface):
         menu.setup(
             ("$" + _("Prefer Dark _Mode"), "win.preferdarkmode"),
             ("$" + _("Use _Header Bar"), "win.showheaderbar"),
-            ("$" + _("Show _Log Pane"), "win.showlog"),
+            ("$" + _("Show _Log History Pane"), "win.showlog"),
+            (">" + _("L_og Categories"), self.popup_menu_log_categories),
             ("", None),
             ("O" + _("Buddy List in Separate Tab"), "win.togglebuddylist", "tab"),
             ("O" + _("Buddy List in Chat Rooms"), "win.togglebuddylist", "chatrooms"),
@@ -1791,8 +1792,8 @@ class NicotineFrame(UserInterface):
 
     def create_log_context_menu(self):
 
-        popup_categories = PopupMenu(self)
-        popup_categories.setup(
+        self.popup_menu_log_categories = PopupMenu(self)
+        self.popup_menu_log_categories.setup(
             ("$" + _("Downloads"), "win.logdownloads"),
             ("$" + _("Uploads"), "win.loguploads"),
             ("$" + _("Search"), "win.logsearches"),
@@ -1813,7 +1814,7 @@ class NicotineFrame(UserInterface):
             ("#" + _("_Open Log Folder"), self.on_view_debug_logs),
             ("#" + _("Open _Transfer Log"), self.on_view_transfer_log),
             ("", None),
-            (">" + _("_Log Categories"), popup_categories),
+            (">" + _("_Log Categories"), self.popup_menu_log_categories),
             ("", None),
             ("#" + _("Clear Log View"), self.log_textview.on_clear_all_text)
         )


### PR DESCRIPTION
Added: Item in View menu, since 4 options are relevant when the Log History Pane is hidden.

This would only be appropriate if the selected Log items did not affect file logging like they currently do.