### PR TITLE
Use strings that can easily be translated

### DIFF
--- a/pynicotine/gtkgui/userbrowse.py
+++ b/pynicotine/gtkgui/userbrowse.py
@@ -930,7 +930,7 @@ class UserBrowse(UserInterface):
     def on_download_directory_to(self, *args, recurse=False):
 
         if recurse:
-            str_title = _("Select Destination Folder for this Recursive Download")
+            str_title = _("Select Destination Folder for this Download (with subfolders)")
         else:
             str_title = _("Select Destination Folder for this Download")
 

--- a/pynicotine/gtkgui/userbrowse.py
+++ b/pynicotine/gtkgui/userbrowse.py
@@ -930,9 +930,9 @@ class UserBrowse(UserInterface):
     def on_download_directory_to(self, *args, recurse=False):
 
         if recurse:
-            str_title = _("Select destination folder for this recursive download")
+            str_title = _("Select Destination Folder for this Recursive Download")
         else:
-            str_title = _("Select destination folder for this download")
+            str_title = _("Select Destination Folder for this Download")
 
         choose_dir(
             parent=self.frame.MainWindow,

--- a/pynicotine/gtkgui/userbrowse.py
+++ b/pynicotine/gtkgui/userbrowse.py
@@ -930,7 +930,7 @@ class UserBrowse(UserInterface):
     def on_download_directory_to(self, *args, recurse=False):
 
         if recurse:
-            str_title = _("Select Destination folder for Downloading Multiple Folders")
+            str_title = _("Select Destination Folder for Downloading Multiple Folders")
         else:
             str_title = _("Select Destination Folder")
 

--- a/pynicotine/gtkgui/userbrowse.py
+++ b/pynicotine/gtkgui/userbrowse.py
@@ -930,9 +930,9 @@ class UserBrowse(UserInterface):
     def on_download_directory_to(self, *args, recurse=False):
 
         if recurse:
-            str_title = _("Select Destination for Downloading Folder with Subfolders from User")
+            str_title = _("Select destination folder for this recursive download")
         else:
-            str_title = _("Select Destination for Downloading a Folder from User")
+            str_title = _("Select destination folder for this download")
 
         choose_dir(
             parent=self.frame.MainWindow,

--- a/pynicotine/gtkgui/userbrowse.py
+++ b/pynicotine/gtkgui/userbrowse.py
@@ -930,9 +930,9 @@ class UserBrowse(UserInterface):
     def on_download_directory_to(self, *args, recurse=False):
 
         if recurse:
-            str_title = _("Select Destination Folder for this Download (with subfolders)")
+            str_title = _("Select Destination folder for Downloading Multiple Folders")
         else:
-            str_title = _("Select Destination Folder for this Download")
+            str_title = _("Select Destination Folder")
 
         choose_dir(
             parent=self.frame.MainWindow,

--- a/pynicotine/gtkgui/userbrowse.py
+++ b/pynicotine/gtkgui/userbrowse.py
@@ -930,7 +930,7 @@ class UserBrowse(UserInterface):
     def on_download_directory_to(self, *args, recurse=False):
 
         if recurse:
-            str_title = _("Select Destination Folder for Downloading Multiple Folders")
+            str_title = _("Select Destination for Downloading Multiple Folders")
         else:
             str_title = _("Select Destination Folder")
 


### PR DESCRIPTION
The existing string, although well intended, was hard to understand. I tried explaining it differently, and then translated it to German, French and Dutch, to test if the translation still made sense. Since it didn't, I tried again with another string, and that one worked in all four languages.