### PR TITLE
settings/userinterface.ui: Move TraySettings from Notifications

### DIFF
--- a/pynicotine/gtkgui/settingswindow.py
+++ b/pynicotine/gtkgui/settingswindow.py
@@ -2476,7 +2476,7 @@ class NotificationsFrame(UserInterface):
                 "notification_popup_private_message": self.NotificationPopupPrivateMessage.get_active(),
                 "notification_popup_chatroom": self.NotificationPopupChatroom.get_active(),
                 "notification_popup_chatroom_mention": self.NotificationPopupChatroomMention.get_active()
-            },
+            }
         }
 
 

--- a/pynicotine/gtkgui/settingswindow.py
+++ b/pynicotine/gtkgui/settingswindow.py
@@ -1454,7 +1454,9 @@ class UserInterfaceFrame(UserInterface):
                 "tab_hilite": self.EntryHighlightTab,
                 "tab_changed": self.EntryChangedTab,
                 "dark_mode": self.DarkMode,
-                "exitdialog": self.CloseAction
+                "exitdialog": self.CloseAction,
+                "trayicon": self.TrayiconCheck,
+                "startup_hidden": self.StartupHidden
             }
         }
 
@@ -1481,6 +1483,14 @@ class UserInterfaceFrame(UserInterface):
     def set_settings(self):
 
         self.p.set_widgets_data(self.options)
+
+        if sys.platform == "darwin" or Gtk.get_major_version() == 4:
+            # Tray icons don't work as expected on macOS, so hide widgets
+            self.TraySettings.hide()
+            return
+
+        sensitive = self.TrayiconCheck.get_active()
+        self.StartupHidden.set_sensitive(sensitive)
 
         for page_id, enabled in config.sections["ui"]["modes_visible"].items():
             widget = self.tabs.get(page_id)
@@ -1578,9 +1588,20 @@ class UserInterfaceFrame(UserInterface):
                 "tab_default": self.EntryRegularTab.get_text(),
                 "tab_changed": self.EntryChangedTab.get_text(),
                 "dark_mode": self.DarkMode.get_active(),
-                "exitdialog": self.CloseAction.get_active()
+                "exitdialog": self.CloseAction.get_active(),
+                "trayicon": self.TrayiconCheck.get_active(),
+                "startup_hidden": self.StartupHidden.get_active()
             }
         }
+
+    """ Tray """
+
+    def on_toggle_tray(self, widget):
+
+        self.StartupHidden.set_sensitive(widget.get_active())
+
+        if not widget.get_active() and self.StartupHidden.get_active():
+            self.StartupHidden.set_active(widget.get_active())
 
     """ Icons """
 
@@ -2439,34 +2460,10 @@ class NotificationsFrame(UserInterface):
                 "notification_popup_chatroom": self.NotificationPopupChatroom,
                 "notification_popup_chatroom_mention": self.NotificationPopupChatroomMention
             },
-            "ui": {
-                "trayicon": self.TrayiconCheck,
-                "startup_hidden": self.StartupHidden
-            }
         }
 
     def set_settings(self):
         self.p.set_widgets_data(self.options)
-
-        if sys.platform == "darwin" or Gtk.get_major_version() == 4:
-            # Tray icons don't work as expected on macOS
-            self.hide_tray_icon_settings()
-            return
-
-        sensitive = self.TrayiconCheck.get_active()
-        self.StartupHidden.set_sensitive(sensitive)
-
-    def hide_tray_icon_settings(self):
-
-        # Hide widgets
-        self.TraySettings.hide()
-
-    def on_toggle_tray(self, widget):
-
-        self.StartupHidden.set_sensitive(widget.get_active())
-
-        if not widget.get_active() and self.StartupHidden.get_active():
-            self.StartupHidden.set_active(widget.get_active())
 
     def get_settings(self):
 
@@ -2480,10 +2477,6 @@ class NotificationsFrame(UserInterface):
                 "notification_popup_chatroom": self.NotificationPopupChatroom.get_active(),
                 "notification_popup_chatroom_mention": self.NotificationPopupChatroomMention.get_active()
             },
-            "ui": {
-                "trayicon": self.TrayiconCheck.get_active(),
-                "startup_hidden": self.StartupHidden.get_active()
-            }
         }
 
 

--- a/pynicotine/gtkgui/settingswindow.py
+++ b/pynicotine/gtkgui/settingswindow.py
@@ -1,3483 +1,2390 @@
-# COPYRIGHT (C) 2020-2021 Nicotine+ Team
-# COPYRIGHT (C) 2016-2017 Michael Labouebe <gfarmerfr@free.fr>
-# COPYRIGHT (C) 2016 Mutnick <muhing@yahoo.com>
-# COPYRIGHT (C) 2008-2011 Quinox <quinox@users.sf.net>
-# COPYRIGHT (C) 2008 Gallows <g4ll0ws@gmail.com>
-# COPYRIGHT (C) 2006-2009 Daelstorm <daelstorm@gmail.com>
-# COPYRIGHT (C) 2003-2004 Hyriand <hyriand@thegraveyard.org>
-#
-# GNU GENERAL PUBLIC LICENSE
-#    Version 3, 29 June 2007
-#
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <http://www.gnu.org/licenses/>.
-
-import os
-import re
-import socket
-import sys
-import time
-
-import gi
-from gi.repository import Gdk
-from gi.repository import GdkPixbuf
-from gi.repository import GLib
-from gi.repository import GObject
-from gi.repository import Gtk
-
-from pynicotine.config import config
-from pynicotine.gtkgui.widgets.filechooser import FileChooserButton
-from pynicotine.gtkgui.widgets.filechooser import choose_dir
-from pynicotine.gtkgui.widgets.filechooser import save_file
-from pynicotine.gtkgui.widgets.dialogs import dialog_hide
-from pynicotine.gtkgui.widgets.dialogs import entry_dialog
-from pynicotine.gtkgui.widgets.dialogs import generic_dialog
-from pynicotine.gtkgui.widgets.dialogs import message_dialog
-from pynicotine.gtkgui.widgets.dialogs import set_dialog_properties
-from pynicotine.gtkgui.widgets.textview import TextView
-from pynicotine.gtkgui.widgets.theme import get_icon
-from pynicotine.gtkgui.widgets.theme import set_dark_mode
-from pynicotine.gtkgui.widgets.theme import set_global_font
-from pynicotine.gtkgui.widgets.theme import update_widget_visuals
-from pynicotine.gtkgui.widgets.treeview import initialise_columns
-from pynicotine.gtkgui.widgets.ui import UserInterface
-from pynicotine.logfacility import log
-from pynicotine.utils import open_file_path
-from pynicotine.utils import open_uri
-from pynicotine.utils import unescape
-
-
-class NetworkFrame(UserInterface):
-
-    def __init__(self, parent):
-
-        super().__init__("ui/settings/network.ui")
-
-        self.p = parent
-        self.frame = self.p.frame
-
-        self.needportmap = False
-
-        self.options = {
-            "server": {
-                "server": None,
-                "login": self.Login,
-                "portrange": None,
-                "autoaway": self.AutoAway,
-                "autoreply": self.AutoReply,
-                "interface": self.Interface,
-                "upnp": self.UseUPnP,
-                "upnp_interval": self.UPnPInterval,
-                "auto_connect_startup": self.AutoConnectStartup,
-                "ctcpmsgs": self.ctcptogglebutton
-            }
-        }
-
-    def set_settings(self):
-
-        self.p.set_widgets_data(self.options)
-
-        server = config.sections["server"]
-
-        if server["server"] is not None:
-            self.Server.set_text("%s:%i" % (server["server"][0], server["server"][1]))
-
-        if self.frame.np.protothread.listenport is None:
-            self.CurrentPort.set_text(_("Listening port is not set"))
-        else:
-            text = _("Public IP address is <b>%(ip)s</b> and active listening port is <b>%(port)s</b>") % {
-                "ip": self.frame.np.ipaddress or _("unknown"),
-                "port": self.frame.np.protothread.listenport
-            }
-            self.CurrentPort.set_markup(text)
-
-        url = config.portchecker_url % str(self.frame.np.protothread.listenport)
-        text = "<a href='" + url + "' title='" + url + "'>" + _("Check Port Status") + "</a>"
-        self.CheckPortLabel.set_markup(text)
-        self.CheckPortLabel.connect("activate-link", lambda x, url: open_uri(url))
-
-        if server["portrange"] is not None:
-            self.FirstPort.set_value(server["portrange"][0])
-            self.LastPort.set_value(server["portrange"][1])
-
-        if server["ctcpmsgs"] is not None:
-            self.ctcptogglebutton.set_active(not server["ctcpmsgs"])
-
-        self.needportmap = False
-        self.on_toggle_upnp(self.UseUPnP)
-
-        if sys.platform not in ("linux", "darwin"):
-            for widget in (self.InterfaceLabel, self.Interface):
-                widget.get_parent().hide()
-
-            return
-
-        self.Interface.remove_all()
-        self.Interface.append_text("")
-
-        try:
-            for _i, interface in socket.if_nameindex():
-                self.Interface.append_text(interface)
-
-        except (AttributeError, OSError):
-            pass
-
-    def get_settings(self):
-
-        try:
-            server = self.Server.get_text().split(":")
-            server[1] = int(server[1])
-            server = tuple(server)
-
-        except Exception:
-            server = config.defaults["server"]["server"]
-
-        firstport = min(self.FirstPort.get_value_as_int(), self.LastPort.get_value_as_int())
-        lastport = max(self.FirstPort.get_value_as_int(), self.LastPort.get_value_as_int())
-        portrange = (firstport, lastport)
-
-        return {
-            "server": {
-                "server": server,
-                "login": self.Login.get_text(),
-                "portrange": portrange,
-                "autoaway": self.AutoAway.get_value_as_int(),
-                "autoreply": self.AutoReply.get_text(),
-                "interface": self.Interface.get_active_text(),
-                "upnp": self.UseUPnP.get_active(),
-                "upnp_interval": self.UPnPInterval.get_value_as_int(),
-                "auto_connect_startup": self.AutoConnectStartup.get_active(),
-                "ctcpmsgs": not self.ctcptogglebutton.get_active()
-            }
-        }
-
-    def on_change_password_response(self, dialog, response_id, logged_in):
-
-        password = dialog.get_response_value()
-        dialog.destroy()
-
-        if response_id != Gtk.ResponseType.OK:
-            return
-
-        if logged_in != self.p.frame.np.logged_in:
-            message_dialog(
-                parent=self.p.dialog,
-                title=_("Password Change Rejected"),
-                message=("Since your login status changed, your password has not been changed. Please try again.")
-            )
-            return
-
-        if not password:
-            self.on_change_password()
-            return
-
-        if not self.p.frame.np.logged_in:
-            config.sections["server"]["passw"] = password
-            config.write_configuration()
-            return
-
-        self.frame.np.request_change_password(password)
-
-    def on_change_password(self, *args):
-
-        if self.p.frame.np.logged_in:
-            message = _("Enter a new password for your Soulseek account:")
-        else:
-            message = (_("You are currently logged out of the Soulseek network. If you want to change "
-                         "the password of an existing Soulseek account, you need to be logged into that account.")
-                       + "\n\n"
-                       + _("Enter password to use when logging in:"))
-
-        entry_dialog(
-            parent=self.p.dialog,
-            title=_("Change Password"),
-            message=message,
-            visibility=False,
-            callback=self.on_change_password_response,
-            callback_data=self.p.frame.np.logged_in
-        )
-
-    def on_toggle_upnp(self, widget, *args):
-
-        active = widget.get_active()
-        self.needportmap = active
-
-        self.UPnPInterval.set_sensitive(active)
-
-    def on_modify_upnp_interval(self, widget, *args):
-        self.needportmap = True
-
-
-class DownloadsFrame(UserInterface):
-
-    def __init__(self, parent):
-
-        super().__init__("ui/settings/downloads.ui")
-
-        self.p = parent
-        self.frame = self.p.frame
-        self.needrescan = False
-
-        self.IncompleteDir = FileChooserButton(
-            self.IncompleteDir, parent.dialog, "folder"
-        )
-        self.DownloadDir = FileChooserButton(
-            self.DownloadDir, parent.dialog, "folder", self.on_choose_download_dir
-        )
-        self.UploadDir = FileChooserButton(
-            self.UploadDir, parent.dialog, "folder"
-        )
-
-        self.options = {
-            "transfers": {
-                "autoclear_downloads": self.AutoclearFinished,
-                "lock": self.LockIncoming,
-                "reverseorder": self.DownloadReverseOrder,
-                "remotedownloads": self.RemoteDownloads,
-                "uploadallowed": self.UploadsAllowed,
-                "incompletedir": self.IncompleteDir,
-                "downloaddir": self.DownloadDir,
-                "uploaddir": self.UploadDir,
-                "downloadfilters": self.FilterView,
-                "enablefilters": self.DownloadFilter,
-                "downloadlimit": self.DownloadSpeed,
-                "downloadlimitalt": self.DownloadSpeedAlternative,
-                "usernamesubfolders": self.UsernameSubfolders,
-                "afterfinish": self.AfterDownload,
-                "afterfolder": self.AfterFolder
-            }
-        }
-
-        self.filterlist = Gtk.ListStore(
-            str,
-            bool
-        )
-
-        self.downloadfilters = []
-
-        self.column_numbers = list(range(self.filterlist.get_n_columns()))
-        cols = initialise_columns(
-            None, self.FilterView,
-            ["filter", _("Filter"), -1, "text", None],
-            ["escaped", _("Escaped"), 40, "toggle", None]
-        )
-
-        cols["filter"].set_sort_column_id(0)
-        cols["escaped"].set_sort_column_id(1)
-        renderers = cols["escaped"].get_cells()
-
-        for render in renderers:
-            render.connect('toggled', self.cell_toggle_callback, self.filterlist, 1)
-
-        self.FilterView.set_model(self.filterlist)
-
-    def set_settings(self):
-
-        self.p.set_widgets_data(self.options)
-
-        self.UploadsAllowed.set_sensitive(self.RemoteDownloads.get_active())
-
-        self.filtersiters = {}
-        self.filterlist.clear()
-
-        if config.sections["transfers"]["downloadfilters"]:
-            for dfilter in config.sections["transfers"]["downloadfilters"]:
-                dfilter, escaped = dfilter
-                self.filtersiters[dfilter] = self.filterlist.insert_with_valuesv(
-                    -1, self.column_numbers, [str(dfilter), bool(escaped)]
-                )
-
-        self.on_enable_filters_toggle(self.DownloadFilter)
-
-        self.needrescan = False
-
-    def get_settings(self):
-
-        try:
-            uploadallowed = self.UploadsAllowed.get_active()
-        except Exception:
-            uploadallowed = 0
-
-        if not self.RemoteDownloads.get_active():
-            uploadallowed = 0
-
-        return {
-            "transfers": {
-                "autoclear_downloads": self.AutoclearFinished.get_active(),
-                "lock": self.LockIncoming.get_active(),
-                "reverseorder": self.DownloadReverseOrder.get_active(),
-                "remotedownloads": self.RemoteDownloads.get_active(),
-                "uploadallowed": uploadallowed,
-                "incompletedir": self.IncompleteDir.get_path(),
-                "downloaddir": self.DownloadDir.get_path(),
-                "uploaddir": self.UploadDir.get_path(),
-                "downloadfilters": self.get_filter_list(),
-                "enablefilters": self.DownloadFilter.get_active(),
-                "downloadlimit": self.DownloadSpeed.get_value_as_int(),
-                "downloadlimitalt": self.DownloadSpeedAlternative.get_value_as_int(),
-                "usernamesubfolders": self.UsernameSubfolders.get_active(),
-                "afterfinish": self.AfterDownload.get_text(),
-                "afterfolder": self.AfterFolder.get_text()
-            }
-        }
-
-    def on_choose_download_dir(self):
-
-        # Get the transfers section
-        transfers = config.sections["transfers"]
-
-        # This function will be called upon creating the settings window,
-        # so only force a scan if the user changes his donwload directory
-        if transfers["sharedownloaddir"] and self.DownloadDir.get_path() != transfers["downloaddir"]:
-            self.needrescan = True
-
-    def on_remote_downloads(self, widget):
-
-        sensitive = widget.get_active()
-
-        self.UploadsAllowed.set_sensitive(sensitive)
-
-    def on_enable_filters_toggle(self, widget):
-
-        sensitive = widget.get_active()
-
-        self.VerifyFilters.set_sensitive(sensitive)
-        self.VerifiedLabel.set_sensitive(sensitive)
-        self.DefaultFilters.set_sensitive(sensitive)
-        self.RemoveFilter.set_sensitive(sensitive)
-        self.EditFilter.set_sensitive(sensitive)
-        self.AddFilter.set_sensitive(sensitive)
-        self.FilterView.set_sensitive(sensitive)
-
-    def on_add_filter_response(self, dialog, response_id, data):
-
-        dfilter = dialog.get_response_value()
-        escaped = dialog.get_second_response_value()
-        dialog.destroy()
-
-        if response_id != Gtk.ResponseType.OK:
-            return
-
-        if dfilter in self.filtersiters:
-            self.filterlist.set(self.filtersiters[dfilter], 0, dfilter, 1, escaped)
-        else:
-            self.filtersiters[dfilter] = self.filterlist.insert_with_valuesv(
-                -1, self.column_numbers, [dfilter, escaped]
-            )
-
-        self.on_verify_filter(self.VerifyFilters)
-
-    def on_add_filter(self, *args):
-
-        entry_dialog(
-            parent=self.p.dialog,
-            title=_("Add Download Filter"),
-            message=_("Enter a new download filter:"),
-            callback=self.on_add_filter_response,
-            option=True,
-            optionvalue=True,
-            optionmessage="Escape this filter?",
-            droplist=list(self.filtersiters.keys())
-        )
-
-    def get_filter_list(self):
-
-        self.downloadfilters = []
-
-        df = sorted(self.filtersiters.keys())
-
-        for dfilter in df:
-            iterator = self.filtersiters[dfilter]
-            dfilter = self.filterlist.get_value(iterator, 0)
-            escaped = self.filterlist.get_value(iterator, 1)
-            self.downloadfilters.append([dfilter, int(escaped)])
-
-        return self.downloadfilters
-
-    def on_edit_filter_response(self, dialog, response_id, data):
-
-        new_dfilter = dialog.get_response_value()
-        escaped = dialog.get_second_response_value()
-        dialog.destroy()
-
-        if response_id != Gtk.ResponseType.OK:
-            return
-
-        dfilter = self.get_selected_filter()
-
-        if not dfilter:
-            return
-
-        iterator = self.filtersiters[dfilter]
-
-        if new_dfilter in self.filtersiters:
-            self.filterlist.set(self.filtersiters[new_dfilter], 0, new_dfilter, 1, escaped)
-        else:
-            self.filtersiters[new_dfilter] = self.filterlist.insert_with_valuesv(
-                -1, self.column_numbers, [new_dfilter, escaped]
-            )
-            del self.filtersiters[dfilter]
-            self.filterlist.remove(iterator)
-
-        self.on_verify_filter(self.VerifyFilters)
-
-    def on_edit_filter(self, *args):
-
-        dfilter = self.get_selected_filter()
-
-        if not dfilter:
-            return
-
-        iterator = self.filtersiters[dfilter]
-        escapedvalue = self.filterlist.get_value(iterator, 1)
-
-        entry_dialog(
-            parent=self.p.dialog,
-            title=_("Edit Download Filter"),
-            message=_("Modify the following download filter:"),
-            callback=self.on_edit_filter_response,
-            default=dfilter,
-            option=True,
-            optionvalue=escapedvalue,
-            optionmessage="Escape this filter?",
-            droplist=list(self.filtersiters.keys())
-        )
-
-    def get_selected_filter(self):
-
-        model, paths = self.FilterView.get_selection().get_selected_rows()
-
-        for path in paths:
-            iterator = model.get_iter(path)
-            return model.get_value(iterator, 0)
-
-        return None
-
-    def on_remove_filter(self, *args):
-
-        dfilter = self.get_selected_filter()
-
-        if not dfilter:
-            return
-
-        iterator = self.filtersiters[dfilter]
-        self.filterlist.remove(iterator)
-
-        del self.filtersiters[dfilter]
-
-        self.on_verify_filter(self.VerifyFilters)
-
-    def on_default_filters(self, *args):
-
-        self.filtersiters = {}
-        self.filterlist.clear()
-
-        for dfilter in config.defaults["transfers"]["downloadfilters"]:
-            dfilter, escaped = dfilter
-            self.filtersiters[dfilter] = self.filterlist.insert_with_valuesv(
-                -1, self.column_numbers, [dfilter, escaped]
-            )
-
-        self.on_verify_filter(self.VerifyFilters)
-
-    def on_verify_filter(self, widget):
-
-        outfilter = "(\\\\("
-
-        df = sorted(self.filtersiters.keys())
-
-        proccessedfilters = []
-        failed = {}
-
-        for dfilter in df:
-
-            iterator = self.filtersiters[dfilter]
-            dfilter = self.filterlist.get_value(iterator, 0)
-            escaped = self.filterlist.get_value(iterator, 1)
-
-            if escaped:
-                dfilter = re.escape(dfilter)
-                dfilter = dfilter.replace("\\*", ".*")
-            else:
-                # Avoid "Nothing to repeat" error
-                dfilter = dfilter.replace("*", "\\*").replace("+", "\\+")
-
-            try:
-                re.compile("(" + dfilter + ")")
-                outfilter += dfilter
-                proccessedfilters.append(dfilter)
-            except Exception as e:
-                failed[dfilter] = e
-
-            if filter is not df[-1]:
-                outfilter += "|"
-
-        outfilter += ")$)"
-
-        try:
-            re.compile(outfilter)
-
-        except Exception as e:
-            failed[outfilter] = e
-
-        if failed:
-            errors = ""
-
-            for dfilter, error in failed.items():
-                errors += "Filter: %(filter)s Error: %(error)s " % {
-                    'filter': dfilter,
-                    'error': error
-                }
-
-            error = _("%(num)d Failed! %(error)s " % {
-                'num': len(failed),
-                'error': errors}
-            )
-
-            self.VerifiedLabel.set_markup("<span foreground=\"#e04f5e\">%s</span>" % error)
-        else:
-            self.VerifiedLabel.set_text(_("Filters Successful"))
-
-    def cell_toggle_callback(self, widget, index, treeview, pos):
-
-        iterator = self.filterlist.get_iter(index)
-        value = self.filterlist.get_value(iterator, pos)
-
-        self.filterlist.set(iterator, pos, not value)
-
-        self.on_verify_filter(self.VerifyFilters)
-
-
-class SharesFrame(UserInterface):
-
-    def __init__(self, parent):
-
-        super().__init__("ui/settings/shares.ui")
-
-        self.p = parent
-        self.frame = self.p.frame
-
-        self.needrescan = False
-        self.shareddirs = []
-        self.bshareddirs = []
-
-        self.shareslist = Gtk.ListStore(
-            str,
-            str,
-            bool
-        )
-
-        self.Shares.set_model(self.shareslist)
-        self.column_numbers = list(range(self.shareslist.get_n_columns()))
-        cols = initialise_columns(
-            None, self.Shares,
-            ["virtual_folder", _("Virtual Folder"), 0, "text", None],
-            ["folder", _("Folder"), -1, "text", None],
-            ["buddies", _("Buddy-only"), 0, "toggle", None],
-        )
-
-        cols["virtual_folder"].set_sort_column_id(0)
-        cols["folder"].set_sort_column_id(1)
-        cols["buddies"].set_sort_column_id(2)
-
-        for render in cols["buddies"].get_cells():
-            render.connect('toggled', self.cell_toggle_callback, self.Shares)
-
-        self.options = {
-            "transfers": {
-                "rescanonstartup": self.RescanOnStartup,
-                "sharedownloaddir": self.ShareDownloadDir,
-                "buddysharestrustedonly": self.BuddySharesTrustedOnly
-            }
-        }
-
-    def set_settings(self):
-
-        transfers = config.sections["transfers"]
-        self.shareslist.clear()
-
-        self.p.set_widgets_data(self.options)
-
-        for (virtual, actual, *unused) in transfers["buddyshared"]:
-
-            self.shareslist.insert_with_valuesv(-1, self.column_numbers, [
-                str(virtual),
-                str(actual),
-                True
-            ])
-
-        for (virtual, actual, *unused) in transfers["shared"]:
-
-            self.shareslist.insert_with_valuesv(-1, self.column_numbers, [
-                str(virtual),
-                str(actual),
-                False
-            ])
-
-        self.shareddirs = transfers["shared"][:]
-        self.bshareddirs = transfers["buddyshared"][:]
-
-        self.needrescan = False
-
-    def get_settings(self):
-
-        return {
-            "transfers": {
-                "shared": self.shareddirs[:],
-                "buddyshared": self.bshareddirs[:],
-                "rescanonstartup": self.RescanOnStartup.get_active(),
-                "sharedownloaddir": self.ShareDownloadDir.get_active(),
-                "buddysharestrustedonly": self.BuddySharesTrustedOnly.get_active()
-            }
-        }
-
-    def on_share_download_dir_toggled(self, widget):
-        self.needrescan = True
-
-    def set_shared_dir_buddy_only(self, iterator, buddy_only):
-
-        virtual = self.shareslist.get_value(iterator, 0)
-        directory = self.shareslist.get_value(iterator, 1)
-        share = (virtual, directory)
-        self.needrescan = True
-
-        self.shareslist.set_value(iterator, 2, buddy_only)
-
-        if buddy_only:
-            self.shareddirs.remove(share)
-            self.bshareddirs.append(share)
-            return
-
-        self.bshareddirs.remove(share)
-        self.shareddirs.append(share)
-
-    def cell_toggle_callback(self, widget, index, treeview):
-
-        store = treeview.get_model()
-        iterator = store.get_iter(index)
-
-        buddy_only = not self.shareslist.get_value(iterator, 2)
-        self.set_shared_dir_buddy_only(iterator, buddy_only)
-
-    def add_shared_dir_response(self, dialog, response_id, data):
-
-        virtual = dialog.get_response_value()
-        buddy = dialog.get_second_response_value()
-        dialog.destroy()
-
-        if response_id != Gtk.ResponseType.OK:
-            return
-
-        # Remove slashes from share name to avoid path conflicts
-        if virtual:
-            virtual = virtual.replace('/', '_').replace('\\', '_')
-
-        # If the virtual share name is not already used
-        if not virtual or virtual in (x[0] for x in self.shareddirs + self.bshareddirs):
-            message_dialog(
-                parent=self.p.dialog,
-                title=_("Unable to Share Folder"),
-                message=_("The chosen virtual name is either empty or already exists")
-            )
-            return
-
-        directory = data
-
-        self.shareslist.insert_with_valuesv(-1, self.column_numbers, [
-            virtual,
-            directory,
-            buddy
-        ])
-
-        if buddy:
-            shared_dirs = self.bshareddirs
-        else:
-            shared_dirs = self.shareddirs
-
-        shared_dirs.append((virtual, directory))
-        self.needrescan = True
-
-    def add_shared_dir(self, folder):
-
-        if folder is None:
-            return
-
-        # If the directory is already shared
-        if folder in (x[1] for x in self.shareddirs + self.bshareddirs):
-            message_dialog(
-                parent=self.p.dialog,
-                title=_("Unable to Share Folder"),
-                message=_("The chosen folder is already shared.")
-            )
-            return
-
-        entry_dialog(
-            parent=self.p.dialog,
-            title=_("Set Virtual Name"),
-            message=_("Enter virtual name for '%(dir)s':") % {'dir': folder},
-            default=os.path.basename(os.path.normpath(folder)),
-            option=True,
-            optionmessage=_("Share with buddies only"),
-            callback=self.add_shared_dir_response,
-            callback_data=folder
-        )
-
-    def on_add_shared_dir_selected(self, selected, data):
-
-        for folder in selected:
-            self.add_shared_dir(folder)
-
-    def on_add_shared_dir(self, *args):
-
-        choose_dir(
-            parent=self.p.dialog,
-            callback=self.on_add_shared_dir_selected,
-            title=_("Add a Shared Folder")
-        )
-
-    def on_edit_shared_dir_response(self, dialog, response_id, path):
-
-        virtual = dialog.get_response_value()
-        buddy_only = dialog.get_second_response_value()
-        dialog.destroy()
-
-        if response_id != Gtk.ResponseType.OK:
-            return
-
-        if not virtual:
-            return
-
-        # Remove slashes from share name to avoid path conflicts
-        iterator = self.shareslist.get_iter(path)
-        virtual = virtual.replace('/', '_').replace('\\', '_')
-        directory = self.shareslist.get_value(iterator, 1)
-        oldvirtual = self.shareslist.get_value(iterator, 0)
-        oldmapping = (oldvirtual, directory)
-        newmapping = (virtual, directory)
-
-        self.set_shared_dir_buddy_only(iterator, buddy_only)
-        self.shareslist.set_value(iterator, 0, virtual)
-
-        if oldmapping in self.bshareddirs:
-            shared_dirs = self.bshareddirs
-        else:
-            shared_dirs = self.shareddirs
-
-        shared_dirs.remove(oldmapping)
-        shared_dirs.append(newmapping)
-
-        self.needrescan = True
-
-    def on_edit_shared_dir(self, *args):
-
-        model, paths = self.Shares.get_selection().get_selected_rows()
-
-        for path in reversed(paths):
-            iterator = model.get_iter(path)
-            virtual_name = model.get_value(iterator, 0)
-            folder = model.get_value(iterator, 1)
-            buddy_only = model.get_value(iterator, 2)
-
-            entry_dialog(
-                parent=self.p.dialog,
-                title=_("Edit Shared Folder"),
-                message=_("Enter new virtual name for '%(dir)s':") % {'dir': folder},
-                default=virtual_name,
-                option=True,
-                optionvalue=buddy_only,
-                optionmessage="Share with buddies only?",
-                callback=self.on_edit_shared_dir_response,
-                callback_data=path
-            )
-
-    def on_remove_shared_dir(self, *args):
-
-        model, paths = self.Shares.get_selection().get_selected_rows()
-
-        for path in reversed(paths):
-            iterator = model.get_iter(path)
-            virtual = model.get_value(iterator, 0)
-            actual = model.get_value(iterator, 1)
-            mapping = (virtual, actual)
-
-            if mapping in self.bshareddirs:
-                self.bshareddirs.remove(mapping)
-            else:
-                self.shareddirs.remove(mapping)
-
-            model.remove(iterator)
-
-        if paths:
-            self.needrescan = True
-
-
-class UploadsFrame(UserInterface):
-
-    def __init__(self, parent):
-
-        super().__init__("ui/settings/uploads.ui")
-
-        self.p = parent
-        self.frame = self.p.frame
-
-        self.options = {
-            "transfers": {
-                "autoclear_uploads": self.AutoclearFinished,
-                "uploadbandwidth": self.QueueBandwidth,
-                "useupslots": self.QueueUseSlots,
-                "uploadslots": self.QueueSlots,
-                "uselimit": self.Limit,
-                "uploadlimit": self.LimitSpeed,
-                "uploadlimitalt": self.LimitSpeedAlternative,
-                "fifoqueue": self.FirstInFirstOut,
-                "limitby": self.LimitTotalTransfers,
-                "queuelimit": self.MaxUserQueue,
-                "filelimit": self.MaxUserFiles,
-                "friendsnolimits": self.FriendsNoLimits,
-                "preferfriends": self.PreferFriends
-            }
-        }
-
-    def set_settings(self):
-
-        self.p.set_widgets_data(self.options)
-
-        self.on_queue_use_slots_toggled(self.QueueUseSlots)
-        self.on_limit_toggled(self.Limit)
-
-    def get_settings(self):
-
-        return {
-            "transfers": {
-                "autoclear_uploads": self.AutoclearFinished.get_active(),
-                "uploadbandwidth": self.QueueBandwidth.get_value_as_int(),
-                "useupslots": self.QueueUseSlots.get_active(),
-                "uploadslots": self.QueueSlots.get_value_as_int(),
-                "uselimit": self.Limit.get_active(),
-                "uploadlimit": self.LimitSpeed.get_value_as_int(),
-                "uploadlimitalt": self.LimitSpeedAlternative.get_value_as_int(),
-                "fifoqueue": bool(self.FirstInFirstOut.get_active()),
-                "limitby": self.LimitTotalTransfers.get_active(),
-                "queuelimit": self.MaxUserQueue.get_value_as_int(),
-                "filelimit": self.MaxUserFiles.get_value_as_int(),
-                "friendsnolimits": self.FriendsNoLimits.get_active(),
-                "preferfriends": self.PreferFriends.get_active()
-            }
-        }
-
-    def on_queue_use_slots_toggled(self, widget):
-
-        sensitive = widget.get_active()
-
-        self.QueueSlots.set_sensitive(sensitive)
-
-        self.QueueBandwidth.set_sensitive(not sensitive)
-        self.QueueBandwidthText1.set_sensitive(not sensitive)
-
-    def on_limit_toggled(self, widget):
-        sensitive = widget.get_active()
-        self.LimitSpeed.set_sensitive(sensitive)
-
-
-class UserInfoFrame(UserInterface):
-
-    def __init__(self, parent):
-
-        super().__init__("ui/settings/userinfo.ui")
-
-        self.p = parent
-        self.frame = self.p.frame
-
-        self.ImageChooser = FileChooserButton(self.ImageChooser, parent.dialog, "image")
-
-        self.options = {
-            "userinfo": {
-                "descr": None,
-                "pic": self.ImageChooser
-            }
-        }
-
-    def set_settings(self):
-
-        self.p.set_widgets_data(self.options)
-
-        if config.sections["userinfo"]["descr"] is not None:
-            descr = unescape(config.sections["userinfo"]["descr"])
-            self.Description.get_buffer().set_text(descr)
-
-    def get_settings(self):
-
-        buffer = self.Description.get_buffer()
-
-        start = buffer.get_start_iter()
-        end = buffer.get_end_iter()
-
-        descr = buffer.get_text(start, end, True).replace("; ", ", ").__repr__()
-
-        return {
-            "userinfo": {
-                "descr": descr,
-                "pic": self.ImageChooser.get_path()
-            }
-        }
-
-    def on_default_image(self, widget):
-        self.ImageChooser.clear()
-
-
-class IgnoredUsersFrame(UserInterface):
-
-    def __init__(self, parent):
-
-        super().__init__("ui/settings/ignore.ui")
-
-        self.p = parent
-        self.frame = self.p.frame
-
-        self.options = {
-            "server": {
-                "ignorelist": self.IgnoredUsers,
-                "ipignorelist": self.IgnoredIPs
-            }
-        }
-
-        self.ignored_users = []
-        self.ignorelist = Gtk.ListStore(str)
-
-        self.user_column_numbers = list(range(self.ignorelist.get_n_columns()))
-        cols = initialise_columns(
-            None, self.IgnoredUsers,
-            ["username", _("Username"), -1, "text", None]
-        )
-        cols["username"].set_sort_column_id(0)
-
-        self.IgnoredUsers.set_model(self.ignorelist)
-
-        self.ignored_ips = {}
-        self.ignored_ips_list = Gtk.ListStore(str, str)
-
-        self.ip_column_numbers = list(range(self.ignored_ips_list.get_n_columns()))
-        cols = initialise_columns(
-            None, self.IgnoredIPs,
-            ["ip_address", _("IP Address"), -1, "text", None],
-            ["user", _("User"), -1, "text", None]
-        )
-        cols["ip_address"].set_sort_column_id(0)
-        cols["user"].set_sort_column_id(1)
-
-        self.IgnoredIPs.set_model(self.ignored_ips_list)
-
-    def set_settings(self):
-        server = config.sections["server"]
-
-        self.ignorelist.clear()
-        self.ignored_ips_list.clear()
-        self.ignored_users = []
-        self.ignored_ips = {}
-        self.p.set_widgets_data(self.options)
-
-        if server["ignorelist"] is not None:
-            self.ignored_users = server["ignorelist"][:]
-
-        if server["ipignorelist"] is not None:
-            self.ignored_ips = server["ipignorelist"].copy()
-            for ip, user in self.ignored_ips.items():
-                self.ignored_ips_list.insert_with_valuesv(-1, self.ip_column_numbers, [
-                    str(ip), str(user)
-                ])
-
-    def get_settings(self):
-        return {
-            "server": {
-                "ignorelist": self.ignored_users[:],
-                "ipignorelist": self.ignored_ips.copy()
-            }
-        }
-
-    def on_add_ignored_response(self, dialog, response_id, data):
-
-        user = dialog.get_response_value()
-        dialog.destroy()
-
-        if response_id != Gtk.ResponseType.OK:
-            return
-
-        if user and user not in self.ignored_users:
-            self.ignored_users.append(user)
-            self.ignorelist.insert_with_valuesv(-1, self.user_column_numbers, [str(user)])
-
-    def on_add_ignored(self, widget):
-
-        entry_dialog(
-            parent=self.p.dialog,
-            title=_("Ignore User"),
-            message=_("Enter the name of the user you want to ignore:"),
-            callback=self.on_add_ignored_response
-        )
-
-    def on_remove_ignored(self, widget):
-
-        model, paths = self.IgnoredUsers.get_selection().get_selected_rows()
-
-        for path in reversed(paths):
-            iterator = model.get_iter(path)
-            user = model.get_value(iterator, 0)
-
-            model.remove(iterator)
-            self.ignored_users.remove(user)
-
-    def on_add_ignored_ip_response(self, dialog, response_id, data):
-
-        ip = dialog.get_response_value()
-        dialog.destroy()
-
-        if response_id != Gtk.ResponseType.OK:
-            return
-
-        if ip is None or ip == "" or ip.count(".") != 3:
-            return
-
-        for chars in ip.split("."):
-
-            if chars == "*":
-                continue
-            if not chars.isdigit():
-                return
-
-            try:
-                if int(chars) > 255:
-                    return
-            except Exception:
-                return
-
-        if ip not in self.ignored_ips:
-            self.ignored_ips[ip] = ""
-            self.ignored_ips_list.insert_with_valuesv(-1, self.ip_column_numbers, [ip, ""])
-
-    def on_add_ignored_ip(self, widget):
-
-        entry_dialog(
-            parent=self.p.dialog,
-            title=_("Ignore IP Address"),
-            message=_("Enter an IP address you want to ignore:") + " " + _("* is a wildcard"),
-            callback=self.on_add_ignored_ip_response
-        )
-
-    def on_remove_ignored_ip(self, widget):
-
-        model, paths = self.IgnoredIPs.get_selection().get_selected_rows()
-
-        for path in reversed(paths):
-            iterator = model.get_iter(path)
-            ip = model.get_value(iterator, 0)
-
-            model.remove(iterator)
-            del self.ignored_ips[ip]
-
-
-class BannedUsersFrame(UserInterface):
-
-    def __init__(self, parent):
-
-        super().__init__("ui/settings/ban.ui")
-
-        self.p = parent
-        self.frame = self.p.frame
-
-        self.options = {
-            "server": {
-                "banlist": self.BannedList,
-                "ipblocklist": self.BlockedList
-            },
-            "transfers": {
-                "usecustomban": self.UseCustomBan,
-                "customban": self.CustomBan,
-                "geoblock": self.GeoBlock,
-                "geoblockcc": self.GeoBlockCC,
-                "usecustomgeoblock": self.UseCustomGeoBlock,
-                "customgeoblock": self.CustomGeoBlock
-            }
-        }
-
-        self.banlist = []
-        self.banlist_model = Gtk.ListStore(str)
-
-        self.ban_column_numbers = list(range(self.banlist_model.get_n_columns()))
-        cols = initialise_columns(
-            None, self.BannedList,
-            ["username", _("Username"), -1, "text", None]
-        )
-        cols["username"].set_sort_column_id(0)
-
-        self.BannedList.set_model(self.banlist_model)
-
-        self.blocked_list = {}
-        self.blocked_list_model = Gtk.ListStore(str, str)
-
-        self.block_column_numbers = list(range(self.blocked_list_model.get_n_columns()))
-        cols = initialise_columns(
-            None, self.BlockedList,
-            ["ip_address", _("IP Address"), -1, "text", None],
-            ["user", _("User"), -1, "text", None]
-        )
-        cols["ip_address"].set_sort_column_id(0)
-        cols["user"].set_sort_column_id(1)
-
-        self.BlockedList.set_model(self.blocked_list_model)
-
-    def set_settings(self):
-
-        self.need_ip_block = False
-        server = config.sections["server"]
-        self.banlist_model.clear()
-        self.blocked_list_model.clear()
-
-        self.banlist = server["banlist"][:]
-        self.p.set_widgets_data(self.options)
-
-        self.on_country_codes_toggled(self.GeoBlock)
-
-        if config.sections["transfers"]["geoblockcc"] is not None:
-            self.GeoBlockCC.set_text(config.sections["transfers"]["geoblockcc"][0])
-
-        self.on_use_custom_geo_block_toggled(self.UseCustomGeoBlock)
-        self.on_use_custom_ban_toggled(self.UseCustomBan)
-
-        if server["ipblocklist"] is not None:
-            self.blocked_list = server["ipblocklist"].copy()
-            for blocked, user in server["ipblocklist"].items():
-                self.blocked_list_model.insert_with_valuesv(-1, self.block_column_numbers, [
-                    str(blocked),
-                    str(user)
-                ])
-
-    def get_settings(self):
-        return {
-            "server": {
-                "banlist": self.banlist[:],
-                "ipblocklist": self.blocked_list.copy()
-            },
-            "transfers": {
-                "usecustomban": self.UseCustomBan.get_active(),
-                "customban": self.CustomBan.get_text(),
-                "geoblock": self.GeoBlock.get_active(),
-                "geoblockcc": [self.GeoBlockCC.get_text().upper()],
-                "usecustomgeoblock": self.UseCustomGeoBlock.get_active(),
-                "customgeoblock": self.CustomGeoBlock.get_text()
-            }
-        }
-
-    def on_country_codes_toggled(self, widget):
-        self.GeoBlockCC.set_sensitive(widget.get_active())
-
-    def on_use_custom_geo_block_toggled(self, widget):
-        self.CustomGeoBlock.set_sensitive(widget.get_active())
-
-    def on_use_custom_ban_toggled(self, widget):
-        self.CustomBan.set_sensitive(widget.get_active())
-
-    def on_add_banned_response(self, dialog, response_id, data):
-
-        user = dialog.get_response_value()
-        dialog.destroy()
-
-        if response_id != Gtk.ResponseType.OK:
-            return
-
-        if user and user not in self.banlist:
-            self.banlist.append(user)
-            self.banlist_model.insert_with_valuesv(-1, self.ban_column_numbers, [user])
-
-    def on_add_banned(self, widget):
-
-        entry_dialog(
-            parent=self.p.dialog,
-            title=_("Ban User"),
-            message=_("Enter the name of the user you want to ban:"),
-            callback=self.on_add_banned_response
-        )
-
-    def on_remove_banned(self, widget):
-
-        model, paths = self.BannedList.get_selection().get_selected_rows()
-
-        for path in reversed(paths):
-            iterator = model.get_iter(path)
-            user = model.get_value(iterator, 0)
-
-            model.remove(iterator)
-            self.banlist.remove(user)
-
-    def on_add_blocked_response(self, dialog, response_id, data):
-
-        ip = dialog.get_response_value()
-        dialog.destroy()
-
-        if response_id != Gtk.ResponseType.OK:
-            return
-
-        if ip is None or ip == "" or ip.count(".") != 3:
-            return
-
-        for chars in ip.split("."):
-
-            if chars == "*":
-                continue
-            if not chars.isdigit():
-                return
-
-            try:
-                if int(chars) > 255:
-                    return
-            except Exception:
-                return
-
-        if ip not in self.blocked_list:
-            self.blocked_list[ip] = ""
-            self.blocked_list_model.insert_with_valuesv(-1, self.block_column_numbers, [ip, ""])
-            self.need_ip_block = True
-
-    def on_add_blocked(self, widget):
-
-        entry_dialog(
-            parent=self.p.dialog,
-            title=_("Block IP Address"),
-            message=_("Enter an IP address you want to block:") + " " + _("* is a wildcard"),
-            callback=self.on_add_blocked_response
-        )
-
-    def on_remove_blocked(self, widget):
-
-        model, paths = self.BlockedList.get_selection().get_selected_rows()
-
-        for path in reversed(paths):
-            iterator = model.get_iter(path)
-            ip = model.get_value(iterator, 0)
-
-            self.blocked_list_model.remove(iterator)
-            del self.blocked_list[ip]
-
-
-class TextToSpeechFrame(UserInterface):
-
-    def __init__(self, parent):
-
-        super().__init__("ui/settings/tts.ui")
-
-        self.p = parent
-        self.frame = self.p.frame
-
-        self.options = {
-            "ui": {
-                "speechenabled": self.TextToSpeech,
-                "speechcommand": self.TTSCommand,
-                "speechrooms": self.RoomMessage,
-                "speechprivate": self.PrivateMessage
-            }
-        }
-
-    def on_default_private(self, widget):
-        self.PrivateMessage.set_text(config.defaults["ui"]["speechprivate"])
-
-    def on_default_rooms(self, widget):
-        self.RoomMessage.set_text(config.defaults["ui"]["speechrooms"])
-
-    def on_default_tts(self, widget):
-        self.TTSCommand.get_child().set_text(config.defaults["ui"]["speechcommand"])
-
-    def set_settings(self):
-
-        self.p.set_widgets_data(self.options)
-
-        for i in ("%(user)s", "%(message)s"):
-            if i not in config.sections["ui"]["speechprivate"]:
-                self.default_private(None)
-
-            if i not in config.sections["ui"]["speechrooms"]:
-                self.default_rooms(None)
-
-    def get_settings(self):
-
-        return {
-            "ui": {
-                "speechenabled": self.TextToSpeech.get_active(),
-                "speechcommand": self.TTSCommand.get_child().get_text(),
-                "speechrooms": self.RoomMessage.get_text(),
-                "speechprivate": self.PrivateMessage.get_text()
-            }
-        }
-
-
-class UserInterfaceFrame(UserInterface):
-
-    def __init__(self, parent):
-
-        super().__init__("ui/settings/userinterface.ui")
-
-        self.p = parent
-        self.frame = self.p.frame
-
-        self.tabs = {
-            "search": self.EnableSearchTab,
-            "downloads": self.EnableDownloadsTab,
-            "uploads": self.EnableUploadsTab,
-            "userbrowse": self.EnableUserBrowseTab,
-            "userinfo": self.EnableUserInfoTab,
-            "private": self.EnablePrivateTab,
-            "userlist": self.EnableUserListTab,
-            "chatrooms": self.EnableChatroomsTab,
-            "interests": self.EnableInterestsTab
-        }
-
-        # Define options for each GtkComboBox using a liststore
-        # The first element is the translated string,
-        # the second is a GtkPositionType
-        self.pos_list = Gtk.ListStore(str, str)
-        column_numbers = list(range(self.pos_list.get_n_columns()))
-
-        for item in ([_("Top"), "Top"], [_("Bottom"), "Bottom"], [_("Left"), "Left"], [_("Right"), "Right"]):
-            self.pos_list.insert_with_valuesv(-1, column_numbers, item)
-
-        cell = Gtk.CellRendererText()
-
-        self.MainPosition.set_model(self.pos_list)
-        self.MainPosition.pack_start(cell, True)
-        self.MainPosition.add_attribute(cell, 'text', 0)
-
-        self.ChatRoomsPosition.set_model(self.pos_list)
-        self.ChatRoomsPosition.pack_start(cell, True)
-        self.ChatRoomsPosition.add_attribute(cell, 'text', 0)
-
-        self.PrivateChatPosition.set_model(self.pos_list)
-        self.PrivateChatPosition.pack_start(cell, True)
-        self.PrivateChatPosition.add_attribute(cell, 'text', 0)
-
-        self.SearchPosition.set_model(self.pos_list)
-        self.SearchPosition.pack_start(cell, True)
-        self.SearchPosition.add_attribute(cell, 'text', 0)
-
-        self.UserInfoPosition.set_model(self.pos_list)
-        self.UserInfoPosition.pack_start(cell, True)
-        self.UserInfoPosition.add_attribute(cell, 'text', 0)
-
-        self.UserBrowsePosition.set_model(self.pos_list)
-        self.UserBrowsePosition.pack_start(cell, True)
-        self.UserBrowsePosition.add_attribute(cell, 'text', 0)
-
-        self.ThemeDir = FileChooserButton(self.ThemeDir, parent.dialog, "folder")
-
-        liststore = Gtk.ListStore(GdkPixbuf.Pixbuf, str)
-        column_numbers = list(range(liststore.get_n_columns()))
-        self.IconView.set_model(liststore)
-
-        for row in (
-            [GObject.Value(GObject.TYPE_OBJECT, get_icon("online")), _("Connected")],
-            [GObject.Value(GObject.TYPE_OBJECT, get_icon("offline")), _("Disconnected")],
-            [GObject.Value(GObject.TYPE_OBJECT, get_icon("away")), _("Away")],
-            [GObject.Value(GObject.TYPE_OBJECT, get_icon("hilite")), _("Highlight")],
-            [GObject.Value(GObject.TYPE_OBJECT, get_icon("hilite3")), _("Highlight")],
-            [GObject.Value(GObject.TYPE_OBJECT, get_icon("n")), _("Window")],
-            [GObject.Value(GObject.TYPE_OBJECT, get_icon("notify")), _("Notification")]
-        ):
-            liststore.insert_with_valuesv(-1, column_numbers, row)
-
-        if sys.platform != "darwin" and Gtk.get_major_version() != 4:
-            for row in (
-                [GObject.Value(GObject.TYPE_OBJECT, get_icon("trayicon_connect")),
-                    _("Connected (Tray)")],
-                [GObject.Value(GObject.TYPE_OBJECT, get_icon("trayicon_disconnect")),
-                    _("Disconnected (Tray)")],
-                [GObject.Value(GObject.TYPE_OBJECT, get_icon("trayicon_away")),
-                    _("Away (Tray)")],
-                [GObject.Value(GObject.TYPE_OBJECT, get_icon("trayicon_msg")),
-                    _("Message (Tray)")]
-            ):
-                liststore.insert_with_valuesv(-1, column_numbers, row)
-
-        self.needcolors = False
-        self.options = {
-            "notifications": {
-                "notification_tab_colors": self.NotificationTabColors
-            },
-            "transfers": {
-                "download_doubleclick": self.DownloadDoubleClick,
-                "upload_doubleclick": self.UploadDoubleClick
-            },
-            "ui": {
-                "globalfont": self.SelectGlobalFont,
-                "chatfont": self.SelectChatFont,
-                "listfont": self.SelectListFont,
-                "searchfont": self.SelectSearchFont,
-                "transfersfont": self.SelectTransfersFont,
-                "browserfont": self.SelectBrowserFont,
-                "usernamestyle": self.UsernameStyle,
-
-                "file_path_tooltips": self.FilePathTooltips,
-                "reverse_file_paths": self.ReverseFilePaths,
-
-                "tabmain": self.MainPosition,
-                "tabrooms": self.ChatRoomsPosition,
-                "tabprivate": self.PrivateChatPosition,
-                "tabsearch": self.SearchPosition,
-                "tabinfo": self.UserInfoPosition,
-                "tabbrowse": self.UserBrowsePosition,
-                "tab_select_previous": self.TabSelectPrevious,
-                "tabclosers": self.TabClosers,
-                "tab_status_icons": self.TabStatusIcons,
-
-                "icontheme": self.ThemeDir,
-
-                "chatlocal": self.EntryLocal,
-                "chatremote": self.EntryRemote,
-                "chatme": self.EntryMe,
-                "chathilite": self.EntryHighlight,
-                "textbg": self.EntryBackground,
-                "inputcolor": self.EntryInput,
-                "search": self.EntryImmediate,
-                "searchq": self.EntryQueue,
-                "useraway": self.EntryAway,
-                "useronline": self.EntryOnline,
-                "useroffline": self.EntryOffline,
-                "usernamehotspots": self.UsernameHotspots,
-                "urlcolor": self.EntryURL,
-                "tab_default": self.EntryRegularTab,
-                "tab_hilite": self.EntryHighlightTab,
-                "tab_changed": self.EntryChangedTab,
-                "dark_mode": self.DarkMode,
-                "exitdialog": self.CloseAction,
-                "trayicon": self.TrayiconCheck,
-                "startup_hidden": self.StartupHidden
-            }
-        }
-
-        self.colorsd = {
-            "ui": {
-                "chatlocal": self.PickLocal,
-                "chatremote": self.PickRemote,
-                "chatme": self.PickMe,
-                "chathilite": self.PickHighlight,
-                "textbg": self.PickBackground,
-                "inputcolor": self.PickInput,
-                "search": self.PickImmediate,
-                "searchq": self.PickQueue,
-                "useraway": self.PickAway,
-                "useronline": self.PickOnline,
-                "useroffline": self.PickOffline,
-                "urlcolor": self.PickURL,
-                "tab_default": self.PickRegularTab,
-                "tab_hilite": self.PickHighlightTab,
-                "tab_changed": self.PickChangedTab
-            }
-        }
-
-    def set_settings(self):
-
-        self.p.set_widgets_data(self.options)
-
-        if sys.platform == "darwin" or Gtk.get_major_version() == 4:
-            # Tray icons don't work as expected on macOS, so hide widgets
-            self.TraySettings.hide()
-            return
-
-        sensitive = self.TrayiconCheck.get_active()
-        self.StartupHidden.set_sensitive(sensitive)
-
-        for page_id, enabled in config.sections["ui"]["modes_visible"].items():
-            widget = self.tabs.get(page_id)
-
-            if widget is not None:
-                widget.set_active(enabled)
-
-        # Function to set the default iter from the value found in the config file
-        def set_active_conf(model, path, iterator, data):
-            if model.get_value(iterator, 1).lower() == data["cfg"].lower():
-                data["combobox"].set_active_iter(iterator)
-
-        # Override settings for the GtkComboBox defining ui positioning
-        for opt in [
-            "tabmain", "tabrooms", "tabprivate",
-            "tabsearch", "tabinfo", "tabbrowse"
-        ]:
-            # Get the value in the config file
-            config_val = config.sections["ui"][opt]
-
-            # Iterate over entries to find which one should be active
-            self.options["ui"][opt].get_model().foreach(set_active_conf, {
-                "cfg": config_val,
-                "combobox": self.options["ui"][opt]
-            })
-
-        self.on_username_hotspots_toggled(self.UsernameHotspots)
-        self.on_tab_notification_color_toggled(self.NotificationTabColors)
-
-        self.update_color_buttons()
-        self.needcolors = False
-
-    def get_settings(self):
-
-        # Get iters from GtkComboBox fields
-        iter_main = self.pos_list.get_iter(self.MainPosition.get_active())
-        iter_rooms = self.pos_list.get_iter(self.ChatRoomsPosition.get_active())
-        iter_private = self.pos_list.get_iter(self.PrivateChatPosition.get_active())
-        iter_search = self.pos_list.get_iter(self.SearchPosition.get_active())
-        iter_info = self.pos_list.get_iter(self.UserInfoPosition.get_active())
-        iter_browse = self.pos_list.get_iter(self.UserBrowsePosition.get_active())
-
-        enabled_tabs = {}
-
-        for page_id, widget in self.tabs.items():
-            enabled_tabs[page_id] = widget.get_active()
-
-        return {
-            "notifications": {
-                "notification_tab_colors": self.NotificationTabColors.get_active()
-            },
-            "transfers": {
-                "download_doubleclick": self.DownloadDoubleClick.get_active(),
-                "upload_doubleclick": self.UploadDoubleClick.get_active()
-            },
-            "ui": {
-                "globalfont": self.SelectGlobalFont.get_font(),
-                "chatfont": self.SelectChatFont.get_font(),
-                "listfont": self.SelectListFont.get_font(),
-                "searchfont": self.SelectSearchFont.get_font(),
-                "transfersfont": self.SelectTransfersFont.get_font(),
-                "browserfont": self.SelectBrowserFont.get_font(),
-                "usernamestyle": self.UsernameStyle.get_active_text(),
-
-                "file_path_tooltips": self.FilePathTooltips.get_active(),
-                "reverse_file_paths": self.ReverseFilePaths.get_active(),
-
-                "tabmain": self.pos_list.get_value(iter_main, 1),
-                "tabrooms": self.pos_list.get_value(iter_rooms, 1),
-                "tabprivate": self.pos_list.get_value(iter_private, 1),
-                "tabsearch": self.pos_list.get_value(iter_search, 1),
-                "tabinfo": self.pos_list.get_value(iter_info, 1),
-                "tabbrowse": self.pos_list.get_value(iter_browse, 1),
-                "modes_visible": enabled_tabs,
-                "tab_select_previous": self.TabSelectPrevious.get_active(),
-                "tabclosers": self.TabClosers.get_active(),
-                "tab_status_icons": self.TabStatusIcons.get_active(),
-
-                "icontheme": self.ThemeDir.get_path(),
-
-                "chatlocal": self.EntryLocal.get_text(),
-                "chatremote": self.EntryRemote.get_text(),
-                "chatme": self.EntryMe.get_text(),
-                "chathilite": self.EntryHighlight.get_text(),
-                "urlcolor": self.EntryURL.get_text(),
-                "textbg": self.EntryBackground.get_text(),
-                "inputcolor": self.EntryInput.get_text(),
-                "search": self.EntryImmediate.get_text(),
-                "searchq": self.EntryQueue.get_text(),
-                "useraway": self.EntryAway.get_text(),
-                "useronline": self.EntryOnline.get_text(),
-                "useroffline": self.EntryOffline.get_text(),
-                "usernamehotspots": self.UsernameHotspots.get_active(),
-                "tab_hilite": self.EntryHighlightTab.get_text(),
-                "tab_default": self.EntryRegularTab.get_text(),
-                "tab_changed": self.EntryChangedTab.get_text(),
-                "dark_mode": self.DarkMode.get_active(),
-                "exitdialog": self.CloseAction.get_active(),
-                "trayicon": self.TrayiconCheck.get_active(),
-                "startup_hidden": self.StartupHidden.get_active()
-            }
-        }
-
-    """ Tray """
-
-    def on_toggle_tray(self, widget):
-
-        self.StartupHidden.set_sensitive(widget.get_active())
-
-        if not widget.get_active() and self.StartupHidden.get_active():
-            self.StartupHidden.set_active(widget.get_active())
-
-    """ Icons """
-
-    def on_default_theme(self, widget):
-        self.ThemeDir.clear()
-
-    """ Fonts """
-
-    def on_default_font(self, widget):
-
-        font_button = getattr(self, Gtk.Buildable.get_name(widget).replace("Default", "Select"))
-        font_button.set_font_name("")
-
-        self.needcolors = True
-
-    def on_fonts_changed(self, widget):
-        self.needcolors = True
-
-    """ Colors """
-
-    def update_color_button(self, config, color_id):
-
-        for section, value in self.colorsd.items():
-            if color_id in value:
-                color_button = self.colorsd[section][color_id]
-                rgba = Gdk.RGBA()
-
-                rgba.parse(config[section][color_id])
-                color_button.set_rgba(rgba)
-                break
-
-    def update_color_buttons(self):
-
-        for section, color_ids in self.colorsd.items():
-            for color_id in color_ids:
-                self.update_color_button(config.sections, color_id)
-
-    def set_default_color(self, section, color_id):
-
-        defaults = config.defaults
-        widget = self.options[section][color_id]
-
-        if isinstance(widget, Gtk.Entry):
-            widget.set_text(defaults[section][color_id])
-
-        self.update_color_button(defaults, color_id)
-
-    def clear_color(self, section, color_id):
-
-        widget = self.options[section][color_id]
-
-        if isinstance(widget, Gtk.Entry):
-            widget.set_text("")
-
-        color_button = self.colorsd[section][color_id]
-        color_button.set_rgba(Gdk.RGBA())
-
-    def on_color_set(self, widget):
-
-        rgba = widget.get_rgba()
-        color = "#%02X%02X%02X" % (round(rgba.red * 255), round(rgba.green * 255), round(rgba.blue * 255))
-        entry = getattr(self, Gtk.Buildable.get_name(widget).replace("Pick", "Entry"))
-        entry.set_text(color)
-
-    def on_default_color(self, widget):
-
-        entry = getattr(self, Gtk.Buildable.get_name(widget).replace("Default", "Entry"))
-
-        for section in self.options:
-            for key, value in self.options[section].items():
-                if value is entry:
-                    self.set_default_color(section, key)
-                    return
-
-        entry.set_text("")
-
-    def on_username_hotspots_toggled(self, widget):
-
-        sensitive = widget.get_active()
-
-        self.EntryAway.set_sensitive(sensitive)
-        self.EntryOnline.set_sensitive(sensitive)
-        self.EntryOffline.set_sensitive(sensitive)
-
-        self.DefaultAway.set_sensitive(sensitive)
-        self.DefaultOnline.set_sensitive(sensitive)
-        self.DefaultOffline.set_sensitive(sensitive)
-
-        self.PickAway.set_sensitive(sensitive)
-        self.PickOnline.set_sensitive(sensitive)
-        self.PickOffline.set_sensitive(sensitive)
-
-    def on_tab_notification_color_toggled(self, widget):
-
-        sensitive = widget.get_active()
-
-        self.EntryChangedTab.set_sensitive(sensitive)
-        self.EntryHighlightTab.set_sensitive(sensitive)
-
-        self.DefaultChangedTab.set_sensitive(sensitive)
-        self.DefaultHighlightTab.set_sensitive(sensitive)
-
-        self.PickChangedTab.set_sensitive(sensitive)
-        self.PickHighlightTab.set_sensitive(sensitive)
-
-    def on_colors_changed(self, widget):
-
-        if isinstance(widget, Gtk.Entry):
-            rgba = Gdk.RGBA()
-            rgba.parse(widget.get_text())
-
-            color_button = getattr(self, Gtk.Buildable.get_name(widget).replace("Entry", "Pick"))
-            color_button.set_rgba(rgba)
-
-        self.needcolors = True
-
-
-class LoggingFrame(UserInterface):
-
-    def __init__(self, parent):
-
-        super().__init__("ui/settings/log.ui")
-
-        self.p = parent
-        self.frame = self.p.frame
-
-        self.PrivateLogDir = FileChooserButton(self.PrivateLogDir, parent.dialog, "folder")
-        self.RoomLogDir = FileChooserButton(self.RoomLogDir, parent.dialog, "folder")
-        self.TransfersLogDir = FileChooserButton(self.TransfersLogDir, parent.dialog, "folder")
-        self.DebugLogDir = FileChooserButton(self.DebugLogDir, parent.dialog, "folder")
-
-        self.options = {
-            "logging": {
-                "privatechat": self.LogPrivate,
-                "privatelogsdir": self.PrivateLogDir,
-                "chatrooms": self.LogRooms,
-                "roomlogsdir": self.RoomLogDir,
-                "transfers": self.LogTransfers,
-                "transferslogsdir": self.TransfersLogDir,
-                "debug_file_output": self.LogDebug,
-                "debuglogsdir": self.DebugLogDir,
-                "rooms_timestamp": self.ChatRoomFormat,
-                "private_timestamp": self.PrivateChatFormat,
-                "log_timestamp": self.LogFileFormat,
-                "timestamps": self.ShowTimeStamps,
-                "readroomlines": self.RoomLogLines,
-                "readprivatelines": self.PrivateLogLines,
-                "readroomlogs": self.ReadRoomLogs
-            },
-            "privatechat": {
-                "store": self.ReopenPrivateChats
-            }
-        }
-
-    def set_settings(self):
-        self.p.set_widgets_data(self.options)
-
-    def get_settings(self):
-
-        return {
-            "logging": {
-                "privatechat": self.LogPrivate.get_active(),
-                "privatelogsdir": self.PrivateLogDir.get_path(),
-                "chatrooms": self.LogRooms.get_active(),
-                "roomlogsdir": self.RoomLogDir.get_path(),
-                "transfers": self.LogTransfers.get_active(),
-                "transferslogsdir": self.TransfersLogDir.get_path(),
-                "debug_file_output": self.LogDebug.get_active(),
-                "debuglogsdir": self.DebugLogDir.get_path(),
-                "readroomlogs": self.ReadRoomLogs.get_active(),
-                "readroomlines": self.RoomLogLines.get_value_as_int(),
-                "readprivatelines": self.PrivateLogLines.get_value_as_int(),
-                "private_timestamp": self.PrivateChatFormat.get_text(),
-                "rooms_timestamp": self.ChatRoomFormat.get_text(),
-                "log_timestamp": self.LogFileFormat.get_text(),
-                "timestamps": self.ShowTimeStamps.get_active()
-            },
-            "privatechat": {
-                "store": self.ReopenPrivateChats.get_active()
-            },
-        }
-
-    def on_default_timestamp(self, widget):
-        self.LogFileFormat.set_text(config.defaults["logging"]["log_timestamp"])
-
-    def on_room_default_timestamp(self, widget):
-        self.ChatRoomFormat.set_text(config.defaults["logging"]["rooms_timestamp"])
-
-    def on_private_default_timestamp(self, widget):
-        self.PrivateChatFormat.set_text(config.defaults["logging"]["private_timestamp"])
-
-
-class SearchesFrame(UserInterface):
-
-    def __init__(self, parent):
-
-        super().__init__("ui/settings/search.ui")
-
-        self.p = parent
-        self.frame = self.p.frame
-
-        self.filter_help = UserInterface("ui/popovers/searchfilters.ui")
-        self.ShowSearchHelp.set_popover(self.filter_help.popover)
-
-        if Gtk.get_major_version() == 4:
-            button = self.ShowSearchHelp.get_first_child()
-            button.set_child(self.FilterHelpLabel)
-            button.get_style_context().remove_class("image-button")
-        else:
-            self.ShowSearchHelp.add(self.FilterHelpLabel)
-
-        self.options = {
-            "searches": {
-                "maxresults": self.MaxResults,
-                "enablefilters": self.EnableFilters,
-                "re_filter": self.RegexpFilters,
-                "defilter": None,
-                "search_results": self.ToggleResults,
-                "max_displayed_results": self.MaxDisplayedResults,
-                "min_search_chars": self.MinSearchChars,
-                "remove_special_chars": self.RemoveSpecialChars,
-                "enable_history": self.EnableSearchHistory,
-                "private_search_results": self.ShowPrivateSearchResults
-            }
-        }
-
-    def set_settings(self):
-
-        try:
-            searches = config.sections["searches"]
-        except Exception:
-            searches = None
-
-        self.p.set_widgets_data(self.options)
-
-        if searches["defilter"] is not None:
-            self.FilterIn.set_text(str(searches["defilter"][0]))
-            self.FilterOut.set_text(str(searches["defilter"][1]))
-            self.FilterSize.set_text(str(searches["defilter"][2]))
-            self.FilterBR.set_text(str(searches["defilter"][3]))
-            self.FilterFree.set_active(searches["defilter"][4])
-
-            if len(searches["defilter"]) > 5:
-                self.FilterCC.set_text(str(searches["defilter"][5]))
-
-            if len(searches["defilter"]) > 6:
-                self.FilterType.set_text(str(searches["defilter"][6]))
-
-        self.ClearSearchHistorySuccess.hide()
-        self.ClearFilterHistorySuccess.hide()
-
-        self.on_enable_filters_toggled(self.EnableFilters)
-        self.on_enable_search_results(self.ToggleResults)
-
-    def get_settings(self):
-
-        return {
-            "searches": {
-                "maxresults": self.MaxResults.get_value_as_int(),
-                "enablefilters": self.EnableFilters.get_active(),
-                "re_filter": self.RegexpFilters.get_active(),
-                "defilter": [
-                    self.FilterIn.get_text(),
-                    self.FilterOut.get_text(),
-                    self.FilterSize.get_text(),
-                    self.FilterBR.get_text(),
-                    self.FilterFree.get_active(),
-                    self.FilterCC.get_text(),
-                    self.FilterType.get_text()
-                ],
-                "search_results": self.ToggleResults.get_active(),
-                "max_displayed_results": self.MaxDisplayedResults.get_value_as_int(),
-                "min_search_chars": self.MinSearchChars.get_value_as_int(),
-                "remove_special_chars": self.RemoveSpecialChars.get_active(),
-                "enable_history": self.EnableSearchHistory.get_active(),
-                "private_search_results": self.ShowPrivateSearchResults.get_active()
-            }
-        }
-
-    def on_clear_search_history(self, widget):
-        self.frame.search.clear_search_history()
-        self.ClearSearchHistorySuccess.show()
-
-    def on_clear_filter_history(self, widget):
-        self.frame.search.clear_filter_history()
-        self.ClearFilterHistorySuccess.show()
-
-    def on_enable_filters_toggled(self, widget):
-        active = widget.get_active()
-        for w in (self.FilterIn, self.FilterOut, self.FilterType, self.FilterSize,
-                  self.FilterBR, self.FilterCC, self.FilterFree):
-            w.set_sensitive(active)
-
-    def on_enable_search_results(self, widget):
-        active = widget.get_active()
-        for w in (self.MinSearchCharsL1, self.MinSearchChars,
-                  self.MaxResults, self.MaxResultsL1):
-            w.set_sensitive(active)
-
-
-class UrlHandlersFrame(UserInterface):
-
-    def __init__(self, parent):
-
-        super().__init__("ui/settings/urlhandlers.ui")
-
-        self.p = parent
-        self.frame = self.p.frame
-
-        self.options = {
-            "urls": {
-                "protocols": None
-            },
-            "ui": {
-                "filemanager": self.FileManagerCombo
-            },
-            "players": {
-                "default": self.audioPlayerCombo
-            }
-        }
-
-        self.protocolmodel = Gtk.ListStore(str, str)
-        self.protocols = {}
-
-        self.column_numbers = list(range(self.protocolmodel.get_n_columns()))
-        cols = initialise_columns(
-            None, self.ProtocolHandlers,
-            ["protocol", _("Protocol"), -1, "text", None],
-            ["command", _("Command"), -1, "combo", None]
-        )
-
-        cols["protocol"].set_sort_column_id(0)
-        cols["command"].set_sort_column_id(1)
-
-        self.ProtocolHandlers.set_model(self.protocolmodel)
-
-        renderers = cols["command"].get_cells()
-        for render in renderers:
-            render.connect('edited', self.cell_edited_callback, self.ProtocolHandlers, 1)
-
-    def set_settings(self):
-
-        self.protocolmodel.clear()
-        self.protocols.clear()
-
-        self.p.set_widgets_data(self.options)
-
-        for key in config.sections["urls"]["protocols"].keys():
-            if config.sections["urls"]["protocols"][key][-1:] == "&":
-                command = config.sections["urls"]["protocols"][key][:-1].rstrip()
-            else:
-                command = config.sections["urls"]["protocols"][key]
-
-            self.protocols[key] = self.protocolmodel.insert_with_valuesv(-1, self.column_numbers, [
-                str(key), str(command)
-            ])
-
-    def get_settings(self):
-
-        protocols = {}
-        iterator = self.protocolmodel.get_iter_first()
-
-        while iterator is not None:
-            protocol = self.protocolmodel.get_value(iterator, 0)
-            handler = self.protocolmodel.get_value(iterator, 1)
-            protocols[protocol] = handler
-
-            iterator = self.protocolmodel.iter_next(iterator)
-
-        return {
-            "urls": {
-                "protocols": protocols
-            },
-            "ui": {
-                "filemanager": self.FileManagerCombo.get_child().get_text()
-            },
-            "players": {
-                "default": self.audioPlayerCombo.get_child().get_text()
-            }
-        }
-
-    def cell_edited_callback(self, widget, index, value, treeview, pos):
-
-        store = treeview.get_model()
-        iterator = store.get_iter(index)
-        store.set(iterator, pos, value)
-
-    def on_add(self, widget):
-
-        protocol = self.ProtocolCombo.get_child().get_text()
-        command = self.Handler.get_child().get_text()
-
-        self.ProtocolCombo.get_child().set_text("")
-        self.Handler.get_child().set_text("")
-
-        if protocol in self.protocols:
-            self.protocolmodel.set(self.protocols[protocol], 1, command)
-        else:
-            self.protocols[protocol] = self.protocolmodel.insert_with_valuesv(
-                -1, self.column_numbers, [protocol, command]
-            )
-
-    def on_remove(self, widget):
-
-        model, paths = self.ProtocolHandlers.get_selection().get_selected_rows()
-
-        for path in reversed(paths):
-            iterator = model.get_iter(path)
-            protocol = self.protocolmodel.get_value(iterator, 0)
-
-            model.remove(iterator)
-            del self.protocols[protocol]
-
-
-class CensorReplaceListFrame(UserInterface):
-
-    def __init__(self, parent):
-
-        super().__init__("ui/settings/censorreplace.ui")
-
-        self.p = parent
-        self.frame = self.p.frame
-
-        self.options = {
-            "words": {
-                "censored": self.CensorList,
-                "censorwords": self.CensorCheck,
-                "censorfill": self.CensorReplaceCombo,
-                "autoreplaced": self.ReplacementList,
-                "replacewords": self.ReplaceCheck
-            }
-        }
-
-        self.censor_list_model = Gtk.ListStore(str)
-
-        cols = initialise_columns(
-            None, self.CensorList,
-            ["pattern", _("Pattern"), -1, "edit", None]
-        )
-        cols["pattern"].set_sort_column_id(0)
-
-        self.CensorList.set_model(self.censor_list_model)
-
-        renderers = cols["pattern"].get_cells()
-        for render in renderers:
-            render.connect('edited', self.censor_cell_edited_callback, self.CensorList, 0)
-
-        self.replace_list_model = Gtk.ListStore(str, str)
-
-        self.column_numbers = list(range(self.replace_list_model.get_n_columns()))
-        cols = initialise_columns(
-            None, self.ReplacementList,
-            ["pattern", _("Pattern"), 150, "edit", None],
-            ["replacement", _("Replacement"), -1, "edit", None]
-        )
-        cols["pattern"].set_sort_column_id(0)
-        cols["replacement"].set_sort_column_id(1)
-
-        self.ReplacementList.set_model(self.replace_list_model)
-
-        pos = 0
-        for (column_id, column) in cols.items():
-            renderers = column.get_cells()
-            for render in renderers:
-                render.connect('edited', self.replace_cell_edited_callback, self.ReplacementList, pos)
-
-            pos += 1
-
-    def set_settings(self):
-
-        self.censor_list_model.clear()
-        self.replace_list_model.clear()
-
-        self.p.set_widgets_data(self.options)
-
-        for word, replacement in config.sections["words"]["autoreplaced"].items():
-            self.replace_list_model.insert_with_valuesv(-1, self.column_numbers, [
-                str(word),
-                str(replacement)
-            ])
-
-        self.on_censor_check(self.CensorCheck)
-        self.on_replace_check(self.ReplaceCheck)
-
-    def get_settings(self):
-
-        censored = []
-        autoreplaced = {}
-
-        iterator = self.censor_list_model.get_iter_first()
-
-        while iterator is not None:
-            word = self.censor_list_model.get_value(iterator, 0)
-            censored.append(word)
-            iterator = self.censor_list_model.iter_next(iterator)
-
-        iterator = self.replace_list_model.get_iter_first()
-
-        while iterator is not None:
-            word = self.replace_list_model.get_value(iterator, 0)
-            replacement = self.replace_list_model.get_value(iterator, 1)
-            autoreplaced[word] = replacement
-            iterator = self.replace_list_model.iter_next(iterator)
-
-        return {
-            "words": {
-                "censored": censored,
-                "censorwords": self.CensorCheck.get_active(),
-                "censorfill": self.CensorReplaceCombo.get_active_text(),
-                "autoreplaced": autoreplaced,
-                "replacewords": self.ReplaceCheck.get_active()
-            }
-        }
-
-    def censor_cell_edited_callback(self, widget, index, value, treeview, pos):
-
-        store = treeview.get_model()
-        iterator = store.get_iter(index)
-
-        if value != "" and not value.isspace() and len(value) > 2:
-            store.set(iterator, pos, value)
-        else:
-            store.remove(iterator)
-
-    def replace_cell_edited_callback(self, widget, index, value, treeview, pos):
-
-        store = treeview.get_model()
-        iterator = store.get_iter(index)
-        store.set(iterator, pos, value)
-
-    def on_replace_check(self, widget):
-        sensitive = widget.get_active()
-        self.ReplacementsContainer.set_sensitive(sensitive)
-
-    def on_censor_check(self, widget):
-        sensitive = widget.get_active()
-        self.CensorContainer.set_sensitive(sensitive)
-
-    def on_add_censored_response(self, dialog, response_id, data):
-
-        pattern = dialog.get_response_value()
-        dialog.destroy()
-
-        if response_id != Gtk.ResponseType.OK:
-            return
-
-        if pattern:
-            self.censor_list_model.insert_with_valuesv(-1, [0], [pattern])
-
-    def on_add_censored(self, widget):
-
-        entry_dialog(
-            parent=self.p.dialog,
-            title=_("Censor Pattern"),
-            message=_("Enter a pattern you want to censor. Add spaces around the pattern if you don't "
-                      "want to match strings inside words (may fail at the beginning and end of lines)."),
-            callback=self.on_add_censored_response
-        )
-
-    def on_remove_censored(self, widget):
-
-        model, paths = self.CensorList.get_selection().get_selected_rows()
-
-        for path in reversed(paths):
-            iterator = model.get_iter(path)
-            model.remove(iterator)
-
-    def on_add_replacement(self, widget):
-
-        iterator = self.replace_list_model.insert_with_valuesv(-1, self.column_numbers, ["", ""])
-        selection = self.ReplacementList.get_selection()
-        selection.select_iter(iterator)
-        col = self.ReplacementList.get_column(0)
-
-        self.ReplacementList.set_cursor(self.replace_list_model.get_path(iterator), col, True)
-
-    def on_remove_replacement(self, widget):
-
-        model, paths = self.ReplacementList.get_selection().get_selected_rows()
-
-        for path in reversed(paths):
-            iterator = model.get_iter(path)
-            model.remove(iterator)
-
-
-class CompletionFrame(UserInterface):
-
-    def __init__(self, parent):
-
-        super().__init__("ui/settings/completion.ui")
-
-        self.p = parent
-        self.frame = self.p.frame
-
-        self.options = {
-            "words": {
-                "tab": self.CompletionTabCheck,
-                "cycle": self.CompletionCycleCheck,
-                "dropdown": self.CompletionDropdownCheck,
-                "characters": self.CharactersCompletion,
-                "roomnames": self.CompleteRoomNamesCheck,
-                "buddies": self.CompleteBuddiesCheck,
-                "roomusers": self.CompleteUsersInRoomsCheck,
-                "commands": self.CompleteCommandsCheck,
-                "aliases": self.CompleteAliasesCheck,
-                "onematch": self.OneMatchCheck
-            },
-            "ui": {
-                "spellcheck": self.SpellCheck
-            }
-        }
-
-    def set_settings(self):
-        self.needcompletion = False
-
-        try:
-            gi.require_version('Gspell', '1')
-            from gi.repository import Gspell  # noqa: F401
-
-        except (ImportError, ValueError):
-            self.SpellCheck.hide()
-
-        self.p.set_widgets_data(self.options)
-
-    def on_completion_changed(self, widget):
-        self.needcompletion = True
-
-    def on_completion_tab_check(self, widget):
-        sensitive = self.CompletionTabCheck.get_active()
-        self.needcompletion = True
-
-        self.CompletionCycleCheck.set_sensitive(sensitive)
-        self.CompleteRoomNamesCheck.set_sensitive(sensitive)
-        self.CompleteBuddiesCheck.set_sensitive(sensitive)
-        self.CompleteUsersInRoomsCheck.set_sensitive(sensitive)
-        self.CompleteCommandsCheck.set_sensitive(sensitive)
-        self.CompleteAliasesCheck.set_sensitive(sensitive)
-        self.CompletionDropdownCheck.set_sensitive(sensitive)
-
-        self.on_completion_dropdown_check(widget)
-
-    def on_completion_dropdown_check(self, widget):
-        sensitive = (self.CompletionTabCheck.get_active() and self.CompletionDropdownCheck.get_active())
-        self.needcompletion = True
-
-        self.CharactersCompletion.set_sensitive(sensitive)
-        self.OneMatchCheck.set_sensitive(sensitive)
-
-    def get_settings(self):
-        return {
-            "words": {
-                "tab": self.CompletionTabCheck.get_active(),
-                "cycle": self.CompletionCycleCheck.get_active(),
-                "dropdown": self.CompletionDropdownCheck.get_active(),
-                "characters": self.CharactersCompletion.get_value_as_int(),
-                "roomnames": self.CompleteRoomNamesCheck.get_active(),
-                "buddies": self.CompleteBuddiesCheck.get_active(),
-                "roomusers": self.CompleteUsersInRoomsCheck.get_active(),
-                "commands": self.CompleteCommandsCheck.get_active(),
-                "aliases": self.CompleteAliasesCheck.get_active(),
-                "onematch": self.OneMatchCheck.get_active()
-            },
-            "ui": {
-                "spellcheck": self.SpellCheck.get_active()
-            }
-        }
-
-
-class NowPlayingFrame(UserInterface):
-
-    def __init__(self, parent):
-
-        super().__init__("ui/settings/nowplaying.ui")
-
-        self.p = parent
-        self.frame = self.p.frame
-
-        self.options = {
-            "players": {
-                "npothercommand": self.NPCommand
-            }
-        }
-
-        self.player_replacers = []
-
-        # Default format list
-        self.default_format_list = [
-            "$n",
-            "$n ($f)",
-            "$a - $t",
-            "[$a] $t",
-            "$a - $b - $t",
-            "$a - $b - $t ($l/$r KBps) from $y $c"
-        ]
-        self.custom_format_list = []
-
-        # Suppy the information needed for the Now Playing class to return a song
-        self.test_now_playing.connect(
-            "clicked",
-            self.p.frame.np.now_playing.display_now_playing,
-            self.set_now_playing_example,  # Callback to update the song displayed
-            self.get_player,               # Callback to retrieve selected player
-            self.get_command,              # Callback to retrieve command text
-            self.get_format                # Callback to retrieve format text
-        )
-
-    def set_settings(self):
-
-        self.p.set_widgets_data(self.options)
-
-        # Save reference to format list for get_settings()
-        self.custom_format_list = config.sections["players"]["npformatlist"]
-
-        # Update UI with saved player
-        self.set_player(config.sections["players"]["npplayer"])
-        self.update_now_playing_info()
-
-        # Add formats
-        self.NPFormat.remove_all()
-
-        for item in self.default_format_list:
-            self.NPFormat.append_text(str(item))
-
-        if self.custom_format_list:
-            for item in self.custom_format_list:
-                self.NPFormat.append_text(str(item))
-
-        if config.sections["players"]["npformat"] == "":
-            # If there's no default format in the config: set the first of the list
-            self.NPFormat.set_active(0)
-        else:
-            # If there's is a default format in the config: select the right item
-            for (i, v) in enumerate(self.NPFormat.get_model()):
-                if v[0] == config.sections["players"]["npformat"]:
-                    self.NPFormat.set_active(i)
-
-    def get_player(self):
-
-        if self.NP_lastfm.get_active():
-            player = "lastfm"
-        elif self.NP_mpris.get_active():
-            player = "mpris"
-        elif self.NP_listenbrainz.get_active():
-            player = "listenbrainz"
-        elif self.NP_other.get_active():
-            player = "other"
-
-        return player
-
-    def get_command(self):
-        return self.NPCommand.get_text()
-
-    def get_format(self):
-        return self.NPFormat.get_child().get_text()
-
-    def set_player(self, player):
-
-        if player == "lastfm":
-            self.NP_lastfm.set_active(True)
-        elif player == 'listenbrainz':
-            self.NP_listenbrainz.set_active(True)
-        elif player == "other":
-            self.NP_other.set_active(True)
-        else:
-            self.NP_mpris.set_active(True)
-
-    def update_now_playing_info(self, widget=None):
-
-        if self.NP_lastfm.get_active():
-            self.player_replacers = ["$n", "$t", "$a", "$b"]
-            self.player_input.set_text(_("Username;APIKEY:"))
-
-        elif self.NP_mpris.get_active():
-            self.player_replacers = ["$n", "$p", "$a", "$b", "$t", "$y", "$c", "$r", "$k", "$l", "$f"]
-            self.player_input.set_text(_("Client name (e.g. amarok, audacious, exaile) or empty for auto:"))
-
-        elif self.NP_listenbrainz.get_active():
-            self.player_replacers = ["$n", "$t", "$a", "$b"]
-            self.player_input.set_text(_("Username:"))
-
-        elif self.NP_other.get_active():
-            self.player_replacers = ["$n"]
-            self.player_input.set_text(_("Command:"))
-
-        legend = ""
-
-        for item in self.player_replacers:
-            legend += item + "\t"
-
-            if item == "$t":
-                legend += _("Title")
-            elif item == "$n":
-                legend += _("Now Playing (typically \"%(artist)s - %(title)s\")") % {
-                    'artist': _("Artist"), 'title': _("Title")}
-            elif item == "$l":
-                legend += _("Length")
-            elif item == "$r":
-                legend += _("Bitrate")
-            elif item == "$c":
-                legend += _("Comment")
-            elif item == "$a":
-                legend += _("Artist")
-            elif item == "$b":
-                legend += _("Album")
-            elif item == "$k":
-                legend += _("Track Number")
-            elif item == "$y":
-                legend += _("Year")
-            elif item == "$f":
-                legend += _("Filename (URI)")
-            elif item == "$p":
-                legend += _("Program")
-
-            legend += "\n"
-
-        self.Legend.set_text(legend[:-1])
-
-    def set_now_playing_example(self, title):
-        self.Example.set_text(title)
-
-    def get_settings(self):
-
-        npformat = self.get_format()
-
-        if (npformat and not npformat.isspace()
-                and npformat not in self.custom_format_list
-                and npformat not in self.default_format_list):
-            self.custom_format_list.append(npformat)
-
-        return {
-            "players": {
-                "npplayer": self.get_player(),
-                "npothercommand": self.get_command(),
-                "npformat": npformat,
-                "npformatlist": self.custom_format_list
-            }
-        }
-
-
-class NotificationsFrame(UserInterface):
-
-    def __init__(self, parent):
-
-        super().__init__("ui/settings/notifications.ui")
-
-        self.p = parent
-        self.frame = self.p.frame
-
-        self.options = {
-            "notifications": {
-                "notification_window_title": self.NotificationWindowTitle,
-                "notification_popup_sound": self.NotificationPopupSound,
-                "notification_popup_file": self.NotificationPopupFile,
-                "notification_popup_folder": self.NotificationPopupFolder,
-                "notification_popup_private_message": self.NotificationPopupPrivateMessage,
-                "notification_popup_chatroom": self.NotificationPopupChatroom,
-                "notification_popup_chatroom_mention": self.NotificationPopupChatroomMention
-            },
-        }
-
-    def set_settings(self):
-        self.p.set_widgets_data(self.options)
-
-    def get_settings(self):
-
-        return {
-            "notifications": {
-                "notification_window_title": self.NotificationWindowTitle.get_active(),
-                "notification_popup_sound": self.NotificationPopupSound.get_active(),
-                "notification_popup_file": self.NotificationPopupFile.get_active(),
-                "notification_popup_folder": self.NotificationPopupFolder.get_active(),
-                "notification_popup_private_message": self.NotificationPopupPrivateMessage.get_active(),
-                "notification_popup_chatroom": self.NotificationPopupChatroom.get_active(),
-                "notification_popup_chatroom_mention": self.NotificationPopupChatroomMention.get_active()
-            }
-        }
-
-
-class PluginsFrame(UserInterface):
-
-    """ Plugin preferences dialog """
-
-    class PluginPreferencesDialog(Gtk.Dialog):
-        """ Class used to build a custom dialog for the plugins """
-
-        def __init__(self, parent, name):
-
-            self.settings = parent.p
-
-            # Build the window
-            Gtk.Dialog.__init__(
-                self,
-                title=_("%s Properties") % name,
-                modal=True,
-                default_width=600,
-                use_header_bar=Gtk.Settings.get_default().get_property("gtk-dialogs-use-header")
-            )
-            set_dialog_properties(self, self.settings.dialog)
-            self.get_style_context().add_class("preferences")
-
-            self.add_buttons(
-                _("Cancel"), Gtk.ResponseType.CANCEL, _("OK"), Gtk.ResponseType.OK
-            )
-
-            self.set_default_response(Gtk.ResponseType.OK)
-            self.connect("response", self.on_response)
-
-            self.primary_container = Gtk.Box()
-            self.primary_container.set_orientation(Gtk.Orientation.VERTICAL)
-            self.primary_container.set_margin_top(14)
-            self.primary_container.set_margin_bottom(14)
-            self.primary_container.set_margin_start(18)
-            self.primary_container.set_margin_end(18)
-            self.primary_container.set_spacing(12)
-
-            self.get_content_area().add(self.primary_container)
-
-            self.tw = {}
-            self.options = {}
-            self.plugin = None
-
-        def generate_label(self, text):
-
-            label = Gtk.Label.new(text)
-            label.set_use_markup(True)
-            label.set_hexpand(True)
-            label.set_xalign(0)
-
-            if Gtk.get_major_version() == 4:
-                label.set_wrap(True)
-            else:
-                label.set_line_wrap(True)
-
-            return label
-
-        def generate_widget_container(self, description, vertical=False):
-
-            container = Gtk.Box()
-            container.set_spacing(12)
-
-            if vertical:
-                container.set_orientation(Gtk.Orientation.VERTICAL)
-
-            label = self.generate_label(description)
-            container.add(label)
-            self.primary_container.add(container)
-
-            return (container, label)
-
-        def generate_tree_view(self, name, description, value):
-
-            container = Gtk.Box()
-            container.set_spacing(6)
-
-            scrolled_window = Gtk.ScrolledWindow()
-            scrolled_window.set_hexpand(True)
-            scrolled_window.set_vexpand(True)
-            scrolled_window.set_min_content_height(200)
-            scrolled_window.set_min_content_width(350)
-            scrolled_window.set_policy(Gtk.PolicyType.AUTOMATIC, Gtk.PolicyType.AUTOMATIC)
-
-            self.tw[name] = Gtk.TreeView()
-            self.tw[name].set_model(Gtk.ListStore(str))
-
-            if Gtk.get_major_version() == 4:
-                scrolled_window.set_has_frame(True)
-                scrolled_window.set_child(self.tw[name])
-            else:
-                scrolled_window.set_shadow_type(Gtk.ShadowType.IN)
-                scrolled_window.add(self.tw[name])
-
-            container.add(scrolled_window)
-
-            cols = initialise_columns(
-                None, self.tw[name],
-                [description, description, 150, "edit", None]
-            )
-
-            try:
-                self.settings.set_widget(self.tw[name], value)
-            except Exception:
-                pass
-
-            self.add_button = Gtk.Button.new_with_label(_("Add"))
-            self.remove_button = Gtk.Button.new_with_label(_("Remove"))
-
-            box = Gtk.Box()
-            box.set_spacing(6)
-
-            box.add(self.add_button)
-            box.add(self.remove_button)
-
-            self.primary_container.add(container)
-            self.primary_container.add(box)
-
-            renderers = cols[description].get_cells()
-            for render in renderers:
-                render.connect('edited', self.cell_edited_callback, self.tw[name])
-
-            self.add_button.connect("clicked", self.on_add, self.tw[name])
-            self.remove_button.connect("clicked", self.on_remove, self.tw[name])
-
-        def cell_edited_callback(self, widget, index, value, treeview):
-            store = treeview.get_model()
-            iterator = store.get_iter(index)
-            store.set(iterator, 0, value)
-
-        def add_options(self, plugin, options=None):
-
-            if options is None:
-                options = {}
-
-            self.options = options
-            self.plugin = plugin
-            config_name = plugin.lower()
-
-            for name, data in options.items():
-                if config_name not in config.sections["plugins"]:
-                    continue
-
-                if name not in config.sections["plugins"][config_name]:
-                    continue
-
-                value = config.sections["plugins"][config_name][name]
-
-                if data["type"] in ("integer", "int", "float"):
-                    container, label = self.generate_widget_container(data["description"])
-
-                    minimum = data.get("minimum") or 0
-                    maximum = data.get("maximum") or 99999
-                    stepsize = data.get("stepsize") or 1
-                    decimals = 2
-
-                    if data["type"] in ("integer", "int"):
-                        decimals = 0
-
-                    self.tw[name] = button = Gtk.SpinButton.new(
-                        Gtk.Adjustment.new(0, minimum, maximum, stepsize, 10, 0),
-                        1, decimals)
-                    button.set_valign(Gtk.Align.CENTER)
-                    label.set_mnemonic_widget(button)
-                    self.settings.set_widget(button, config.sections["plugins"][config_name][name])
-
-                    container.add(self.tw[name])
-
-                elif data["type"] in ("bool",):
-                    container = Gtk.Box()
-
-                    self.tw[name] = Gtk.CheckButton.new_with_label(data["description"])
-                    self.settings.set_widget(self.tw[name], config.sections["plugins"][config_name][name])
-
-                    self.primary_container.add(container)
-                    container.add(self.tw[name])
-
-                elif data["type"] in ("radio",):
-                    container, label = self.generate_widget_container(data["description"])
-
-                    vbox = Gtk.Box()
-                    vbox.set_spacing(6)
-                    vbox.set_orientation(Gtk.Orientation.VERTICAL)
-                    container.add(vbox)
-
-                    last_radio = None
-                    group_radios = []
-
-                    for label in data["options"]:
-                        if Gtk.get_major_version() == 4:
-                            radio = Gtk.CheckButton.new_with_label(label)
-                        else:
-                            radio = Gtk.RadioButton.new_with_label_from_widget(last_radio, label)
-
-                        if not last_radio:
-                            self.tw[name] = radio
-
-                        elif Gtk.get_major_version() == 4:
-                            radio.set_group(last_radio)
-
-                        last_radio = radio
-                        group_radios.append(radio)
-                        vbox.add(radio)
-
-                    label.set_mnemonic_widget(self.tw[name])
-                    self.tw[name].group_radios = group_radios
-                    self.settings.set_widget(self.tw[name], config.sections["plugins"][config_name][name])
-
-                elif data["type"] in ("dropdown",):
-                    container, label = self.generate_widget_container(data["description"])
-
-                    self.tw[name] = combobox = Gtk.ComboBoxText()
-                    label.set_mnemonic_widget(combobox)
-                    combobox.set_valign(Gtk.Align.CENTER)
-
-                    for text_label in data["options"]:
-                        combobox.append_text(text_label)
-
-                    self.settings.set_widget(combobox, config.sections["plugins"][config_name][name])
-
-                    container.add(self.tw[name])
-
-                elif data["type"] in ("str", "string"):
-                    container, label = self.generate_widget_container(data["description"])
-
-                    self.tw[name] = entry = Gtk.Entry()
-                    entry.set_hexpand(True)
-                    entry.set_valign(Gtk.Align.CENTER)
-                    label.set_mnemonic_widget(entry)
-                    self.settings.set_widget(entry, config.sections["plugins"][config_name][name])
-
-                    container.add(entry)
-
-                elif data["type"] in ("textview"):
-                    container, label = self.generate_widget_container(data["description"], vertical=True)
-
-                    self.tw[name] = textview = Gtk.TextView()
-                    textview.set_accepts_tab(False)
-                    textview.set_pixels_above_lines(1)
-                    textview.set_pixels_below_lines(1)
-                    textview.set_left_margin(8)
-                    textview.set_right_margin(8)
-                    textview.set_top_margin(5)
-                    textview.set_bottom_margin(5)
-
-                    label.set_mnemonic_widget(textview)
-                    self.settings.set_widget(textview, config.sections["plugins"][config_name][name])
-
-                    frame_container = Gtk.Frame()
-
-                    scrolled_window = Gtk.ScrolledWindow()
-                    scrolled_window.set_hexpand(True)
-                    scrolled_window.set_vexpand(True)
-                    scrolled_window.set_min_content_height(200)
-                    scrolled_window.set_min_content_width(600)
-
-                    if Gtk.get_major_version() == 4:
-                        frame_container.set_child(textview)
-                        scrolled_window.set_child(frame_container)
-                        container.append(scrolled_window)
-
-                    else:
-                        frame_container.add(textview)
-                        scrolled_window.add(frame_container)
-                        container.add(scrolled_window)
-
-                elif data["type"] in ("list string",):
-                    self.generate_tree_view(name, data["description"], value)
-
-                elif data["type"] in ("file",):
-                    container, label = self.generate_widget_container(data["description"])
-
-                    button_widget = Gtk.Button()
-                    button_widget.set_hexpand(True)
-
-                    try:
-                        chooser = data["chooser"]
-                    except KeyError:
-                        chooser = None
-
-                    self.tw[name] = FileChooserButton(button_widget, self, chooser)
-                    button_widget.set_valign(Gtk.Align.CENTER)
-                    label.set_mnemonic_widget(button_widget)
-                    self.settings.set_widget(self.tw[name], config.sections["plugins"][config_name][name])
-
-                    container.add(button_widget)
-
-                else:
-                    log.add_debug("Unknown setting type '%s', data '%s'", (name, data))
-
-            if Gtk.get_major_version() == 3:
-                self.show_all()
-
-        def on_add(self, widget, treeview):
-
-            iterator = treeview.get_model().append([""])
-            col = treeview.get_column(0)
-
-            treeview.set_cursor(treeview.get_model().get_path(iterator), col, True)
-
-        def on_remove(self, widget, treeview):
-            selection = treeview.get_selection()
-            iterator = selection.get_selected()[1]
-            if iterator is not None:
-                treeview.get_model().remove(iterator)
-
-        def on_response(self, dialog, response_id):
-
-            if response_id == Gtk.ResponseType.OK:
-                for name in self.options:
-                    value = self.settings.get_widget_data(self.tw[name])
-                    if value is not None:
-                        config.sections["plugins"][self.plugin.lower()][name] = value
-
-                self.settings.frame.np.pluginhandler.plugin_settings(
-                    self.plugin, self.settings.frame.np.pluginhandler.enabled_plugins[self.plugin])
-
-            self.destroy()
-
-    """ Initialize plugin list """
-
-    def __init__(self, parent):
-
-        super().__init__("ui/settings/plugin.ui")
-
-        self.p = parent
-        self.frame = self.p.frame
-
-        self.options = {
-            "plugins": {
-                "enable": self.PluginsEnable
-            }
-        }
-
-        self.plugins_model = Gtk.ListStore(bool, str, str)
-        self.plugins = []
-        self.pluginsiters = {}
-        self.selected_plugin = None
-        self.descr_textview = TextView(self.PluginDescription)
-
-        self.column_numbers = list(range(self.plugins_model.get_n_columns()))
-        cols = initialise_columns(
-            None, self.PluginTreeView,
-            ["enabled", _("Enabled"), 0, "toggle", None],
-            ["plugin", _("Plugin"), 380, "text", None]
-        )
-
-        cols["enabled"].set_sort_column_id(0)
-        cols["plugin"].set_sort_column_id(1)
-
-        renderers = cols["enabled"].get_cells()
-        column_pos = 0
-
-        for render in renderers:
-            render.connect('toggled', self.cell_toggle_callback, self.PluginTreeView, column_pos)
-
-        self.PluginTreeView.set_model(self.plugins_model)
-
-    def on_add_plugins(self, widget):
-
-        try:
-            if not os.path.isdir(config.plugin_dir):
-                os.makedirs(config.plugin_dir)
-
-            open_file_path(config.plugin_dir)
-
-        except Exception as e:
-            log.add("Failed to open folder containing user plugins: %s", e)
-
-    def on_plugin_properties(self, widget):
-
-        if self.selected_plugin is None:
-            return
-
-        plugin_info = self.frame.np.pluginhandler.get_plugin_info(self.selected_plugin)
-        dialog = self.PluginPreferencesDialog(self, plugin_info.get("Name", self.selected_plugin))
-
-        dialog.add_options(
-            self.selected_plugin,
-            self.frame.np.pluginhandler.get_plugin_settings(self.selected_plugin)
-        )
-
-        dialog.present_with_time(Gdk.CURRENT_TIME)
-
-    def on_select_plugin(self, selection):
-
-        model, iterator = selection.get_selected()
-
-        if iterator is None:
-            self.selected_plugin = _("No Plugin Selected")
-            info = {}
-        else:
-            self.selected_plugin = model.get_value(iterator, 2)
-            info = self.frame.np.pluginhandler.get_plugin_info(self.selected_plugin)
-
-        self.PluginName.set_markup("<b>%(name)s</b>" % {"name": info.get("Name", self.selected_plugin)})
-        self.PluginVersion.set_markup("<b>%(version)s</b>" % {"version": info.get("Version", '-')})
-        self.PluginAuthor.set_markup("<b>%(author)s</b>" % {"author": ", ".join(info.get("Authors", '-'))})
-
-        self.descr_textview.clear()
-        self.descr_textview.append_line("%(description)s" % {
-            "description": info.get("Description", '').replace(r'\n', '\n')},
-            showstamp=False, scroll=False)
-
-        self.check_properties_button(self.selected_plugin)
-
-    def cell_toggle_callback(self, widget, index, treeview, pos):
-
-        iterator = self.plugins_model.get_iter(index)
-        plugin = self.plugins_model.get_value(iterator, 2)
-        value = self.plugins_model.get_value(iterator, 0)
-        self.plugins_model.set(iterator, pos, not value)
-
-        if not value:
-            self.frame.np.pluginhandler.enable_plugin(plugin)
-        else:
-            self.frame.np.pluginhandler.disable_plugin(plugin)
-
-        self.check_properties_button(plugin)
-
-    def check_properties_button(self, plugin):
-        settings = self.frame.np.pluginhandler.get_plugin_settings(plugin)
-
-        if settings is not None:
-            self.PluginProperties.set_sensitive(True)
-        else:
-            self.PluginProperties.set_sensitive(False)
-
-    def set_settings(self):
-
-        self.p.set_widgets_data(self.options)
-        self.on_plugins_enable(None)
-        self.pluginsiters = {}
-        self.plugins_model.clear()
-        plugins = sorted(self.frame.np.pluginhandler.list_installed_plugins())
-
-        for plugin in plugins:
-            try:
-                info = self.frame.np.pluginhandler.get_plugin_info(plugin)
-            except IOError:
-                continue
-
-            enabled = (plugin in config.sections["plugins"]["enabled"])
-            self.pluginsiters[filter] = self.plugins_model.insert_with_valuesv(
-                -1, self.column_numbers, [enabled, info.get('Name', plugin), plugin]
-            )
-
-        return {}
-
-    def get_enabled_plugins(self):
-
-        enabled_plugins = []
-
-        for plugin in self.plugins_model:
-            enabled = self.plugins_model.get_value(plugin.iter, 0)
-
-            if enabled:
-                plugin_name = self.plugins_model.get_value(plugin.iter, 2)
-                enabled_plugins.append(plugin_name)
-
-        return enabled_plugins
-
-    def on_plugins_enable(self, *args):
-
-        active = self.PluginsEnable.get_active()
-
-        for widget in (self.PluginTreeView, self.PluginInfo):
-            widget.set_sensitive(active)
-
-        if active:
-            # Enable all selected plugins
-            for plugin in self.get_enabled_plugins():
-                self.frame.np.pluginhandler.enable_plugin(plugin)
-
-            return
-
-        # Disable all plugins
-        for plugin in self.frame.np.pluginhandler.enabled_plugins.copy():
-            self.frame.np.pluginhandler.disable_plugin(plugin)
-
-    def get_settings(self):
-
-        return {
-            "plugins": {
-                "enable": self.PluginsEnable.get_active(),
-                "enabled": self.get_enabled_plugins()
-            }
-        }
-
-
-class Settings(UserInterface):
-
-    def __init__(self, frame):
-
-        super().__init__("ui/dialogs/preferences.ui")
-
-        self.frame = frame
-        self.dialog = dialog = generic_dialog(
-            parent=frame.MainWindow,
-            content_box=self.main,
-            quit_callback=self.on_delete,
-            title=_("Preferences"),
-            width=960,
-            height=650
-        )
-
-        dialog.add_buttons(
-            _("Cancel"), Gtk.ResponseType.CANCEL,
-            _("Export"), Gtk.ResponseType.HELP,
-            _("Apply"), Gtk.ResponseType.APPLY,
-            _("OK"), Gtk.ResponseType.OK
-        )
-
-        dialog.set_default_response(Gtk.ResponseType.OK)
-        dialog.connect("response", self.on_response)
-
-        style_context = dialog.get_style_context()
-        style_context.add_class("preferences")
-        style_context.add_class("preferences-border")
-
-        self.pages = {}
-        self.page_ids = [("Network", _("Network"), "network-wireless-symbolic"),
-                         ("UserInterface", _("User Interface"), "view-grid-symbolic"),
-                         ("Shares", _("Shares"), "folder-symbolic"),
-                         ("Downloads", _("Downloads"), "document-save-symbolic"),
-                         ("Uploads", _("Uploads"), "emblem-shared-symbolic"),
-                         ("Searches", _("Searches"), "system-search-symbolic"),
-                         ("UserInfo", _("User Info"), "avatar-default-symbolic"),
-                         ("Notifications", _("Notifications"), "mail-unread-symbolic"),
-                         ("Logging", _("Logging"), "emblem-documents-symbolic"),
-                         ("NowPlaying", _("Now Playing"), "folder-music-symbolic"),
-                         ("CensorReplaceList", _("Chat Censor & Replace"), "insert-text-symbolic"),
-                         ("Completion", _("Chat Completion"), "format-indent-more-symbolic"),
-                         ("TextToSpeech", _("Text-to-Speech"), "audio-volume-high-symbolic"),
-                         ("BannedUsers", _("Banned Users"), "action-unavailable-symbolic"),
-                         ("IgnoredUsers", _("Ignored Users"), "microphone-sensitivity-muted-symbolic"),
-                         ("Plugins", _("Plugins"), "list-add-symbolic"),
-                         ("UrlHandlers", _("URL Handlers"), "insert-link-symbolic")]
-
-        for page_id, label, icon_name in self.page_ids:
-            box = Gtk.Box()
-            box.set_margin_top(8)
-            box.set_margin_bottom(8)
-            box.set_margin_start(12)
-            box.set_margin_end(42)
-            box.set_spacing(12)
-            box.show()
-
-            icon = Gtk.Image()
-            icon.set_property("icon-name", icon_name)
-            icon.show()
-
-            label = Gtk.Label.new(label)
-            label.set_xalign(0)
-            label.show()
-
-            box.add(icon)
-            box.add(label)
-
-            self.preferences_list.insert(box, -1)
-
-        self.update_visuals()
-
-    def update_visuals(self, scope=None):
-
-        if not scope:
-            for page in self.pages.values():
-                self.update_visuals(page)
-
-            scope = self
-
-        for widget in list(scope.__dict__.values()):
-            update_widget_visuals(widget)
-
-    def set_active_page(self, page):
-
-        pos = 0
-        for page_id, _label, _icon_name in self.page_ids:
-            if page_id == page:
-                break
-
-            pos += 1
-
-        row = self.preferences_list.get_row_at_index(pos)
-        self.preferences_list.select_row(row)
-
-    def set_combobox_value(self, combobox, option):
-
-        # Attempt to match the value with an existing item
-        iterator = combobox.get_model().get_iter_first()
-
-        while iterator is not None:
-            word = combobox.get_model().get_value(iterator, 0)
-
-            if word.lower() == option or word == option:
-                combobox.set_active_iter(iterator)
-                break
-
-            iterator = combobox.get_model().iter_next(iterator)
-
-        # Custom value provided
-        if combobox.get_has_entry():
-            if Gtk.get_major_version() == 4:
-                entry = combobox.get_child()
-            else:
-                entry = combobox.get_children()[0]
-
-            entry.set_text(option)
-
-    def set_widgets_data(self, options):
-
-        for section, keys in options.items():
-            if section not in config.sections:
-                continue
-
-            for key in keys:
-                widget = options[section][key]
-
-                if widget is None:
-                    continue
-
-                if config.sections[section][key] is None:
-                    self.clear_widget(widget)
-                else:
-                    self.set_widget(widget, config.sections[section][key])
-
-    def get_widget_data(self, widget):
-
-        if isinstance(widget, Gtk.SpinButton):
-            if widget.get_digits() > 0:
-                return widget.get_value()
-
-            return widget.get_value_as_int()
-
-        elif isinstance(widget, Gtk.Entry):
-            return widget.get_text()
-
-        elif isinstance(widget, Gtk.TextView):
-            buffer = widget.get_buffer()
-            start, end = buffer.get_bounds()
-
-            return widget.get_buffer().get_text(start, end, True)
-
-        elif isinstance(widget, Gtk.CheckButton):
-            try:
-                # Radio button
-                for radio in widget.group_radios:
-                    if radio.get_active():
-                        return widget.group_radios.index(radio)
-
-                return 0
-
-            except (AttributeError, TypeError):
-                # Regular check button
-                return widget.get_active()
-
-        elif isinstance(widget, Gtk.ComboBox):
-            return widget.get_model().get(widget.get_active_iter(), 0)[0]
-
-        elif isinstance(widget, Gtk.FontButton):
-            widget.get_font()
-
-        elif isinstance(widget, Gtk.TreeView) and widget.get_model().get_n_columns() == 1:
-            wlist = []
-            iterator = widget.get_model().get_iter_first()
-
-            while iterator:
-                word = widget.get_model().get_value(iterator, 0)
-
-                if word is not None:
-                    wlist.append(word)
-
-                iterator = widget.get_model().iter_next(iterator)
-
-            return wlist
-
-        elif isinstance(widget, FileChooserButton):
-            return widget.get_path()
-
-    def clear_widget(self, widget):
-
-        if isinstance(widget, Gtk.SpinButton):
-            widget.set_value(0)
-
-        elif isinstance(widget, Gtk.Entry):
-            widget.set_text("")
-
-        elif isinstance(widget, Gtk.TextView):
-            widget.get_buffer().set_text("")
-
-        elif isinstance(widget, Gtk.CheckButton):
-            widget.set_active(0)
-
-        elif isinstance(widget, Gtk.ComboBox):
-            self.set_combobox_item(widget, "")
-
-        elif isinstance(widget, Gtk.FontButton):
-            widget.set_font("")
-
-    def set_widget(self, widget, value):
-
-        if isinstance(widget, Gtk.SpinButton):
-            try:
-                widget.set_value(value)
-
-            except TypeError:
-                # Not a numerical value
-                pass
-
-        elif isinstance(widget, Gtk.Entry):
-            if isinstance(value, (str, int)):
-                widget.set_text(value)
-
-        elif isinstance(widget, Gtk.TextView):
-            if isinstance(value, (str, int)):
-                widget.get_buffer().set_text(value)
-
-        elif isinstance(widget, Gtk.CheckButton):
-            try:
-                # Radio button
-                if isinstance(value, int) and value < len(widget.group_radios):
-                    widget.group_radios[value].set_active(True)
-
-            except (AttributeError, TypeError):
-                # Regular check button
-                widget.set_active(value)
-
-        elif isinstance(widget, Gtk.ComboBox):
-            if isinstance(value, str):
-                self.set_combobox_value(widget, value)
-
-            elif isinstance(value, int):
-                widget.set_active(value)
-
-            # If an invalid value was provided, select first item
-            if not widget.get_has_entry() and widget.get_active() < 0:
-                widget.set_active(0)
-
-        elif isinstance(widget, Gtk.FontButton):
-            widget.set_font(value)
-
-        elif isinstance(widget, Gtk.TreeView) and isinstance(value, list) and widget.get_model().get_n_columns() == 1:
-            model = widget.get_model()
-            column_numbers = list(range(model.get_n_columns()))
-
-            for item in value:
-                model.insert_with_valuesv(-1, column_numbers, [str(item)])
-
-        elif isinstance(widget, FileChooserButton):
-            widget.set_path(value)
-
-    def set_settings(self):
-
-        for page in self.pages.values():
-            page.set_settings()
-
-    def get_settings(self):
-
-        config = {
-            "server": {},
-            "transfers": {},
-            "userinfo": {},
-            "logging": {},
-            "searches": {},
-            "privatechat": {},
-            "ui": {},
-            "urls": {},
-            "players": {},
-            "words": {},
-            "notifications": {},
-            "plugins": {}
-        }
-
-        for page in self.pages.values():
-            sub = page.get_settings()
-            for key, data in sub.items():
-                config[key].update(data)
-
-        try:
-            need_portmap = self.pages["Network"].needportmap
-
-        except KeyError:
-            need_portmap = False
-
-        try:
-            need_rescan = self.pages["Shares"].needrescan
-
-        except KeyError:
-            need_rescan = False
-
-        if not need_rescan:
-            try:
-                need_rescan = self.pages["Downloads"].needrescan
-
-            except KeyError:
-                need_rescan = False
-
-        try:
-            need_colors = self.pages["UserInterface"].needcolors
-
-        except KeyError:
-            need_colors = False
-
-        try:
-            need_completion = self.pages["Completion"].needcompletion
-
-        except KeyError:
-            need_completion = False
-
-        try:
-            need_ip_block = self.pages["BannedUsers"].need_ip_block
-
-        except KeyError:
-            need_ip_block = False
-
-        return need_portmap, need_rescan, need_colors, need_completion, need_ip_block, config
-
-    def update_settings(self, settings_closed=False):
-
-        need_portmap, need_rescan, need_colors, need_completion, need_ip_block, new_config = self.get_settings()
-
-        for key, data in new_config.items():
-            config.sections[key].update(data)
-
-        if need_portmap:
-            self.frame.np.add_upnp_portmapping()
-
-        if need_colors:
-            set_global_font(config.sections["ui"]["globalfont"])
-
-            self.frame.chatrooms.update_visuals()
-            self.frame.privatechat.update_visuals()
-            self.frame.search.update_visuals()
-            self.frame.downloads.update_visuals()
-            self.frame.uploads.update_visuals()
-            self.frame.userinfo.update_visuals()
-            self.frame.userbrowse.update_visuals()
-            self.frame.userlist.update_visuals()
-            self.frame.interests.update_visuals()
-
-            self.frame.update_visuals()
-            self.update_visuals()
-
-        if need_completion:
-            self.frame.update_completions()
-
-        if need_ip_block:
-            self.frame.np.network_filter.close_blocked_ip_connections()
-
-        # Dark mode
-        dark_mode_state = config.sections["ui"]["dark_mode"]
-        set_dark_mode(dark_mode_state)
-        self.frame.dark_mode_action.set_state(GLib.Variant.new_boolean(dark_mode_state))
-
-        # UPnP
-        if not config.sections["server"]["upnp"] and self.frame.np.upnp_timer:
-            self.frame.np.upnp_timer.cancel()
-
-        # Chatrooms
-        self.frame.chatrooms.toggle_chat_buttons()
-
-        # Search
-        self.frame.search.populate_search_history()
-
-        # Transfers
-        self.frame.np.transfers.update_limits()
-        self.frame.np.transfers.update_download_filters()
-        self.frame.np.transfers.check_upload_queue()
-
-        # Tray icon
-        if not config.sections["ui"]["trayicon"] and self.frame.tray_icon.is_visible():
-            self.frame.tray_icon.hide()
-
-        elif config.sections["ui"]["trayicon"] and not self.frame.tray_icon.is_visible():
-            self.frame.tray_icon.load()
-
-        # Main notebook
-        self.frame.set_tab_positions()
-        self.frame.set_main_tabs_visibility()
-
-        for i in range(self.frame.MainNotebook.get_n_pages()):
-            page = self.frame.MainNotebook.get_nth_page(i)
-            tab_label = self.frame.MainNotebook.get_tab_label(page)
-            tab_label.set_text_color(0)
-            self.frame.set_tab_expand(page)
-
-        # Other notebooks
-        for w in (self.frame.chatrooms, self.frame.privatechat, self.frame.userinfo,
-                  self.frame.userbrowse, self.frame.search):
-            w.set_tab_closers()
-            w.set_text_colors(None)
-
-        # Update configuration
-        config.write_configuration()
-
-        if config.need_config():
-            self.frame.connect_action.set_enabled(False)
-            self.frame.on_fast_configure()
-
-        elif not self.frame.np.active_server_conn:
-            self.frame.connect_action.set_enabled(True)
-
-        if not settings_closed:
-            return
-
-        if need_rescan:
-            self.frame.np.shares.rescan_shares()
-
-        if not config.sections["ui"]["trayicon"]:
-            self.frame.MainWindow.present_with_time(Gdk.CURRENT_TIME)
-
-    def back_up_config_response(self, selected, data):
-        config.write_config_backup(selected)
-
-    def back_up_config(self, *args):
-
-        save_file(
-            parent=self.frame.MainWindow,
-            callback=self.back_up_config_response,
-            initialdir=os.path.dirname(config.filename),
-            initialfile="config backup %s.tar.bz2" % (time.strftime("%Y-%m-%d %H_%M_%S")),
-            title=_("Pick a File Name for Config Backup")
-        )
-
-    def on_switch_page(self, listbox, row):
-
-        page_id, _label, _icon_name = self.page_ids[row.get_index()]
-        child = self.viewport.get_child()
-
-        if child:
-            if Gtk.get_major_version() == 4:
-                self.viewport.set_child(None)
-            else:
-                self.viewport.remove(child)
-
-        if page_id not in self.pages:
-            self.pages[page_id] = page = getattr(sys.modules[__name__], page_id + "Frame")(self)
-            page.set_settings()
-
-            for obj in page.__dict__.values():
-                if isinstance(obj, Gtk.CheckButton):
-                    if Gtk.get_major_version() == 4:
-                        obj.get_last_child().set_wrap(True)
-                    else:
-                        obj.get_children()[-1].set_line_wrap(True)
-
-            page.Main.set_margin_start(18)
-            page.Main.set_margin_end(18)
-            page.Main.set_margin_top(14)
-            page.Main.set_margin_bottom(18)
-
-            self.update_visuals(page)
-
-        if Gtk.get_major_version() == 4:
-            self.viewport.set_child(self.pages[page_id].Main)
-        else:
-            self.viewport.add(self.pages[page_id].Main)
-
-    def on_delete(self, *args):
-        dialog_hide(self.dialog)
-        return True
-
-    def on_response(self, dialog, response_id):
-
-        if response_id == Gtk.ResponseType.OK:
-            self.update_settings(settings_closed=True)
-
-        elif response_id == Gtk.ResponseType.APPLY:
-            self.update_settings()
-            return True
-
-        elif response_id == Gtk.ResponseType.HELP:
-            self.back_up_config()
-            return True
-
-        dialog_hide(self.dialog)
-
-    def show(self, *args):
-
-        # Shrink the dialog if it's larger than the main window
-        if Gtk.get_major_version() == 4:
-            main_width = self.frame.MainWindow.get_width()
-            main_height = self.frame.MainWindow.get_height()
-        else:
-            main_width, main_height = self.frame.MainWindow.get_size()
-
-        new_width = dialog_width = self.dialog.get_property("default-width")
-        new_height = dialog_height = self.dialog.get_property("default-height")
-
-        if dialog_width > main_width:
-            new_width = main_width - 30
-
-        if dialog_height > main_height:
-            new_height = main_height - 30
-
-        if Gtk.get_major_version() == 4:
-            self.dialog.set_default_size(new_width, new_height)
-        else:
-            self.dialog.resize(new_width, new_height)
-
-        # Show the dialog
-        self.dialog.present_with_time(Gdk.CURRENT_TIME)
+<?xml version="1.0" encoding="UTF-8"?>
+<interface>
+  <object class="GtkBox" id="Main">
+    <property name="visible">1</property>
+    <property name="spacing">30</property>
+    <property name="orientation">vertical</property>
+    <child>
+      <object class="GtkBox">
+        <property name="visible">1</property>
+        <property name="spacing">12</property>
+        <property name="orientation">vertical</property>
+        <child>
+          <object class="GtkLabel">
+            <property name="visible">1</property>
+            <property name="halign">start</property>
+            <property name="label" translatable="yes">User Interface</property>
+            <attributes>
+              <attribute name="weight" value="bold"/>
+            </attributes>
+          </object>
+        </child>
+        <child>
+          <object class="GtkFlowBox">
+            <property name="visible">1</property>
+            <property name="homogeneous">1</property>
+            <property name="column-spacing">12</property>
+            <property name="row-spacing">12</property>
+            <property name="min-children-per-line">1</property>
+            <property name="max-children-per-line">3</property>
+            <property name="selection-mode">none</property>
+            <child>
+              <object class="GtkFlowBoxChild">
+                <property name="visible">1</property>
+                <property name="focusable">0</property>
+                <child>
+                  <object class="GtkCheckButton" id="DarkMode">
+                    <property name="label" translatable="yes">Prefer dark mode</property>
+                    <property name="visible">1</property>
+                    <property name="tooltip_text" translatable="yes">Note that the operating system&apos;s theme may take precedence.</property>
+                  </object>
+                </child>
+              </object>
+            </child>
+            <child>
+              <object class="GtkFlowBoxChild">
+                <property name="visible">1</property>
+                <property name="focusable">0</property>
+                <child>
+                  <object class="GtkBox" id = "TraySettings">
+                    <property name="visible">1</property>
+                    <property name="focusable">0</property>
+                    <child>
+                      <object class="GtkCheckButton" id="TrayiconCheck">
+                        <property name="label" translatable="yes">Display tray icon</property>
+                        <property name="visible">1</property>
+                        <property name="use-underline">1</property>
+                        <signal name="toggled" handler="on_toggle_tray" swapped="no"/>
+                      </object>
+                    </child>
+                    <child>
+                      <object class="GtkLabel">
+                        <property name="visible">1</property>
+                        <property name="halign">start</property>
+                        <property name="label">    </property>
+                      </object>
+                    </child>
+                    <child>
+                      <object class="GtkCheckButton" id="StartupHidden">
+                        <property name="label" translatable="yes">Minimize to tray on startup</property>
+                        <property name="visible">1</property>
+                        <property name="use-underline">1</property>
+                      </object>
+                    </child>
+                  </object>
+                </child>
+              </object>
+            </child>
+          </object>
+        </child>
+        <child>
+          <object class="GtkFlowBox">
+            <property name="visible">1</property>
+            <property name="homogeneous">1</property>
+            <property name="column-spacing">24</property>
+            <property name="row-spacing">12</property>
+            <property name="max-children-per-line">2</property>
+            <property name="selection-mode">none</property>
+            <child>
+              <object class="GtkFlowBoxChild">
+                <property name="visible">1</property>
+                <property name="focusable">0</property>
+                <child>
+                  <object class="GtkLabel">
+                    <property name="visible">1</property>
+                    <property name="label" translatable="yes">When closing Nicotine+:</property>
+                    <property name="xalign">0</property>
+                    <property name="mnemonic_widget">CloseAction</property>
+                  </object>
+                </child>
+              </object>
+            </child>
+            <child>
+              <object class="GtkFlowBoxChild">
+                <property name="visible">1</property>
+                <property name="focusable">0</property>
+                <child>
+                  <object class="GtkComboBoxText" id="CloseAction">
+                    <property name="visible">1</property>
+                    <items>
+                      <item translatable="yes">Quit program</item>
+                      <item translatable="yes">Show confirmation dialog</item>
+                      <item translatable="yes">Run in the background</item>
+                    </items>
+                  </object>
+                </child>
+              </object>
+            </child>
+          </object>
+        </child>
+      </object>
+    </child>
+    <child>
+      <object class="GtkBox">
+        <property name="visible">1</property>
+        <property name="spacing">18</property>
+        <property name="orientation">vertical</property>
+        <child>
+          <object class="GtkBox">
+            <property name="visible">1</property>
+            <property name="spacing">12</property>
+            <property name="orientation">vertical</property>
+            <child>
+              <object class="GtkLabel">
+                <property name="visible">1</property>
+                <property name="label" translatable="yes">Primary Tabs</property>
+                <property name="xalign">0</property>
+                <attributes>
+                  <attribute name="weight" value="bold"/>
+                </attributes>
+              </object>
+            </child>
+            <child>
+              <object class="GtkCheckButton" id="TabSelectPrevious">
+                <property name="label" translatable="yes">Remember previous primary tab on startup</property>
+                <property name="visible">1</property>
+              </object>
+            </child>
+            <child>
+              <object class="GtkFlowBox">
+                <property name="visible">1</property>
+                <property name="column-spacing">12</property>
+                <property name="row-spacing">12</property>
+                <property name="max-children-per-line">2</property>
+                <property name="selection-mode">none</property>
+                <child>
+                  <object class="GtkFlowBoxChild">
+                    <property name="visible">1</property>
+                    <property name="focusable">0</property>
+                    <child>
+                      <object class="GtkLabel" id="MainTabsLabel">
+                        <property name="visible">1</property>
+                        <property name="xalign">0</property>
+                        <property name="label" translatable="yes">Tab bar position:</property>
+                        <property name="mnemonic_widget">MainPosition</property>
+                      </object>
+                    </child>
+                  </object>
+                </child>
+                <child>
+                  <object class="GtkFlowBoxChild">
+                    <property name="visible">1</property>
+                    <property name="focusable">0</property>
+                    <child>
+                      <object class="GtkComboBoxText" id="MainPosition">
+                        <property name="visible">1</property>
+                        <property name="hexpand">1</property>
+                      </object>
+                    </child>
+                  </object>
+                </child>
+              </object>
+            </child>
+          </object>
+        </child>
+        <child>
+          <object class="GtkBox">
+            <property name="visible">1</property>
+            <property name="spacing">18</property>
+            <property name="orientation">vertical</property>
+            <child>
+              <object class="GtkLabel">
+                <property name="visible">1</property>
+                <property name="label" translatable="yes">Visible primary tabs:</property>
+                <property name="xalign">0</property>
+                <property name="mnemonic_widget">EnableSearchTab</property>
+              </object>
+            </child>
+            <child>
+              <object class="GtkFlowBox">
+                <property name="visible">1</property>
+                <property name="homogeneous">1</property>
+                <property name="column-spacing">18</property>
+                <property name="row-spacing">12</property>
+                <property name="min-children-per-line">1</property>
+                <property name="max-children-per-line">3</property>
+                <property name="selection-mode">none</property>
+                <child>
+                  <object class="GtkFlowBoxChild">
+                    <property name="visible">1</property>
+                    <property name="focusable">0</property>
+                    <child>
+                      <object class="GtkCheckButton" id="EnableSearchTab">
+                        <property name="label" translatable="yes">Search Files</property>
+                        <property name="visible">1</property>
+                      </object>
+                    </child>
+                  </object>
+                </child>
+                <child>
+                  <object class="GtkFlowBoxChild">
+                    <property name="visible">1</property>
+                    <property name="focusable">0</property>
+                    <child>
+                      <object class="GtkCheckButton" id="EnableDownloadsTab">
+                        <property name="label" translatable="yes">Downloads</property>
+                        <property name="visible">1</property>
+                      </object>
+                    </child>
+                  </object>
+                </child>
+                <child>
+                  <object class="GtkFlowBoxChild">
+                    <property name="visible">1</property>
+                    <property name="focusable">0</property>
+                    <child>
+                      <object class="GtkCheckButton" id="EnableUploadsTab">
+                        <property name="label" translatable="yes">Uploads</property>
+                        <property name="visible">1</property>
+                      </object>
+                    </child>
+                  </object>
+                </child>
+                <child>
+                  <object class="GtkFlowBoxChild">
+                    <property name="visible">1</property>
+                    <property name="focusable">0</property>
+                    <child>
+                      <object class="GtkCheckButton" id="EnableUserBrowseTab">
+                        <property name="label" translatable="yes">Browse Shares</property>
+                        <property name="visible">1</property>
+                      </object>
+                    </child>
+                  </object>
+                </child>
+                <child>
+                  <object class="GtkFlowBoxChild">
+                    <property name="visible">1</property>
+                    <property name="focusable">0</property>
+                    <child>
+                      <object class="GtkCheckButton" id="EnableUserInfoTab">
+                        <property name="label" translatable="yes">User Info</property>
+                        <property name="visible">1</property>
+                      </object>
+                    </child>
+                  </object>
+                </child>
+                <child>
+                  <object class="GtkFlowBoxChild">
+                    <property name="visible">1</property>
+                    <property name="focusable">0</property>
+                    <child>
+                      <object class="GtkCheckButton" id="EnablePrivateTab">
+                        <property name="label" translatable="yes">Private Chat</property>
+                        <property name="visible">1</property>
+                      </object>
+                    </child>
+                  </object>
+                </child>
+                <child>
+                  <object class="GtkFlowBoxChild">
+                    <property name="visible">1</property>
+                    <property name="focusable">0</property>
+                    <child>
+                      <object class="GtkCheckButton" id="EnableUserListTab">
+                        <property name="label" translatable="yes">Buddies</property>
+                        <property name="visible">1</property>
+                      </object>
+                    </child>
+                  </object>
+                </child>
+                <child>
+                  <object class="GtkFlowBoxChild">
+                    <property name="visible">1</property>
+                    <property name="focusable">0</property>
+                    <child>
+                      <object class="GtkCheckButton" id="EnableChatroomsTab">
+                        <property name="label" translatable="yes">Chat Rooms</property>
+                        <property name="visible">1</property>
+                      </object>
+                    </child>
+                  </object>
+                </child>
+                <child>
+                  <object class="GtkFlowBoxChild">
+                    <property name="visible">1</property>
+                    <property name="focusable">0</property>
+                    <child>
+                      <object class="GtkCheckButton" id="EnableInterestsTab">
+                        <property name="label" translatable="yes">Interests</property>
+                        <property name="visible">1</property>
+                      </object>
+                    </child>
+                  </object>
+                </child>
+              </object>
+            </child>
+          </object>
+        </child>
+      </object>
+    </child>
+    <child>
+      <object class="GtkBox">
+        <property name="visible">1</property>
+        <property name="spacing">30</property>
+        <property name="orientation">vertical</property>
+        <child>
+          <object class="GtkBox">
+            <property name="visible">1</property>
+            <property name="spacing">12</property>
+            <property name="orientation">vertical</property>
+            <child>
+              <object class="GtkLabel">
+                <property name="visible">1</property>
+                <property name="label" translatable="yes">Lists</property>
+                <property name="xalign">0</property>
+                <attributes>
+                  <attribute name="weight" value="bold"/>
+                </attributes>
+              </object>
+            </child>
+            <child>
+              <object class="GtkCheckButton" id="FilePathTooltips">
+                <property name="label" translatable="yes">Show file path tooltips in file list views</property>
+                <property name="visible">1</property>
+                <property name="use-underline">1</property>
+              </object>
+            </child>
+            <child>
+              <object class="GtkCheckButton" id="ReverseFilePaths">
+                <property name="label" translatable="yes">Show reverse file paths in search and transfer views (requires a restart)</property>
+                <property name="visible">1</property>
+                <property name="use-underline">1</property>
+              </object>
+            </child>
+          </object>
+        </child>
+        <child>
+          <object class="GtkFlowBox">
+            <property name="visible">1</property>
+            <property name="row-spacing">12</property>
+            <property name="column-spacing">12</property>
+            <property name="max-children-per-line">2</property>
+            <property name="selection-mode">none</property>
+            <child>
+              <object class="GtkFlowBoxChild">
+                <property name="visible">1</property>
+                <property name="focusable">0</property>
+                <child>
+                  <object class="GtkLabel">
+                    <property name="visible">1</property>
+                    <property name="label" translatable="yes">Double-click action for downloads:</property>
+                    <property name="xalign">0</property>
+                    <property name="mnemonic_widget">DownloadDoubleClick</property>
+                  </object>
+                </child>
+              </object>
+            </child>
+            <child>
+              <object class="GtkFlowBoxChild">
+                <property name="visible">1</property>
+                <property name="focusable">0</property>
+                <child>
+                  <object class="GtkComboBoxText" id="DownloadDoubleClick">
+                    <property name="visible">1</property>
+                    <items>
+                      <item>Nothing</item>
+                      <item>Send to Player</item>
+                      <item>Open in File Manager</item>
+                      <item>Search</item>
+                      <item>Pause</item>
+                      <item>Clear</item>
+                      <item>Resume</item>
+                      <item>Browse Folder</item>
+                    </items>
+                  </object>
+                </child>
+              </object>
+            </child>
+            <child>
+              <object class="GtkFlowBoxChild">
+                <property name="visible">1</property>
+                <property name="focusable">0</property>
+                <child>
+                  <object class="GtkLabel">
+                    <property name="visible">1</property>
+                    <property name="label" translatable="yes">Double-click action for uploads:</property>
+                    <property name="xalign">0</property>
+                    <property name="mnemonic_widget">UploadDoubleClick</property>
+                  </object>
+                </child>
+              </object>
+            </child>
+            <child>
+              <object class="GtkFlowBoxChild">
+                <property name="visible">1</property>
+                <property name="focusable">0</property>
+                <child>
+                  <object class="GtkComboBoxText" id="UploadDoubleClick">
+                    <property name="visible">1</property>
+                    <items>
+                      <item>Nothing</item>
+                      <item>Send to Player</item>
+                      <item>Open in File Manager</item>
+                      <item>Search</item>
+                      <item>Abort</item>
+                      <item>Clear</item>
+                      <item>Retry</item>
+                      <item>Browse Folder</item>
+                    </items>
+                  </object>
+                </child>
+              </object>
+            </child>
+          </object>
+        </child>
+        <child>
+          <object class="GtkFlowBox">
+            <property name="visible">1</property>
+            <property name="homogeneous">1</property>
+            <property name="column-spacing">12</property>
+            <property name="row-spacing">12</property>
+            <property name="min-children-per-line">1</property>
+            <property name="max-children-per-line">2</property>
+            <property name="selection-mode">none</property>
+            <child>
+              <object class="GtkFlowBoxChild">
+                <property name="visible">1</property>
+                <property name="focusable">0</property>
+                <child>
+                  <object class="GtkBox">
+                    <property name="visible">1</property>
+                    <property name="spacing">12</property>
+                    <child>
+                      <object class="GtkLabel">
+                        <property name="visible">1</property>
+                        <property name="label" translatable="yes">List text color:</property>
+                        <property name="hexpand">1</property>
+                        <property name="xalign">0</property>
+                        <property name="wrap">1</property>
+                        <property name="mnemonic_widget">PickImmediate</property>
+                      </object>
+                    </child>
+                    <child>
+                      <object class="GtkColorButton" id="PickImmediate">
+                        <property name="visible">1</property>
+                        <signal name="color-set" handler="on_color_set"/>
+                      </object>
+                    </child>
+                  </object>
+                </child>
+              </object>
+            </child>
+            <child>
+              <object class="GtkFlowBoxChild">
+                <property name="visible">1</property>
+                <property name="focusable">0</property>
+                <child>
+                  <object class="GtkBox">
+                    <property name="visible">1</property>
+                    <property name="spacing">12</property>
+                    <child>
+                      <object class="GtkEntry" id="EntryImmediate">
+                        <property name="visible">1</property>
+                        <property name="hexpand">1</property>
+                        <property name="width-chars">16</property>
+                        <signal name="changed" handler="on_colors_changed"/>
+                      </object>
+                    </child>
+                    <child>
+                      <object class="GtkButton" id="DefaultImmediate">
+                        <property name="visible">1</property>
+                        <property name="halign">start</property>
+                        <signal name="clicked" handler="on_default_color"/>
+                        <child>
+                          <object class="GtkBox">
+                            <property name="visible">1</property>
+                            <property name="spacing">6</property>
+                            <child>
+                              <object class="GtkImage">
+                                <property name="visible">1</property>
+                                <property name="icon-name">view-refresh-symbolic</property>
+                              </object>
+                            </child>
+                            <child>
+                              <object class="GtkLabel">
+                                <property name="visible">1</property>
+                                <property name="label" translatable="yes">Default</property>
+                                <property name="use-underline">1</property>
+                              </object>
+                            </child>
+                          </object>
+                        </child>
+                      </object>
+                    </child>
+                  </object>
+                </child>
+              </object>
+            </child>
+            <child>
+              <object class="GtkFlowBoxChild">
+                <property name="visible">1</property>
+                <property name="focusable">0</property>
+                <child>
+                  <object class="GtkBox">
+                    <property name="visible">1</property>
+                    <property name="spacing">12</property>
+                    <child>
+                      <object class="GtkLabel">
+                        <property name="visible">1</property>
+                        <property name="label" translatable="yes">Queued search result text color:</property>
+                        <property name="hexpand">1</property>
+                        <property name="xalign">0</property>
+                        <property name="wrap">1</property>
+                        <property name="mnemonic_widget">PickQueue</property>
+                      </object>
+                    </child>
+                    <child>
+                      <object class="GtkColorButton" id="PickQueue">
+                        <property name="visible">1</property>
+                        <signal name="color-set" handler="on_color_set"/>
+                      </object>
+                    </child>
+                  </object>
+                </child>
+              </object>
+            </child>
+            <child>
+              <object class="GtkFlowBoxChild">
+                <property name="visible">1</property>
+                <property name="focusable">0</property>
+                <child>
+                  <object class="GtkBox">
+                    <property name="visible">1</property>
+                    <property name="spacing">12</property>
+                    <child>
+                      <object class="GtkEntry" id="EntryQueue">
+                        <property name="visible">1</property>
+                        <property name="hexpand">1</property>
+                        <property name="width-chars">16</property>
+                        <signal name="changed" handler="on_colors_changed"/>
+                      </object>
+                    </child>
+                    <child>
+                      <object class="GtkButton" id="DefaultQueue">
+                        <property name="visible">1</property>
+                        <property name="halign">start</property>
+                        <signal name="clicked" handler="on_default_color"/>
+                        <child>
+                          <object class="GtkBox">
+                            <property name="visible">1</property>
+                            <property name="spacing">6</property>
+                            <child>
+                              <object class="GtkImage">
+                                <property name="visible">1</property>
+                                <property name="icon-name">view-refresh-symbolic</property>
+                              </object>
+                            </child>
+                            <child>
+                              <object class="GtkLabel">
+                                <property name="visible">1</property>
+                                <property name="label" translatable="yes">Default</property>
+                                <property name="use-underline">1</property>
+                              </object>
+                            </child>
+                          </object>
+                        </child>
+                      </object>
+                    </child>
+                  </object>
+                </child>
+              </object>
+            </child>
+          </object>
+        </child>
+      </object>
+    </child>
+    <child>
+      <object class="GtkBox">
+        <property name="visible">1</property>
+        <property name="spacing">30</property>
+        <property name="orientation">vertical</property>
+        <child>
+          <object class="GtkBox">
+            <property name="visible">1</property>
+            <property name="spacing">12</property>
+            <property name="orientation">vertical</property>
+            <child>
+              <object class="GtkLabel">
+                <property name="visible">1</property>
+                <property name="label" translatable="yes">Secondary Tabs</property>
+                <property name="xalign">0</property>
+                <attributes>
+                  <attribute name="weight" value="bold"/>
+                </attributes>
+              </object>
+            </child>
+            <child>
+              <object class="GtkCheckButton" id="TabClosers">
+                <property name="label" translatable="yes">Close-buttons on secondary tabs</property>
+                <property name="visible">1</property>
+              </object>
+            </child>
+            <child>
+              <object class="GtkCheckButton" id="TabStatusIcons">
+                <property name="label" translatable="yes">Tabs show user status icons instead of status text</property>
+                <property name="visible">1</property>
+              </object>
+            </child>
+          </object>
+        </child>
+        <child>
+          <object class="GtkFlowBox">
+            <property name="visible">1</property>
+            <property name="column-spacing">12</property>
+            <property name="row-spacing">12</property>
+            <property name="max-children-per-line">2</property>
+            <property name="selection-mode">none</property>
+            <child>
+              <object class="GtkFlowBoxChild">
+                <property name="visible">1</property>
+                <property name="focusable">0</property>
+                <child>
+                  <object class="GtkLabel" id="ChatRoomsLabel">
+                    <property name="visible">1</property>
+                    <property name="xalign">0</property>
+                    <property name="label" translatable="yes">Chat room tab bar position:</property>
+                    <property name="mnemonic_widget">ChatRoomsPosition</property>
+                  </object>
+                </child>
+              </object>
+            </child>
+            <child>
+              <object class="GtkFlowBoxChild">
+                <property name="visible">1</property>
+                <property name="focusable">0</property>
+                <child>
+                  <object class="GtkComboBoxText" id="ChatRoomsPosition">
+                    <property name="visible">1</property>
+                    <property name="hexpand">1</property>
+                  </object>
+                </child>
+              </object>
+            </child>
+            <child>
+              <object class="GtkFlowBoxChild">
+                <property name="visible">1</property>
+                <property name="focusable">0</property>
+                <child>
+                  <object class="GtkLabel" id="PrivateChatLabel">
+                    <property name="visible">1</property>
+                    <property name="xalign">0</property>
+                    <property name="label" translatable="yes">Private chat tab bar position:</property>
+                    <property name="mnemonic_widget">PrivateChatPosition</property>
+                  </object>
+                </child>
+              </object>
+            </child>
+            <child>
+              <object class="GtkFlowBoxChild">
+                <property name="visible">1</property>
+                <property name="focusable">0</property>
+                <child>
+                  <object class="GtkComboBoxText" id="PrivateChatPosition">
+                    <property name="visible">1</property>
+                    <property name="hexpand">1</property>
+                  </object>
+                </child>
+              </object>
+            </child>
+            <child>
+              <object class="GtkFlowBoxChild">
+                <property name="visible">1</property>
+                <property name="focusable">0</property>
+                <child>
+                  <object class="GtkLabel" id="SearchLabel">
+                    <property name="visible">1</property>
+                    <property name="xalign">0</property>
+                    <property name="label" translatable="yes">Search tab bar position:</property>
+                    <property name="mnemonic_widget">SearchPosition</property>
+                  </object>
+                </child>
+              </object>
+            </child>
+            <child>
+              <object class="GtkFlowBoxChild">
+                <property name="visible">1</property>
+                <property name="focusable">0</property>
+                <child>
+                  <object class="GtkComboBoxText" id="SearchPosition">
+                    <property name="visible">1</property>
+                    <property name="hexpand">1</property>
+                  </object>
+                </child>
+              </object>
+            </child>
+            <child>
+              <object class="GtkFlowBoxChild">
+                <property name="visible">1</property>
+                <property name="focusable">0</property>
+                <child>
+                  <object class="GtkLabel" id="UserInfoLabel">
+                    <property name="visible">1</property>
+                    <property name="xalign">0</property>
+                    <property name="label" translatable="yes">User info tab bar position:</property>
+                    <property name="mnemonic_widget">UserInfoPosition</property>
+                  </object>
+                </child>
+              </object>
+            </child>
+            <child>
+              <object class="GtkFlowBoxChild">
+                <property name="visible">1</property>
+                <property name="focusable">0</property>
+                <child>
+                  <object class="GtkComboBoxText" id="UserInfoPosition">
+                    <property name="visible">1</property>
+                    <property name="hexpand">1</property>
+                  </object>
+                </child>
+              </object>
+            </child>
+            <child>
+              <object class="GtkFlowBoxChild">
+                <property name="visible">1</property>
+                <property name="focusable">0</property>
+                <child>
+                  <object class="GtkLabel" id="UserBrowseLabel">
+                    <property name="visible">1</property>
+                    <property name="xalign">0</property>
+                    <property name="label" translatable="yes">User browse tab bar position:</property>
+                    <property name="mnemonic_widget">UserBrowsePosition</property>
+                  </object>
+                </child>
+              </object>
+            </child>
+            <child>
+              <object class="GtkFlowBoxChild">
+                <property name="visible">1</property>
+                <property name="focusable">0</property>
+                <child>
+                  <object class="GtkComboBoxText" id="UserBrowsePosition">
+                    <property name="visible">1</property>
+                    <property name="hexpand">1</property>
+                  </object>
+                </child>
+              </object>
+            </child>
+          </object>
+        </child>
+      </object>
+    </child>
+    <child>
+      <object class="GtkBox">
+        <property name="visible">1</property>
+        <property name="spacing">30</property>
+        <property name="orientation">vertical</property>
+        <child>
+          <object class="GtkBox">
+            <property name="visible">1</property>
+            <property name="spacing">12</property>
+            <property name="orientation">vertical</property>
+            <child>
+              <object class="GtkLabel">
+                <property name="visible">1</property>
+                <property name="xalign">0</property>
+                <property name="margin-top">12</property>
+                <property name="label" translatable="yes">Chats</property>
+                <property name="wrap">1</property>
+                <attributes>
+                  <attribute name="weight" value="bold"/>
+                </attributes>
+              </object>
+            </child>
+            <child>
+              <object class="GtkCheckButton" id="UsernameHotspots">
+                <property name="label" translatable="yes">Colored and clickable usernames</property>
+                <property name="visible">1</property>
+                <property name="use-underline">1</property>
+                <signal name="toggled" handler="on_username_hotspots_toggled" swapped="no"/>
+              </object>
+            </child>
+            <child>
+              <object class="GtkFlowBox">
+                <property name="visible">1</property>
+                <property name="column-spacing">12</property>
+                <property name="row-spacing">12</property>
+                <property name="max-children-per-line">2</property>
+                <property name="selection-mode">none</property>
+                <child>
+                  <object class="GtkFlowBoxChild">
+                    <property name="visible">1</property>
+                    <property name="focusable">0</property>
+                    <child>
+                      <object class="GtkLabel">
+                        <property name="visible">1</property>
+                        <property name="label" translatable="yes">Chat username appearance:</property>
+                        <property name="xalign">0</property>
+                        <property name="wrap">1</property>
+                        <property name="mnemonic_widget">UsernameStyle</property>
+                      </object>
+                    </child>
+                  </object>
+                </child>
+                <child>
+                  <object class="GtkFlowBoxChild">
+                    <property name="visible">1</property>
+                    <property name="focusable">0</property>
+                    <child>
+                      <object class="GtkComboBoxText" id="UsernameStyle">
+                        <property name="visible">1</property>
+                        <signal name="changed" handler="on_colors_changed"/>
+                        <items>
+                          <item id="bold" translatable="yes">bold</item>
+                          <item id="italic" translatable="yes">italic</item>
+                          <item id="underline" translatable="yes">underline</item>
+                          <item id="normal" translatable="yes">normal</item>
+                        </items>
+                      </object>
+                    </child>
+                  </object>
+                </child>
+              </object>
+            </child>
+          </object>
+        </child>
+        <child>
+          <object class="GtkFlowBox">
+            <property name="visible">1</property>
+            <property name="homogeneous">1</property>
+            <property name="column-spacing">12</property>
+            <property name="row-spacing">12</property>
+            <property name="min-children-per-line">1</property>
+            <property name="max-children-per-line">2</property>
+            <property name="selection-mode">none</property>
+            <child>
+              <object class="GtkFlowBoxChild">
+                <property name="visible">1</property>
+                <property name="focusable">0</property>
+                <child>
+                  <object class="GtkBox">
+                    <property name="visible">1</property>
+                    <property name="spacing">12</property>
+                    <child>
+                      <object class="GtkLabel">
+                        <property name="visible">1</property>
+                        <property name="label" translatable="yes">Remote text color:</property>
+                        <property name="hexpand">1</property>
+                        <property name="xalign">0</property>
+                        <property name="wrap">1</property>
+                        <property name="mnemonic_widget">PickRemote</property>
+                      </object>
+                    </child>
+                    <child>
+                      <object class="GtkColorButton" id="PickRemote">
+                        <property name="visible">1</property>
+                        <signal name="color-set" handler="on_color_set"/>
+                      </object>
+                    </child>
+                  </object>
+                </child>
+              </object>
+            </child>
+            <child>
+              <object class="GtkFlowBoxChild">
+                <property name="visible">1</property>
+                <property name="focusable">0</property>
+                <child>
+                  <object class="GtkBox">
+                    <property name="visible">1</property>
+                    <property name="spacing">12</property>
+                    <child>
+                      <object class="GtkEntry" id="EntryRemote">
+                        <property name="visible">1</property>
+                        <property name="hexpand">1</property>
+                        <property name="width-chars">16</property>
+                        <signal name="changed" handler="on_colors_changed"/>
+                      </object>
+                    </child>
+                    <child>
+                      <object class="GtkButton" id="DefaultRemote">
+                        <property name="visible">1</property>
+                        <property name="halign">start</property>
+                        <signal name="clicked" handler="on_default_color"/>
+                        <child>
+                          <object class="GtkBox">
+                            <property name="visible">1</property>
+                            <property name="spacing">6</property>
+                            <child>
+                              <object class="GtkImage">
+                                <property name="visible">1</property>
+                                <property name="icon-name">view-refresh-symbolic</property>
+                              </object>
+                            </child>
+                            <child>
+                              <object class="GtkLabel">
+                                <property name="visible">1</property>
+                                <property name="label" translatable="yes">Default</property>
+                                <property name="use-underline">1</property>
+                              </object>
+                            </child>
+                          </object>
+                        </child>
+                      </object>
+                    </child>
+                  </object>
+                </child>
+              </object>
+            </child>
+            <child>
+              <object class="GtkFlowBoxChild">
+                <property name="visible">1</property>
+                <property name="focusable">0</property>
+                <child>
+                  <object class="GtkBox">
+                    <property name="visible">1</property>
+                    <property name="spacing">12</property>
+                    <child>
+                      <object class="GtkLabel">
+                        <property name="visible">1</property>
+                        <property name="label" translatable="yes">Local text color:</property>
+                        <property name="hexpand">1</property>
+                        <property name="xalign">0</property>
+                        <property name="wrap">1</property>
+                        <property name="mnemonic_widget">PickLocal</property>
+                      </object>
+                    </child>
+                    <child>
+                      <object class="GtkColorButton" id="PickLocal">
+                        <property name="visible">1</property>
+                        <signal name="color-set" handler="on_color_set"/>
+                      </object>
+                    </child>
+                  </object>
+                </child>
+              </object>
+            </child>
+            <child>
+              <object class="GtkFlowBoxChild">
+                <property name="visible">1</property>
+                <property name="focusable">0</property>
+                <child>
+                  <object class="GtkBox">
+                    <property name="visible">1</property>
+                    <property name="spacing">12</property>
+                    <child>
+                      <object class="GtkEntry" id="EntryLocal">
+                        <property name="visible">1</property>
+                        <property name="hexpand">1</property>
+                        <property name="width-chars">16</property>
+                        <signal name="changed" handler="on_colors_changed"/>
+                      </object>
+                    </child>
+                    <child>
+                      <object class="GtkButton" id="DefaultLocal">
+                        <property name="visible">1</property>
+                        <property name="halign">start</property>
+                        <signal name="clicked" handler="on_default_color"/>
+                        <child>
+                          <object class="GtkBox">
+                            <property name="visible">1</property>
+                            <property name="spacing">6</property>
+                            <child>
+                              <object class="GtkImage">
+                                <property name="visible">1</property>
+                                <property name="icon-name">view-refresh-symbolic</property>
+                              </object>
+                            </child>
+                            <child>
+                              <object class="GtkLabel">
+                                <property name="visible">1</property>
+                                <property name="label" translatable="yes">Default</property>
+                                <property name="use-underline">1</property>
+                              </object>
+                            </child>
+                          </object>
+                        </child>
+                      </object>
+                    </child>
+                  </object>
+                </child>
+              </object>
+            </child>
+            <child>
+              <object class="GtkFlowBoxChild">
+                <property name="visible">1</property>
+                <property name="focusable">0</property>
+                <child>
+                  <object class="GtkBox">
+                    <property name="visible">1</property>
+                    <property name="spacing">12</property>
+                    <child>
+                      <object class="GtkLabel">
+                        <property name="visible">1</property>
+                        <property name="label" translatable="yes">/me action text color:</property>
+                        <property name="hexpand">1</property>
+                        <property name="xalign">0</property>
+                        <property name="wrap">1</property>
+                        <property name="mnemonic_widget">PickMe</property>
+                      </object>
+                    </child>
+                    <child>
+                      <object class="GtkColorButton" id="PickMe">
+                        <property name="visible">1</property>
+                        <signal name="color-set" handler="on_color_set"/>
+                      </object>
+                    </child>
+                  </object>
+                </child>
+              </object>
+            </child>
+            <child>
+              <object class="GtkFlowBoxChild">
+                <property name="visible">1</property>
+                <property name="focusable">0</property>
+                <child>
+                  <object class="GtkBox">
+                    <property name="visible">1</property>
+                    <property name="spacing">12</property>
+                    <child>
+                      <object class="GtkEntry" id="EntryMe">
+                        <property name="visible">1</property>
+                        <property name="hexpand">1</property>
+                        <property name="width-chars">16</property>
+                        <signal name="changed" handler="on_colors_changed"/>
+                      </object>
+                    </child>
+                    <child>
+                      <object class="GtkButton" id="DefaultMe">
+                        <property name="visible">1</property>
+                        <property name="halign">start</property>
+                        <signal name="clicked" handler="on_default_color"/>
+                        <child>
+                          <object class="GtkBox">
+                            <property name="visible">1</property>
+                            <property name="spacing">6</property>
+                            <child>
+                              <object class="GtkImage">
+                                <property name="visible">1</property>
+                                <property name="icon-name">view-refresh-symbolic</property>
+                              </object>
+                            </child>
+                            <child>
+                              <object class="GtkLabel">
+                                <property name="visible">1</property>
+                                <property name="label" translatable="yes">Default</property>
+                                <property name="use-underline">1</property>
+                              </object>
+                            </child>
+                          </object>
+                        </child>
+                      </object>
+                    </child>
+                  </object>
+                </child>
+              </object>
+            </child>
+            <child>
+              <object class="GtkFlowBoxChild">
+                <property name="visible">1</property>
+                <property name="focusable">0</property>
+                <child>
+                  <object class="GtkBox">
+                    <property name="visible">1</property>
+                    <property name="spacing">12</property>
+                    <child>
+                      <object class="GtkLabel">
+                        <property name="visible">1</property>
+                        <property name="label" translatable="yes">Highlighted text color:</property>
+                        <property name="hexpand">1</property>
+                        <property name="xalign">0</property>
+                        <property name="wrap">1</property>
+                        <property name="mnemonic_widget">PickHighlight</property>
+                      </object>
+                    </child>
+                    <child>
+                      <object class="GtkColorButton" id="PickHighlight">
+                        <property name="visible">1</property>
+                        <signal name="color-set" handler="on_color_set"/>
+                      </object>
+                    </child>
+                  </object>
+                </child>
+              </object>
+            </child>
+            <child>
+              <object class="GtkFlowBoxChild">
+                <property name="visible">1</property>
+                <property name="focusable">0</property>
+                <child>
+                  <object class="GtkBox">
+                    <property name="visible">1</property>
+                    <property name="spacing">12</property>
+                    <child>
+                      <object class="GtkEntry" id="EntryHighlight">
+                        <property name="visible">1</property>
+                        <property name="hexpand">1</property>
+                        <property name="width-chars">16</property>
+                        <signal name="changed" handler="on_colors_changed"/>
+                      </object>
+                    </child>
+                    <child>
+                      <object class="GtkButton" id="DefaultHighlight">
+                        <property name="visible">1</property>
+                        <property name="halign">start</property>
+                        <signal name="clicked" handler="on_default_color"/>
+                        <child>
+                          <object class="GtkBox">
+                            <property name="visible">1</property>
+                            <property name="spacing">6</property>
+                            <child>
+                              <object class="GtkImage">
+                                <property name="visible">1</property>
+                                <property name="icon-name">view-refresh-symbolic</property>
+                              </object>
+                            </child>
+                            <child>
+                              <object class="GtkLabel">
+                                <property name="visible">1</property>
+                                <property name="label" translatable="yes">Default</property>
+                                <property name="use-underline">1</property>
+                              </object>
+                            </child>
+                          </object>
+                        </child>
+                      </object>
+                    </child>
+                  </object>
+                </child>
+              </object>
+            </child>
+            <child>
+              <object class="GtkFlowBoxChild">
+                <property name="visible">1</property>
+                <property name="focusable">0</property>
+                <child>
+                  <object class="GtkBox">
+                    <property name="visible">1</property>
+                    <property name="spacing">12</property>
+                    <child>
+                      <object class="GtkLabel">
+                        <property name="visible">1</property>
+                        <property name="label" translatable="yes">URL link text color:</property>
+                        <property name="hexpand">1</property>
+                        <property name="xalign">0</property>
+                        <property name="wrap">1</property>
+                        <property name="mnemonic_widget">PickURL</property>
+                      </object>
+                    </child>
+                    <child>
+                      <object class="GtkColorButton" id="PickURL">
+                        <property name="visible">1</property>
+                        <signal name="color-set" handler="on_color_set"/>
+                      </object>
+                    </child>
+                  </object>
+                </child>
+              </object>
+            </child>
+            <child>
+              <object class="GtkFlowBoxChild">
+                <property name="visible">1</property>
+                <property name="focusable">0</property>
+                <child>
+                  <object class="GtkBox">
+                    <property name="visible">1</property>
+                    <property name="spacing">12</property>
+                    <child>
+                      <object class="GtkEntry" id="EntryURL">
+                        <property name="visible">1</property>
+                        <property name="hexpand">1</property>
+                        <property name="width-chars">16</property>
+                        <signal name="changed" handler="on_colors_changed"/>
+                      </object>
+                    </child>
+                    <child>
+                      <object class="GtkButton" id="DefaultURL">
+                        <property name="visible">1</property>
+                        <property name="halign">start</property>
+                        <signal name="clicked" handler="on_default_color"/>
+                        <child>
+                          <object class="GtkBox">
+                            <property name="visible">1</property>
+                            <property name="spacing">6</property>
+                            <child>
+                              <object class="GtkImage">
+                                <property name="visible">1</property>
+                                <property name="icon-name">view-refresh-symbolic</property>
+                              </object>
+                            </child>
+                            <child>
+                              <object class="GtkLabel">
+                                <property name="visible">1</property>
+                                <property name="label" translatable="yes">Default</property>
+                                <property name="use-underline">1</property>
+                              </object>
+                            </child>
+                          </object>
+                        </child>
+                      </object>
+                    </child>
+                  </object>
+                </child>
+              </object>
+            </child>
+            <child>
+              <object class="GtkFlowBoxChild">
+                <property name="visible">1</property>
+                <property name="focusable">0</property>
+                <child>
+                  <object class="GtkBox">
+                    <property name="visible">1</property>
+                    <property name="spacing">12</property>
+                    <child>
+                      <object class="GtkLabel">
+                        <property name="visible">1</property>
+                        <property name="label" translatable="yes">Online text color:</property>
+                        <property name="hexpand">1</property>
+                        <property name="xalign">0</property>
+                        <property name="wrap">1</property>
+                        <property name="mnemonic_widget">PickOnline</property>
+                      </object>
+                    </child>
+                    <child>
+                      <object class="GtkColorButton" id="PickOnline">
+                        <property name="visible">1</property>
+                        <signal name="color-set" handler="on_color_set"/>
+                      </object>
+                    </child>
+                  </object>
+                </child>
+              </object>
+            </child>
+            <child>
+              <object class="GtkFlowBoxChild">
+                <property name="visible">1</property>
+                <property name="focusable">0</property>
+                <child>
+                  <object class="GtkBox">
+                    <property name="visible">1</property>
+                    <property name="spacing">12</property>
+                    <child>
+                      <object class="GtkEntry" id="EntryOnline">
+                        <property name="visible">1</property>
+                        <property name="hexpand">1</property>
+                        <property name="width-chars">16</property>
+                        <signal name="changed" handler="on_colors_changed"/>
+                      </object>
+                    </child>
+                    <child>
+                      <object class="GtkButton" id="DefaultOnline">
+                        <property name="visible">1</property>
+                        <property name="halign">start</property>
+                        <signal name="clicked" handler="on_default_color"/>
+                        <child>
+                          <object class="GtkBox">
+                            <property name="visible">1</property>
+                            <property name="spacing">6</property>
+                            <child>
+                              <object class="GtkImage">
+                                <property name="visible">1</property>
+                                <property name="icon-name">view-refresh-symbolic</property>
+                              </object>
+                            </child>
+                            <child>
+                              <object class="GtkLabel">
+                                <property name="visible">1</property>
+                                <property name="label" translatable="yes">Default</property>
+                                <property name="use-underline">1</property>
+                              </object>
+                            </child>
+                          </object>
+                        </child>
+                      </object>
+                    </child>
+                  </object>
+                </child>
+              </object>
+            </child>
+            <child>
+              <object class="GtkFlowBoxChild">
+                <property name="visible">1</property>
+                <property name="focusable">0</property>
+                <child>
+                  <object class="GtkBox">
+                    <property name="visible">1</property>
+                    <property name="spacing">12</property>
+                    <child>
+                      <object class="GtkLabel">
+                        <property name="visible">1</property>
+                        <property name="label" translatable="yes">Offline text color:</property>
+                        <property name="hexpand">1</property>
+                        <property name="xalign">0</property>
+                        <property name="wrap">1</property>
+                        <property name="mnemonic_widget">PickOffline</property>
+                      </object>
+                    </child>
+                    <child>
+                      <object class="GtkColorButton" id="PickOffline">
+                        <property name="visible">1</property>
+                        <signal name="color-set" handler="on_color_set"/>
+                      </object>
+                    </child>
+                  </object>
+                </child>
+              </object>
+            </child>
+            <child>
+              <object class="GtkFlowBoxChild">
+                <property name="visible">1</property>
+                <property name="focusable">0</property>
+                <child>
+                  <object class="GtkBox">
+                    <property name="visible">1</property>
+                    <property name="spacing">12</property>
+                    <child>
+                      <object class="GtkEntry" id="EntryOffline">
+                        <property name="visible">1</property>
+                        <property name="hexpand">1</property>
+                        <property name="width-chars">16</property>
+                        <signal name="changed" handler="on_colors_changed"/>
+                      </object>
+                    </child>
+                    <child>
+                      <object class="GtkButton" id="DefaultOffline">
+                        <property name="visible">1</property>
+                        <property name="halign">start</property>
+                        <signal name="clicked" handler="on_default_color"/>
+                        <child>
+                          <object class="GtkBox">
+                            <property name="visible">1</property>
+                            <property name="spacing">6</property>
+                            <child>
+                              <object class="GtkImage">
+                                <property name="visible">1</property>
+                                <property name="icon-name">view-refresh-symbolic</property>
+                              </object>
+                            </child>
+                            <child>
+                              <object class="GtkLabel">
+                                <property name="visible">1</property>
+                                <property name="label" translatable="yes">Default</property>
+                                <property name="use-underline">1</property>
+                              </object>
+                            </child>
+                          </object>
+                        </child>
+                      </object>
+                    </child>
+                  </object>
+                </child>
+              </object>
+            </child>
+            <child>
+              <object class="GtkFlowBoxChild">
+                <property name="visible">1</property>
+                <property name="focusable">0</property>
+                <child>
+                  <object class="GtkBox">
+                    <property name="visible">1</property>
+                    <property name="spacing">12</property>
+                    <child>
+                      <object class="GtkLabel">
+                        <property name="visible">1</property>
+                        <property name="label" translatable="yes">Away text color:</property>
+                        <property name="hexpand">1</property>
+                        <property name="xalign">0</property>
+                        <property name="wrap">1</property>
+                        <property name="mnemonic_widget">PickAway</property>
+                      </object>
+                    </child>
+                    <child>
+                      <object class="GtkColorButton" id="PickAway">
+                        <property name="visible">1</property>
+                        <signal name="color-set" handler="on_color_set"/>
+                      </object>
+                    </child>
+                  </object>
+                </child>
+              </object>
+            </child>
+            <child>
+              <object class="GtkFlowBoxChild">
+                <property name="visible">1</property>
+                <property name="focusable">0</property>
+                <child>
+                  <object class="GtkBox">
+                    <property name="visible">1</property>
+                    <property name="spacing">12</property>
+                    <child>
+                      <object class="GtkEntry" id="EntryAway">
+                        <property name="visible">1</property>
+                        <property name="hexpand">1</property>
+                        <property name="width-chars">16</property>
+                        <signal name="changed" handler="on_colors_changed"/>
+                      </object>
+                    </child>
+                    <child>
+                      <object class="GtkButton" id="DefaultAway">
+                        <property name="visible">1</property>
+                        <property name="halign">start</property>
+                        <signal name="clicked" handler="on_default_color"/>
+                        <child>
+                          <object class="GtkBox">
+                            <property name="visible">1</property>
+                            <property name="spacing">6</property>
+                            <child>
+                              <object class="GtkImage">
+                                <property name="visible">1</property>
+                                <property name="icon-name">view-refresh-symbolic</property>
+                              </object>
+                            </child>
+                            <child>
+                              <object class="GtkLabel">
+                                <property name="visible">1</property>
+                                <property name="label" translatable="yes">Default</property>
+                                <property name="use-underline">1</property>
+                              </object>
+                            </child>
+                          </object>
+                        </child>
+                      </object>
+                    </child>
+                  </object>
+                </child>
+              </object>
+            </child>
+          </object>
+        </child>
+      </object>
+    </child>
+    <child>
+      <object class="GtkBox">
+        <property name="visible">1</property>
+        <property name="spacing">12</property>
+        <property name="orientation">vertical</property>
+        <child>
+          <object class="GtkLabel">
+            <property name="visible">1</property>
+            <property name="xalign">0</property>
+            <property name="label" translatable="yes">Text Entries</property>
+            <property name="wrap">1</property>
+            <attributes>
+              <attribute name="weight" value="bold"/>
+            </attributes>
+          </object>
+        </child>
+        <child>
+          <object class="GtkFlowBox">
+            <property name="visible">1</property>
+            <property name="homogeneous">1</property>
+            <property name="column-spacing">12</property>
+            <property name="row-spacing">12</property>
+            <property name="min-children-per-line">1</property>
+            <property name="max-children-per-line">2</property>
+            <property name="selection-mode">none</property>
+            <child>
+              <object class="GtkFlowBoxChild">
+                <property name="visible">1</property>
+                <property name="focusable">0</property>
+                <child>
+                  <object class="GtkBox">
+                    <property name="visible">1</property>
+                    <property name="spacing">12</property>
+                    <child>
+                      <object class="GtkLabel">
+                        <property name="visible">1</property>
+                        <property name="label" translatable="yes">Text entry background color:</property>
+                        <property name="hexpand">1</property>
+                        <property name="xalign">0</property>
+                        <property name="wrap">1</property>
+                        <property name="mnemonic_widget">PickBackground</property>
+                      </object>
+                    </child>
+                    <child>
+                      <object class="GtkColorButton" id="PickBackground">
+                        <property name="visible">1</property>
+                        <signal name="color-set" handler="on_color_set"/>
+                      </object>
+                    </child>
+                  </object>
+                </child>
+              </object>
+            </child>
+            <child>
+              <object class="GtkFlowBoxChild">
+                <property name="visible">1</property>
+                <property name="focusable">0</property>
+                <child>
+                  <object class="GtkBox">
+                    <property name="visible">1</property>
+                    <property name="spacing">12</property>
+                    <child>
+                      <object class="GtkEntry" id="EntryBackground">
+                        <property name="visible">1</property>
+                        <property name="hexpand">1</property>
+                        <property name="width-chars">16</property>
+                        <signal name="changed" handler="on_colors_changed"/>
+                      </object>
+                    </child>
+                    <child>
+                      <object class="GtkButton" id="DefaultBackground">
+                        <property name="visible">1</property>
+                        <property name="halign">start</property>
+                        <signal name="clicked" handler="on_default_color"/>
+                        <child>
+                          <object class="GtkBox">
+                            <property name="visible">1</property>
+                            <property name="spacing">6</property>
+                            <child>
+                              <object class="GtkImage">
+                                <property name="visible">1</property>
+                                <property name="icon-name">view-refresh-symbolic</property>
+                              </object>
+                            </child>
+                            <child>
+                              <object class="GtkLabel">
+                                <property name="visible">1</property>
+                                <property name="label" translatable="yes">Default</property>
+                                <property name="use-underline">1</property>
+                              </object>
+                            </child>
+                          </object>
+                        </child>
+                      </object>
+                    </child>
+                  </object>
+                </child>
+              </object>
+            </child>
+            <child>
+              <object class="GtkFlowBoxChild">
+                <property name="visible">1</property>
+                <property name="focusable">0</property>
+                <child>
+                  <object class="GtkBox">
+                    <property name="visible">1</property>
+                    <property name="spacing">12</property>
+                    <child>
+                      <object class="GtkLabel">
+                        <property name="visible">1</property>
+                        <property name="label" translatable="yes">Text entry text color:</property>
+                        <property name="hexpand">1</property>
+                        <property name="xalign">0</property>
+                        <property name="wrap">1</property>
+                        <property name="mnemonic_widget">PickInput</property>
+                      </object>
+                    </child>
+                    <child>
+                      <object class="GtkColorButton" id="PickInput">
+                        <property name="visible">1</property>
+                        <signal name="color-set" handler="on_color_set"/>
+                      </object>
+                    </child>
+                  </object>
+                </child>
+              </object>
+            </child>
+            <child>
+              <object class="GtkFlowBoxChild">
+                <property name="visible">1</property>
+                <property name="focusable">0</property>
+                <child>
+                  <object class="GtkBox">
+                    <property name="visible">1</property>
+                    <property name="spacing">12</property>
+                    <child>
+                      <object class="GtkEntry" id="EntryInput">
+                        <property name="visible">1</property>
+                        <property name="hexpand">1</property>
+                        <property name="width-chars">16</property>
+                        <signal name="changed" handler="on_colors_changed"/>
+                      </object>
+                    </child>
+                    <child>
+                      <object class="GtkButton" id="DefaultInput">
+                        <property name="visible">1</property>
+                        <property name="halign">start</property>
+                        <signal name="clicked" handler="on_default_color"/>
+                        <child>
+                          <object class="GtkBox">
+                            <property name="visible">1</property>
+                            <property name="spacing">6</property>
+                            <child>
+                              <object class="GtkImage">
+                                <property name="visible">1</property>
+                                <property name="icon-name">view-refresh-symbolic</property>
+                              </object>
+                            </child>
+                            <child>
+                              <object class="GtkLabel">
+                                <property name="visible">1</property>
+                                <property name="label" translatable="yes">Default</property>
+                                <property name="use-underline">1</property>
+                              </object>
+                            </child>
+                          </object>
+                        </child>
+                      </object>
+                    </child>
+                  </object>
+                </child>
+              </object>
+            </child>
+          </object>
+        </child>
+      </object>
+    </child>
+    <child>
+      <object class="GtkBox">
+        <property name="visible">1</property>
+        <property name="spacing">12</property>
+        <property name="orientation">vertical</property>
+        <child>
+          <object class="GtkLabel">
+            <property name="visible">1</property>
+            <property name="label" translatable="yes">Tab Labels</property>
+            <property name="xalign">0</property>
+            <attributes>
+              <attribute name="weight" value="bold"/>
+            </attributes>
+          </object>
+        </child>
+        <child>
+          <object class="GtkCheckButton" id="NotificationTabColors">
+            <property name="visible">1</property>
+            <property name="label" translatable="yes">Notification changes the tab&apos;s text color</property>
+            <signal name="toggled" handler="on_tab_notification_color_toggled" swapped="no"/>
+          </object>
+        </child>
+        <child>
+          <object class="GtkFlowBox">
+            <property name="visible">1</property>
+            <property name="homogeneous">1</property>
+            <property name="column-spacing">12</property>
+            <property name="row-spacing">12</property>
+            <property name="min-children-per-line">1</property>
+            <property name="max-children-per-line">2</property>
+            <property name="selection-mode">none</property>
+            <child>
+              <object class="GtkFlowBoxChild">
+                <property name="visible">1</property>
+                <property name="focusable">0</property>
+                <child>
+                  <object class="GtkBox">
+                    <property name="visible">1</property>
+                    <property name="spacing">12</property>
+                    <child>
+                      <object class="GtkLabel">
+                        <property name="visible">1</property>
+                        <property name="label" translatable="yes">Regular tab label color:</property>
+                        <property name="hexpand">1</property>
+                        <property name="xalign">0</property>
+                        <property name="wrap">1</property>
+                        <property name="mnemonic_widget">PickRegularTab</property>
+                      </object>
+                    </child>
+                    <child>
+                      <object class="GtkColorButton" id="PickRegularTab">
+                        <property name="visible">1</property>
+                        <signal name="color-set" handler="on_color_set"/>
+                      </object>
+                    </child>
+                  </object>
+                </child>
+              </object>
+            </child>
+            <child>
+              <object class="GtkFlowBoxChild">
+                <property name="visible">1</property>
+                <property name="focusable">0</property>
+                <child>
+                  <object class="GtkBox">
+                    <property name="visible">1</property>
+                    <property name="spacing">12</property>
+                    <child>
+                      <object class="GtkEntry" id="EntryRegularTab">
+                        <property name="visible">1</property>
+                        <property name="hexpand">1</property>
+                        <property name="width-chars">16</property>
+                        <signal name="changed" handler="on_colors_changed"/>
+                      </object>
+                    </child>
+                    <child>
+                      <object class="GtkButton" id="DefaultRegularTab">
+                        <property name="visible">1</property>
+                        <property name="halign">start</property>
+                        <signal name="clicked" handler="on_default_color"/>
+                        <child>
+                          <object class="GtkBox">
+                            <property name="visible">1</property>
+                            <property name="spacing">6</property>
+                            <child>
+                              <object class="GtkImage">
+                                <property name="visible">1</property>
+                                <property name="icon-name">view-refresh-symbolic</property>
+                              </object>
+                            </child>
+                            <child>
+                              <object class="GtkLabel">
+                                <property name="visible">1</property>
+                                <property name="label" translatable="yes">Default</property>
+                                <property name="use-underline">1</property>
+                              </object>
+                            </child>
+                          </object>
+                        </child>
+                      </object>
+                    </child>
+                  </object>
+                </child>
+              </object>
+            </child>
+            <child>
+              <object class="GtkFlowBoxChild">
+                <property name="visible">1</property>
+                <property name="focusable">0</property>
+                <child>
+                  <object class="GtkBox">
+                    <property name="visible">1</property>
+                    <property name="spacing">12</property>
+                    <child>
+                      <object class="GtkLabel">
+                        <property name="visible">1</property>
+                        <property name="label" translatable="yes">Changed tab label color:</property>
+                        <property name="hexpand">1</property>
+                        <property name="xalign">0</property>
+                        <property name="wrap">1</property>
+                        <property name="mnemonic_widget">PickChangedTab</property>
+                      </object>
+                    </child>
+                    <child>
+                      <object class="GtkColorButton" id="PickChangedTab">
+                        <property name="visible">1</property>
+                        <signal name="color-set" handler="on_color_set"/>
+                      </object>
+                    </child>
+                  </object>
+                </child>
+              </object>
+            </child>
+            <child>
+              <object class="GtkFlowBoxChild">
+                <property name="visible">1</property>
+                <property name="focusable">0</property>
+                <child>
+                  <object class="GtkBox">
+                    <property name="visible">1</property>
+                    <property name="spacing">12</property>
+                    <child>
+                      <object class="GtkEntry" id="EntryChangedTab">
+                        <property name="visible">1</property>
+                        <property name="hexpand">1</property>
+                        <property name="width-chars">16</property>
+                        <signal name="changed" handler="on_colors_changed"/>
+                      </object>
+                    </child>
+                    <child>
+                      <object class="GtkButton" id="DefaultChangedTab">
+                        <property name="visible">1</property>
+                        <property name="halign">start</property>
+                        <signal name="clicked" handler="on_default_color"/>
+                        <child>
+                          <object class="GtkBox">
+                            <property name="visible">1</property>
+                            <property name="spacing">6</property>
+                            <child>
+                              <object class="GtkImage">
+                                <property name="visible">1</property>
+                                <property name="icon-name">view-refresh-symbolic</property>
+                              </object>
+                            </child>
+                            <child>
+                              <object class="GtkLabel">
+                                <property name="visible">1</property>
+                                <property name="label" translatable="yes">Default</property>
+                                <property name="use-underline">1</property>
+                              </object>
+                            </child>
+                          </object>
+                        </child>
+                      </object>
+                    </child>
+                  </object>
+                </child>
+              </object>
+            </child>
+            <child>
+              <object class="GtkFlowBoxChild">
+                <property name="visible">1</property>
+                <property name="focusable">0</property>
+                <child>
+                  <object class="GtkBox">
+                    <property name="visible">1</property>
+                    <property name="spacing">12</property>
+                    <child>
+                      <object class="GtkLabel">
+                        <property name="visible">1</property>
+                        <property name="label" translatable="yes">Highlighted tab label color:</property>
+                        <property name="hexpand">1</property>
+                        <property name="xalign">0</property>
+                        <property name="wrap">1</property>
+                        <property name="mnemonic_widget">PickHighlightTab</property>
+                      </object>
+                    </child>
+                    <child>
+                      <object class="GtkColorButton" id="PickHighlightTab">
+                        <property name="visible">1</property>
+                        <signal name="color-set" handler="on_color_set"/>
+                      </object>
+                    </child>
+                  </object>
+                </child>
+              </object>
+            </child>
+            <child>
+              <object class="GtkFlowBoxChild">
+                <property name="visible">1</property>
+                <property name="focusable">0</property>
+                <child>
+                  <object class="GtkBox">
+                    <property name="visible">1</property>
+                    <property name="spacing">12</property>
+                    <child>
+                      <object class="GtkEntry" id="EntryHighlightTab">
+                        <property name="visible">1</property>
+                        <property name="hexpand">1</property>
+                        <property name="width-chars">16</property>
+                        <signal name="changed" handler="on_colors_changed"/>
+                      </object>
+                    </child>
+                    <child>
+                      <object class="GtkButton" id="DefaultHighlightTab">
+                        <property name="visible">1</property>
+                        <property name="halign">start</property>
+                        <signal name="clicked" handler="on_default_color"/>
+                        <child>
+                          <object class="GtkBox">
+                            <property name="visible">1</property>
+                            <property name="spacing">6</property>
+                            <child>
+                              <object class="GtkImage">
+                                <property name="visible">1</property>
+                                <property name="icon-name">view-refresh-symbolic</property>
+                              </object>
+                            </child>
+                            <child>
+                              <object class="GtkLabel">
+                                <property name="visible">1</property>
+                                <property name="label" translatable="yes">Default</property>
+                                <property name="use-underline">1</property>
+                              </object>
+                            </child>
+                          </object>
+                        </child>
+                      </object>
+                    </child>
+                  </object>
+                </child>
+              </object>
+            </child>
+          </object>
+        </child>
+      </object>
+    </child>
+    <child>
+      <object class="GtkBox">
+        <property name="visible">1</property>
+        <property name="spacing">12</property>
+        <property name="orientation">vertical</property>
+        <child>
+          <object class="GtkLabel">
+            <property name="visible">1</property>
+            <property name="halign">start</property>
+            <property name="label" translatable="yes">Fonts</property>
+            <attributes>
+              <attribute name="weight" value="bold"/>
+            </attributes>
+          </object>
+        </child>
+        <child>
+          <object class="GtkFlowBox">
+            <property name="visible">1</property>
+            <property name="column-spacing">12</property>
+            <property name="row-spacing">12</property>
+            <property name="max-children-per-line">2</property>
+            <property name="selection-mode">none</property>
+            <child>
+              <object class="GtkFlowBoxChild">
+                <property name="visible">1</property>
+                <property name="focusable">0</property>
+                <child>
+                  <object class="GtkLabel">
+                    <property name="visible">1</property>
+                    <property name="label" translatable="yes">Global font:</property>
+                    <property name="xalign">0</property>
+                    <property name="wrap">1</property>
+                    <property name="mnemonic_widget">SelectGlobalFont</property>
+                  </object>
+                </child>
+              </object>
+            </child>
+            <child>
+              <object class="GtkFlowBoxChild">
+                <property name="visible">1</property>
+                <property name="focusable">0</property>
+                <child>
+                  <object class="GtkBox">
+                    <property name="visible">1</property>
+                    <property name="spacing">12</property>
+                    <child>
+                      <object class="GtkFontButton" id="SelectGlobalFont">
+                        <property name="visible">1</property>
+                        <property name="hexpand">1</property>
+                        <property name="font">Sans 12</property>
+                        <property name="width-request">250</property>
+                        <signal name="font-set" handler="on_fonts_changed"/>
+                      </object>
+                    </child>
+                    <child>
+                      <object class="GtkButton" id="DefaultGlobalFont">
+                        <property name="visible">1</property>
+                        <signal name="clicked" handler="on_default_font"/>
+                        <child>
+                          <object class="GtkBox">
+                            <property name="visible">1</property>
+                            <property name="spacing">6</property>
+                            <child>
+                              <object class="GtkImage">
+                                <property name="visible">1</property>
+                                <property name="icon-name">view-refresh-symbolic</property>
+                              </object>
+                            </child>
+                            <child>
+                              <object class="GtkLabel">
+                                <property name="visible">1</property>
+                                <property name="label" translatable="yes">Default</property>
+                                <property name="use-underline">1</property>
+                              </object>
+                            </child>
+                          </object>
+                        </child>
+                      </object>
+                    </child>
+                  </object>
+                </child>
+              </object>
+            </child>
+            <child>
+              <object class="GtkFlowBoxChild">
+                <property name="visible">1</property>
+                <property name="focusable">0</property>
+                <child>
+                  <object class="GtkLabel">
+                    <property name="visible">1</property>
+                    <property name="label" translatable="yes">Chat font:</property>
+                    <property name="xalign">0</property>
+                    <property name="wrap">1</property>
+                    <property name="mnemonic_widget">SelectChatFont</property>
+                  </object>
+                </child>
+              </object>
+            </child>
+            <child>
+              <object class="GtkFlowBoxChild">
+                <property name="visible">1</property>
+                <property name="focusable">0</property>
+                <child>
+                  <object class="GtkBox">
+                    <property name="visible">1</property>
+                    <property name="spacing">12</property>
+                    <child>
+                      <object class="GtkFontButton" id="SelectChatFont">
+                        <property name="visible">1</property>
+                        <property name="hexpand">1</property>
+                        <property name="font">Sans 12</property>
+                        <property name="width-request">250</property>
+                        <signal name="font-set" handler="on_fonts_changed"/>
+                      </object>
+                    </child>
+                    <child>
+                      <object class="GtkButton" id="DefaultChatFont">
+                        <property name="visible">1</property>
+                        <signal name="clicked" handler="on_default_font"/>
+                        <child>
+                          <object class="GtkBox">
+                            <property name="visible">1</property>
+                            <property name="spacing">6</property>
+                            <child>
+                              <object class="GtkImage">
+                                <property name="visible">1</property>
+                                <property name="icon-name">view-refresh-symbolic</property>
+                              </object>
+                            </child>
+                            <child>
+                              <object class="GtkLabel">
+                                <property name="visible">1</property>
+                                <property name="label" translatable="yes">Default</property>
+                                <property name="use-underline">1</property>
+                              </object>
+                            </child>
+                          </object>
+                        </child>
+                      </object>
+                    </child>
+                  </object>
+                </child>
+              </object>
+            </child>
+            <child>
+              <object class="GtkFlowBoxChild">
+                <property name="visible">1</property>
+                <property name="focusable">0</property>
+                <child>
+                  <object class="GtkLabel">
+                    <property name="visible">1</property>
+                    <property name="label" translatable="yes">List font:</property>
+                    <property name="xalign">0</property>
+                    <property name="wrap">1</property>
+                    <property name="mnemonic_widget">SelectListFont</property>
+                  </object>
+                </child>
+              </object>
+            </child>
+            <child>
+              <object class="GtkFlowBoxChild">
+                <property name="visible">1</property>
+                <property name="focusable">0</property>
+                <child>
+                  <object class="GtkBox">
+                    <property name="visible">1</property>
+                    <property name="spacing">12</property>
+                    <child>
+                      <object class="GtkFontButton" id="SelectListFont">
+                        <property name="visible">1</property>
+                        <property name="hexpand">1</property>
+                        <property name="font">Sans 12</property>
+                        <property name="width-request">250</property>
+                        <signal name="font-set" handler="on_fonts_changed"/>
+                      </object>
+                    </child>
+                    <child>
+                      <object class="GtkButton" id="DefaultListFont">
+                        <property name="visible">1</property>
+                        <signal name="clicked" handler="on_default_font"/>
+                        <child>
+                          <object class="GtkBox">
+                            <property name="visible">1</property>
+                            <property name="spacing">6</property>
+                            <child>
+                              <object class="GtkImage">
+                                <property name="visible">1</property>
+                                <property name="icon-name">view-refresh-symbolic</property>
+                              </object>
+                            </child>
+                            <child>
+                              <object class="GtkLabel">
+                                <property name="visible">1</property>
+                                <property name="label" translatable="yes">Default</property>
+                                <property name="use-underline">1</property>
+                              </object>
+                            </child>
+                          </object>
+                        </child>
+                      </object>
+                    </child>
+                  </object>
+                </child>
+              </object>
+            </child>
+            <child>
+              <object class="GtkFlowBoxChild">
+                <property name="visible">1</property>
+                <property name="focusable">0</property>
+                <child>
+                  <object class="GtkLabel">
+                    <property name="visible">1</property>
+                    <property name="label" translatable="yes">Transfers font:</property>
+                    <property name="xalign">0</property>
+                    <property name="wrap">1</property>
+                    <property name="mnemonic_widget">SelectTransfersFont</property>
+                  </object>
+                </child>
+              </object>
+            </child>
+            <child>
+              <object class="GtkFlowBoxChild">
+                <property name="visible">1</property>
+                <property name="focusable">0</property>
+                <child>
+                  <object class="GtkBox">
+                    <property name="visible">1</property>
+                    <property name="spacing">12</property>
+                    <child>
+                      <object class="GtkFontButton" id="SelectTransfersFont">
+                        <property name="visible">1</property>
+                        <property name="hexpand">1</property>
+                        <property name="font">Sans 12</property>
+                        <property name="width-request">250</property>
+                        <signal name="font-set" handler="on_fonts_changed"/>
+                      </object>
+                    </child>
+                    <child>
+                      <object class="GtkButton" id="DefaultTransfersFont">
+                        <property name="visible">1</property>
+                        <signal name="clicked" handler="on_default_font"/>
+                        <child>
+                          <object class="GtkBox">
+                            <property name="visible">1</property>
+                            <property name="spacing">6</property>
+                            <child>
+                              <object class="GtkImage">
+                                <property name="visible">1</property>
+                                <property name="icon-name">view-refresh-symbolic</property>
+                              </object>
+                            </child>
+                            <child>
+                              <object class="GtkLabel">
+                                <property name="visible">1</property>
+                                <property name="label" translatable="yes">Default</property>
+                                <property name="use-underline">1</property>
+                              </object>
+                            </child>
+                          </object>
+                        </child>
+                      </object>
+                    </child>
+                  </object>
+                </child>
+              </object>
+            </child>
+            <child>
+              <object class="GtkFlowBoxChild">
+                <property name="visible">1</property>
+                <property name="focusable">0</property>
+                <child>
+                  <object class="GtkLabel">
+                    <property name="visible">1</property>
+                    <property name="label" translatable="yes">Search font:</property>
+                    <property name="xalign">0</property>
+                    <property name="wrap">1</property>
+                    <property name="mnemonic_widget">SelectSearchFont</property>
+                  </object>
+                </child>
+              </object>
+            </child>
+            <child>
+              <object class="GtkFlowBoxChild">
+                <property name="visible">1</property>
+                <property name="focusable">0</property>
+                <child>
+                  <object class="GtkBox">
+                    <property name="visible">1</property>
+                    <property name="spacing">12</property>
+                    <child>
+                      <object class="GtkFontButton" id="SelectSearchFont">
+                        <property name="visible">1</property>
+                        <property name="hexpand">1</property>
+                        <property name="font">Sans 12</property>
+                        <property name="width-request">250</property>
+                        <signal name="font-set" handler="on_fonts_changed"/>
+                      </object>
+                    </child>
+                    <child>
+                      <object class="GtkButton" id="DefaultSearchFont">
+                        <property name="visible">1</property>
+                        <signal name="clicked" handler="on_default_font"/>
+                        <child>
+                          <object class="GtkBox">
+                            <property name="visible">1</property>
+                            <property name="spacing">6</property>
+                            <child>
+                              <object class="GtkImage">
+                                <property name="visible">1</property>
+                                <property name="icon-name">view-refresh-symbolic</property>
+                              </object>
+                            </child>
+                            <child>
+                              <object class="GtkLabel">
+                                <property name="visible">1</property>
+                                <property name="label" translatable="yes">Default</property>
+                                <property name="use-underline">1</property>
+                              </object>
+                            </child>
+                          </object>
+                        </child>
+                      </object>
+                    </child>
+                  </object>
+                </child>
+              </object>
+            </child>
+            <child>
+              <object class="GtkFlowBoxChild">
+                <property name="visible">1</property>
+                <property name="focusable">0</property>
+                <child>
+                  <object class="GtkLabel">
+                    <property name="visible">1</property>
+                    <property name="label" translatable="yes">Browse font:</property>
+                    <property name="xalign">0</property>
+                    <property name="wrap">1</property>
+                    <property name="mnemonic_widget">SelectBrowserFont</property>
+                  </object>
+                </child>
+              </object>
+            </child>
+            <child>
+              <object class="GtkFlowBoxChild">
+                <property name="visible">1</property>
+                <property name="focusable">0</property>
+                <child>
+                  <object class="GtkBox">
+                    <property name="visible">1</property>
+                    <property name="spacing">12</property>
+                    <child>
+                      <object class="GtkFontButton" id="SelectBrowserFont">
+                        <property name="visible">1</property>
+                        <property name="hexpand">1</property>
+                        <property name="font">Sans 12</property>
+                        <property name="width-request">250</property>
+                        <signal name="font-set" handler="on_fonts_changed"/>
+                      </object>
+                    </child>
+                    <child>
+                      <object class="GtkButton" id="DefaultBrowserFont">
+                        <property name="visible">1</property>
+                        <signal name="clicked" handler="on_default_font"/>
+                        <child>
+                          <object class="GtkBox">
+                            <property name="visible">1</property>
+                            <property name="spacing">6</property>
+                            <child>
+                              <object class="GtkImage">
+                                <property name="visible">1</property>
+                                <property name="icon-name">view-refresh-symbolic</property>
+                              </object>
+                            </child>
+                            <child>
+                              <object class="GtkLabel">
+                                <property name="visible">1</property>
+                                <property name="label" translatable="yes">Default</property>
+                                <property name="use-underline">1</property>
+                              </object>
+                            </child>
+                          </object>
+                        </child>
+                      </object>
+                    </child>
+                  </object>
+                </child>
+              </object>
+            </child>
+          </object>
+        </child>
+      </object>
+    </child>
+    <child>
+      <object class="GtkBox">
+        <property name="visible">1</property>
+        <property name="spacing">12</property>
+        <property name="orientation">vertical</property>
+        <child>
+          <object class="GtkLabel">
+            <property name="visible">1</property>
+            <property name="label" translatable="yes">Icons</property>
+            <property name="xalign">0</property>
+            <attributes>
+              <attribute name="weight" value="bold"/>
+            </attributes>
+          </object>
+        </child>
+        <child>
+          <object class="GtkBox">
+            <property name="visible">1</property>
+            <property name="spacing">18</property>
+            <property name="orientation">vertical</property>
+            <child>
+              <object class="GtkFlowBox">
+                <property name="visible">1</property>
+                <property name="homogeneous">1</property>
+                <property name="column-spacing">12</property>
+                <property name="row-spacing">12</property>
+                <property name="max-children-per-line">2</property>
+                <property name="selection-mode">none</property>
+                <child>
+                  <object class="GtkFlowBoxChild">
+                    <property name="visible">1</property>
+                    <property name="focusable">0</property>
+                    <child>
+                      <object class="GtkLabel">
+                        <property name="visible">1</property>
+                        <property name="label" translatable="yes">Icon theme folder (requires restart):</property>
+                        <property name="xalign">0</property>
+                        <property name="mnemonic_widget">ThemeDir</property>
+                      </object>
+                    </child>
+                  </object>
+                </child>
+                <child>
+                  <object class="GtkFlowBoxChild">
+                    <property name="visible">1</property>
+                    <property name="focusable">0</property>
+                    <child>
+                      <object class="GtkBox">
+                        <property name="visible">1</property>
+                        <property name="spacing">12</property>
+                        <child>
+                          <object class="GtkButton" id="ThemeDir">
+                            <property name="visible">1</property>
+                            <property name="hexpand">1</property>
+                            <property name="width-request">160</property>
+                          </object>
+                        </child>
+                        <child>
+                          <object class="GtkButton" id="DefaultTheme">
+                            <property name="visible">1</property>
+                            <signal name="clicked" handler="on_default_theme" swapped="no"/>
+                            <child>
+                              <object class="GtkBox">
+                                <property name="visible">1</property>
+                                <property name="spacing">6</property>
+                                <child>
+                                  <object class="GtkImage">
+                                    <property name="visible">1</property>
+                                    <property name="icon-name">edit-clear-symbolic</property>
+                                  </object>
+                                </child>
+                                <child>
+                                  <object class="GtkLabel">
+                                    <property name="visible">1</property>
+                                    <property name="label" translatable="yes">Clear</property>
+                                    <property name="use-underline">1</property>
+                                  </object>
+                                </child>
+                              </object>
+                            </child>
+                          </object>
+                        </child>
+                      </object>
+                    </child>
+                  </object>
+                </child>
+              </object>
+            </child>
+            <child>
+              <object class="GtkFrame">
+                <property name="visible">1</property>
+                <child>
+                  <object class="GtkFlowBox" id="IconView">
+                    <property name="visible">1</property>
+                    <property name="column-spacing">24</property>
+                    <property name="row-spacing">24</property>
+                    <property name="margin-start">24</property>
+                    <property name="margin-end">24</property>
+                    <property name="margin-top">24</property>
+                    <property name="margin-bottom">24</property>
+                    <property name="selection-mode">none</property>
+                  </object>
+                </child>
+                <style>
+                  <class name="view"/>
+                </style>
+              </object>
+            </child>
+          </object>
+        </child>
+      </object>
+    </child>
+  </object>
+</interface>

--- a/pynicotine/gtkgui/ui/settings/notifications.ui
+++ b/pynicotine/gtkgui/ui/settings/notifications.ui
@@ -80,44 +80,5 @@
         </child>
       </object>
     </child>
-    <child>
-      <object class="GtkBox" id="TraySettings">
-        <property name="visible">1</property>
-        <property name="spacing">12</property>
-        <property name="orientation">vertical</property>
-        <child>
-          <object class="GtkLabel">
-            <property name="visible">1</property>
-            <property name="label" translatable="yes">Tray</property>
-            <property name="xalign">0</property>
-            <attributes>
-              <attribute name="weight" value="bold"/>
-            </attributes>
-          </object>
-        </child>
-        <child>
-          <object class="GtkBox">
-            <property name="visible">1</property>
-            <property name="spacing">12</property>
-            <property name="orientation">vertical</property>
-            <child>
-              <object class="GtkCheckButton" id="TrayiconCheck">
-                <property name="label" translatable="yes">Display tray icon</property>
-                <property name="visible">1</property>
-                <property name="use-underline">1</property>
-                <signal name="toggled" handler="on_toggle_tray" swapped="no"/>
-              </object>
-            </child>
-            <child>
-              <object class="GtkCheckButton" id="StartupHidden">
-                <property name="label" translatable="yes">Minimize to tray on startup</property>
-                <property name="visible">1</property>
-                <property name="use-underline">1</property>
-              </object>
-            </child>
-          </object>
-        </child>
-      </object>
-    </child>
   </object>
 </interface>

--- a/pynicotine/gtkgui/ui/settings/userinterface.ui
+++ b/pynicotine/gtkgui/ui/settings/userinterface.ui
@@ -20,29 +20,23 @@
           </object>
         </child>
         <child>
-          <object class="GtkCheckButton" id="DarkMode">
-            <property name="label" translatable="yes">Prefer dark mode</property>
-            <property name="visible">1</property>
-            <property name="tooltip_text" translatable="yes">Note that the operating system&apos;s theme may take precedence.</property>
-          </object>
-        </child>
-        <child>
           <object class="GtkFlowBox">
             <property name="visible">1</property>
-            <property name="column-spacing">12</property>
+            <property name="homogeneous">1</property>
+            <property name="column-spacing">18</property>
             <property name="row-spacing">12</property>
-            <property name="max-children-per-line">2</property>
+            <property name="min-children-per-line">1</property>
+            <property name="max-children-per-line">3</property>
             <property name="selection-mode">none</property>
             <child>
               <object class="GtkFlowBoxChild">
                 <property name="visible">1</property>
                 <property name="focusable">0</property>
                 <child>
-                  <object class="GtkLabel">
+                  <object class="GtkCheckButton" id="DarkMode">
+                    <property name="label" translatable="yes">Prefer dark mode</property>
                     <property name="visible">1</property>
-                    <property name="label" translatable="yes">When closing Nicotine+:</property>
-                    <property name="xalign">0</property>
-                    <property name="mnemonic_widget">CloseAction</property>
+                    <property name="tooltip_text" translatable="yes">Note that the operating system&apos;s theme may take precedence.</property>
                   </object>
                 </child>
               </object>
@@ -52,13 +46,24 @@
                 <property name="visible">1</property>
                 <property name="focusable">0</property>
                 <child>
-                  <object class="GtkComboBoxText" id="CloseAction">
+                  <object class="GtkBox" id = "TraySettings">
                     <property name="visible">1</property>
-                    <items>
-                      <item translatable="yes">Quit program</item>
-                      <item translatable="yes">Show confirmation dialog</item>
-                      <item translatable="yes">Run in the background</item>
-                    </items>
+                    <property name="focusable">0</property>
+                    <child>
+                      <object class="GtkCheckButton" id="TrayiconCheck">
+                        <property name="label" translatable="yes">Display tray icon</property>
+                        <property name="visible">1</property>
+                        <property name="use-underline">1</property>
+                        <signal name="toggled" handler="on_toggle_tray" swapped="no"/>
+                      </object>
+                    </child>
+                    <child>
+                      <object class="GtkCheckButton" id="StartupHidden">
+                        <property name="label" translatable="yes">Minimize to tray on startup</property>
+                        <property name="visible">1</property>
+                        <property name="use-underline">1</property>
+                      </object>
+                    </child>
                   </object>
                 </child>
               </object>
@@ -68,73 +73,60 @@
       </object>
     </child>
     <child>
-      <object class="GtkBox">
+      <object class="GtkFlowBox">
         <property name="visible">1</property>
-        <property name="spacing">18</property>
-        <property name="orientation">vertical</property>
+        <property name="homogeneous">1</property>
+        <property name="column-spacing">18</property>
+        <property name="row-spacing">2</property>
+        <property name="min-children-per-line">2</property>
+        <property name="max-children-per-line">2</property>
+        <property name="selection-mode">none</property>
         <child>
-          <object class="GtkBox">
+          <object class="GtkFlowBoxChild">
             <property name="visible">1</property>
-            <property name="spacing">12</property>
-            <property name="orientation">vertical</property>
+            <property name="focusable">0</property>
             <child>
               <object class="GtkLabel">
                 <property name="visible">1</property>
-                <property name="label" translatable="yes">Primary Tabs</property>
+                <property name="label" translatable="yes">When closing Nicotine+:</property>
                 <property name="xalign">0</property>
-                <attributes>
-                  <attribute name="weight" value="bold"/>
-                </attributes>
-              </object>
-            </child>
-            <child>
-              <object class="GtkCheckButton" id="TabSelectPrevious">
-                <property name="label" translatable="yes">View previous primary tab on startup</property>
-                <property name="visible">1</property>
-              </object>
-            </child>
-            <child>
-              <object class="GtkFlowBox">
-                <property name="visible">1</property>
-                <property name="column-spacing">12</property>
-                <property name="row-spacing">12</property>
-                <property name="max-children-per-line">2</property>
-                <property name="selection-mode">none</property>
-                <child>
-                  <object class="GtkFlowBoxChild">
-                    <property name="visible">1</property>
-                    <property name="focusable">0</property>
-                    <child>
-                      <object class="GtkLabel" id="MainTabsLabel">
-                        <property name="visible">1</property>
-                        <property name="xalign">0</property>
-                        <property name="label" translatable="yes">Tab bar position:</property>
-                        <property name="mnemonic_widget">MainPosition</property>
-                      </object>
-                    </child>
-                  </object>
-                </child>
-                <child>
-                  <object class="GtkFlowBoxChild">
-                    <property name="visible">1</property>
-                    <property name="focusable">0</property>
-                    <child>
-                      <object class="GtkComboBox" id="MainPosition">
-                        <property name="visible">1</property>
-                        <property name="hexpand">1</property>
-                      </object>
-                    </child>
-                  </object>
-                </child>
+                <property name="mnemonic_widget">CloseAction</property>
               </object>
             </child>
           </object>
         </child>
         <child>
-          <object class="GtkBox">
+          <object class="GtkFlowBoxChild">
             <property name="visible">1</property>
-            <property name="spacing">18</property>
-            <property name="orientation">vertical</property>
+            <property name="focusable">0</property>
+            <child>
+              <object class="GtkComboBoxText" id="CloseAction">
+                <property name="visible">1</property>
+                <items>
+                  <item translatable="yes">Quit program</item>
+                  <item translatable="yes">Show confirmation dialog</item>
+                  <item translatable="yes">Run in the background</item>
+                </items>
+              </object>
+            </child>
+          </object>
+        </child>
+      </object>
+    </child>
+
+    <child>
+      <object class="GtkFlowBox">
+        <property name="visible">1</property>
+        <property name="homogeneous">1</property>
+        <property name="column-spacing">24</property>
+        <property name="row-spacing">6</property>
+        <property name="min-children-per-line">2</property>
+        <property name="max-children-per-line">2</property>
+        <property name="selection-mode">none</property>
+        <child>
+          <object class="GtkFlowBoxChild">
+            <property name="visible">1</property>
+            <property name="focusable">0</property>
             <child>
               <object class="GtkLabel">
                 <property name="visible">1</property>
@@ -143,6 +135,33 @@
                 <property name="mnemonic_widget">EnableSearchTab</property>
               </object>
             </child>
+          </object>
+        </child>
+        <child>
+          <object class="GtkFlowBoxChild">
+            <property name="visible">1</property>
+            <property name="focusable">0</property>
+            <child>
+              <object class="GtkCheckButton" id="TabSelectPrevious">
+                <property name="label" translatable="yes">Rememeber previous primary tab on startup</property>
+                <property name="visible">1</property>
+              </object>
+            </child>
+          </object>
+        </child>
+      </object>
+    </child>
+
+    <child>
+      <object class="GtkBox">
+        <property name="visible">1</property>
+        <property name="spacing">12</property>
+        <property name="orientation">vertical</property>
+        <child>
+          <object class="GtkBox">
+            <property name="visible">1</property>
+            <property name="spacing">12</property>
+            <property name="orientation">vertical</property>
             <child>
               <object class="GtkFlowBox">
                 <property name="visible">1</property>
@@ -264,8 +283,588 @@
             </child>
           </object>
         </child>
+        <child>
+          <object class="GtkBox">
+            <property name="visible">1</property>
+            <property name="spacing">12</property>
+            <property name="orientation">vertical</property>
+          </object>
+        </child>
+        <child>
+          <object class="GtkBox">
+            <property name="visible">1</property>
+            <property name="spacing">6</property>
+            <property name="orientation">vertical</property>
+            <child>
+              <object class="GtkFlowBox">
+                <property name="visible">1</property>
+                <property name="column-spacing">18</property>
+                <property name="row-spacing">6</property>
+                <property name="min-children-per-line">4</property>
+                <property name="max-children-per-line">4</property>
+                <property name="selection-mode">none</property>
+                <child>
+                  <object class="GtkFlowBoxChild">
+                    <property name="visible">1</property>
+                    <property name="focusable">0</property>
+                    <child>
+                      <object class="GtkLabel">
+                        <property name="visible">1</property>
+                        <property name="xalign">0</property>
+                        <property name="label"></property>
+                      </object>
+                    </child>
+                  </object>
+                </child>
+                <child>
+                  <object class="GtkFlowBoxChild">
+                    <property name="visible">1</property>
+                    <property name="focusable">0</property>
+                    <child>
+                      <object class="GtkLabel" id="MainTabsLabel">
+                        <property name="visible">1</property>
+                        <property name="xalign">0</property>
+                        <property name="label" translatable="yes">Primary tab bar position:</property>
+                        <property name="mnemonic_widget">MainPosition</property>
+                      </object>
+                    </child>
+                  </object>
+                </child>
+                <child>
+                  <object class="GtkFlowBoxChild">
+                    <property name="visible">1</property>
+                    <property name="focusable">0</property>
+                    <child>
+                      <object class="GtkBox">
+                        <property name="visible">1</property>
+                        <property name="focusable">0</property>
+                        <child>
+                          <object class="GtkComboBox" id="MainPosition">
+                            <property name="visible">1</property>
+                            <property name="hexpand">1</property>
+                          </object>
+                        </child>
+                      </object>
+                    </child>
+                  </object>
+                </child>
+                <child>
+                  <object class="GtkFlowBoxChild">
+                    <property name="visible">1</property>
+                    <property name="focusable">0</property>
+                    <child>
+                      <object class="GtkLabel">
+                        <property name="visible">1</property>
+                        <property name="xalign">0</property>
+                        <property name="label"></property>
+                      </object>
+                    </child>
+                  </object>
+                </child>
+              </object>
+            </child>
+          </object>
+        </child>
       </object>
     </child>
+    <child>
+      <object class="GtkBox">
+        <property name="visible">1</property>
+        <property name="spacing">6</property>
+        <property name="orientation">vertical</property>
+        <child>
+          <object class="GtkBox">
+            <property name="visible">1</property>
+            <property name="spacing">6</property>
+            <property name="orientation">vertical</property>
+            <child>
+              <object class="GtkFlowBox">
+                <property name="visible">1</property>
+                <property name="homogeneous">1</property>
+                <property name="column-spacing">24</property>
+                <property name="row-spacing">12</property>
+                <property name="min-children-per-line">2</property>
+                <property name="max-children-per-line">2</property>
+                <property name="selection-mode">none</property>
+                <child>
+                  <object class="GtkFlowBoxChild">
+                    <property name="visible">1</property>
+                    <property name="focusable">0</property>
+                    <child>
+                      <object class="GtkLabel">
+                        <property name="visible">1</property>
+                        <property name="label" translatable="yes">Secondary Tab Bar Positions</property>
+                        <property name="xalign">0</property>
+                        <attributes>
+                          <attribute name="weight" value="bold"/>
+                        </attributes>
+                      </object>
+                    </child>
+                  </object>
+                </child>
+                <child>
+                  <object class="GtkFlowBoxChild">
+                    <property name="visible">1</property>
+                    <property name="focusable">0</property>
+                    <child>
+                      <object class="GtkCheckButton" id="TabClosers">
+                        <property name="label" translatable="yes">Close-buttons on secondary tabs</property>
+                        <property name="visible">1</property>
+                      </object>
+                    </child>
+                  </object>
+                </child>
+              </object>
+            </child>
+          </object>
+        </child>
+        <child>
+          <object class="GtkBox">
+            <property name="visible">1</property>
+            <property name="spacing">24</property>
+            <property name="orientation">vertical</property>
+          </object>
+        </child>
+        <child>
+          <object class="GtkFlowBox">
+            <property name="visible">1</property>
+            <property name="column-spacing">12</property>
+            <property name="row-spacing">12</property>
+            <property name="min-children-per-line">4</property>
+            <property name="max-children-per-line">4</property>
+            <property name="selection-mode">none</property>
+            <child>
+              <object class="GtkFlowBoxChild">
+                <property name="visible">1</property>
+                <property name="focusable">0</property>
+                <child>
+                  <object class="GtkLabel" id="SearchLabel">
+                    <property name="visible">1</property>
+                    <property name="xalign">0</property>
+                    <property name="label" translatable="yes">Search Files:</property>
+                    <property name="mnemonic_widget">SearchPosition</property>
+                  </object>
+                </child>
+              </object>
+            </child>
+            <child>
+              <object class="GtkFlowBoxChild">
+                <property name="visible">1</property>
+                <property name="focusable">0</property>
+                <child>
+                  <object class="GtkComboBox" id="SearchPosition">
+                    <property name="visible">1</property>
+                    <property name="hexpand">1</property>
+                  </object>
+                </child>
+              </object>
+            </child>
+            <child>
+              <object class="GtkFlowBoxChild">
+                <property name="visible">1</property>
+                <property name="focusable">0</property>
+                <child>
+                  <object class="GtkLabel" id="UserBrowseLabel">
+                    <property name="visible">1</property>
+                    <property name="xalign">0</property>
+                    <property name="label" translatable="yes">Browse Shares:</property>
+                    <property name="mnemonic_widget">UserBrowsePosition</property>
+                  </object>
+                </child>
+              </object>
+            </child>
+            <child>
+              <object class="GtkFlowBoxChild">
+                <property name="visible">1</property>
+                <property name="focusable">0</property>
+                <child>
+                  <object class="GtkComboBox" id="UserBrowsePosition">
+                    <property name="visible">1</property>
+                    <property name="hexpand">1</property>
+                  </object>
+                </child>
+              </object>
+            </child>
+            <child>
+              <object class="GtkFlowBoxChild">
+                <property name="visible">1</property>
+                <property name="focusable">0</property>
+                <child>
+                  <object class="GtkLabel" id="ChatRoomsLabel">
+                    <property name="visible">1</property>
+                    <property name="xalign">0</property>
+                    <property name="label" translatable="yes">Chat Rooms:</property>
+                    <property name="mnemonic_widget">ChatRoomsPosition</property>
+                  </object>
+                </child>
+              </object>
+            </child>
+            <child>
+              <object class="GtkFlowBoxChild">
+                <property name="visible">1</property>
+                <property name="focusable">0</property>
+                <child>
+                  <object class="GtkComboBox" id="ChatRoomsPosition">
+                    <property name="visible">1</property>
+                    <property name="hexpand">1</property>
+                  </object>
+                </child>
+              </object>
+            </child>
+            <child>
+              <object class="GtkFlowBoxChild">
+                <property name="visible">1</property>
+                <property name="focusable">0</property>
+                <child>
+                  <object class="GtkLabel" id="PrivateChatLabel">
+                    <property name="visible">1</property>
+                    <property name="xalign">0</property>
+                    <property name="label" translatable="yes">Private Chat:</property>
+                    <property name="mnemonic_widget">PrivateChatPosition</property>
+                  </object>
+                </child>
+              </object>
+            </child>
+            <child>
+              <object class="GtkFlowBoxChild">
+                <property name="visible">1</property>
+                <property name="focusable">0</property>
+                <child>
+                  <object class="GtkComboBox" id="PrivateChatPosition">
+                    <property name="visible">1</property>
+                    <property name="hexpand">1</property>
+                  </object>
+                </child>
+              </object>
+            </child>
+            <child>
+              <object class="GtkFlowBoxChild">
+                <property name="visible">1</property>
+                <property name="focusable">0</property>
+                <child>
+                  <object class="GtkLabel" id="UserInfoLabel">
+                    <property name="visible">1</property>
+                    <property name="xalign">0</property>
+                    <property name="label" translatable="yes">User Info:</property>
+                    <property name="mnemonic_widget">UserInfoPosition</property>
+                  </object>
+                </child>
+              </object>
+            </child>
+            <child>
+              <object class="GtkFlowBoxChild">
+                <property name="visible">1</property>
+                <property name="focusable">0</property>
+                <child>
+                  <object class="GtkComboBox" id="UserInfoPosition">
+                    <property name="visible">1</property>
+                    <property name="hexpand">1</property>
+                  </object>
+                </child>
+              </object>
+            </child>
+          </object>
+        </child>
+
+      </object>
+    </child>
+
+    <child>
+      <object class="GtkBox">
+        <property name="visible">1</property>
+        <property name="spacing">12</property>
+        <property name="orientation">vertical</property>
+        <child>
+          <object class="GtkLabel">
+            <property name="visible">1</property>
+            <property name="label" translatable="yes">Tab Text</property>
+            <property name="xalign">0</property>
+            <attributes>
+              <attribute name="weight" value="bold"/>
+            </attributes>
+          </object>
+        </child>
+
+        <child>
+          <object class="GtkBox">
+            <property name="visible">1</property>
+            <child>
+              <object class="GtkFlowBox">
+                <property name="visible">1</property>
+                <property name="homogeneous">1</property>
+                <property name="column-spacing">24</property>
+                <property name="row-spacing">12</property>
+                <property name="min-children-per-line">2</property>
+                <property name="max-children-per-line">4</property>
+                <property name="selection-mode">none</property>
+                <child>
+                  <object class="GtkFlowBoxChild">
+                    <property name="visible">1</property>
+                    <property name="focusable">0</property>
+                    <child>
+                      <object class="GtkCheckButton" id="NotificationTabColors">
+                        <property name="visible">1</property>
+                        <property name="label" translatable="yes">Notification changes the tab&apos;s text color</property>
+                        <signal name="toggled" handler="on_tab_notification_color_toggled" swapped="no"/>
+                      </object>
+                    </child>
+                  </object>
+                </child>
+                <child>
+                  <object class="GtkFlowBoxChild">
+                    <property name="visible">1</property>
+                    <property name="focusable">0</property>
+                    <child>
+                      <object class="GtkCheckButton" id="TabStatusIcons">
+                        <property name="label" translatable="yes">Tabs show user status icons instead of status text</property>
+                        <property name="visible">1</property>
+                      </object>
+                    </child>
+                  </object>
+                </child>
+              </object>
+            </child>
+          </object>
+        </child>
+
+        <child>
+          <object class="GtkFlowBox">
+            <property name="visible">1</property>
+            <property name="homogeneous">1</property>
+            <property name="column-spacing">12</property>
+            <property name="row-spacing">12</property>
+            <property name="min-children-per-line">1</property>
+            <property name="max-children-per-line">2</property>
+            <property name="selection-mode">none</property>
+            <child>
+              <object class="GtkFlowBoxChild">
+                <property name="visible">1</property>
+                <property name="focusable">0</property>
+                <child>
+                  <object class="GtkBox">
+                    <property name="visible">1</property>
+                    <property name="spacing">12</property>
+                    <child>
+                      <object class="GtkLabel">
+                        <property name="visible">1</property>
+                        <property name="label" translatable="yes">Regular tab text color:</property>
+                        <property name="hexpand">1</property>
+                        <property name="xalign">0</property>
+                        <property name="wrap">1</property>
+                        <property name="mnemonic_widget">PickRegularTab</property>
+                      </object>
+                    </child>
+                    <child>
+                      <object class="GtkColorButton" id="PickRegularTab">
+                        <property name="visible">1</property>
+                        <signal name="color-set" handler="on_color_set"/>
+                      </object>
+                    </child>
+                  </object>
+                </child>
+              </object>
+            </child>
+            <child>
+              <object class="GtkFlowBoxChild">
+                <property name="visible">1</property>
+                <property name="focusable">0</property>
+                <child>
+                  <object class="GtkBox">
+                    <property name="visible">1</property>
+                    <property name="spacing">12</property>
+                    <child>
+                      <object class="GtkEntry" id="EntryRegularTab">
+                        <property name="visible">1</property>
+                        <property name="hexpand">1</property>
+                        <property name="width-chars">16</property>
+                        <signal name="changed" handler="on_colors_changed"/>
+                      </object>
+                    </child>
+                    <child>
+                      <object class="GtkButton" id="DefaultRegularTab">
+                        <property name="visible">1</property>
+                        <property name="halign">start</property>
+                        <signal name="clicked" handler="on_default_color"/>
+                        <child>
+                          <object class="GtkBox">
+                            <property name="visible">1</property>
+                            <property name="spacing">6</property>
+                            <child>
+                              <object class="GtkImage">
+                                <property name="visible">1</property>
+                                <property name="icon-name">view-refresh-symbolic</property>
+                              </object>
+                            </child>
+                            <child>
+                              <object class="GtkLabel">
+                                <property name="visible">1</property>
+                                <property name="label" translatable="yes">Default</property>
+                                <property name="use-underline">1</property>
+                              </object>
+                            </child>
+                          </object>
+                        </child>
+                      </object>
+                    </child>
+                  </object>
+                </child>
+              </object>
+            </child>
+            <child>
+              <object class="GtkFlowBoxChild">
+                <property name="visible">1</property>
+                <property name="focusable">0</property>
+                <child>
+                  <object class="GtkBox">
+                    <property name="visible">1</property>
+                    <property name="spacing">12</property>
+                    <child>
+                      <object class="GtkLabel">
+                        <property name="visible">1</property>
+                        <property name="label" translatable="yes">Changed tab text color:</property>
+                        <property name="hexpand">1</property>
+                        <property name="xalign">0</property>
+                        <property name="wrap">1</property>
+                        <property name="mnemonic_widget">PickChangedTab</property>
+                      </object>
+                    </child>
+                    <child>
+                      <object class="GtkColorButton" id="PickChangedTab">
+                        <property name="visible">1</property>
+                        <signal name="color-set" handler="on_color_set"/>
+                      </object>
+                    </child>
+                  </object>
+                </child>
+              </object>
+            </child>
+            <child>
+              <object class="GtkFlowBoxChild">
+                <property name="visible">1</property>
+                <property name="focusable">0</property>
+                <child>
+                  <object class="GtkBox">
+                    <property name="visible">1</property>
+                    <property name="spacing">12</property>
+                    <child>
+                      <object class="GtkEntry" id="EntryChangedTab">
+                        <property name="visible">1</property>
+                        <property name="hexpand">1</property>
+                        <property name="width-chars">16</property>
+                        <signal name="changed" handler="on_colors_changed"/>
+                      </object>
+                    </child>
+                    <child>
+                      <object class="GtkButton" id="DefaultChangedTab">
+                        <property name="visible">1</property>
+                        <property name="halign">start</property>
+                        <signal name="clicked" handler="on_default_color"/>
+                        <child>
+                          <object class="GtkBox">
+                            <property name="visible">1</property>
+                            <property name="spacing">6</property>
+                            <child>
+                              <object class="GtkImage">
+                                <property name="visible">1</property>
+                                <property name="icon-name">view-refresh-symbolic</property>
+                              </object>
+                            </child>
+                            <child>
+                              <object class="GtkLabel">
+                                <property name="visible">1</property>
+                                <property name="label" translatable="yes">Default</property>
+                                <property name="use-underline">1</property>
+                              </object>
+                            </child>
+                          </object>
+                        </child>
+                      </object>
+                    </child>
+                  </object>
+                </child>
+              </object>
+            </child>
+            <child>
+              <object class="GtkFlowBoxChild">
+                <property name="visible">1</property>
+                <property name="focusable">0</property>
+                <child>
+                  <object class="GtkBox">
+                    <property name="visible">1</property>
+                    <property name="spacing">12</property>
+                    <child>
+                      <object class="GtkLabel">
+                        <property name="visible">1</property>
+                        <property name="label" translatable="yes">Highlighted tab text color:</property>
+                        <property name="hexpand">1</property>
+                        <property name="xalign">0</property>
+                        <property name="wrap">1</property>
+                        <property name="mnemonic_widget">PickHighlightTab</property>
+                      </object>
+                    </child>
+                    <child>
+                      <object class="GtkColorButton" id="PickHighlightTab">
+                        <property name="visible">1</property>
+                        <signal name="color-set" handler="on_color_set"/>
+                      </object>
+                    </child>
+                  </object>
+                </child>
+              </object>
+            </child>
+            <child>
+              <object class="GtkFlowBoxChild">
+                <property name="visible">1</property>
+                <property name="focusable">0</property>
+                <child>
+                  <object class="GtkBox">
+                    <property name="visible">1</property>
+                    <property name="spacing">12</property>
+                    <child>
+                      <object class="GtkEntry" id="EntryHighlightTab">
+                        <property name="visible">1</property>
+                        <property name="hexpand">1</property>
+                        <property name="width-chars">16</property>
+                        <signal name="changed" handler="on_colors_changed"/>
+                      </object>
+                    </child>
+                    <child>
+                      <object class="GtkButton" id="DefaultHighlightTab">
+                        <property name="visible">1</property>
+                        <property name="halign">start</property>
+                        <signal name="clicked" handler="on_default_color"/>
+                        <child>
+                          <object class="GtkBox">
+                            <property name="visible">1</property>
+                            <property name="spacing">6</property>
+                            <child>
+                              <object class="GtkImage">
+                                <property name="visible">1</property>
+                                <property name="icon-name">view-refresh-symbolic</property>
+                              </object>
+                            </child>
+                            <child>
+                              <object class="GtkLabel">
+                                <property name="visible">1</property>
+                                <property name="label" translatable="yes">Default</property>
+                                <property name="use-underline">1</property>
+                              </object>
+                            </child>
+                          </object>
+                        </child>
+                      </object>
+                    </child>
+                  </object>
+                </child>
+              </object>
+            </child>
+          </object>
+        </child>
+      </object>
+    </child>
+
+
+
     <child>
       <object class="GtkBox">
         <property name="visible">1</property>
@@ -534,181 +1133,6 @@
                         </child>
                       </object>
                     </child>
-                  </object>
-                </child>
-              </object>
-            </child>
-          </object>
-        </child>
-      </object>
-    </child>
-    <child>
-      <object class="GtkBox">
-        <property name="visible">1</property>
-        <property name="spacing">30</property>
-        <property name="orientation">vertical</property>
-        <child>
-          <object class="GtkBox">
-            <property name="visible">1</property>
-            <property name="spacing">12</property>
-            <property name="orientation">vertical</property>
-            <child>
-              <object class="GtkLabel">
-                <property name="visible">1</property>
-                <property name="label" translatable="yes">Secondary Tabs</property>
-                <property name="xalign">0</property>
-                <attributes>
-                  <attribute name="weight" value="bold"/>
-                </attributes>
-              </object>
-            </child>
-            <child>
-              <object class="GtkCheckButton" id="TabClosers">
-                <property name="label" translatable="yes">Close-buttons on secondary tabs</property>
-                <property name="visible">1</property>
-              </object>
-            </child>
-            <child>
-              <object class="GtkCheckButton" id="TabStatusIcons">
-                <property name="label" translatable="yes">Tabs show user status icons instead of status text</property>
-                <property name="visible">1</property>
-              </object>
-            </child>
-          </object>
-        </child>
-        <child>
-          <object class="GtkFlowBox">
-            <property name="visible">1</property>
-            <property name="column-spacing">12</property>
-            <property name="row-spacing">12</property>
-            <property name="max-children-per-line">2</property>
-            <property name="selection-mode">none</property>
-            <child>
-              <object class="GtkFlowBoxChild">
-                <property name="visible">1</property>
-                <property name="focusable">0</property>
-                <child>
-                  <object class="GtkLabel" id="ChatRoomsLabel">
-                    <property name="visible">1</property>
-                    <property name="xalign">0</property>
-                    <property name="label" translatable="yes">Chat room tab bar position:</property>
-                    <property name="mnemonic_widget">ChatRoomsPosition</property>
-                  </object>
-                </child>
-              </object>
-            </child>
-            <child>
-              <object class="GtkFlowBoxChild">
-                <property name="visible">1</property>
-                <property name="focusable">0</property>
-                <child>
-                  <object class="GtkComboBox" id="ChatRoomsPosition">
-                    <property name="visible">1</property>
-                    <property name="hexpand">1</property>
-                  </object>
-                </child>
-              </object>
-            </child>
-            <child>
-              <object class="GtkFlowBoxChild">
-                <property name="visible">1</property>
-                <property name="focusable">0</property>
-                <child>
-                  <object class="GtkLabel" id="PrivateChatLabel">
-                    <property name="visible">1</property>
-                    <property name="xalign">0</property>
-                    <property name="label" translatable="yes">Private chat tab bar position:</property>
-                    <property name="mnemonic_widget">PrivateChatPosition</property>
-                  </object>
-                </child>
-              </object>
-            </child>
-            <child>
-              <object class="GtkFlowBoxChild">
-                <property name="visible">1</property>
-                <property name="focusable">0</property>
-                <child>
-                  <object class="GtkComboBox" id="PrivateChatPosition">
-                    <property name="visible">1</property>
-                    <property name="hexpand">1</property>
-                  </object>
-                </child>
-              </object>
-            </child>
-            <child>
-              <object class="GtkFlowBoxChild">
-                <property name="visible">1</property>
-                <property name="focusable">0</property>
-                <child>
-                  <object class="GtkLabel" id="SearchLabel">
-                    <property name="visible">1</property>
-                    <property name="xalign">0</property>
-                    <property name="label" translatable="yes">Search tab bar position:</property>
-                    <property name="mnemonic_widget">SearchPosition</property>
-                  </object>
-                </child>
-              </object>
-            </child>
-            <child>
-              <object class="GtkFlowBoxChild">
-                <property name="visible">1</property>
-                <property name="focusable">0</property>
-                <child>
-                  <object class="GtkComboBox" id="SearchPosition">
-                    <property name="visible">1</property>
-                    <property name="hexpand">1</property>
-                  </object>
-                </child>
-              </object>
-            </child>
-            <child>
-              <object class="GtkFlowBoxChild">
-                <property name="visible">1</property>
-                <property name="focusable">0</property>
-                <child>
-                  <object class="GtkLabel" id="UserInfoLabel">
-                    <property name="visible">1</property>
-                    <property name="xalign">0</property>
-                    <property name="label" translatable="yes">User info tab bar position:</property>
-                    <property name="mnemonic_widget">UserInfoPosition</property>
-                  </object>
-                </child>
-              </object>
-            </child>
-            <child>
-              <object class="GtkFlowBoxChild">
-                <property name="visible">1</property>
-                <property name="focusable">0</property>
-                <child>
-                  <object class="GtkComboBox" id="UserInfoPosition">
-                    <property name="visible">1</property>
-                    <property name="hexpand">1</property>
-                  </object>
-                </child>
-              </object>
-            </child>
-            <child>
-              <object class="GtkFlowBoxChild">
-                <property name="visible">1</property>
-                <property name="focusable">0</property>
-                <child>
-                  <object class="GtkLabel" id="UserBrowseLabel">
-                    <property name="visible">1</property>
-                    <property name="xalign">0</property>
-                    <property name="label" translatable="yes">User browse tab bar position:</property>
-                    <property name="mnemonic_widget">UserBrowsePosition</property>
-                  </object>
-                </child>
-              </object>
-            </child>
-            <child>
-              <object class="GtkFlowBoxChild">
-                <property name="visible">1</property>
-                <property name="focusable">0</property>
-                <child>
-                  <object class="GtkComboBox" id="UserBrowsePosition">
-                    <property name="visible">1</property>
-                    <property name="hexpand">1</property>
                   </object>
                 </child>
               </object>
@@ -1541,263 +1965,6 @@
                     </child>
                     <child>
                       <object class="GtkButton" id="DefaultInput">
-                        <property name="visible">1</property>
-                        <property name="halign">start</property>
-                        <signal name="clicked" handler="on_default_color"/>
-                        <child>
-                          <object class="GtkBox">
-                            <property name="visible">1</property>
-                            <property name="spacing">6</property>
-                            <child>
-                              <object class="GtkImage">
-                                <property name="visible">1</property>
-                                <property name="icon-name">view-refresh-symbolic</property>
-                              </object>
-                            </child>
-                            <child>
-                              <object class="GtkLabel">
-                                <property name="visible">1</property>
-                                <property name="label" translatable="yes">Default</property>
-                                <property name="use-underline">1</property>
-                              </object>
-                            </child>
-                          </object>
-                        </child>
-                      </object>
-                    </child>
-                  </object>
-                </child>
-              </object>
-            </child>
-          </object>
-        </child>
-      </object>
-    </child>
-    <child>
-      <object class="GtkBox">
-        <property name="visible">1</property>
-        <property name="spacing">12</property>
-        <property name="orientation">vertical</property>
-        <child>
-          <object class="GtkLabel">
-            <property name="visible">1</property>
-            <property name="label" translatable="yes">Tab Labels</property>
-            <property name="xalign">0</property>
-            <attributes>
-              <attribute name="weight" value="bold"/>
-            </attributes>
-          </object>
-        </child>
-        <child>
-          <object class="GtkCheckButton" id="NotificationTabColors">
-            <property name="visible">1</property>
-            <property name="label" translatable="yes">Notification changes the tab&apos;s text color</property>
-            <signal name="toggled" handler="on_tab_notification_color_toggled" swapped="no"/>
-          </object>
-        </child>
-        <child>
-          <object class="GtkFlowBox">
-            <property name="visible">1</property>
-            <property name="homogeneous">1</property>
-            <property name="column-spacing">12</property>
-            <property name="row-spacing">12</property>
-            <property name="min-children-per-line">1</property>
-            <property name="max-children-per-line">2</property>
-            <property name="selection-mode">none</property>
-            <child>
-              <object class="GtkFlowBoxChild">
-                <property name="visible">1</property>
-                <property name="focusable">0</property>
-                <child>
-                  <object class="GtkBox">
-                    <property name="visible">1</property>
-                    <property name="spacing">12</property>
-                    <child>
-                      <object class="GtkLabel">
-                        <property name="visible">1</property>
-                        <property name="label" translatable="yes">Regular tab label color:</property>
-                        <property name="hexpand">1</property>
-                        <property name="xalign">0</property>
-                        <property name="wrap">1</property>
-                        <property name="mnemonic_widget">PickRegularTab</property>
-                      </object>
-                    </child>
-                    <child>
-                      <object class="GtkColorButton" id="PickRegularTab">
-                        <property name="visible">1</property>
-                        <signal name="color-set" handler="on_color_set"/>
-                      </object>
-                    </child>
-                  </object>
-                </child>
-              </object>
-            </child>
-            <child>
-              <object class="GtkFlowBoxChild">
-                <property name="visible">1</property>
-                <property name="focusable">0</property>
-                <child>
-                  <object class="GtkBox">
-                    <property name="visible">1</property>
-                    <property name="spacing">12</property>
-                    <child>
-                      <object class="GtkEntry" id="EntryRegularTab">
-                        <property name="visible">1</property>
-                        <property name="hexpand">1</property>
-                        <property name="width-chars">16</property>
-                        <signal name="changed" handler="on_colors_changed"/>
-                      </object>
-                    </child>
-                    <child>
-                      <object class="GtkButton" id="DefaultRegularTab">
-                        <property name="visible">1</property>
-                        <property name="halign">start</property>
-                        <signal name="clicked" handler="on_default_color"/>
-                        <child>
-                          <object class="GtkBox">
-                            <property name="visible">1</property>
-                            <property name="spacing">6</property>
-                            <child>
-                              <object class="GtkImage">
-                                <property name="visible">1</property>
-                                <property name="icon-name">view-refresh-symbolic</property>
-                              </object>
-                            </child>
-                            <child>
-                              <object class="GtkLabel">
-                                <property name="visible">1</property>
-                                <property name="label" translatable="yes">Default</property>
-                                <property name="use-underline">1</property>
-                              </object>
-                            </child>
-                          </object>
-                        </child>
-                      </object>
-                    </child>
-                  </object>
-                </child>
-              </object>
-            </child>
-            <child>
-              <object class="GtkFlowBoxChild">
-                <property name="visible">1</property>
-                <property name="focusable">0</property>
-                <child>
-                  <object class="GtkBox">
-                    <property name="visible">1</property>
-                    <property name="spacing">12</property>
-                    <child>
-                      <object class="GtkLabel">
-                        <property name="visible">1</property>
-                        <property name="label" translatable="yes">Changed tab label color:</property>
-                        <property name="hexpand">1</property>
-                        <property name="xalign">0</property>
-                        <property name="wrap">1</property>
-                        <property name="mnemonic_widget">PickChangedTab</property>
-                      </object>
-                    </child>
-                    <child>
-                      <object class="GtkColorButton" id="PickChangedTab">
-                        <property name="visible">1</property>
-                        <signal name="color-set" handler="on_color_set"/>
-                      </object>
-                    </child>
-                  </object>
-                </child>
-              </object>
-            </child>
-            <child>
-              <object class="GtkFlowBoxChild">
-                <property name="visible">1</property>
-                <property name="focusable">0</property>
-                <child>
-                  <object class="GtkBox">
-                    <property name="visible">1</property>
-                    <property name="spacing">12</property>
-                    <child>
-                      <object class="GtkEntry" id="EntryChangedTab">
-                        <property name="visible">1</property>
-                        <property name="hexpand">1</property>
-                        <property name="width-chars">16</property>
-                        <signal name="changed" handler="on_colors_changed"/>
-                      </object>
-                    </child>
-                    <child>
-                      <object class="GtkButton" id="DefaultChangedTab">
-                        <property name="visible">1</property>
-                        <property name="halign">start</property>
-                        <signal name="clicked" handler="on_default_color"/>
-                        <child>
-                          <object class="GtkBox">
-                            <property name="visible">1</property>
-                            <property name="spacing">6</property>
-                            <child>
-                              <object class="GtkImage">
-                                <property name="visible">1</property>
-                                <property name="icon-name">view-refresh-symbolic</property>
-                              </object>
-                            </child>
-                            <child>
-                              <object class="GtkLabel">
-                                <property name="visible">1</property>
-                                <property name="label" translatable="yes">Default</property>
-                                <property name="use-underline">1</property>
-                              </object>
-                            </child>
-                          </object>
-                        </child>
-                      </object>
-                    </child>
-                  </object>
-                </child>
-              </object>
-            </child>
-            <child>
-              <object class="GtkFlowBoxChild">
-                <property name="visible">1</property>
-                <property name="focusable">0</property>
-                <child>
-                  <object class="GtkBox">
-                    <property name="visible">1</property>
-                    <property name="spacing">12</property>
-                    <child>
-                      <object class="GtkLabel">
-                        <property name="visible">1</property>
-                        <property name="label" translatable="yes">Highlighted tab label color:</property>
-                        <property name="hexpand">1</property>
-                        <property name="xalign">0</property>
-                        <property name="wrap">1</property>
-                        <property name="mnemonic_widget">PickHighlightTab</property>
-                      </object>
-                    </child>
-                    <child>
-                      <object class="GtkColorButton" id="PickHighlightTab">
-                        <property name="visible">1</property>
-                        <signal name="color-set" handler="on_color_set"/>
-                      </object>
-                    </child>
-                  </object>
-                </child>
-              </object>
-            </child>
-            <child>
-              <object class="GtkFlowBoxChild">
-                <property name="visible">1</property>
-                <property name="focusable">0</property>
-                <child>
-                  <object class="GtkBox">
-                    <property name="visible">1</property>
-                    <property name="spacing">12</property>
-                    <child>
-                      <object class="GtkEntry" id="EntryHighlightTab">
-                        <property name="visible">1</property>
-                        <property name="hexpand">1</property>
-                        <property name="width-chars">16</property>
-                        <signal name="changed" handler="on_colors_changed"/>
-                      </object>
-                    </child>
-                    <child>
-                      <object class="GtkButton" id="DefaultHighlightTab">
                         <property name="visible">1</property>
                         <property name="halign">start</property>
                         <signal name="clicked" handler="on_default_color"/>

--- a/pynicotine/gtkgui/ui/settings/userinterface.ui
+++ b/pynicotine/gtkgui/ui/settings/userinterface.ui
@@ -428,7 +428,7 @@
         <child>
           <object class="GtkFlowBox">
             <property name="visible">1</property>
-            <property name="column-spacing">12</property>
+            <property name="column-spacing">48</property>
             <property name="row-spacing">12</property>
             <property name="min-children-per-line">4</property>
             <property name="max-children-per-line">4</property>
@@ -565,10 +565,8 @@
             </child>
           </object>
         </child>
-
       </object>
     </child>
-
     <child>
       <object class="GtkBox">
         <property name="visible">1</property>
@@ -584,7 +582,6 @@
             </attributes>
           </object>
         </child>
-
         <child>
           <object class="GtkBox">
             <property name="visible">1</property>
@@ -626,7 +623,6 @@
             </child>
           </object>
         </child>
-
         <child>
           <object class="GtkFlowBox">
             <property name="visible">1</property>
@@ -862,9 +858,6 @@
         </child>
       </object>
     </child>
-
-
-
     <child>
       <object class="GtkBox">
         <property name="visible">1</property>

--- a/pynicotine/gtkgui/ui/settings/userinterface.ui
+++ b/pynicotine/gtkgui/ui/settings/userinterface.ui
@@ -20,16 +20,68 @@
           </object>
         </child>
         <child>
-          <object class="GtkCheckButton" id="DarkMode">
-            <property name="label" translatable="yes">Prefer dark mode</property>
+          <object class="GtkFlowBox">
             <property name="visible">1</property>
-            <property name="tooltip_text" translatable="yes">Note that the operating system&apos;s theme may take precedence.</property>
+            <property name="homogeneous">1</property>
+            <property name="column-spacing">12</property>
+            <property name="row-spacing">12</property>
+            <property name="min-children-per-line">1</property>
+            <property name="max-children-per-line">3</property>
+            <property name="selection-mode">none</property>
+            <child>
+              <object class="GtkFlowBoxChild">
+                <property name="visible">1</property>
+                <property name="focusable">0</property>
+                <child>
+                  <object class="GtkCheckButton" id="DarkMode">
+                    <property name="label" translatable="yes">Prefer dark mode</property>
+                    <property name="visible">1</property>
+                    <property name="tooltip_text" translatable="yes">Note that the operating system&apos;s theme may take precedence.</property>
+                  </object>
+                </child>
+              </object>
+            </child>
+            <child>
+              <object class="GtkFlowBoxChild">
+                <property name="visible">1</property>
+                <property name="focusable">0</property>
+                <child>
+                  <object class="GtkBox" id = "TraySettings">
+                    <property name="visible">1</property>
+                    <property name="focusable">0</property>
+                    <child>
+                      <object class="GtkCheckButton" id="TrayiconCheck">
+                        <property name="label" translatable="yes">Display tray icon</property>
+                        <property name="visible">1</property>
+                        <property name="use-underline">1</property>
+                        <signal name="toggled" handler="on_toggle_tray" swapped="no"/>
+                      </object>
+                    </child>
+                    <child>
+                      <object class="GtkLabel">
+                        <property name="visible">1</property>
+                        <property name="halign">start</property>
+                        <property name="label">    </property>
+                      </object>
+                    </child>
+                    <child>
+                      <object class="GtkCheckButton" id="StartupHidden">
+                        <property name="label" translatable="yes">Minimize to tray on startup</property>
+                        <property name="visible">1</property>
+                        <property name="use-underline">1</property>
+                      </object>
+                    </child>
+                  </object>
+                </child>
+              </object>
+            </child>
           </object>
         </child>
         <child>
           <object class="GtkFlowBox">
             <property name="visible">1</property>
-            <property name="column-spacing">12</property>
+            <property name="homogeneous">1</property>
+            <property name="column-spacing">24</property>
             <property name="row-spacing">12</property>
             <property name="max-children-per-line">2</property>
             <property name="selection-mode">none</property>
@@ -89,7 +141,7 @@
             </child>
             <child>
               <object class="GtkCheckButton" id="TabSelectPrevious">
-                <property name="label" translatable="yes">View previous primary tab on startup</property>
+                <property name="label" translatable="yes">Remember previous primary tab on startup</property>
                 <property name="visible">1</property>
               </object>
             </child>

--- a/pynicotine/gtkgui/ui/settings/userinterface.ui
+++ b/pynicotine/gtkgui/ui/settings/userinterface.ui
@@ -20,23 +20,29 @@
           </object>
         </child>
         <child>
+          <object class="GtkCheckButton" id="DarkMode">
+            <property name="label" translatable="yes">Prefer dark mode</property>
+            <property name="visible">1</property>
+            <property name="tooltip_text" translatable="yes">Note that the operating system&apos;s theme may take precedence.</property>
+          </object>
+        </child>
+        <child>
           <object class="GtkFlowBox">
             <property name="visible">1</property>
-            <property name="homogeneous">1</property>
-            <property name="column-spacing">18</property>
+            <property name="column-spacing">12</property>
             <property name="row-spacing">12</property>
-            <property name="min-children-per-line">1</property>
-            <property name="max-children-per-line">3</property>
+            <property name="max-children-per-line">2</property>
             <property name="selection-mode">none</property>
             <child>
               <object class="GtkFlowBoxChild">
                 <property name="visible">1</property>
                 <property name="focusable">0</property>
                 <child>
-                  <object class="GtkCheckButton" id="DarkMode">
-                    <property name="label" translatable="yes">Prefer dark mode</property>
+                  <object class="GtkLabel">
                     <property name="visible">1</property>
-                    <property name="tooltip_text" translatable="yes">Note that the operating system&apos;s theme may take precedence.</property>
+                    <property name="label" translatable="yes">When closing Nicotine+:</property>
+                    <property name="xalign">0</property>
+                    <property name="mnemonic_widget">CloseAction</property>
                   </object>
                 </child>
               </object>
@@ -46,24 +52,13 @@
                 <property name="visible">1</property>
                 <property name="focusable">0</property>
                 <child>
-                  <object class="GtkBox" id = "TraySettings">
+                  <object class="GtkComboBoxText" id="CloseAction">
                     <property name="visible">1</property>
-                    <property name="focusable">0</property>
-                    <child>
-                      <object class="GtkCheckButton" id="TrayiconCheck">
-                        <property name="label" translatable="yes">Display tray icon</property>
-                        <property name="visible">1</property>
-                        <property name="use-underline">1</property>
-                        <signal name="toggled" handler="on_toggle_tray" swapped="no"/>
-                      </object>
-                    </child>
-                    <child>
-                      <object class="GtkCheckButton" id="StartupHidden">
-                        <property name="label" translatable="yes">Minimize to tray on startup</property>
-                        <property name="visible">1</property>
-                        <property name="use-underline">1</property>
-                      </object>
-                    </child>
+                    <items>
+                      <item translatable="yes">Quit program</item>
+                      <item translatable="yes">Show confirmation dialog</item>
+                      <item translatable="yes">Run in the background</item>
+                    </items>
                   </object>
                 </child>
               </object>
@@ -73,60 +68,73 @@
       </object>
     </child>
     <child>
-      <object class="GtkFlowBox">
+      <object class="GtkBox">
         <property name="visible">1</property>
-        <property name="homogeneous">1</property>
-        <property name="column-spacing">18</property>
-        <property name="row-spacing">2</property>
-        <property name="min-children-per-line">2</property>
-        <property name="max-children-per-line">2</property>
-        <property name="selection-mode">none</property>
+        <property name="spacing">18</property>
+        <property name="orientation">vertical</property>
         <child>
-          <object class="GtkFlowBoxChild">
+          <object class="GtkBox">
             <property name="visible">1</property>
-            <property name="focusable">0</property>
+            <property name="spacing">12</property>
+            <property name="orientation">vertical</property>
             <child>
               <object class="GtkLabel">
                 <property name="visible">1</property>
-                <property name="label" translatable="yes">When closing Nicotine+:</property>
+                <property name="label" translatable="yes">Primary Tabs</property>
                 <property name="xalign">0</property>
-                <property name="mnemonic_widget">CloseAction</property>
+                <attributes>
+                  <attribute name="weight" value="bold"/>
+                </attributes>
               </object>
             </child>
-          </object>
-        </child>
-        <child>
-          <object class="GtkFlowBoxChild">
-            <property name="visible">1</property>
-            <property name="focusable">0</property>
             <child>
-              <object class="GtkComboBoxText" id="CloseAction">
+              <object class="GtkCheckButton" id="TabSelectPrevious">
+                <property name="label" translatable="yes">View previous primary tab on startup</property>
                 <property name="visible">1</property>
-                <items>
-                  <item translatable="yes">Quit program</item>
-                  <item translatable="yes">Show confirmation dialog</item>
-                  <item translatable="yes">Run in the background</item>
-                </items>
+              </object>
+            </child>
+            <child>
+              <object class="GtkFlowBox">
+                <property name="visible">1</property>
+                <property name="column-spacing">12</property>
+                <property name="row-spacing">12</property>
+                <property name="max-children-per-line">2</property>
+                <property name="selection-mode">none</property>
+                <child>
+                  <object class="GtkFlowBoxChild">
+                    <property name="visible">1</property>
+                    <property name="focusable">0</property>
+                    <child>
+                      <object class="GtkLabel" id="MainTabsLabel">
+                        <property name="visible">1</property>
+                        <property name="xalign">0</property>
+                        <property name="label" translatable="yes">Tab bar position:</property>
+                        <property name="mnemonic_widget">MainPosition</property>
+                      </object>
+                    </child>
+                  </object>
+                </child>
+                <child>
+                  <object class="GtkFlowBoxChild">
+                    <property name="visible">1</property>
+                    <property name="focusable">0</property>
+                    <child>
+                      <object class="GtkComboBoxText" id="MainPosition">
+                        <property name="visible">1</property>
+                        <property name="hexpand">1</property>
+                      </object>
+                    </child>
+                  </object>
+                </child>
               </object>
             </child>
           </object>
         </child>
-      </object>
-    </child>
-
-    <child>
-      <object class="GtkFlowBox">
-        <property name="visible">1</property>
-        <property name="homogeneous">1</property>
-        <property name="column-spacing">24</property>
-        <property name="row-spacing">6</property>
-        <property name="min-children-per-line">2</property>
-        <property name="max-children-per-line">2</property>
-        <property name="selection-mode">none</property>
         <child>
-          <object class="GtkFlowBoxChild">
+          <object class="GtkBox">
             <property name="visible">1</property>
-            <property name="focusable">0</property>
+            <property name="spacing">18</property>
+            <property name="orientation">vertical</property>
             <child>
               <object class="GtkLabel">
                 <property name="visible">1</property>
@@ -135,33 +143,6 @@
                 <property name="mnemonic_widget">EnableSearchTab</property>
               </object>
             </child>
-          </object>
-        </child>
-        <child>
-          <object class="GtkFlowBoxChild">
-            <property name="visible">1</property>
-            <property name="focusable">0</property>
-            <child>
-              <object class="GtkCheckButton" id="TabSelectPrevious">
-                <property name="label" translatable="yes">Rememeber previous primary tab on startup</property>
-                <property name="visible">1</property>
-              </object>
-            </child>
-          </object>
-        </child>
-      </object>
-    </child>
-
-    <child>
-      <object class="GtkBox">
-        <property name="visible">1</property>
-        <property name="spacing">12</property>
-        <property name="orientation">vertical</property>
-        <child>
-          <object class="GtkBox">
-            <property name="visible">1</property>
-            <property name="spacing">12</property>
-            <property name="orientation">vertical</property>
             <child>
               <object class="GtkFlowBox">
                 <property name="visible">1</property>
@@ -275,579 +256,6 @@
                       <object class="GtkCheckButton" id="EnableInterestsTab">
                         <property name="label" translatable="yes">Interests</property>
                         <property name="visible">1</property>
-                      </object>
-                    </child>
-                  </object>
-                </child>
-              </object>
-            </child>
-          </object>
-        </child>
-        <child>
-          <object class="GtkBox">
-            <property name="visible">1</property>
-            <property name="spacing">12</property>
-            <property name="orientation">vertical</property>
-          </object>
-        </child>
-        <child>
-          <object class="GtkBox">
-            <property name="visible">1</property>
-            <property name="spacing">6</property>
-            <property name="orientation">vertical</property>
-            <child>
-              <object class="GtkFlowBox">
-                <property name="visible">1</property>
-                <property name="column-spacing">18</property>
-                <property name="row-spacing">6</property>
-                <property name="min-children-per-line">4</property>
-                <property name="max-children-per-line">4</property>
-                <property name="selection-mode">none</property>
-                <child>
-                  <object class="GtkFlowBoxChild">
-                    <property name="visible">1</property>
-                    <property name="focusable">0</property>
-                    <child>
-                      <object class="GtkLabel">
-                        <property name="visible">1</property>
-                        <property name="xalign">0</property>
-                        <property name="label"></property>
-                      </object>
-                    </child>
-                  </object>
-                </child>
-                <child>
-                  <object class="GtkFlowBoxChild">
-                    <property name="visible">1</property>
-                    <property name="focusable">0</property>
-                    <child>
-                      <object class="GtkLabel" id="MainTabsLabel">
-                        <property name="visible">1</property>
-                        <property name="xalign">0</property>
-                        <property name="label" translatable="yes">Primary tab bar position:</property>
-                        <property name="mnemonic_widget">MainPosition</property>
-                      </object>
-                    </child>
-                  </object>
-                </child>
-                <child>
-                  <object class="GtkFlowBoxChild">
-                    <property name="visible">1</property>
-                    <property name="focusable">0</property>
-                    <child>
-                      <object class="GtkBox">
-                        <property name="visible">1</property>
-                        <property name="focusable">0</property>
-                        <child>
-                          <object class="GtkComboBox" id="MainPosition">
-                            <property name="visible">1</property>
-                            <property name="hexpand">1</property>
-                          </object>
-                        </child>
-                      </object>
-                    </child>
-                  </object>
-                </child>
-                <child>
-                  <object class="GtkFlowBoxChild">
-                    <property name="visible">1</property>
-                    <property name="focusable">0</property>
-                    <child>
-                      <object class="GtkLabel">
-                        <property name="visible">1</property>
-                        <property name="xalign">0</property>
-                        <property name="label"></property>
-                      </object>
-                    </child>
-                  </object>
-                </child>
-              </object>
-            </child>
-          </object>
-        </child>
-      </object>
-    </child>
-    <child>
-      <object class="GtkBox">
-        <property name="visible">1</property>
-        <property name="spacing">6</property>
-        <property name="orientation">vertical</property>
-        <child>
-          <object class="GtkBox">
-            <property name="visible">1</property>
-            <property name="spacing">6</property>
-            <property name="orientation">vertical</property>
-            <child>
-              <object class="GtkFlowBox">
-                <property name="visible">1</property>
-                <property name="homogeneous">1</property>
-                <property name="column-spacing">24</property>
-                <property name="row-spacing">12</property>
-                <property name="min-children-per-line">2</property>
-                <property name="max-children-per-line">2</property>
-                <property name="selection-mode">none</property>
-                <child>
-                  <object class="GtkFlowBoxChild">
-                    <property name="visible">1</property>
-                    <property name="focusable">0</property>
-                    <child>
-                      <object class="GtkLabel">
-                        <property name="visible">1</property>
-                        <property name="label" translatable="yes">Secondary Tab Bar Positions</property>
-                        <property name="xalign">0</property>
-                        <attributes>
-                          <attribute name="weight" value="bold"/>
-                        </attributes>
-                      </object>
-                    </child>
-                  </object>
-                </child>
-                <child>
-                  <object class="GtkFlowBoxChild">
-                    <property name="visible">1</property>
-                    <property name="focusable">0</property>
-                    <child>
-                      <object class="GtkCheckButton" id="TabClosers">
-                        <property name="label" translatable="yes">Close-buttons on secondary tabs</property>
-                        <property name="visible">1</property>
-                      </object>
-                    </child>
-                  </object>
-                </child>
-              </object>
-            </child>
-          </object>
-        </child>
-        <child>
-          <object class="GtkBox">
-            <property name="visible">1</property>
-            <property name="spacing">24</property>
-            <property name="orientation">vertical</property>
-          </object>
-        </child>
-        <child>
-          <object class="GtkFlowBox">
-            <property name="visible">1</property>
-            <property name="column-spacing">48</property>
-            <property name="row-spacing">12</property>
-            <property name="min-children-per-line">4</property>
-            <property name="max-children-per-line">4</property>
-            <property name="selection-mode">none</property>
-            <child>
-              <object class="GtkFlowBoxChild">
-                <property name="visible">1</property>
-                <property name="focusable">0</property>
-                <child>
-                  <object class="GtkLabel" id="SearchLabel">
-                    <property name="visible">1</property>
-                    <property name="xalign">0</property>
-                    <property name="label" translatable="yes">Search Files:</property>
-                    <property name="mnemonic_widget">SearchPosition</property>
-                  </object>
-                </child>
-              </object>
-            </child>
-            <child>
-              <object class="GtkFlowBoxChild">
-                <property name="visible">1</property>
-                <property name="focusable">0</property>
-                <child>
-                  <object class="GtkComboBox" id="SearchPosition">
-                    <property name="visible">1</property>
-                    <property name="hexpand">1</property>
-                  </object>
-                </child>
-              </object>
-            </child>
-            <child>
-              <object class="GtkFlowBoxChild">
-                <property name="visible">1</property>
-                <property name="focusable">0</property>
-                <child>
-                  <object class="GtkLabel" id="UserBrowseLabel">
-                    <property name="visible">1</property>
-                    <property name="xalign">0</property>
-                    <property name="label" translatable="yes">Browse Shares:</property>
-                    <property name="mnemonic_widget">UserBrowsePosition</property>
-                  </object>
-                </child>
-              </object>
-            </child>
-            <child>
-              <object class="GtkFlowBoxChild">
-                <property name="visible">1</property>
-                <property name="focusable">0</property>
-                <child>
-                  <object class="GtkComboBox" id="UserBrowsePosition">
-                    <property name="visible">1</property>
-                    <property name="hexpand">1</property>
-                  </object>
-                </child>
-              </object>
-            </child>
-            <child>
-              <object class="GtkFlowBoxChild">
-                <property name="visible">1</property>
-                <property name="focusable">0</property>
-                <child>
-                  <object class="GtkLabel" id="ChatRoomsLabel">
-                    <property name="visible">1</property>
-                    <property name="xalign">0</property>
-                    <property name="label" translatable="yes">Chat Rooms:</property>
-                    <property name="mnemonic_widget">ChatRoomsPosition</property>
-                  </object>
-                </child>
-              </object>
-            </child>
-            <child>
-              <object class="GtkFlowBoxChild">
-                <property name="visible">1</property>
-                <property name="focusable">0</property>
-                <child>
-                  <object class="GtkComboBox" id="ChatRoomsPosition">
-                    <property name="visible">1</property>
-                    <property name="hexpand">1</property>
-                  </object>
-                </child>
-              </object>
-            </child>
-            <child>
-              <object class="GtkFlowBoxChild">
-                <property name="visible">1</property>
-                <property name="focusable">0</property>
-                <child>
-                  <object class="GtkLabel" id="PrivateChatLabel">
-                    <property name="visible">1</property>
-                    <property name="xalign">0</property>
-                    <property name="label" translatable="yes">Private Chat:</property>
-                    <property name="mnemonic_widget">PrivateChatPosition</property>
-                  </object>
-                </child>
-              </object>
-            </child>
-            <child>
-              <object class="GtkFlowBoxChild">
-                <property name="visible">1</property>
-                <property name="focusable">0</property>
-                <child>
-                  <object class="GtkComboBox" id="PrivateChatPosition">
-                    <property name="visible">1</property>
-                    <property name="hexpand">1</property>
-                  </object>
-                </child>
-              </object>
-            </child>
-            <child>
-              <object class="GtkFlowBoxChild">
-                <property name="visible">1</property>
-                <property name="focusable">0</property>
-                <child>
-                  <object class="GtkLabel" id="UserInfoLabel">
-                    <property name="visible">1</property>
-                    <property name="xalign">0</property>
-                    <property name="label" translatable="yes">User Info:</property>
-                    <property name="mnemonic_widget">UserInfoPosition</property>
-                  </object>
-                </child>
-              </object>
-            </child>
-            <child>
-              <object class="GtkFlowBoxChild">
-                <property name="visible">1</property>
-                <property name="focusable">0</property>
-                <child>
-                  <object class="GtkComboBox" id="UserInfoPosition">
-                    <property name="visible">1</property>
-                    <property name="hexpand">1</property>
-                  </object>
-                </child>
-              </object>
-            </child>
-          </object>
-        </child>
-      </object>
-    </child>
-    <child>
-      <object class="GtkBox">
-        <property name="visible">1</property>
-        <property name="spacing">12</property>
-        <property name="orientation">vertical</property>
-        <child>
-          <object class="GtkLabel">
-            <property name="visible">1</property>
-            <property name="label" translatable="yes">Tab Text</property>
-            <property name="xalign">0</property>
-            <attributes>
-              <attribute name="weight" value="bold"/>
-            </attributes>
-          </object>
-        </child>
-        <child>
-          <object class="GtkBox">
-            <property name="visible">1</property>
-            <child>
-              <object class="GtkFlowBox">
-                <property name="visible">1</property>
-                <property name="homogeneous">1</property>
-                <property name="column-spacing">24</property>
-                <property name="row-spacing">12</property>
-                <property name="min-children-per-line">2</property>
-                <property name="max-children-per-line">4</property>
-                <property name="selection-mode">none</property>
-                <child>
-                  <object class="GtkFlowBoxChild">
-                    <property name="visible">1</property>
-                    <property name="focusable">0</property>
-                    <child>
-                      <object class="GtkCheckButton" id="NotificationTabColors">
-                        <property name="visible">1</property>
-                        <property name="label" translatable="yes">Notification changes the tab&apos;s text color</property>
-                        <signal name="toggled" handler="on_tab_notification_color_toggled" swapped="no"/>
-                      </object>
-                    </child>
-                  </object>
-                </child>
-                <child>
-                  <object class="GtkFlowBoxChild">
-                    <property name="visible">1</property>
-                    <property name="focusable">0</property>
-                    <child>
-                      <object class="GtkCheckButton" id="TabStatusIcons">
-                        <property name="label" translatable="yes">Tabs show user status icons instead of status text</property>
-                        <property name="visible">1</property>
-                      </object>
-                    </child>
-                  </object>
-                </child>
-              </object>
-            </child>
-          </object>
-        </child>
-        <child>
-          <object class="GtkFlowBox">
-            <property name="visible">1</property>
-            <property name="homogeneous">1</property>
-            <property name="column-spacing">12</property>
-            <property name="row-spacing">12</property>
-            <property name="min-children-per-line">1</property>
-            <property name="max-children-per-line">2</property>
-            <property name="selection-mode">none</property>
-            <child>
-              <object class="GtkFlowBoxChild">
-                <property name="visible">1</property>
-                <property name="focusable">0</property>
-                <child>
-                  <object class="GtkBox">
-                    <property name="visible">1</property>
-                    <property name="spacing">12</property>
-                    <child>
-                      <object class="GtkLabel">
-                        <property name="visible">1</property>
-                        <property name="label" translatable="yes">Regular tab text color:</property>
-                        <property name="hexpand">1</property>
-                        <property name="xalign">0</property>
-                        <property name="wrap">1</property>
-                        <property name="mnemonic_widget">PickRegularTab</property>
-                      </object>
-                    </child>
-                    <child>
-                      <object class="GtkColorButton" id="PickRegularTab">
-                        <property name="visible">1</property>
-                        <signal name="color-set" handler="on_color_set"/>
-                      </object>
-                    </child>
-                  </object>
-                </child>
-              </object>
-            </child>
-            <child>
-              <object class="GtkFlowBoxChild">
-                <property name="visible">1</property>
-                <property name="focusable">0</property>
-                <child>
-                  <object class="GtkBox">
-                    <property name="visible">1</property>
-                    <property name="spacing">12</property>
-                    <child>
-                      <object class="GtkEntry" id="EntryRegularTab">
-                        <property name="visible">1</property>
-                        <property name="hexpand">1</property>
-                        <property name="width-chars">16</property>
-                        <signal name="changed" handler="on_colors_changed"/>
-                      </object>
-                    </child>
-                    <child>
-                      <object class="GtkButton" id="DefaultRegularTab">
-                        <property name="visible">1</property>
-                        <property name="halign">start</property>
-                        <signal name="clicked" handler="on_default_color"/>
-                        <child>
-                          <object class="GtkBox">
-                            <property name="visible">1</property>
-                            <property name="spacing">6</property>
-                            <child>
-                              <object class="GtkImage">
-                                <property name="visible">1</property>
-                                <property name="icon-name">view-refresh-symbolic</property>
-                              </object>
-                            </child>
-                            <child>
-                              <object class="GtkLabel">
-                                <property name="visible">1</property>
-                                <property name="label" translatable="yes">Default</property>
-                                <property name="use-underline">1</property>
-                              </object>
-                            </child>
-                          </object>
-                        </child>
-                      </object>
-                    </child>
-                  </object>
-                </child>
-              </object>
-            </child>
-            <child>
-              <object class="GtkFlowBoxChild">
-                <property name="visible">1</property>
-                <property name="focusable">0</property>
-                <child>
-                  <object class="GtkBox">
-                    <property name="visible">1</property>
-                    <property name="spacing">12</property>
-                    <child>
-                      <object class="GtkLabel">
-                        <property name="visible">1</property>
-                        <property name="label" translatable="yes">Changed tab text color:</property>
-                        <property name="hexpand">1</property>
-                        <property name="xalign">0</property>
-                        <property name="wrap">1</property>
-                        <property name="mnemonic_widget">PickChangedTab</property>
-                      </object>
-                    </child>
-                    <child>
-                      <object class="GtkColorButton" id="PickChangedTab">
-                        <property name="visible">1</property>
-                        <signal name="color-set" handler="on_color_set"/>
-                      </object>
-                    </child>
-                  </object>
-                </child>
-              </object>
-            </child>
-            <child>
-              <object class="GtkFlowBoxChild">
-                <property name="visible">1</property>
-                <property name="focusable">0</property>
-                <child>
-                  <object class="GtkBox">
-                    <property name="visible">1</property>
-                    <property name="spacing">12</property>
-                    <child>
-                      <object class="GtkEntry" id="EntryChangedTab">
-                        <property name="visible">1</property>
-                        <property name="hexpand">1</property>
-                        <property name="width-chars">16</property>
-                        <signal name="changed" handler="on_colors_changed"/>
-                      </object>
-                    </child>
-                    <child>
-                      <object class="GtkButton" id="DefaultChangedTab">
-                        <property name="visible">1</property>
-                        <property name="halign">start</property>
-                        <signal name="clicked" handler="on_default_color"/>
-                        <child>
-                          <object class="GtkBox">
-                            <property name="visible">1</property>
-                            <property name="spacing">6</property>
-                            <child>
-                              <object class="GtkImage">
-                                <property name="visible">1</property>
-                                <property name="icon-name">view-refresh-symbolic</property>
-                              </object>
-                            </child>
-                            <child>
-                              <object class="GtkLabel">
-                                <property name="visible">1</property>
-                                <property name="label" translatable="yes">Default</property>
-                                <property name="use-underline">1</property>
-                              </object>
-                            </child>
-                          </object>
-                        </child>
-                      </object>
-                    </child>
-                  </object>
-                </child>
-              </object>
-            </child>
-            <child>
-              <object class="GtkFlowBoxChild">
-                <property name="visible">1</property>
-                <property name="focusable">0</property>
-                <child>
-                  <object class="GtkBox">
-                    <property name="visible">1</property>
-                    <property name="spacing">12</property>
-                    <child>
-                      <object class="GtkLabel">
-                        <property name="visible">1</property>
-                        <property name="label" translatable="yes">Highlighted tab text color:</property>
-                        <property name="hexpand">1</property>
-                        <property name="xalign">0</property>
-                        <property name="wrap">1</property>
-                        <property name="mnemonic_widget">PickHighlightTab</property>
-                      </object>
-                    </child>
-                    <child>
-                      <object class="GtkColorButton" id="PickHighlightTab">
-                        <property name="visible">1</property>
-                        <signal name="color-set" handler="on_color_set"/>
-                      </object>
-                    </child>
-                  </object>
-                </child>
-              </object>
-            </child>
-            <child>
-              <object class="GtkFlowBoxChild">
-                <property name="visible">1</property>
-                <property name="focusable">0</property>
-                <child>
-                  <object class="GtkBox">
-                    <property name="visible">1</property>
-                    <property name="spacing">12</property>
-                    <child>
-                      <object class="GtkEntry" id="EntryHighlightTab">
-                        <property name="visible">1</property>
-                        <property name="hexpand">1</property>
-                        <property name="width-chars">16</property>
-                        <signal name="changed" handler="on_colors_changed"/>
-                      </object>
-                    </child>
-                    <child>
-                      <object class="GtkButton" id="DefaultHighlightTab">
-                        <property name="visible">1</property>
-                        <property name="halign">start</property>
-                        <signal name="clicked" handler="on_default_color"/>
-                        <child>
-                          <object class="GtkBox">
-                            <property name="visible">1</property>
-                            <property name="spacing">6</property>
-                            <child>
-                              <object class="GtkImage">
-                                <property name="visible">1</property>
-                                <property name="icon-name">view-refresh-symbolic</property>
-                              </object>
-                            </child>
-                            <child>
-                              <object class="GtkLabel">
-                                <property name="visible">1</property>
-                                <property name="label" translatable="yes">Default</property>
-                                <property name="use-underline">1</property>
-                              </object>
-                            </child>
-                          </object>
-                        </child>
                       </object>
                     </child>
                   </object>
@@ -1147,6 +555,181 @@
             <child>
               <object class="GtkLabel">
                 <property name="visible">1</property>
+                <property name="label" translatable="yes">Secondary Tabs</property>
+                <property name="xalign">0</property>
+                <attributes>
+                  <attribute name="weight" value="bold"/>
+                </attributes>
+              </object>
+            </child>
+            <child>
+              <object class="GtkCheckButton" id="TabClosers">
+                <property name="label" translatable="yes">Close-buttons on secondary tabs</property>
+                <property name="visible">1</property>
+              </object>
+            </child>
+            <child>
+              <object class="GtkCheckButton" id="TabStatusIcons">
+                <property name="label" translatable="yes">Tabs show user status icons instead of status text</property>
+                <property name="visible">1</property>
+              </object>
+            </child>
+          </object>
+        </child>
+        <child>
+          <object class="GtkFlowBox">
+            <property name="visible">1</property>
+            <property name="column-spacing">12</property>
+            <property name="row-spacing">12</property>
+            <property name="max-children-per-line">2</property>
+            <property name="selection-mode">none</property>
+            <child>
+              <object class="GtkFlowBoxChild">
+                <property name="visible">1</property>
+                <property name="focusable">0</property>
+                <child>
+                  <object class="GtkLabel" id="ChatRoomsLabel">
+                    <property name="visible">1</property>
+                    <property name="xalign">0</property>
+                    <property name="label" translatable="yes">Chat room tab bar position:</property>
+                    <property name="mnemonic_widget">ChatRoomsPosition</property>
+                  </object>
+                </child>
+              </object>
+            </child>
+            <child>
+              <object class="GtkFlowBoxChild">
+                <property name="visible">1</property>
+                <property name="focusable">0</property>
+                <child>
+                  <object class="GtkComboBoxText" id="ChatRoomsPosition">
+                    <property name="visible">1</property>
+                    <property name="hexpand">1</property>
+                  </object>
+                </child>
+              </object>
+            </child>
+            <child>
+              <object class="GtkFlowBoxChild">
+                <property name="visible">1</property>
+                <property name="focusable">0</property>
+                <child>
+                  <object class="GtkLabel" id="PrivateChatLabel">
+                    <property name="visible">1</property>
+                    <property name="xalign">0</property>
+                    <property name="label" translatable="yes">Private chat tab bar position:</property>
+                    <property name="mnemonic_widget">PrivateChatPosition</property>
+                  </object>
+                </child>
+              </object>
+            </child>
+            <child>
+              <object class="GtkFlowBoxChild">
+                <property name="visible">1</property>
+                <property name="focusable">0</property>
+                <child>
+                  <object class="GtkComboBoxText" id="PrivateChatPosition">
+                    <property name="visible">1</property>
+                    <property name="hexpand">1</property>
+                  </object>
+                </child>
+              </object>
+            </child>
+            <child>
+              <object class="GtkFlowBoxChild">
+                <property name="visible">1</property>
+                <property name="focusable">0</property>
+                <child>
+                  <object class="GtkLabel" id="SearchLabel">
+                    <property name="visible">1</property>
+                    <property name="xalign">0</property>
+                    <property name="label" translatable="yes">Search tab bar position:</property>
+                    <property name="mnemonic_widget">SearchPosition</property>
+                  </object>
+                </child>
+              </object>
+            </child>
+            <child>
+              <object class="GtkFlowBoxChild">
+                <property name="visible">1</property>
+                <property name="focusable">0</property>
+                <child>
+                  <object class="GtkComboBoxText" id="SearchPosition">
+                    <property name="visible">1</property>
+                    <property name="hexpand">1</property>
+                  </object>
+                </child>
+              </object>
+            </child>
+            <child>
+              <object class="GtkFlowBoxChild">
+                <property name="visible">1</property>
+                <property name="focusable">0</property>
+                <child>
+                  <object class="GtkLabel" id="UserInfoLabel">
+                    <property name="visible">1</property>
+                    <property name="xalign">0</property>
+                    <property name="label" translatable="yes">User info tab bar position:</property>
+                    <property name="mnemonic_widget">UserInfoPosition</property>
+                  </object>
+                </child>
+              </object>
+            </child>
+            <child>
+              <object class="GtkFlowBoxChild">
+                <property name="visible">1</property>
+                <property name="focusable">0</property>
+                <child>
+                  <object class="GtkComboBoxText" id="UserInfoPosition">
+                    <property name="visible">1</property>
+                    <property name="hexpand">1</property>
+                  </object>
+                </child>
+              </object>
+            </child>
+            <child>
+              <object class="GtkFlowBoxChild">
+                <property name="visible">1</property>
+                <property name="focusable">0</property>
+                <child>
+                  <object class="GtkLabel" id="UserBrowseLabel">
+                    <property name="visible">1</property>
+                    <property name="xalign">0</property>
+                    <property name="label" translatable="yes">User browse tab bar position:</property>
+                    <property name="mnemonic_widget">UserBrowsePosition</property>
+                  </object>
+                </child>
+              </object>
+            </child>
+            <child>
+              <object class="GtkFlowBoxChild">
+                <property name="visible">1</property>
+                <property name="focusable">0</property>
+                <child>
+                  <object class="GtkComboBoxText" id="UserBrowsePosition">
+                    <property name="visible">1</property>
+                    <property name="hexpand">1</property>
+                  </object>
+                </child>
+              </object>
+            </child>
+          </object>
+        </child>
+      </object>
+    </child>
+    <child>
+      <object class="GtkBox">
+        <property name="visible">1</property>
+        <property name="spacing">30</property>
+        <property name="orientation">vertical</property>
+        <child>
+          <object class="GtkBox">
+            <property name="visible">1</property>
+            <property name="spacing">12</property>
+            <property name="orientation">vertical</property>
+            <child>
+              <object class="GtkLabel">
+                <property name="visible">1</property>
                 <property name="xalign">0</property>
                 <property name="margin-top">12</property>
                 <property name="label" translatable="yes">Chats</property>
@@ -1195,10 +778,10 @@
                         <property name="visible">1</property>
                         <signal name="changed" handler="on_colors_changed"/>
                         <items>
-                          <item translatable="yes">bold</item>
-                          <item translatable="yes">italic</item>
-                          <item translatable="yes">underline</item>
-                          <item translatable="yes">normal</item>
+                          <item id="bold" translatable="yes">bold</item>
+                          <item id="italic" translatable="yes">italic</item>
+                          <item id="underline" translatable="yes">underline</item>
+                          <item id="normal" translatable="yes">normal</item>
                         </items>
                       </object>
                     </child>
@@ -1998,6 +1581,263 @@
         <child>
           <object class="GtkLabel">
             <property name="visible">1</property>
+            <property name="label" translatable="yes">Tab Labels</property>
+            <property name="xalign">0</property>
+            <attributes>
+              <attribute name="weight" value="bold"/>
+            </attributes>
+          </object>
+        </child>
+        <child>
+          <object class="GtkCheckButton" id="NotificationTabColors">
+            <property name="visible">1</property>
+            <property name="label" translatable="yes">Notification changes the tab&apos;s text color</property>
+            <signal name="toggled" handler="on_tab_notification_color_toggled" swapped="no"/>
+          </object>
+        </child>
+        <child>
+          <object class="GtkFlowBox">
+            <property name="visible">1</property>
+            <property name="homogeneous">1</property>
+            <property name="column-spacing">12</property>
+            <property name="row-spacing">12</property>
+            <property name="min-children-per-line">1</property>
+            <property name="max-children-per-line">2</property>
+            <property name="selection-mode">none</property>
+            <child>
+              <object class="GtkFlowBoxChild">
+                <property name="visible">1</property>
+                <property name="focusable">0</property>
+                <child>
+                  <object class="GtkBox">
+                    <property name="visible">1</property>
+                    <property name="spacing">12</property>
+                    <child>
+                      <object class="GtkLabel">
+                        <property name="visible">1</property>
+                        <property name="label" translatable="yes">Regular tab label color:</property>
+                        <property name="hexpand">1</property>
+                        <property name="xalign">0</property>
+                        <property name="wrap">1</property>
+                        <property name="mnemonic_widget">PickRegularTab</property>
+                      </object>
+                    </child>
+                    <child>
+                      <object class="GtkColorButton" id="PickRegularTab">
+                        <property name="visible">1</property>
+                        <signal name="color-set" handler="on_color_set"/>
+                      </object>
+                    </child>
+                  </object>
+                </child>
+              </object>
+            </child>
+            <child>
+              <object class="GtkFlowBoxChild">
+                <property name="visible">1</property>
+                <property name="focusable">0</property>
+                <child>
+                  <object class="GtkBox">
+                    <property name="visible">1</property>
+                    <property name="spacing">12</property>
+                    <child>
+                      <object class="GtkEntry" id="EntryRegularTab">
+                        <property name="visible">1</property>
+                        <property name="hexpand">1</property>
+                        <property name="width-chars">16</property>
+                        <signal name="changed" handler="on_colors_changed"/>
+                      </object>
+                    </child>
+                    <child>
+                      <object class="GtkButton" id="DefaultRegularTab">
+                        <property name="visible">1</property>
+                        <property name="halign">start</property>
+                        <signal name="clicked" handler="on_default_color"/>
+                        <child>
+                          <object class="GtkBox">
+                            <property name="visible">1</property>
+                            <property name="spacing">6</property>
+                            <child>
+                              <object class="GtkImage">
+                                <property name="visible">1</property>
+                                <property name="icon-name">view-refresh-symbolic</property>
+                              </object>
+                            </child>
+                            <child>
+                              <object class="GtkLabel">
+                                <property name="visible">1</property>
+                                <property name="label" translatable="yes">Default</property>
+                                <property name="use-underline">1</property>
+                              </object>
+                            </child>
+                          </object>
+                        </child>
+                      </object>
+                    </child>
+                  </object>
+                </child>
+              </object>
+            </child>
+            <child>
+              <object class="GtkFlowBoxChild">
+                <property name="visible">1</property>
+                <property name="focusable">0</property>
+                <child>
+                  <object class="GtkBox">
+                    <property name="visible">1</property>
+                    <property name="spacing">12</property>
+                    <child>
+                      <object class="GtkLabel">
+                        <property name="visible">1</property>
+                        <property name="label" translatable="yes">Changed tab label color:</property>
+                        <property name="hexpand">1</property>
+                        <property name="xalign">0</property>
+                        <property name="wrap">1</property>
+                        <property name="mnemonic_widget">PickChangedTab</property>
+                      </object>
+                    </child>
+                    <child>
+                      <object class="GtkColorButton" id="PickChangedTab">
+                        <property name="visible">1</property>
+                        <signal name="color-set" handler="on_color_set"/>
+                      </object>
+                    </child>
+                  </object>
+                </child>
+              </object>
+            </child>
+            <child>
+              <object class="GtkFlowBoxChild">
+                <property name="visible">1</property>
+                <property name="focusable">0</property>
+                <child>
+                  <object class="GtkBox">
+                    <property name="visible">1</property>
+                    <property name="spacing">12</property>
+                    <child>
+                      <object class="GtkEntry" id="EntryChangedTab">
+                        <property name="visible">1</property>
+                        <property name="hexpand">1</property>
+                        <property name="width-chars">16</property>
+                        <signal name="changed" handler="on_colors_changed"/>
+                      </object>
+                    </child>
+                    <child>
+                      <object class="GtkButton" id="DefaultChangedTab">
+                        <property name="visible">1</property>
+                        <property name="halign">start</property>
+                        <signal name="clicked" handler="on_default_color"/>
+                        <child>
+                          <object class="GtkBox">
+                            <property name="visible">1</property>
+                            <property name="spacing">6</property>
+                            <child>
+                              <object class="GtkImage">
+                                <property name="visible">1</property>
+                                <property name="icon-name">view-refresh-symbolic</property>
+                              </object>
+                            </child>
+                            <child>
+                              <object class="GtkLabel">
+                                <property name="visible">1</property>
+                                <property name="label" translatable="yes">Default</property>
+                                <property name="use-underline">1</property>
+                              </object>
+                            </child>
+                          </object>
+                        </child>
+                      </object>
+                    </child>
+                  </object>
+                </child>
+              </object>
+            </child>
+            <child>
+              <object class="GtkFlowBoxChild">
+                <property name="visible">1</property>
+                <property name="focusable">0</property>
+                <child>
+                  <object class="GtkBox">
+                    <property name="visible">1</property>
+                    <property name="spacing">12</property>
+                    <child>
+                      <object class="GtkLabel">
+                        <property name="visible">1</property>
+                        <property name="label" translatable="yes">Highlighted tab label color:</property>
+                        <property name="hexpand">1</property>
+                        <property name="xalign">0</property>
+                        <property name="wrap">1</property>
+                        <property name="mnemonic_widget">PickHighlightTab</property>
+                      </object>
+                    </child>
+                    <child>
+                      <object class="GtkColorButton" id="PickHighlightTab">
+                        <property name="visible">1</property>
+                        <signal name="color-set" handler="on_color_set"/>
+                      </object>
+                    </child>
+                  </object>
+                </child>
+              </object>
+            </child>
+            <child>
+              <object class="GtkFlowBoxChild">
+                <property name="visible">1</property>
+                <property name="focusable">0</property>
+                <child>
+                  <object class="GtkBox">
+                    <property name="visible">1</property>
+                    <property name="spacing">12</property>
+                    <child>
+                      <object class="GtkEntry" id="EntryHighlightTab">
+                        <property name="visible">1</property>
+                        <property name="hexpand">1</property>
+                        <property name="width-chars">16</property>
+                        <signal name="changed" handler="on_colors_changed"/>
+                      </object>
+                    </child>
+                    <child>
+                      <object class="GtkButton" id="DefaultHighlightTab">
+                        <property name="visible">1</property>
+                        <property name="halign">start</property>
+                        <signal name="clicked" handler="on_default_color"/>
+                        <child>
+                          <object class="GtkBox">
+                            <property name="visible">1</property>
+                            <property name="spacing">6</property>
+                            <child>
+                              <object class="GtkImage">
+                                <property name="visible">1</property>
+                                <property name="icon-name">view-refresh-symbolic</property>
+                              </object>
+                            </child>
+                            <child>
+                              <object class="GtkLabel">
+                                <property name="visible">1</property>
+                                <property name="label" translatable="yes">Default</property>
+                                <property name="use-underline">1</property>
+                              </object>
+                            </child>
+                          </object>
+                        </child>
+                      </object>
+                    </child>
+                  </object>
+                </child>
+              </object>
+            </child>
+          </object>
+        </child>
+      </object>
+    </child>
+    <child>
+      <object class="GtkBox">
+        <property name="visible">1</property>
+        <property name="spacing">12</property>
+        <property name="orientation">vertical</property>
+        <child>
+          <object class="GtkLabel">
+            <property name="visible">1</property>
             <property name="halign">start</property>
             <property name="label" translatable="yes">Fonts</property>
             <attributes>
@@ -2474,13 +2314,20 @@
               <object class="GtkFrame">
                 <property name="visible">1</property>
                 <child>
-                  <object class="GtkIconView" id="IconView">
+                  <object class="GtkFlowBox" id="IconView">
                     <property name="visible">1</property>
-                    <property name="pixbuf-column">0</property>
-                    <property name="text-column">1</property>
+                    <property name="column-spacing">24</property>
+                    <property name="row-spacing">24</property>
+                    <property name="margin-start">24</property>
+                    <property name="margin-end">24</property>
+                    <property name="margin-top">24</property>
+                    <property name="margin-bottom">24</property>
                     <property name="selection-mode">none</property>
                   </object>
                 </child>
+                <style>
+                  <class name="view"/>
+                </style>
               </object>
             </child>
           </object>

--- a/pynicotine/gtkgui/ui/settings/userinterface.ui
+++ b/pynicotine/gtkgui/ui/settings/userinterface.ui
@@ -124,6 +124,7 @@
             <child>
               <object class="GtkCheckButton" id="TabSelectPrevious">
                 <property name="label" translatable="yes">Remember previous primary tab on startup</property>
+                <property name="tooltip_text" translatable="yes">Start with Search Files by default.</property>
                 <property name="visible">1</property>
               </object>
             </child>

--- a/pynicotine/gtkgui/ui/settings/userinterface.ui
+++ b/pynicotine/gtkgui/ui/settings/userinterface.ui
@@ -117,34 +117,23 @@
             </child>
           </object>
         </child>
-      </object>
-    </child>
-    <child>
-      <object class="GtkBox">
-        <property name="visible">1</property>
-        <property name="spacing">18</property>
-        <property name="orientation">vertical</property>
         <child>
           <object class="GtkBox">
             <property name="visible">1</property>
             <property name="spacing">12</property>
-            <property name="orientation">vertical</property>
-            <child>
-              <object class="GtkLabel">
-                <property name="visible">1</property>
-                <property name="label" translatable="yes">Primary Tabs</property>
-                <property name="xalign">0</property>
-                <attributes>
-                  <attribute name="weight" value="bold"/>
-                </attributes>
-              </object>
-            </child>
             <child>
               <object class="GtkCheckButton" id="TabSelectPrevious">
                 <property name="label" translatable="yes">Remember previous primary tab on startup</property>
                 <property name="visible">1</property>
               </object>
             </child>
+          </object>
+        </child>
+        <child>
+          <object class="GtkBox">
+            <property name="visible">1</property>
+            <property name="spacing">12</property>
+            <property name="orientation">vertical</property>
             <child>
               <object class="GtkFlowBox">
                 <property name="visible">1</property>


### PR DESCRIPTION
- Added: "Display tray icon" and "Minimize to tray on startup" moved into 'User Interface' (from 'Notifications')
- Changed: "View previous primary tab on startup" -> "Remember previous primary tab on startup"
- Removed: "Primary Tabs" catagory header label, because it was unnecessary, the tabs are a part of the "User Interface".