### PR TITLE
youtube_info: API changing, remove dislikes

### DIFF
--- a/pynicotine/plugins/youtube_info/PLUGININFO
+++ b/pynicotine/plugins/youtube_info/PLUGININFO
@@ -1,4 +1,4 @@
 Version = "2021-08-13r00"
 Authors = ['Nicotine+ Team']
 Name = "YouTube Info"
-Description = "This plugin discretely displays information for YouTube links posted in chat (only you can see it).\n\nPlaceholders:\n- %title%\n- %description%\n- %duration%\n- %quality%\n- %channel%\n- %views%\n- %likes%\n- %dislikes%\n\nRequest an API key:\nhttps://developers.google.com/youtube/v3/getting-started"
+Description = "This plugin discretely displays information for YouTube links posted in chat (only you can see it).\n\nPlaceholders:\n- %title%\n- %description%\n- %duration%\n- %quality%\n- %channel%\n- %views%\n- %likes%\n\nRequest an API key:\nhttps://developers.google.com/youtube/v3/getting-started"

--- a/pynicotine/plugins/youtube_info/__init__.py
+++ b/pynicotine/plugins/youtube_info/__init__.py
@@ -166,7 +166,6 @@ class Plugin(BasePlugin):
 
             views = data['statistics'].get('viewCount', 'RESTRICTED')
             likes = data['statistics'].get('likeCount', 'LIKES')
-            dislikes = data['statistics'].get('dislikeCount', 'DISLIKES')
 
         except KeyError:
             # This should not occur
@@ -175,7 +174,6 @@ class Plugin(BasePlugin):
 
         if likes != 'LIKES':
             likes = humanize(int(likes))
-            dislikes = humanize(int(dislikes))
 
         if views != 'RESTRICTED':
             views = humanize(int(views))
@@ -187,7 +185,7 @@ class Plugin(BasePlugin):
 
         return {
             '%title%': title, '%description%': description, '%duration%': duration, '%quality%': quality,
-            '%channel%': channel, '%views%': views, '%likes%': likes, '%dislikes%': dislikes
+            '%channel%': channel, '%views%': views, '%likes%': likes
         }
 
     @staticmethod


### PR DESCRIPTION
Youtube is making statistics.dislikeCount private and will no longer be available after 13th December, 2021.

https://i.imgur.com/9MRwda9.png