### PR TITLE
transferlist.py: Update with lazy_load and Refresh

### DIFF
--- a/pynicotine/gtkgui/frame.py
+++ b/pynicotine/gtkgui/frame.py
@@ -1265,14 +1265,14 @@ class NicotineFrame(UserInterface):
                 GLib.idle_add(lambda: self.PrivateChatEntry.grab_focus() == -1)
 
         elif page == self.uploadsvbox:
-            self.uploads.update(forceupdate=True)
+            self.uploads.lazy_load(seconds=2)
             self.clear_tab_hilite()
 
             if self.uploads.Main.get_visible():
                 GLib.idle_add(lambda: self.uploads.Transfers.grab_focus() == -1)
 
         elif page == self.downloadsvbox:
-            self.downloads.update(forceupdate=True)
+            self.downloads.lazy_load(seconds=2)
             self.clear_tab_hilite()
 
             if self.downloads.Main.get_visible():


### PR DESCRIPTION
- Fixed: Significant and unpleasant delay on switching to either of the transfers tabs when there is a very large data store.
- Fixed: Slight application freeze during startup while loading large transfers history.
- Added: Function for delayed loading of interface to fix hang on switching to a transfer tab with a large data store.
- Added: F5 shortcut key for manual Refresh.

This solves the problem of the slugglish tab switching, but it doesn't address another related performance issue caused by transfers.py calling update on the entire tree model for each individual file operation. Many times these clash.