### PR TITLE
Store and display speeds as integers

### DIFF
--- a/pynicotine/gtkgui/transferlist.py
+++ b/pynicotine/gtkgui/transferlist.py
@@ -377,14 +377,7 @@ class TransferList(UserInterface):
         return "%s / %s" % (human_size(currentbytes), human_size(size))
 
     def get_hspeed(self, speed):
-
-        hspeed = ""
-
-        if speed > 0:
-            speed = float(speed)
-            hspeed = human_speed(speed)
-
-        return hspeed
+        return human_speed(int(speed)) if speed > 0 else ""
 
     def get_helapsed(self, elapsed):
 
@@ -419,7 +412,7 @@ class TransferList(UserInterface):
 
     def update_parent_row(self, initer):
 
-        speed = 0.0
+        speed = 0
         percent = totalsize = position = 0
         elapsed = 0
         salientstatus = ""
@@ -499,10 +492,10 @@ class TransferList(UserInterface):
             status = status + " (%s)" % modifier
 
         size = self.get_size(transfer.size)
-        speed = transfer.speed or 0
+        speed = int(transfer.speed or 0)  # remove floating decimals from bytes per second
         helapsed = self.get_helapsed(transfer.timeelapsed or 0)
 
-        # Modify old transfer
+        # Modify old existing or current in-progress transfer
         if transfer.iterator is not None:
             initer = transfer.iterator
             translated_status = self.translate_status(status)

--- a/pynicotine/utils.py
+++ b/pynicotine/utils.py
@@ -400,11 +400,11 @@ speed_suffixes = ['B/s', 'KiB/s', 'MiB/s', 'GiB/s', 'TiB/s', 'PiB/s', 'EiB/s', '
 
 def human_speed(filesize):
     try:
-        step_unit = 1024.0
+        step_unit = 1024
 
         for i in speed_suffixes:
             if filesize < step_unit:
-                return "%3.1f %s" % (filesize, i)
+                return "%3.0f %s" % (filesize, i)
 
             filesize /= step_unit
 


### PR DESCRIPTION
It is both uninteresting and expensive to know the speed to the nearest 0.1 B/s or 0.1 KiB/s, it's better to round the value up to a whole number for both internal storage and visual display purposes.

- Changed: Don't store bytes with a floating point in Transfers list items, it caused parent rows to be slightly off.
- Changed: Don't display any speed with a decimal place, since B/s; KiB/s; MiB/s etc already provide the accuracy needed.

- ToDo: Ideally, it is only needed to update if the speed in Transfers if it's different by more than 2 KiB/s or so (2048 bytes).

The aim is reduce the update frequency of values in Transfer rows, but the bytes are usually different anyway so it doesn't seem to make much difference. Unsure as to the best place to check for this.

_In future, it could be useful to reduce speed accuracy for less frequent and/or faster calcuations in the core (then this would stop Transfers from being provided long values by process_file_input() in slskproto), but that might have unforeseen consequences if the server requires a specific data type or some such._

Additional improvements for speed and limit calculations require further experimentation and is beyond the scope of this PR.