### PR TITLE
Don't use milliseconds for away and wishlist timers

### DIFF
--- a/pynicotine/gtkgui/frame.py
+++ b/pynicotine/gtkgui/frame.py
@@ -249,7 +249,7 @@ class NicotineFrame(UserInterface):
 
         self.chatrooms.clear_notifications()
         self.privatechat.clear_notifications()
-        self.on_disable_auto_away()
+        self.on_cancel_auto_away()
 
         if Gtk.get_major_version() == 3 and window.get_urgency_hint():
             window.set_urgency_hint(False)
@@ -292,17 +292,17 @@ class NicotineFrame(UserInterface):
 
             key_controller = Gtk.EventControllerKey()
             key_controller.set_propagation_phase(Gtk.PropagationPhase.CAPTURE)
-            key_controller.connect("key-released", self.on_disable_auto_away)
+            key_controller.connect("key-released", self.on_cancel_auto_away)
             self.MainWindow.add_controller(key_controller)
 
         else:
             self.gesture_click = Gtk.GestureMultiPress.new(self.MainWindow)
 
-            self.MainWindow.connect("key-release-event", self.on_disable_auto_away)
+            self.MainWindow.connect("key-release-event", self.on_cancel_auto_away)
 
         self.gesture_click.set_button(0)
         self.gesture_click.set_propagation_phase(Gtk.PropagationPhase.CAPTURE)
-        self.gesture_click.connect("pressed", self.on_disable_auto_away)
+        self.gesture_click.connect("pressed", self.on_cancel_auto_away)
 
         # Exit dialog
         if Gtk.get_major_version() == 4:
@@ -1712,7 +1712,7 @@ class NicotineFrame(UserInterface):
         away_interval = config.sections["server"]["autoaway"]
 
         if away_interval > 0:
-            self.away_timer = GLib.timeout_add(1000 * 60 * away_interval, self.set_auto_away, True)
+            self.away_timer = GLib.timeout_add_seconds(60 * away_interval, self.set_auto_away, True)
 
     def remove_away_timer(self):
 
@@ -1720,7 +1720,7 @@ class NicotineFrame(UserInterface):
             GLib.source_remove(self.away_timer)
             self.away_timer = None
 
-    def on_disable_auto_away(self, *args):
+    def on_cancel_auto_away(self, *args):
 
         current_time = time.time()
 

--- a/pynicotine/gtkgui/wishlist.py
+++ b/pynicotine/gtkgui/wishlist.py
@@ -182,7 +182,7 @@ class WishList(UserInterface):
 
     def set_interval(self, msg):
         self.frame.np.search.do_wishlist_search_interval()
-        self.timer = GLib.timeout_add(msg.seconds * 1000, self.frame.np.search.do_wishlist_search_interval)
+        self.timer = GLib.timeout_add_seconds(msg.seconds, self.frame.np.search.do_wishlist_search_interval)
 
     def server_disconnect(self):
 


### PR DESCRIPTION
- Changed: Away timer use GLib 'timeout_add_seconds', this function allows for more efficient system power usage.
- Changed: Internal function name to 'on_cancel_auto_away' because "disable" is ambiguous with 'remove_away_timer'.
- Changed: Wishlist timer use GLib 'timeout_add_seconds', because it doesn't use milliseconds anyway.

Applying this change might not improve performance of the away timer but it might improve other timers elsewhere. In any case it seems to be best practice and has no apparent downside for this use case.

According to Gtk3 documentation (see links: [timeout_add](https://docs.gtk.org/glib/func.timeout_add.html) ; [timeout_add_seconds](https://docs.gtk.org/glib/func.timeout_add_seconds.html) ; [timeout_add_seconds_full](https://docs.gtk.org/glib/func.timeout_add_seconds_full.html) ) ...

_"If you want to have a timer in the “seconds” range and do not care about the exact time of the first call of the timer, use the g_timeout_add_seconds() function; this function allows for more optimizations and more efficient system power usage."_

_"The grouping of timers to fire at the same time results in a more power and CPU efficient behavior so if your timer is in multiples of seconds and you don’t require the first timer exactly one second from now, the use of g_timeout_add_seconds() is preferred over g_timeout_add()."_