### PR TITLE
Don't display maximum sockets on SocketStatus bar

### DIFF
--- a/pynicotine/gtkgui/frame.py
+++ b/pynicotine/gtkgui/frame.py
@@ -1882,7 +1882,7 @@ class NicotineFrame(UserInterface):
         self.UserStatus.set_text(status)
 
     def set_socket_status(self, status):
-        self.SocketStatus.set_text("%(current)s/%(limit)s" % {'current': status, 'limit': slskproto.MAXSOCKETS})
+        self.SocketStatus.set_text("%(current)s" % {'current': status})
 
     def show_scan_progress(self):
 

--- a/pynicotine/gtkgui/frame.py
+++ b/pynicotine/gtkgui/frame.py
@@ -1881,7 +1881,7 @@ class NicotineFrame(UserInterface):
         self.UserStatus.set_text(status)
 
     def set_socket_status(self, status):
-        self.SocketStatus.set_text("%(current)s" % {'current': status})
+        self.SocketStatus.set_text(str(status))
 
     def show_scan_progress(self):
 

--- a/pynicotine/gtkgui/frame.py
+++ b/pynicotine/gtkgui/frame.py
@@ -33,7 +33,6 @@ from gi.repository import Gio
 from gi.repository import GLib
 from gi.repository import Gtk
 
-from pynicotine import slskproto
 from pynicotine.config import config
 from pynicotine.gtkgui.chatrooms import ChatRooms
 from pynicotine.gtkgui.downloads import Downloads

--- a/pynicotine/gtkgui/ui/mainwindow.ui
+++ b/pynicotine/gtkgui/ui/mainwindow.ui
@@ -1663,7 +1663,7 @@
                         <child>
                           <object class="GtkLabel" id="SocketStatus">
                             <property name="visible">1</property>
-                            <property name="label">0/0</property>
+                            <property name="label">0</property>
                             <attributes>
                               <attribute name="weight" value="normal"/>
                             </attributes>

--- a/pynicotine/slskproto.py
+++ b/pynicotine/slskproto.py
@@ -558,7 +558,9 @@ class SlskProtoThread(threading.Thread):
                 self.listen_socket.bind((ip_address, listenport))
                 self.listen_socket.listen()
                 self.listenport = listenport
-                log.add(_("Listening on port %i"), listenport)
+                log.add(_("Listening on port: %i"), listenport)
+                log.add(_("Data socket limit: %(socks)s maximum set by %(platform)s system"),
+                        {'socks': MAXSOCKETS, 'platform': sys.platform})
                 break
 
             except socket.error:

--- a/pynicotine/slskproto.py
+++ b/pynicotine/slskproto.py
@@ -559,7 +559,7 @@ class SlskProtoThread(threading.Thread):
                 self.listen_socket.listen()
                 self.listenport = listenport
                 log.add(_("Listening on port: %i"), listenport)
-                log.add(_("Data socket limit: %(socks)s maximum set by %(platform)s system"),
+                log.add(_("Data socket limit: %(socks)i maximum set by %(platform)s system"),
                         {'socks': MAXSOCKETS, 'platform': sys.platform})
                 break
 

--- a/pynicotine/slskproto.py
+++ b/pynicotine/slskproto.py
@@ -559,7 +559,7 @@ class SlskProtoThread(threading.Thread):
                 self.listen_socket.listen()
                 self.listenport = listenport
                 log.add(_("Listening on port: %i"), listenport)
-                log.add(_("Data socket limit: %i"), MAXSOCKETS)
+                log.add(_("Maximum data sockets: %i"), MAXSOCKETS)
                 break
 
             except socket.error:

--- a/pynicotine/slskproto.py
+++ b/pynicotine/slskproto.py
@@ -559,8 +559,7 @@ class SlskProtoThread(threading.Thread):
                 self.listen_socket.listen()
                 self.listenport = listenport
                 log.add(_("Listening on port: %i"), listenport)
-                log.add(_("Data socket limit: %(socks)i maximum set by %(platform)s system"),
-                        {'socks': MAXSOCKETS, 'platform': sys.platform})
+                log.add(_("Data socket limit: %i"), MAXSOCKETS)
                 break
 
             except socket.error:


### PR DESCRIPTION
- Removed: Max sockets don't need to be displayed on SocketStatus bar
- Removed: slskproto doesn't need to be imported into frame, since the whole module is required just to get a static value.
- Added: Standard log entry to report maximum data sockets allowed by OS platform, upon establishing local port binding.

Before: ![image](https://user-images.githubusercontent.com/88614182/141496250-641e1a7f-9948-403f-9c67-bae35f7244ae.png) - - - After: ![image](https://user-images.githubusercontent.com/88614182/141495628-9fccdb03-d976-42f4-b8d0-52777ac619a1.png)

Since the MAXSOCKETS value always seems to be the same (it is usually "1024" on most systems, but can be less in some rare cases), it is a waste of both time and space (and possibly resources).

**_DONE:_** Perhaps if knowing this value is important to people running Win32 or with some file limit set, maybe it would be sufficient to mention it in the Standard log, because it isn't something that is going to change during the session.