### PR TITLE
plugin.ui: "Preferences" button / "Properties" window -> "Settings"

### DIFF
--- a/pynicotine/gtkgui/settingswindow.py
+++ b/pynicotine/gtkgui/settingswindow.py
@@ -2629,7 +2629,7 @@ class PluginsFrame(UserInterface):
             # Build the window
             Gtk.Dialog.__init__(
                 self,
-                title=_("%s Properties") % name,
+                title=_("%s Settings") % name,
                 modal=True,
                 default_width=600,
                 use_header_bar=Gtk.Settings.get_default().get_property("gtk-dialogs-use-header")

--- a/pynicotine/gtkgui/ui/settings/plugin.ui
+++ b/pynicotine/gtkgui/ui/settings/plugin.ui
@@ -129,7 +129,7 @@
                                         <child>
                                           <object class="GtkLabel">
                                             <property name="visible">1</property>
-                                            <property name="label" translatable="yes">_Preferences</property>
+                                            <property name="label" translatable="yes">_Properties</property>
                                             <property name="use-underline">1</property>
                                           </object>
                                         </child>

--- a/pynicotine/gtkgui/ui/settings/plugin.ui
+++ b/pynicotine/gtkgui/ui/settings/plugin.ui
@@ -129,7 +129,7 @@
                                         <child>
                                           <object class="GtkLabel">
                                             <property name="visible">1</property>
-                                            <property name="label" translatable="yes">_Properties</property>
+                                            <property name="label" translatable="yes">_Settings</property>
                                             <property name="use-underline">1</property>
                                           </object>
                                         </child>


### PR DESCRIPTION
Fixed: The window is called Plugin "Properties", the "Preferences" button label doesn't match the internal "Settings" terminology.

_Changed:_
![image](https://user-images.githubusercontent.com/88614182/142227957-374fe94b-14c8-45d1-8e71-3610f6eaa9df.png)
