### PR TITLE
shares.py: Display finished count after rescan

### DIFF
--- a/pynicotine/shares.py
+++ b/pynicotine/shares.py
@@ -104,8 +104,7 @@ class Scanner:
                 _new_mtimes, new_files, _new_streams = self.rescan_dirs("buddy", new_mtimes, new_files,
                                                                         new_streams, self.rebuild)
 
-                self.queue.put((_("%(num)s folders found after rescan"), {"num": len(new_files)}, None))
-                self.queue.put((_("Finished rescanning shares"), None, None))
+                self.queue.put((_("%(num)s folders found after rescan, finished."), {"num": len(new_files)}, None))
 
                 self.create_compressed_shares()
 

--- a/pynicotine/shares.py
+++ b/pynicotine/shares.py
@@ -104,7 +104,7 @@ class Scanner:
                 _new_mtimes, new_files, _new_streams = self.rescan_dirs("buddy", new_mtimes, new_files,
                                                                         new_streams, self.rebuild)
 
-                self.queue.put((_("%(num)s folders found after rescan, finished."), {"num": len(new_files)}, None))
+                self.queue.put((_("%(num)s folders found after rescan, finished"), {"num": len(new_files)}, None))
 
                 self.create_compressed_shares()
 

--- a/pynicotine/shares.py
+++ b/pynicotine/shares.py
@@ -104,7 +104,7 @@ class Scanner:
                 _new_mtimes, new_files, _new_streams = self.rescan_dirs("buddy", new_mtimes, new_files,
                                                                         new_streams, self.rebuild)
 
-                self.queue.put((_("%(num)s folders found after rescan, finished"), {"num": len(new_files)}, None))
+                self.queue.put((_("Rescan complete: %(num)s folders found"), {"num": len(new_files)}, None))
 
                 self.create_compressed_shares()
 
@@ -865,7 +865,7 @@ class Shares:
                     if self.ui_callback:
                         self.ui_callback.set_scan_progress(item)
                     else:
-                        log.add(_("Progress: %s"), str(int(item * 100)) + " %")
+                        log.add(_("Rescan progress: %s"), str(int(item * 100)) + " %")
 
                 elif isinstance(item, slskmessages.SharedFileList):
                     if item.type == "normal":


### PR DESCRIPTION
- Removed: "Finished rescanning shares" message, because the "folders found" count is more useful to end with on the Status bar after a manual scan, helps with #1698 , since the user will be able to see if the number of folders counted is correct or not after a manual rescan at least.

This doesn't fully address the issue for scan at startup, because if there is a folder not found error then it is very likely that the rescan will be completed before other startup messages appear that wipe out any Scanner messages from the Statusbar.