### PR TITLE
Remove feature to auto-share download folder

### DIFF
--- a/pynicotine/gtkgui/dialogs/preferences.py
+++ b/pynicotine/gtkgui/dialogs/preferences.py
@@ -227,15 +227,9 @@ class DownloadsFrame(UserInterface):
         self.frame = self.p.frame
         self.needrescan = False
 
-        self.IncompleteDir = FileChooserButton(
-            self.IncompleteDir, parent.dialog, "folder"
-        )
-        self.DownloadDir = FileChooserButton(
-            self.DownloadDir, parent.dialog, "folder", self.on_choose_download_dir
-        )
-        self.UploadDir = FileChooserButton(
-            self.UploadDir, parent.dialog, "folder"
-        )
+        self.IncompleteDir = FileChooserButton(self.IncompleteDir, parent.dialog, "folder")
+        self.DownloadDir = FileChooserButton(self.DownloadDir, parent.dialog, "folder")
+        self.UploadDir = FileChooserButton(self.UploadDir, parent.dialog, "folder")
 
         self.options = {
             "transfers": {
@@ -331,16 +325,6 @@ class DownloadsFrame(UserInterface):
                 "download_doubleclick": self.DownloadDoubleClick.get_active()
             }
         }
-
-    def on_choose_download_dir(self):
-
-        # Get the transfers section
-        transfers = config.sections["transfers"]
-
-        # This function will be called upon creating the settings window,
-        # so only force a scan if the user changes his donwload directory
-        if transfers["sharedownloaddir"] and self.DownloadDir.get_path() != transfers["downloaddir"]:
-            self.needrescan = True
 
     def on_remote_downloads(self, widget):
 
@@ -597,7 +581,6 @@ class SharesFrame(UserInterface):
         self.options = {
             "transfers": {
                 "rescanonstartup": self.RescanOnStartup,
-                "sharedownloaddir": self.ShareDownloadDir,
                 "buddysharestrustedonly": self.BuddySharesTrustedOnly
             }
         }
@@ -637,7 +620,6 @@ class SharesFrame(UserInterface):
                 "shared": self.shareddirs[:],
                 "buddyshared": self.bshareddirs[:],
                 "rescanonstartup": self.RescanOnStartup.get_active(),
-                "sharedownloaddir": self.ShareDownloadDir.get_active(),
                 "buddysharestrustedonly": self.BuddySharesTrustedOnly.get_active()
             }
         }

--- a/pynicotine/gtkgui/ui/settings/shares.ui
+++ b/pynicotine/gtkgui/ui/settings/shares.ui
@@ -42,15 +42,6 @@
               </object>
             </child>
             <child>
-              <object class="GtkCheckButton" id="ShareDownloadDir">
-                <property name="label" translatable="yes">Automatically share completed downloads</property>
-                <property name="visible">1</property>
-                <property name="tooltip_text" translatable="yes">The equivalent of adding your download folder as a public share, however files downloaded to this folder will be automatically accessible to others (no rescan required).</property>
-                <property name="use-underline">1</property>
-                <signal name="toggled" handler="on_share_download_dir_toggled" swapped="no"/>
-              </object>
-            </child>
-            <child>
               <object class="GtkCheckButton" id="BuddySharesTrustedOnly">
                 <property name="label" translatable="yes">Limit buddy-only shares to trusted buddies</property>
                 <property name="visible">1</property>

--- a/pynicotine/transfers.py
+++ b/pynicotine/transfers.py
@@ -1866,12 +1866,6 @@ class Transfers:
 
         config = self.config.sections
 
-        if config["transfers"]["sharedownloaddir"]:
-            """ Folder downloaded and shared. Notify the server of new stats. The
-            reason we don't send this message after each download is to reduce traffic from
-            the server to room users, since every stat update is relayed by the server. """
-            self.core.shares.send_num_shared_folders_files()
-
         if not folderpath:
             return
 
@@ -1933,8 +1927,6 @@ class Transfers:
         i.timeleft = ""
         i.conn = None
 
-        self.core.shares.add_file_to_shared(newname)
-        self.core.shares.add_file_to_buddy_shared(newname)
         self.core.statistics.append_stat_value("completed_downloads", 1)
 
         # Attempt to show notification and execute commands

--- a/test/unit/shares/test_shares.py
+++ b/test/unit/shares/test_shares.py
@@ -49,8 +49,8 @@ class SharesTest(unittest.TestCase):
         self.assertIn(SHARES_DIR, list(shares.share_dbs["mtimes"]))
 
         # Verify that shared files were added
-        self.assertIn(('dummy_file', 0, None, None), shares.share_dbs["files"]["Shares"])
-        self.assertIn(('nicotinetestdata.mp3', 80919, None, None), shares.share_dbs["files"]["Shares"])
+        self.assertIn(['dummy_file', 0, None, None], shares.share_dbs["files"]["Shares"])
+        self.assertIn(['nicotinetestdata.mp3', 80919, None, None], shares.share_dbs["files"]["Shares"])
 
         # Verify that expected folder is empty
         self.assertEqual(len(shares.share_dbs["files"]["Shares\\folder2"]), 0)
@@ -96,26 +96,10 @@ class SharesTest(unittest.TestCase):
         # Check files
         files = shares.share_dbs["files"]["Shares"]
 
-        self.assertNotIn((".abc_file", 0, None, None), files)
-        self.assertNotIn((".hidden_file", 0, None, None), files)
-        self.assertNotIn((".xyz_file", 0, None, None), files)
-        self.assertIn(("dummy_file", 0, None, None), files)
+        self.assertNotIn([".abc_file", 0, None, None], files)
+        self.assertNotIn([".hidden_file", 0, None, None], files)
+        self.assertNotIn([".xyz_file", 0, None, None], files)
+        self.assertIn(["dummy_file", 0, None, None], files)
         self.assertEqual(len(files), 3)
-
-        shares.close_shares(shares.share_dbs)
-
-    def test_shares_add_downloaded(self):
-        """ Test that downloaded files are added to shared files """
-
-        config.sections["transfers"]["shared"] = [("Downloaded", SHARES_DIR)]
-        config.sections["transfers"]["rescanonstartup"] = False
-        config.sections["transfers"]["sharedownloaddir"] = True
-
-        shares = Shares(None, config, deque(), init_shares=False)
-        shares.load_shares(shares.share_dbs, shares.share_db_paths)
-        shares.add_file_to_shared(os.path.join(SHARES_DIR, 'nicotinetestdata.mp3'))
-
-        self.assertIn(('nicotinetestdata.mp3', 80919, None, None), shares.share_dbs["files"]["Downloaded"])
-        self.assertIn(('Downloaded\\nicotinetestdata.mp3', 80919, None, None), shares.share_dbs["fileindex"].values())
 
         shares.close_shares(shares.share_dbs)


### PR DESCRIPTION
This is an old feature from the PySoulSeek days that causes more harm than good.

- It's somewhat painful to maintain and keep in sync with the rest of the scanning code
- With the addition of the username subfolder feature for downloads, it causes privacy concerns
- The general consensus is that downloads should be moved to another folder and reviewed before sharing, since sharing the download folder directly can contribute to issues with incomplete albums
- The original Soulseek client had this feature, but removed it