### PR TITLE
pynicotine.py: Seperate version strings in log on startup

### DIFF
--- a/pynicotine/pynicotine.py
+++ b/pynicotine/pynicotine.py
@@ -274,10 +274,8 @@ class NicotineCore:
 
     def start(self, ui_callback=None, network_callback=None):
 
-        log.add("Loading Nicotine+ %(nic_version)s, using Python %(py_version)s" % {
-            "nic_version": config.version,
-            "py_version": config.python_version
-        })
+        log.add("Loading Nicotine+ %(nic_version)s" % {"nic_version": config.version})
+        log.add("Using Python %(py_version)s" % {"py_version": config.python_version})
 
         self.ui_callback = ui_callback
         self.network_callback = network_callback if network_callback else self.network_event


### PR DESCRIPTION
The date in the version string of the installed Python run-time was ambiguous with the Nicotine+ build date, which is not known.

_Fixed:_
```
12:00:05 Loading GTK 3.22.11
12:00:05 Loading Nicotine+ 3.2.0.rc1
12:00:05 Using Python 3.5.3 (default, Apr  5 2021, 09:00:41) 
[GCC 6.3.0 20170516]
```

The date of Python run-time library is probably not really that useful, but there doesn't seem to be a simple way of excluding it without performing a stripping operation on the string. Unless the Nicotine+ build date can be shown aswell then it would be less confusing to remove the date, or at least show it on a separate line such as has been done here. 