### PR TITLE
search.py: Make filter history update in open tabs

### DIFF
--- a/pynicotine/gtkgui/search.py
+++ b/pynicotine/gtkgui/search.py
@@ -439,7 +439,9 @@ class Search(UserInterface):
         }
 
         self.ShowFilters.set_active(config.sections["searches"]["filters_visible"])
-        self.populate_filters()
+
+        if config.sections["searches"]["enablefilters"]:
+            self.populate_filters()
 
         """ Wishlist """
 
@@ -650,12 +652,12 @@ class Search(UserInterface):
                 self.searches.show_tab(self, self.id, self.text, self.mode)
                 self.showtab = True
 
-            # Update number of results
-            self.update_result_counter()
-
             # Update tab notification
             self.searches.request_changed(self.Main)
             self.frame.request_tab_hilite(self.searches.page_id)
+
+        # Update number of results
+        self.update_result_counter()
 
     def append(self, row):
 

--- a/pynicotine/gtkgui/search.py
+++ b/pynicotine/gtkgui/search.py
@@ -109,6 +109,7 @@ class Searches(IconNotebook):
         for tab in self.pages.values():
             if tab.Main == page:
                 GLib.idle_add(lambda: tab.ResultsList.grab_focus() == -1)
+                tab.populate_filters(set_default_filters=False)
                 return True
 
     def on_search_mode(self, action, state):


### PR DESCRIPTION
- Fixed: Recently added filter was not available in other open tabs
- Fixed: Update counter even if the default results filters mean that there are "0+" results