### PR TITLE
search.py: Update total counter even if all results filtered by default 0+

### DIFF
--- a/pynicotine/gtkgui/search.py
+++ b/pynicotine/gtkgui/search.py
@@ -233,6 +233,7 @@ class Searches(IconNotebook):
         if tab.num_results_found >= tab.max_limit:
             self.frame.np.search.remove_allowed_search_id(msg.token)
             tab.max_limited = True
+            tab.update_result_counter()
             return
 
         tab.add_user_results(msg, username, country)
@@ -656,12 +657,12 @@ class Search(UserInterface):
                 self.searches.show_tab(self, self.id, self.text, self.mode)
                 self.showtab = True
 
-            # Update number of results
-            self.update_result_counter()
-
             # Update tab notification
             self.searches.request_changed(self.Main)
             self.frame.request_tab_hilite(self.searches.page_id)
+
+        # Update number of results, even if they are all filtered
+        self.update_result_counter()
 
     def append(self, row):
 


### PR DESCRIPTION
- Fixed: Counter total and "+" would not update if a default filter is set that causes 0 visible results
- Fixed: Edge case where ">...+" would not be indicated if max_limit was just exactly reached