### PR TITLE
search.py: Clear FreeSlot filter

### DIFF
--- a/pynicotine/gtkgui/search.py
+++ b/pynicotine/gtkgui/search.py
@@ -1419,8 +1419,7 @@ class Search(UserInterface):
             if isinstance(widget, Gtk.ComboBoxText):
                 widget.get_child().set_text("")
 
-            elif isinstance(widget, Gtk.CheckButton):
-                widget.set_active(False)
+        self.FilterFreeSlot.set_active(False)
 
         self.clearing_filters = False
         self.FilterIn.get_child().grab_focus()


### PR DESCRIPTION
- Fixed: When pressing 'Clear all active filters' button, the FreeSlot button didn't toggle off