### PR TITLE
search.py: After clearing don't focus FilterIn if not visible

### DIFF
--- a/pynicotine/gtkgui/search.py
+++ b/pynicotine/gtkgui/search.py
@@ -1416,8 +1416,12 @@ class Search(UserInterface):
 
         self.FilterFreeSlot.set_active(False)
 
+        if self.ShowFilters.get_active():
+            self.FilterIn.get_child().grab_focus()
+        else:
+            self.ResultsList.grab_focus()
+
         self.clearing_filters = False
-        self.FilterIn.get_child().grab_focus()
         self.on_refilter()
 
     def on_clear(self, *_args):


### PR DESCRIPTION
- Fixed: Keyboard focus trap in an invisible ComboBox, since the filters can be cleared without clicking the Clear button whilst the Result filters bar is hidden, by clicking the ResultCounter button