### PR TITLE
ScannerProgress warning if no files are shared (#1698)

### DIFF
--- a/pynicotine/gtkgui/frame.py
+++ b/pynicotine/gtkgui/frame.py
@@ -1836,13 +1836,21 @@ class NicotineFrame(UserInterface):
         self.scan_progress_indeterminate = True
         GLib.idle_add(self.SharesProgress.show)
 
-    def set_scan_progress(self, value):
+    def set_scan_progress(self, value, text):
 
         self.scan_progress_indeterminate = False
         GLib.idle_add(self.SharesProgress.set_fraction, value)
+        GLib.idle_add(self.SharesProgress.set_text, text)
+
+    def set_scan_error(self, text):
+
+        self.scan_progress_indeterminate = False
+        GLib.idle_add(self.SharesProgress.set_fraction, 1.0)  # ToDo: bar stuck after manual scan
+        GLib.idle_add(self.SharesProgress.set_text, text)  # ToDo: set_style_context
 
     def set_scan_indeterminate(self):
         GLib.timeout_add(100, self.pulse_scan_progress)
+        GLib.idle_add(self.SharesProgress.set_text, _("Scanning Shares"))  # ToDo: set_style_context
 
     def pulse_scan_progress(self):
 


### PR DESCRIPTION
Proof of concept for keeping the ScannerProgress bar visible if there is a scanning exception error, or if there are 0 shared folders.

![image](https://user-images.githubusercontent.com/88614182/145216237-8b1e2f12-1d68-4894-ac60-90dbc04ef9e6.png)

Just ideas for #1698 the implementation is a rough draft, but the progress bar gets stuck and needs styling as a button with a red bar (that could allow easy access on click to the Shares settings page of Preferences).

Also with aim to improve debug logging for the shares scanner, and caching number of shared folders and files into variables for other procedures to reference.