### PR TITLE
Leech Detector: Improve wording of logging "after transfer..."

### DIFF
--- a/pynicotine/plugins/leech_detector/__init__.py
+++ b/pynicotine/plugins/leech_detector/__init__.py
@@ -41,7 +41,7 @@ class Plugin(BasePlugin):
             },
             'num_files': {
                 'description': 'Require users to have a minimum number of shared files:',
-                'type': 'int', 'minimum': 1
+                'type': 'int', 'minimum': 0
             },
             'num_folders': {
                 'description': 'Require users to have a minimum number of shared folders:',
@@ -111,18 +111,14 @@ class Plugin(BasePlugin):
         if stats['files'] == 0 and stats['dirs'] >= self.settings['num_folders']:
             # SoulseekQt seems to only send the number of folders to the server in at least some cases
             self.log(
-                "User %s seems to have zero files but does have %s shared folders, "
-                + "the remote client is probably Qt. Not complaining.",
+                "User %s seems to have zero files but does have %s shared folders, the remote client could be wrong.",
                 (user, stats['dirs'])
             )
-            self.probed[user] = 'zero'
-            return
+            # ToDo: Implement alternative fallback method (num_files | num_folders) from a Browse Shares request #
 
         if stats['files'] == 0 and stats['dirs'] == 0:
             # SoulseekQt only sends the number of shared files/folders to the server once on startup (see Issue #1565)
-            self.log("User %s seems to have zero files and no public shared folder, the server could be wrong. "
-                     + "Going to " + self.str_action + " after transfer…", user)
-            # ToDo: Implement alternative fallback method (num_files | num_folders) from a Browse Shares request #
+            self.log("User %s seems to have zero files and no public shared folder, the server could be wrong.", user)
 
         self.log("Leecher detected, %s is only sharing %s files in %s folders. "
                  + "Going to " + self.str_action + " after transfer…", (user, stats['files'], stats['dirs']))

--- a/pynicotine/plugins/leech_detector/__init__.py
+++ b/pynicotine/plugins/leech_detector/__init__.py
@@ -54,6 +54,7 @@ class Plugin(BasePlugin):
         }
 
         self.probed = {}
+        str_action = ""
 
     def loaded_notification(self):
 
@@ -67,13 +68,13 @@ class Plugin(BasePlugin):
             self.settings['num_folders'] = min_num_folders
 
         if self.settings['message']:
-            self.str_log_start = "message leecher"
+            self.str_action = "message leecher"
         else:
-            self.str_log_start = "log leecher"
+            self.str_action = "log leecher"
 
         self.log(
             "Ready to %ss, require users have a minimum of %d files in %d shared public folders.",
-            (self.str_log_start, self.settings['num_files'], self.settings['num_folders'])
+            (self.str_action, self.settings['num_files'], self.settings['num_folders'])
         )
 
     def upload_queued_notification(self, user, virtual_path, real_path):
@@ -120,11 +121,11 @@ class Plugin(BasePlugin):
         if stats['files'] == 0 and stats['dirs'] == 0:
             # SoulseekQt only sends the number of shared files/folders to the server once on startup (see Issue #1565)
             self.log("User %s seems to have zero files and no public shared folder, the server could be wrong. "
-                     + "Going to " + self.str_log_start + " after transfer…", user)
+                     + "Going to " + self.str_action + " after transfer…", user)
             # ToDo: Implement alternative fallback method (num_files | num_folders) from a Browse Shares request #
 
-        self.log("Leecher %s detected, only sharing %s files in %s folders. "
-                 + "Going to " + self.str_log_start + " after transfer…", (user, stats['files'], stats['dirs']))
+        self.log("Leecher detected, %s is only sharing %s files in %s folders. "
+                 + "Going to " + self.str_action + " after transfer…", (user, stats['files'], stats['dirs']))
         self.probed[user] = 'leecher'
 
     def upload_finished_notification(self, user, *_):

--- a/pynicotine/plugins/leech_detector/__init__.py
+++ b/pynicotine/plugins/leech_detector/__init__.py
@@ -54,7 +54,7 @@ class Plugin(BasePlugin):
         }
 
         self.probed = {}
-        str_action = ""
+        self.str_action = ""
 
     def loaded_notification(self):
 


### PR DESCRIPTION
- Added: Extra log line for clients that only seem to report the number of folders, and not files (see Issue #1565)
- Added: State intention upon detection as to what action is "Going to " be taken, and clearly indicate " after transfer..." (see PR #1653)
- Removed: Usage of the word "complain" and "complaint", in preference for "message", because this encourages politeness
- Changed: Improved logging for "getting statistics from server", because "requesting" was ambiguous with a browse shares request
- Changed: Minimum required Files can be set to 0, for users who wish to avoid bugging Qt users whose buggy clients don't send FileStats to server