### PR TITLE
Add newly discovered peer codes

### DIFF
--- a/doc/SLSKPROTOCOL.md
+++ b/doc/SLSKPROTOCOL.md
@@ -2607,12 +2607,12 @@ In Nicotine, these messages are matched to their message number in slskproto.py 
 | 5    | [Shares Reply](#peer-code-5)               |            |
 | 8    | [Search Request](#peer-code-8)             | Obsolete   |
 | 9    | [Search Reply](#peer-code-9)               |            |
-| 10   | Private Room Invitation                    | Deprecated, contents unknown |
-| 14   | Cancelled Queued Transfer                  | Deprecated, contents unknown |
+| 10   | Room Invitation                            | Obsolete, contents unknown |
+| 14   | Cancelled Queued Transfer                  | Obsolete, contents unknown |
 | 15   | [User Info Request](#peer-code-15)         |            |
 | 16   | [User Info Reply](#peer-code-16)           |            |
-| 33   | Send Connect Token                         | Deprecated, contents unknown |
-| 34   | Move Download To Top                       | Deprecated, contents unknown |
+| 33   | Send Connect Token                         | Obsolete, contents unknown |
+| 34   | Move Download To Top                       | Obsolete, contents unknown |
 | 36   | [Folder Contents Request](#peer-code-36)   |            |
 | 37   | [Folder Contents Reply](#peer-code-37)     |            |
 | 40   | [Transfer Request](#peer-code-40)          |            |
@@ -2623,9 +2623,9 @@ In Nicotine, these messages are matched to their message number in slskproto.py 
 | 43   | [Queue Upload](#peer-code-43)              |            |
 | 44   | [Place In Queue Reply](#peer-code-44)      |            |
 | 46   | [Upload Failed](#peer-code-46)             |            |
-| 47   | Exact File Search Request                  | Deprecated, contents unknown |
-| 48   | Queued Downloads                           | Deprecated, contents unknown |
-| 49   | Indirect File Search Request               | Deprecated, contents unknown |
+| 47   | Exact File Search Request                  | Obsolete, contents unknown |
+| 48   | Queued Downloads                           | Obsolete, contents unknown |
+| 49   | Indirect File Search Request               | Obsolete, contents unknown |
 | 50   | [Upload Denied](#peer-code-50)             |            |
 | 51   | [Place In Queue Request](#peer-code-51)    |            |
 | 52   | [Upload Queue Notification](#peer-code-52) | Deprecated |

--- a/doc/SLSKPROTOCOL.md
+++ b/doc/SLSKPROTOCOL.md
@@ -2602,12 +2602,17 @@ In Nicotine, these messages are matched to their message number in slskproto.py 
 
 | Code | Message                                    | Status     |
 | ---- | ------------------------------------------ | ---------- |
+| 1    | Private Message                            | Deprecated, contents unknown |
 | 4    | [Shares Request](#peer-code-4)             |            |
 | 5    | [Shares Reply](#peer-code-5)               |            |
 | 8    | [Search Request](#peer-code-8)             | Obsolete   |
 | 9    | [Search Reply](#peer-code-9)               |            |
+| 10   | Private Room Invitation                    | Deprecated, contents unknown |
+| 14   | Cancelled Queued Transfer                  | Deprecated, contents unknown |
 | 15   | [User Info Request](#peer-code-15)         |            |
 | 16   | [User Info Reply](#peer-code-16)           |            |
+| 33   | Send Connect Token                         | Deprecated, contents unknown |
+| 34   | Move Download To Top                       | Deprecated, contents unknown |
 | 36   | [Folder Contents Request](#peer-code-36)   |            |
 | 37   | [Folder Contents Reply](#peer-code-37)     |            |
 | 40   | [Transfer Request](#peer-code-40)          |            |
@@ -2618,6 +2623,9 @@ In Nicotine, these messages are matched to their message number in slskproto.py 
 | 43   | [Queue Upload](#peer-code-43)              |            |
 | 44   | [Place In Queue Reply](#peer-code-44)      |            |
 | 46   | [Upload Failed](#peer-code-46)             |            |
+| 47   | Exact File Search Request                  | Deprecated, contents unknown |
+| 48   | Queued Downloads                           | Deprecated, contents unknown |
+| 49   | Indirect File Search Request               | Deprecated, contents unknown |
 | 50   | [Upload Denied](#peer-code-50)             |            |
 | 51   | [Place In Queue Request](#peer-code-51)    |            |
 | 52   | [Upload Queue Notification](#peer-code-52) | Deprecated |


### PR DESCRIPTION
I was doing some experimentation today and found that Soulseek Qt logged a name for these codes, as opposed to "unknown" for everything else.  I don't have any further information about them.  I suspect they've all been deprecated for quite some time since this is the first I've heard of them.

Qt didn't respond to any of these, including `Queued Downloads`, which seems like it would be a code-only message, presumably one that would return a list of files queued for uploading on the other end.