### PR TITLE
Add basic tests for get_upload_candidate

### DIFF
--- a/pynicotine/transfers.py
+++ b/pynicotine/transfers.py
@@ -2088,7 +2088,7 @@ class Transfers:
         round_robin_queue = not self.config.sections["transfers"]["fifoqueue"]
         privileged_queue = False
 
-        queued_transfers = OrderedDict()
+        first_queued_transfers = OrderedDict()
         queued_users = {}
         uploading_users = set()
 
@@ -2096,11 +2096,8 @@ class Transfers:
             if i.status == "Queued":
                 user = i.user
 
-                if user not in uploading_users:
-                    if user not in queued_transfers:
-                        queued_transfers[user] = []
-
-                    queued_transfers[user].append(i)
+                if user not in first_queued_transfers and user not in uploading_users:
+                    first_queued_transfers[user] = i
 
                 if user in queued_users:
                     continue
@@ -2117,19 +2114,23 @@ class Transfers:
 
                 uploading_users.add(user)
 
-                if user in queued_transfers:
-                    del queued_transfers[user]
+                if user in first_queued_transfers:
+                    del first_queued_transfers[user]
 
         oldest_time = None
         target_user = None
 
         if not round_robin_queue:
-            for user in queued_transfers:
+            # skip the looping below (except the cleanup) and get the first
+            # user of the highest priority we saw above
+            for user in first_queued_transfers:
                 if not privileged_queue or (privileged_queue and queued_users[user]):
                     target_user = user
                     break
 
         for user, update_time in list(self.user_update_times.items()):
+            # some cleanup, should probably log a warning as this case is
+            # probably a logic bug
             if user not in queued_users:
                 del self.user_update_times[user]
                 continue
@@ -2148,12 +2149,7 @@ class Transfers:
         if not target_user:
             return None
 
-        queued_transfers = queued_transfers[target_user]
-
-        if not queued_transfers:
-            return None
-
-        return queued_transfers[0]
+        return first_queued_transfers[target_user]
 
     def check_upload_queue(self):
         """ Find next file to upload """

--- a/pynicotine/transfers.py
+++ b/pynicotine/transfers.py
@@ -2124,9 +2124,11 @@ class Transfers:
             # skip the looping below (except the cleanup) and get the first
             # user of the highest priority we saw above
             for user in first_queued_transfers:
-                if not privileged_queue or (privileged_queue and queued_users[user]):
-                    target_user = user
-                    break
+                if privileged_queue and not queued_users[user]:
+                    continue
+
+                target_user = user
+                break
 
         for user, update_time in list(self.user_update_times.items()):
             # some cleanup, should probably log a warning as this case is
@@ -2138,13 +2140,15 @@ class Transfers:
             if not round_robin_queue or user in uploading_users:
                 continue
 
-            if not privileged_queue or (privileged_queue and queued_users[user]):
-                if not oldest_time:
-                    oldest_time = update_time + 1
+            if privileged_queue and not queued_users[user]:
+                continue
 
-                if update_time < oldest_time:
-                    target_user = user
-                    oldest_time = update_time
+            if not oldest_time:
+                oldest_time = update_time + 1
+
+            if update_time < oldest_time:
+                target_user = user
+                oldest_time = update_time
 
         if not target_user:
             return None

--- a/pynicotine/transfers.py
+++ b/pynicotine/transfers.py
@@ -1436,7 +1436,6 @@ class Transfers:
             self.downloadsview.update(i)
 
         elif transfer_type == "upload":
-            self.user_update_times[i.user] = time.time()
 
             if auto_clear and self.auto_clear_upload(i):
                 # Upload cleared
@@ -2289,6 +2288,7 @@ class Transfers:
             self.close_file(transfer.file, transfer)
 
             if transfer in self.uploads:
+                self.user_update_times[transfer.user] = time.time()
                 self.check_upload_queue()
                 log.add_upload(
                     _("Upload aborted, user %(user)s file %(file)s"), {

--- a/test/unit/transfers/test_get_upload_candidate.py
+++ b/test/unit/transfers/test_get_upload_candidate.py
@@ -194,6 +194,36 @@ class GetCandidateTest(unittest.TestCase):
             round_robin=True,
         )
 
+    def test_round_robin_returning_user(self):
+        self.base_test(
+            queued=[
+                "user1",
+                "user1",
+                "user2",
+                "user2",
+                "user2",
+                "user3",
+                "user3",
+                "user3",
+                "user1",
+                "user1",
+            ],
+            in_progress=[],
+            expected=[
+                "user1",
+                "user2",
+                "user3",
+                "user1",
+                "user2",
+                "user3",
+                "user1",
+                "user2",
+                "user3",
+                "user1",
+            ],
+            round_robin=True,
+        )
+
     def test_round_robin_in_progress(self):
         self.base_test(
             queued=[
@@ -265,6 +295,35 @@ class GetCandidateTest(unittest.TestCase):
             expected=[
                 "user1",
                 None,
+                "user1",
+            ],
+        )
+
+    def test_fifo_returning_user(self):
+        self.base_test(
+            queued=[
+                "user1",
+                "user1",
+                "user2",
+                "user2",
+                "user2",
+                "user3",
+                "user3",
+                "user3",
+                "user1",
+                "user1",
+            ],
+            in_progress=[],
+            expected=[
+                "user1",
+                "user2",
+                "user1",
+                "user2",
+                "user3",
+                "user2",
+                "user3",
+                "user1",
+                "user3",
                 "user1",
             ],
         )

--- a/test/unit/transfers/test_get_upload_candidate.py
+++ b/test/unit/transfers/test_get_upload_candidate.py
@@ -1,0 +1,307 @@
+# COPYRIGHT (C) 2022 Nicotine+ Team
+#
+# GNU GENERAL PUBLIC LICENSE
+#    Version 3, 29 June 2007
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import os
+import time
+import unittest
+
+from collections import deque
+from unittest.mock import Mock
+
+from pynicotine.config import config
+from pynicotine.transfers import Transfers, Transfer
+
+
+class GetCandidateTest(unittest.TestCase):
+
+    def setUp(self):
+
+        config.data_dir = os.path.dirname(os.path.realpath(__file__))
+        config.filename = os.path.join(config.data_dir, "temp_config")
+
+        config.load_config()
+
+        self.transfers = Transfers(Mock(), config, deque(), Mock())
+
+        self.transfers.privileged_users = {
+            "puser1",
+            "puser2",
+        }
+        self.transfers.config.sections["transfers"]["fifoqueue"] = False
+
+    def set_in_progress(self, transfer):
+        # Not sure in what situation one, some or all of the
+        # following would be set. But the code checks for all of
+        # them.
+        transfer.status = "Getting status"
+        transfer.req = len(self.transfers.uploads)
+        # The upload_finished() code likes having a real connection here and I
+        # don't feel like mocking a real one
+        # transfer.conn = "dummy connection"
+
+    def add_transfers(self, users, in_progress=False):
+        new = []
+        if isinstance(users, str):
+            users = [users]
+        for user in users:
+            fname = "{}/{}".format(user, len(self.transfers.uploads))
+            transfer = Transfer(
+                user=user,
+                path=fname,
+                status="Queued",
+            )
+            if in_progress is True:
+                self.set_in_progress(transfer)
+            new.append(transfer)
+            self.transfers._append_upload(  # pylint: disable=protected-access
+                user,
+                fname,
+                new[-1],
+            )
+        return new
+
+    def add_queued(self, users):
+        return self.add_transfers(users, in_progress=False)
+
+    def add_in_progress(self, users):
+        return self.add_transfers(users, in_progress=True)
+
+    def consume_transfers(self, queued, in_progress, debug=False):
+        """Call self.transfers.get_upload_candidate until no uploads are left.
+
+        Transfers should be added to self.transfers in the desired starting
+        states already.
+
+        One in progress upload will be removed each time get_upload_candidate
+        is called.
+
+        `queued` and `in_progress` should contain the transfers in those
+        states. (They could be inferred from iterating over
+        self.transfers.uploads in this method but I don't want to have yet
+        another place where the state of a transfer is inferred based on
+        several pieces of information. Possibly those checks should be pulled
+        into methods on the transfer object itself. There is a Transferring
+        status but it isn't asserted on everywhere, in particular
+        get_upload_candidate doesn't look at it.)
+
+        All candidates received are returned in a list.
+        """
+        candidates = []
+        none_count = 0  # prevent infinite loop in case of bug or bad test setup
+        num_allowed_nones = 2
+        while len(self.transfers.uploads) > 0 and none_count < num_allowed_nones:
+
+            candidate = self.transfers.get_upload_candidate()
+
+            # "finish" one in progress transfer, if any
+            if in_progress:
+                finished = in_progress.pop(0)
+                # this might work too but maybe too much to mock?
+                # self.transfers.upload_finished(finished)
+                finished.status = "Finished"
+                self.transfers.user_update_times[finished.user] = time.time()
+                self.transfers.uploads.remove(finished)
+
+            if not candidate:
+                none_count += 1
+                if debug:
+                    print("none_count: {}".format(none_count))
+                    if queued:
+                        print("found no candidates out of {} queued uploads".format(len(queued)))
+                candidates.append(None)
+                continue
+
+            none_count = 0
+            if debug:
+                print("candidate: {}".format(candidate.user))
+
+            candidates.append(candidate)
+            queued.remove(candidate)
+            self.set_in_progress(candidate)
+            in_progress.append(candidate)
+
+        # strip pointless retry markers from the end if we never succeeded
+        while candidates[-1] is None:
+            candidates.pop()
+        return candidates
+
+    def base_test(
+        self, queued, in_progress, expected, round_robin=False, debug=False,
+    ):
+        self.transfers.config.sections["transfers"]["fifoqueue"] = not round_robin
+        queued_transfers = self.add_queued(queued)
+        in_progress_transfers = self.add_in_progress(in_progress)
+
+        candidates = self.consume_transfers(queued_transfers, in_progress_transfers, debug=debug)
+
+        users = [transfer.user if transfer else None for transfer in candidates]
+        # `expected` should contain `None` in cases where there aren't
+        # expected to be any queued users without existing in progress uploads
+        self.assertEqual(
+            users,
+            expected,
+        )
+
+    def test_round_robin_basic(self):
+        self.base_test(
+            queued=[
+                "user1",
+                "user1",
+                "user2",
+                "user2",
+                "user3",
+                "user3",
+            ],
+            in_progress=[],
+            expected=[
+                "user1",
+                "user2",
+                "user3",
+                "user1",
+                "user2",
+                "user3",
+            ],
+            round_robin=True,
+        )
+
+    def test_round_robin_one_user(self):
+        self.base_test(
+            queued=[
+                "user1",
+                "user1",
+            ],
+            in_progress=[],
+            expected=[
+                "user1",
+                None,
+                "user1",
+            ],
+            round_robin=True,
+        )
+
+    def test_round_robin_in_progress(self):
+        self.base_test(
+            queued=[
+                "user1",
+                "user1",
+                "user2",
+                "user2",
+            ],
+            in_progress=[
+                "user1",
+            ],
+            expected=[
+                "user2",
+                "user1",
+                "user2",
+                "user1",
+            ],
+            round_robin=True,
+        )
+
+    def test_round_robin_privileged(self):
+        self.base_test(
+            queued=[
+                "user1",
+                "user2",
+                "puser1",
+                "puser1",
+            ],
+            in_progress=[],
+            expected=[
+                "puser1",
+                None,
+                "puser1",
+                "user1",
+                "user2",
+            ],
+            round_robin=True,
+        )
+
+    def test_fifo_basic(self):
+        self.base_test(
+            queued=[
+                "user1",
+                "user1",
+                "user2",
+                "user2",
+                "user3",
+                "user3",
+            ],
+            in_progress=[],
+            expected=[
+                "user1",
+                "user2",
+                "user1",
+                "user2",
+                "user3",
+                None,
+                "user3",
+            ],
+        )
+
+    def test_fifo_one_user(self):
+        self.base_test(
+            queued=[
+                "user1",
+                "user1",
+            ],
+            in_progress=[],
+            expected=[
+                "user1",
+                None,
+                "user1",
+            ],
+        )
+
+    def test_fifo_in_progress(self):
+        self.base_test(
+            queued=[
+                "user1",
+                "user1",
+                "user2",
+                "user2",
+            ],
+            in_progress=[
+                "user1",
+            ],
+            expected=[
+                "user2",
+                "user1",
+                "user2",
+                "user1",
+            ],
+        )
+
+    def test_fifo_privileged(self):
+        self.base_test(
+            queued=[
+                "user1",
+                "user2",
+                "puser1",
+                "puser1",
+            ],
+            in_progress=[],
+            expected=[
+                "puser1",
+                None,
+                "puser1",
+                "user1",
+                "user2",
+            ],
+        )

--- a/test/unit/transfers/test_get_upload_candidate.py
+++ b/test/unit/transfers/test_get_upload_candidate.py
@@ -21,12 +21,25 @@ import time
 import unittest
 
 from collections import deque
-from unittest.mock import Mock
+from unittest.mock import Mock, patch
 
 from pynicotine.config import config
 from pynicotine.transfers import Transfers, Transfer
 
 
+# Make sure time.time() always monotonically increases between calls.
+# In MSYS2/Ming64 time.time() in python seems to return the same value if you
+# call it quickly.
+_TIME = 0
+
+
+def _time_counter():
+    global _TIME  # pylint: disable=global-statement
+    _TIME += 1
+    return _TIME
+
+
+@patch("pynicotine.transfers.time.time", new=_time_counter)
 class GetCandidateTest(unittest.TestCase):
 
     def setUp(self):


### PR DESCRIPTION
Add basic tests for get_upload_candidate, and some tidy up.

"basic" in particular because round robin mode has some dependency on `user_update_times` which these tests aren't doing anything with. And that is updated when connections are closed and file transfers are denied or time out which are a bit out of scope of this test.
The test setup and helpers are a bit verbose, I think that is because transfers.py is not written to be particularly testable. Might just be because I ran out of brain power. Hopefully the tests themselves are clear enough though so you only have to read through that stuff once.