### PR TITLE
Move all protocol-related code to slskproto.py

### DIFF
--- a/pynicotine/gtkgui/dialogs/preferences.py
+++ b/pynicotine/gtkgui/dialogs/preferences.py
@@ -3088,7 +3088,7 @@ class Preferences(UserInterface):
             self.frame.connect_action.set_enabled(False)
             self.frame.on_fast_configure()
 
-        elif not self.frame.np.protothread.server_socket:
+        elif self.frame.np.protothread.server_disconnected:
             self.frame.connect_action.set_enabled(True)
 
         if not settings_closed:

--- a/pynicotine/gtkgui/dialogs/preferences.py
+++ b/pynicotine/gtkgui/dialogs/preferences.py
@@ -3088,7 +3088,7 @@ class Preferences(UserInterface):
             self.frame.connect_action.set_enabled(False)
             self.frame.on_fast_configure()
 
-        elif not self.frame.np.server_conn:
+        elif not self.frame.np.protothread.server_socket:
             self.frame.connect_action.set_enabled(True)
 
         if not settings_closed:

--- a/pynicotine/gtkgui/privatechat.py
+++ b/pynicotine/gtkgui/privatechat.py
@@ -190,8 +190,8 @@ class PrivateChat(UserInterface):
         self.offlinemessage = False
         self.status = 0
 
-        if user in self.frame.np.users:
-            self.status = self.frame.np.users[user].status or 0
+        if user in self.frame.np.user_statuses:
+            self.status = self.frame.np.user_statuses[user] or 0
 
         # Text Search
         TextSearchBar(self.ChatScroll, self.SearchBar, self.SearchEntry,

--- a/pynicotine/gtkgui/widgets/iconnotebook.py
+++ b/pynicotine/gtkgui/widgets/iconnotebook.py
@@ -341,8 +341,8 @@ class IconNotebook:
         if user is not None:
             status = 0
 
-            if user in self.frame.np.users:
-                status = self.frame.np.users[user].status or 0
+            if user in self.frame.np.user_statuses:
+                status = self.frame.np.user_statuses[user] or 0
 
             self.set_user_status(page, text, status)
 

--- a/pynicotine/plugins/examplars/port_checker/__init__.py
+++ b/pynicotine/plugins/examplars/port_checker/__init__.py
@@ -75,8 +75,10 @@ class Plugin(BasePlugin):
 
     def resolve(self, user, announce):
 
-        if user in self.core.users and isinstance(self.core.users[user].addr, tuple):
-            ip_address, port = self.core.users[user].addr
+        user_address = self.core.protothread.user_addresses.get(user)
+
+        if user_address is not None:
+            ip_address, port = user_address
             threading.Thread(target=self.check_port, args=(user, ip_address, port, announce)).start()
         else:
             self.pending_user = user, announce

--- a/pynicotine/pluginsystem.py
+++ b/pynicotine/pluginsystem.py
@@ -559,7 +559,7 @@ class ResponseThrottle:
 
         port = False
         try:
-            _ip_address, port = self.core.users[nick].addr
+            _ip_address, port = self.core.protothread.user_addresses[nick]
         except Exception:
             port = True
 

--- a/pynicotine/privatechat.py
+++ b/pynicotine/privatechat.py
@@ -187,8 +187,10 @@ class PrivateChats:
             if self.core.network_filter.is_user_ignored(msg.user):
                 return
 
-            if msg.user in self.core.users and isinstance(self.core.users[msg.user].addr, tuple):
-                ip_address, _port = self.core.users[msg.user].addr
+            user_address = self.core.protothread.user_addresses.get(msg.user)
+
+            if user_address is not None:
+                ip_address, _port = user_address
                 if self.core.network_filter.is_ip_ignored(ip_address):
                     return
 

--- a/pynicotine/pynicotine.py
+++ b/pynicotine/pynicotine.py
@@ -475,8 +475,10 @@ class NicotineCore:
 
         if msg.sock == self.parent_socket:
             self.send_have_no_parent()
+            return
 
-        self.transfers.conn_close(msg.sock)
+        if msg.conn_type == 'F':
+            self.transfers.conn_close(msg.sock)
 
     def start_upnp_timer(self):
         """ Port mapping entries last 24 hours, we need to regularly renew them.

--- a/pynicotine/pynicotine.py
+++ b/pynicotine/pynicotine.py
@@ -449,14 +449,6 @@ class NicotineCore:
 
     def server_disconnect(self, *_args):
 
-        host, port = self.protothread.server_address
-
-        log.add(
-            _("Disconnected from server %(host)s:%(port)s"), {
-                'host': host,
-                'port': port
-            })
-
         self.logged_in = False
 
         # Clean up connections

--- a/pynicotine/search.py
+++ b/pynicotine/search.py
@@ -330,12 +330,11 @@ class Search:
         if search is None or search["ignore"]:
             return
 
-        conn = msg.conn
-        username = conn.init.target_user
-        addr = conn.addr
+        username = msg.init.target_user
+        ip_address = msg.init.addr[0]
 
-        if addr:
-            country = self.geoip.get_country_code(addr[0])
+        if ip_address:
+            country = self.geoip.get_country_code(ip_address)
         else:
             country = ""
 

--- a/pynicotine/slskmessages.py
+++ b/pynicotine/slskmessages.py
@@ -57,7 +57,9 @@ class ServerConnect(InternalMessage):
 
 
 class ServerDisconnect(InternalMessage):
-    pass
+
+    def __init__(self, manual_disconnect=False):
+        self.manual_disconnect = manual_disconnect
 
 
 class ServerTimeout(InternalMessage):

--- a/pynicotine/slskmessages.py
+++ b/pynicotine/slskmessages.py
@@ -48,12 +48,20 @@ class InternalMessage:
     pass
 
 
-class InitServerConn(InternalMessage):
+class ServerConnect(InternalMessage):
     """ NicotineCore sends this to make networking thread establish a server connection. """
 
     def __init__(self, addr=None, login=None):
         self.addr = addr
         self.login = login
+
+
+class ServerDisconnect(InternalMessage):
+    pass
+
+
+class ServerTimeout(InternalMessage):
+    pass
 
 
 class InitPeerConn(InternalMessage):
@@ -65,19 +73,13 @@ class InitPeerConn(InternalMessage):
         self.init = init
 
 
-class ServerTimeout:
-    pass
-
-
 class ConnClose(InternalMessage):
     """ Sent by networking thread to indicate a connection has been closed."""
 
-    __slots__ = ("conn", "addr", "callback")
+    __slots__ = ("sock",)
 
-    def __init__(self, conn=None, addr=None, callback=True):
-        self.conn = conn
-        self.addr = addr
-        self.callback = callback
+    def __init__(self, sock=None):
+        self.sock = sock
 
 
 class ConnCloseIP(InternalMessage):
@@ -104,14 +106,6 @@ class ShowConnectionErrorMessage(InternalMessage):
         self.msgs = msgs
 
 
-class ConnectToPeerTimeout:
-
-    __slots__ = ("conn",)
-
-    def __init__(self, conn):
-        self.conn = conn
-
-
 class MessageProgress(InternalMessage):
     """ Used to indicate progress of long transfers. """
 
@@ -124,7 +118,7 @@ class MessageProgress(InternalMessage):
         self.total = total
 
 
-class TransferTimeout:
+class TransferTimeout(InternalMessage):
 
     __slots__ = ("transfer",)
 
@@ -146,19 +140,19 @@ class DownloadFile(InternalMessage):
     """ Sent by networking thread to indicate file transfer progress.
     Sent by UI to pass the file object to write. """
 
-    __slots__ = ("conn", "file")
+    __slots__ = ("sock", "file")
 
-    def __init__(self, conn=None, file=None):
-        self.conn = conn
+    def __init__(self, sock=None, file=None):
+        self.sock = sock
         self.file = file
 
 
 class UploadFile(InternalMessage):
 
-    __slots__ = ("conn", "file", "size", "sentbytes", "offset")
+    __slots__ = ("sock", "file", "size", "sentbytes", "offset")
 
-    def __init__(self, conn=None, file=None, size=None, sentbytes=0, offset=None):
-        self.conn = conn
+    def __init__(self, sock=None, file=None, size=None, sentbytes=0, offset=None):
+        self.sock = sock
         self.file = file
         self.size = size
         self.sentbytes = sentbytes
@@ -169,10 +163,10 @@ class FileError(InternalMessage):
     """ Sent by networking thread to indicate that a file error occurred during
     filetransfer. """
 
-    __slots__ = ("conn", "file", "strerror")
+    __slots__ = ("sock", "file", "strerror")
 
-    def __init__(self, conn=None, file=None, strerror=None):
-        self.conn = conn
+    def __init__(self, sock=None, file=None, strerror=None):
+        self.sock = sock
         self.file = file
         self.strerror = strerror
 
@@ -2100,8 +2094,8 @@ class PierceFireWall(PeerInitMessage):
     connection, if it has been asked by the other peer to do so. The token
     is taken from the ConnectToPeer server message. """
 
-    def __init__(self, conn=None, token=None):
-        self.conn = conn
+    def __init__(self, sock=None, token=None):
+        self.sock = sock
         self.token = token
 
     def make_network_message(self):
@@ -2120,8 +2114,11 @@ class PeerInit(PeerInitMessage):
     can be anything. Type is 'P' if it's anything but filetransfer,
     'F' otherwise. """
 
-    def __init__(self, conn=None, init_user=None, target_user=None, conn_type=None, token=0):
-        self.conn = conn
+    __slots__ = ("sock", "addr", "init_user", "target_user", "conn_type", "token")
+
+    def __init__(self, sock=None, addr=None, init_user=None, target_user=None, conn_type=None, token=0):
+        self.sock = sock
+        self.addr = addr
         self.init_user = init_user      # username of peer who initiated the message
         self.target_user = target_user  # username of peer we're connected to
         self.conn_type = conn_type
@@ -2174,8 +2171,8 @@ class GetSharedFileList(PeerMessage):
     """ Peer code: 4 """
     """ We send this to a peer to ask for a list of shared files. """
 
-    def __init__(self, conn):
-        self.conn = conn
+    def __init__(self, init):
+        self.init = init
 
     def make_network_message(self):
         return b""
@@ -2190,8 +2187,8 @@ class SharedFileList(PeerMessage):
     """ A peer responds with a list of shared files when we've sent
     a GetSharedFileList. """
 
-    def __init__(self, conn, shares=None):
-        self.conn = conn
+    def __init__(self, init, shares=None):
+        self.init = init
         self.list = shares
         self.unknown = 0
         self.privatelist = []
@@ -2293,8 +2290,8 @@ class FileSearchRequest(PeerMessage):
     searching for a file. """
     """ OBSOLETE, use UserSearch server message """
 
-    def __init__(self, conn, requestid=None, text=None):
-        self.conn = conn
+    def __init__(self, init, requestid=None, text=None):
+        self.init = init
         self.requestid = requestid
         self.text = text
         self.searchid = None
@@ -2318,12 +2315,12 @@ class FileSearchResult(PeerMessage):
     token/ticket is taken from original FileSearch, UserSearch or
     RoomSearch message. """
 
-    __slots__ = ("conn", "user", "geoip", "token", "list", "privatelist", "freeulslots",
+    __slots__ = ("init", "user", "token", "list", "privatelist", "freeulslots",
                  "ulspeed", "inqueue", "fifoqueue")
 
-    def __init__(self, conn=None, user=None, token=None, shares=None, freeulslots=None,
+    def __init__(self, init=None, user=None, token=None, shares=None, freeulslots=None,
                  ulspeed=None, inqueue=None, fifoqueue=None):
-        self.conn = conn
+        self.init = init
         self.user = user
         self.token = token
         self.list = shares
@@ -2434,8 +2431,8 @@ class UserInfoRequest(PeerMessage):
     """ We ask the other peer to send us their user information, picture
     and all."""
 
-    def __init__(self, conn):
-        self.conn = conn
+    def __init__(self, init):
+        self.init = init
 
     def make_network_message(self):
         return b""
@@ -2449,8 +2446,8 @@ class UserInfoReply(PeerMessage):
     """ Peer code: 16 """
     """ A peer responds with this when we've sent a UserInfoRequest. """
 
-    def __init__(self, conn, descr=None, pic=None, totalupl=None, queuesize=None, slotsavail=None, uploadallowed=None):
-        self.conn = conn
+    def __init__(self, init, descr=None, pic=None, totalupl=None, queuesize=None, slotsavail=None, uploadallowed=None):
+        self.init = init
         self.descr = descr
         self.pic = pic
         self.totalupl = totalupl
@@ -2499,8 +2496,8 @@ class PMessageUser(PeerMessage):
     This is a Nicotine+ extension to the Soulseek protocol. """
     """ DEPRECATED """
 
-    def __init__(self, conn=None, user=None, msg=None):
-        self.conn = conn
+    def __init__(self, init=None, user=None, msg=None):
+        self.init = init
         self.user = user
         self.msg = msg
         self.msgid = None
@@ -2526,8 +2523,8 @@ class FolderContentsRequest(PeerMessage):
     """ Peer code: 36 """
     """ We ask the peer to send us the contents of a single folder. """
 
-    def __init__(self, conn, directory=None):
-        self.conn = conn
+    def __init__(self, init, directory=None):
+        self.init = init
         self.dir = directory
         self.something = None
 
@@ -2548,8 +2545,8 @@ class FolderContentsResponse(PeerMessage):
     """ A peer responds with the contents of a particular folder
     (with all subfolders) when we've sent a FolderContentsRequest. """
 
-    def __init__(self, conn, directory=None, shares=None):
-        self.conn = conn
+    def __init__(self, init, directory=None, shares=None):
+        self.init = init
         self.dir = directory
         self.list = shares
 
@@ -2626,8 +2623,8 @@ class TransferRequest(PeerMessage):
     but Nicotine+, Museek+ and the official clients use the QueueUpload message for
     this purpose today. """
 
-    def __init__(self, conn, direction=None, token=None, file=None, filesize=None, realfile=None):
-        self.conn = conn
+    def __init__(self, init, direction=None, token=None, file=None, filesize=None, realfile=None):
+        self.init = init
         self.direction = direction
         self.token = token
         self.file = file  # virtual file
@@ -2659,8 +2656,8 @@ class TransferResponse(PeerMessage):
     """ Response to TransferRequest - either we (or the other peer) agrees,
     or tells the reason for rejecting the file transfer. """
 
-    def __init__(self, conn, allowed=None, reason=None, token=None, filesize=None):
-        self.conn = conn
+    def __init__(self, init, allowed=None, reason=None, token=None, filesize=None):
+        self.init = init
         self.allowed = allowed
         self.token = token
         self.reason = reason
@@ -2694,8 +2691,8 @@ class PlaceholdUpload(PeerMessage):
     """ Peer code: 42 """
     """ OBSOLETE, no longer used """
 
-    def __init__(self, conn, file=None):
-        self.conn = conn
+    def __init__(self, init, file=None):
+        self.init = init
         self.file = file
 
     def make_network_message(self):
@@ -2711,8 +2708,8 @@ class QueueUpload(PeerMessage):
     Once the recipient is ready to transfer the requested file, they will send an upload
     request. """
 
-    def __init__(self, conn, file=None, legacy_client=False):
-        self.conn = conn
+    def __init__(self, init, file=None, legacy_client=False):
+        self.init = init
         self.file = file
         self.legacy_client = legacy_client
 
@@ -2727,8 +2724,8 @@ class PlaceInQueue(PeerMessage):
     """ Peer code: 44 """
     """ The peer replies with the upload queue placement of the requested file. """
 
-    def __init__(self, conn, filename=None, place=None):
-        self.conn = conn
+    def __init__(self, init, filename=None, place=None):
+        self.init = init
         self.filename = filename
         self.place = place
 
@@ -2757,8 +2754,8 @@ class UploadDenied(PeerMessage):
     """ This message is sent to reject QueueUpload attempts and previously queued
     files. The reason for rejection will appear in the transfer list of the recipient. """
 
-    def __init__(self, conn, file=None, reason=None):
-        self.conn = conn
+    def __init__(self, init, file=None, reason=None):
+        self.init = init
         self.file = file
         self.reason = reason
 
@@ -2784,8 +2781,8 @@ class UploadQueueNotification(PeerMessage):
     """ This message is sent to inform a peer about an upload attempt initiated by us. """
     """ DEPRECATED, sent by Soulseek NS but not SoulseekQt """
 
-    def __init__(self, conn):
-        self.conn = conn
+    def __init__(self, init):
+        self.init = init
 
     def make_network_message(self):
         return b""
@@ -2798,8 +2795,8 @@ class UnknownPeerMessage(PeerMessage):
     """ Peer code: 12547 """
     """ UNKNOWN """
 
-    def __init__(self, conn):
-        self.conn = conn
+    def __init__(self, init):
+        self.init = init
 
     def parse_network_message(self, message):
         # Empty message
@@ -2820,8 +2817,8 @@ class FileRequest(FileMessage):
     start uploading a file. The token is the same as the one previously included
     in the TransferRequest message. """
 
-    def __init__(self, conn, token=None):
-        self.conn = conn
+    def __init__(self, init, token=None):
+        self.init = init
         self.token = token
 
     def make_network_message(self):
@@ -2837,8 +2834,8 @@ class FileOffset(FileMessage):
     to tell them how many bytes of the file we've previously downloaded. If none,
     the offset is 0. """
 
-    def __init__(self, conn, filesize=None, offset=None):
-        self.conn = conn
+    def __init__(self, init, filesize=None, offset=None):
+        self.init = init
         self.filesize = filesize
         self.offset = offset
 
@@ -2866,8 +2863,8 @@ class DistribRequest(InternalMessage):
 class DistribAlive(DistribMessage):
     """ Distrib code: 0 """
 
-    def __init__(self, conn):
-        self.conn = conn
+    def __init__(self, init):
+        self.init = init
 
     def make_network_message(self):
         return b""
@@ -2882,10 +2879,10 @@ class DistribSearch(DistribMessage):
     """ Search request that arrives through the distributed network.
     We transmit the search request to our child peers. """
 
-    __slots__ = ("unknown", "conn", "user", "searchid", "searchterm")
+    __slots__ = ("unknown", "init", "user", "searchid", "searchterm")
 
-    def __init__(self, conn):
-        self.conn = conn
+    def __init__(self, init):
+        self.init = init
         self.unknown = None
         self.user = None
         self.searchid = None
@@ -2911,8 +2908,8 @@ class DistribBranchLevel(DistribMessage):
     """ We tell our distributed children what our position is in our branch (xth
     generation) on the distributed network. """
 
-    def __init__(self, conn, value=None):
-        self.conn = conn
+    def __init__(self, init, value=None):
+        self.init = init
         self.value = value
 
     def make_network_message(self):
@@ -2930,8 +2927,8 @@ class DistribBranchRoot(DistribMessage):
     """ We tell our distributed children the username of the root of the branch
     we’re in on the distributed network. """
 
-    def __init__(self, conn, user=None):
-        self.conn = conn
+    def __init__(self, init, user=None):
+        self.init = init
         self.user = user
 
     def make_network_message(self):
@@ -2950,8 +2947,8 @@ class DistribChildDepth(DistribMessage):
     we have on the distributed network. """
     """ DEPRECATED, sent by Soulseek NS but not SoulseekQt """
 
-    def __init__(self, conn, value=None):
-        self.conn = conn
+    def __init__(self, init, value=None):
+        self.init = init
         self.value = value
 
     def make_network_message(self):
@@ -2970,10 +2967,10 @@ class DistribEmbeddedMessage(DistribMessage):
     of distributed message sent at present is DistribSearch (distributed code 3).
     We unpack the distributed message and distribute it to our child peers. """
 
-    __slots__ = ("conn", "distrib_code", "distrib_message")
+    __slots__ = ("init", "distrib_code", "distrib_message")
 
-    def __init__(self, conn, distrib_code=None, distrib_message=None):
-        self.conn = conn
+    def __init__(self, init, distrib_code=None, distrib_message=None):
+        self.init = init
         self.distrib_code = distrib_code
         self.distrib_message = distrib_message
 

--- a/pynicotine/slskmessages.py
+++ b/pynicotine/slskmessages.py
@@ -76,10 +76,11 @@ class InitPeerConn(InternalMessage):
 class ConnClose(InternalMessage):
     """ Sent by networking thread to indicate a connection has been closed."""
 
-    __slots__ = ("sock",)
+    __slots__ = ("sock", "conn_type")
 
-    def __init__(self, sock=None):
+    def __init__(self, sock=None, conn_type=None):
         self.sock = sock
+        self.conn_type = conn_type
 
 
 class ConnCloseIP(InternalMessage):

--- a/pynicotine/slskproto.py
+++ b/pynicotine/slskproto.py
@@ -46,7 +46,6 @@ from pynicotine.slskmessages import CheckPrivileges
 from pynicotine.slskmessages import ChildDepth
 from pynicotine.slskmessages import ConnClose
 from pynicotine.slskmessages import ConnCloseIP
-from pynicotine.slskmessages import ConnectError
 from pynicotine.slskmessages import ConnectToPeer
 from pynicotine.slskmessages import DistribAlive
 from pynicotine.slskmessages import DistribAliveInterval
@@ -55,6 +54,7 @@ from pynicotine.slskmessages import DistribBranchRoot
 from pynicotine.slskmessages import DistribChildDepth
 from pynicotine.slskmessages import DistribEmbeddedMessage
 from pynicotine.slskmessages import DistribMessage
+from pynicotine.slskmessages import DistribRequest
 from pynicotine.slskmessages import DistribSearch
 from pynicotine.slskmessages import DownloadFile
 from pynicotine.slskmessages import EmbeddedMessage
@@ -77,7 +77,6 @@ from pynicotine.slskmessages import GivePrivileges
 from pynicotine.slskmessages import GlobalRecommendations
 from pynicotine.slskmessages import GlobalUserList
 from pynicotine.slskmessages import HaveNoParent
-from pynicotine.slskmessages import IncConn
 from pynicotine.slskmessages import InitPeerConn
 from pynicotine.slskmessages import InitServerConn
 from pynicotine.slskmessages import ItemRecommendations
@@ -145,9 +144,11 @@ from pynicotine.slskmessages import SearchInactivityTimeout
 from pynicotine.slskmessages import SearchParent
 from pynicotine.slskmessages import SendConnectToken
 from pynicotine.slskmessages import SendDownloadSpeed
+from pynicotine.slskmessages import SendNetworkMessage
 from pynicotine.slskmessages import SendUploadSpeed
 from pynicotine.slskmessages import ServerMessage
 from pynicotine.slskmessages import ServerPing
+from pynicotine.slskmessages import ServerTimeout
 from pynicotine.slskmessages import SetCurrentConnectionCount
 from pynicotine.slskmessages import SetDownloadLimit
 from pynicotine.slskmessages import SetStatus
@@ -155,6 +156,7 @@ from pynicotine.slskmessages import SetUploadLimit
 from pynicotine.slskmessages import SetWaitPort
 from pynicotine.slskmessages import SharedFileList
 from pynicotine.slskmessages import SharedFoldersFiles
+from pynicotine.slskmessages import ShowConnectionErrorMessage
 from pynicotine.slskmessages import SimilarUsers
 from pynicotine.slskmessages import TransferRequest
 from pynicotine.slskmessages import TransferResponse
@@ -237,8 +239,7 @@ class Connection:
 
 class PeerConnection(Connection):
 
-    __slots__ = ("filereq", "filedown", "fileupl", "filereadbytes", "bytestoread", "piercefw",
-                 "lastcallback")
+    __slots__ = ("filereq", "filedown", "fileupl", "filereadbytes", "bytestoread", "piercefw", "lastcallback")
 
     def __init__(self, conn=None, addr=None, events=None, init=None):
         Connection.__init__(self, conn, addr, events)
@@ -249,20 +250,20 @@ class PeerConnection(Connection):
         self.bytestoread = 0
         self.init = init
         self.piercefw = None
-        self.lastactive = time.time()
         self.lastcallback = time.time()
 
 
 class PeerConnectionInProgress:
     """ As all p2p connect()s are non-blocking, this class is used to
-    hold data about a connection that is not yet established. msgObj is
-    a message to be sent after the connection has been established.
-    """
-    __slots__ = ("conn", "msg_obj", "lastactive")
+    hold data about a connection that is not yet established """
 
-    def __init__(self, conn=None, msg_obj=None):
+    __slots__ = ("conn", "addr", "lastactive", "init", "login")
+
+    def __init__(self, conn=None, addr=None, init=None, login=None):
         self.conn = conn
-        self.msg_obj = msg_obj
+        self.addr = addr
+        self.init = init
+        self.login = login
         self.lastactive = time.time()
 
 
@@ -430,6 +431,7 @@ class SlskProtoThread(threading.Thread):
         self._core_callback = core_callback
         self._queue = queue
         self._callback_msgs = []
+        self._init_msgs = {}
         self._want_abort = False
         self.server_disconnected = True
         self.bindip = bindip
@@ -463,10 +465,19 @@ class SlskProtoThread(threading.Thread):
         self.listen_socket.setblocking(0)
 
         self.server_socket = None
+        self.server_address = None
+        self.server_timer = None
+        self.server_timeout_value = -1
+
         self._numsockets = 1
 
         self._conns = {}
         self._connsinprogress = {}
+        self._out_indirect_conn_request_times = {}
+        self._token = 100
+        self.exit = threading.Event()
+        self.user_addresses = {}
+
         self._calc_upload_limit_function = self._calc_upload_limit_none
         self._upload_limit = 0
         self._download_limit = 0
@@ -572,11 +583,19 @@ class SlskProtoThread(threading.Thread):
         """ We've connected to the server """
         self.server_disconnected = False
 
+        if self.server_timer is not None:
+            self.server_timer.cancel()
+            self.server_timer = None
+
     def server_disconnect(self):
         """ We've disconnected from the server, clean up """
 
         self.server_disconnected = True
         self.server_socket = None
+
+        if self.server_timer is not None:
+            self.server_timer.cancel()
+            self.server_timer = None
 
         for connection in self._conns.copy():
             self.close_connection(self._conns, connection)
@@ -585,6 +604,11 @@ class SlskProtoThread(threading.Thread):
             self.close_connection(self._connsinprogress, connection)
 
         self._queue.clear()
+        self._init_msgs.clear()
+
+        # Inform threads we've disconnected
+        self.exit.set()
+        self._out_indirect_conn_request_times.clear()
 
         if not self._want_abort:
             self._callback_msgs.append(SetCurrentConnectionCount(0))
@@ -665,6 +689,53 @@ class SlskProtoThread(threading.Thread):
 
     """ Connections """
 
+    def _check_indirect_connection_timeouts(self):
+
+        while True:
+            curtime = time.time()
+
+            if self._out_indirect_conn_request_times:
+                for init, request_time in list(self._out_indirect_conn_request_times.items()):
+                    username = init.target_user
+                    conn_type = init.conn_type
+
+                    if (curtime - request_time) >= 20:
+                        log.add_conn(("Indirect connect request of type %(type)s to user %(user)s with "
+                                      "token %(token)s expired, giving up"), {
+                            'type': conn_type,
+                            'user': username,
+                            'token': init.token
+                        })
+
+                        self._callback_msgs.append(ShowConnectionErrorMessage(username, list(init.outgoing_msgs)))
+
+                        self._init_msgs.pop(init.token, None)
+                        init.outgoing_msgs.clear()
+                        del self._out_indirect_conn_request_times[init]
+
+            if self.exit.wait(1):
+                # Event set, we're exiting
+                return
+
+    def server_timeout(self):
+        self._core_callback([ServerTimeout()])
+
+    def set_server_timer(self):
+
+        if self.server_timeout_value == -1:
+            self.server_timeout_value = 15
+
+        elif 0 < self.server_timeout_value < 600:
+            self.server_timeout_value = self.server_timeout_value * 2
+
+        self.server_timer = threading.Timer(self.server_timeout_value, self.server_timeout)
+        self.server_timer.name = "ServerTimer"
+        self.server_timer.daemon = True
+        self.server_timer.start()
+
+        log.add(_("The server seems to be down or not responding, retrying in %i seconds"),
+                self.server_timeout_value)
+
     def socket_still_active(self, conn):
 
         try:
@@ -714,6 +785,168 @@ class SlskProtoThread(threading.Thread):
             self.selector.modify(conn_obj.conn, events)
             conn_obj.events = events
 
+    def process_conn_messages(self, init):
+        """ A connection is established with the peer, time to queue up our peer
+        messages for delivery """
+
+        username = init.target_user
+        msgs = init.outgoing_msgs
+
+        if msgs is None:
+            return
+
+        log.add_conn("List of outgoing messages for user %(user)s: %(messages)s", {
+                     'user': username,
+                     'messages': msgs})
+
+        for j in msgs:
+            j.conn = init.conn
+            self._queue.append(j)
+
+        msgs.clear()
+
+    def send_message_to_peer(self, user, message, login, address=None):
+        """ Sends message to a peer. Used primarily when we know the username of a peer,
+        but don't have an active connection. """
+
+        init = None
+
+        if message.__class__ is FileRequest:
+            conn_type = 'F'
+
+        elif message.__class__ is DistribRequest:
+            conn_type = 'D'
+
+        else:
+            conn_type = 'P'
+
+        if conn_type != 'F':
+            # Check if there's already a connection object for the specified username
+
+            for _, i in self._conns.items():
+                if i.init is not None and i.init.target_user == user and i.init.conn_type == conn_type:
+                    init = i.init
+                    break
+
+            if init is None:
+                for _, i in self._connsinprogress.items():
+                    if i.init is not None and i.init.target_user == user and i.init.conn_type == conn_type:
+                        init = i.init
+                        break
+
+            if init is None:
+                for _, i in self._init_msgs.items():
+                    if i.target_user == user and i.conn_type == conn_type:
+                        init = i
+                        break
+
+        if init is not None:
+            log.add_conn("Found existing connection of type %(type)s for user %(user)s, using it.", {
+                'type': conn_type,
+                'user': user
+            })
+
+            init.outgoing_msgs.append(message)
+
+            if init.conn is not None:
+                # We have initiated a connection previously, and it's ready
+                self.process_conn_messages(init)
+
+        else:
+            # This is a new peer, initiate a connection
+            self.initiate_connection_to_peer(user, conn_type, message, login, address)
+
+        log.add_conn("Sending message of type %(type)s to user %(user)s", {
+            'type': message.__class__,
+            'user': user
+        })
+
+    def initiate_connection_to_peer(self, user, conn_type, message, login, address=None):
+        """ Prepare to initiate a connection with a peer """
+
+        init = PeerInit(init_user=login, target_user=user, conn_type=conn_type)
+        init.outgoing_msgs.append(message)
+        addr = None
+
+        if user == login:
+            # Bypass public IP address request if we connect to ourselves
+            addr = (self.bindip or '127.0.0.1', self.listenport)
+
+        elif user in self.user_addresses:
+            addr = self.user_addresses[user]
+
+        elif address is not None:
+            self.user_addresses[user] = addr = address
+
+        if addr is None:
+            self._init_msgs[user] = init
+            self._queue.append(GetPeerAddress(user))
+
+            log.add_conn("Requesting address for user %(user)s", {
+                'user': user
+            })
+
+        else:
+            self.connect_to_peer_direct(user, addr, init)
+
+    def connect_to_peer_direct(self, user, addr, init):
+        """ Initiate a connection with a peer directly """
+
+        self._queue.append(InitPeerConn(addr, init))
+
+        log.add_conn("Initialising direct connection of type %(type)s to user %(user)s", {
+            'type': init.conn_type,
+            'user': user
+        })
+
+    def connect_error(self, error, conn_obj):
+
+        if conn_obj.login:
+            log.add(
+                _("Cannot connect to server %(host)s:%(port)s: %(error)s"), {
+                    'host': conn_obj.addr[0],
+                    'port': conn_obj.addr[1],
+                    'error': error
+                }
+            )
+            self.set_server_timer()
+            return
+
+        if not conn_obj.init.token:
+            # We can't correct to peer directly, request indirect connection
+            self.connect_to_peer_indirect(conn_obj, error)
+            return
+
+        if conn_obj.init in self._out_indirect_conn_request_times:
+            return
+
+        log.add_conn(
+            "Cannot respond to indirect connection request from user %(user)s. Error: %(error)s", {
+                'user': conn_obj.init.target_user,
+                'error': error
+            })
+
+    def connect_to_peer_indirect(self, conn, error):
+        """ Send a message to the server to ask the peer to connect to us instead (indirect connection) """
+
+        self._token += 1
+
+        username = conn.init.target_user
+        conn_type = conn.init.conn_type
+        conn.init.token = self._token
+
+        self._init_msgs[self._token] = conn.init
+        self._out_indirect_conn_request_times[conn.init] = time.time()
+        self._queue.append(ConnectToPeer(self._token, username, conn_type))
+
+        log.add_conn(("Direct connection of type %(type)s to user %(user)s failed, attempting indirect "
+                      "connection with token %(token)s. Error: %(error)s"), {
+            "type": conn_type,
+            "user": username,
+            "token": self._token,
+            "error": error
+        })
+
     def close_connection(self, connection_list, connection):
 
         if connection not in connection_list:
@@ -741,6 +974,15 @@ class SlskProtoThread(threading.Thread):
         if connection is self.server_socket:
             # Disconnected from server, clean up connections and queue
             self.server_disconnect()
+
+        if conn_obj.init is None:
+            return
+
+        log.add_conn("Removed connection of type %(type)s to user %(user)s %(addr)s", {
+            'type': conn_obj.init.conn_type,
+            'user': conn_obj.init.target_user,
+            'addr': conn_obj.addr
+        })
 
     def close_connection_by_ip(self, ip_address):
 
@@ -806,6 +1048,8 @@ class SlskProtoThread(threading.Thread):
 
         try:
             self.server_socket = server_socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+            conn_obj = PeerConnectionInProgress(server_socket, msg_obj.addr, login=msg_obj.login)
+
             server_socket.setblocking(0)
 
             # Detect if our connection to the server is still alive
@@ -820,11 +1064,11 @@ class SlskProtoThread(threading.Thread):
             server_socket.connect_ex(msg_obj.addr)
 
             self.selector.register(server_socket, selectors.EVENT_READ | selectors.EVENT_WRITE)
-            self._connsinprogress[server_socket] = PeerConnectionInProgress(server_socket, msg_obj)
+            self._connsinprogress[server_socket] = conn_obj
             self._numsockets += 1
 
         except socket.error as err:
-            self._callback_msgs.append(ConnectError(msg_obj, err))
+            self.connect_error(err, conn_obj)
             server_socket.close()
             self.server_disconnect()
 
@@ -852,6 +1096,50 @@ class SlskProtoThread(threading.Thread):
                 msg = self.unpack_network_message(
                     self.serverclasses[msgtype], msg_buffer_mem[idx + 8:idx + msgsize_total], msgsize - 4, "server")
 
+                if self.serverclasses[msgtype] is Login and msg.success:
+                    # Check for indirect connection timeouts
+                    self.exit.clear()
+
+                    thread = threading.Thread(target=self._check_indirect_connection_timeouts)
+                    thread.name = "IndirectConnectionTimeoutTimer"
+                    thread.daemon = True
+                    thread.start()
+
+                if self.serverclasses[msgtype] is ConnectToPeer:
+                    user = msg.user
+                    addr = (msg.ip_address, msg.port)
+                    conn_type = msg.conn_type
+                    token = msg.token
+
+                    init = PeerInit(init_user=user, target_user=user, conn_type=conn_type, token=token)
+                    self.connect_to_peer_direct(user, addr, init)
+
+                if self.serverclasses[msgtype] is GetUserStatus:
+                    if msg.status <= 0:
+                        # User went offline, reset stored IP address
+                        if msg.user in self.user_addresses:
+                            del self.user_addresses[msg.user]
+
+                if self.serverclasses[msgtype] is GetPeerAddress:
+                    init = self._init_msgs.pop(msg.user, None)
+
+                    if msg.port == 0:
+                        log.add_conn(
+                            "Server reported port 0 for user %(user)s, giving up", {
+                                'user': msg.user
+                            }
+                        )
+
+                    else:
+                        addr = (msg.ip_address, msg.port)
+
+                        if init is not None:
+                            # We now have the IP address for a user we previously didn't know,
+                            # attempt a direct connection to the peer/user
+                            self.connect_to_peer_direct(msg.user, addr, init)
+
+                    self.user_addresses[msg.user] = (msg.ip_address, msg.port)
+
                 if msg is not None:
                     self._callback_msgs.append(msg)
 
@@ -867,7 +1155,7 @@ class SlskProtoThread(threading.Thread):
     def process_server_output(self, msg_obj):
 
         if self.server_socket not in self._conns:
-            log.add_conn("Can't send the message over the closed connection: %(type)s %(msg_obj)s", {
+            log.add_conn("Cannot send the message over the closed connection: %(type)s %(msg_obj)s", {
                 'type': msg_obj.__class__,
                 'msg_obj': vars(msg_obj)
             })
@@ -908,14 +1196,47 @@ class SlskProtoThread(threading.Thread):
             if msgtype in self.peerinitclasses:
                 msg = self.unpack_network_message(
                     self.peerinitclasses[msgtype], msg_buffer_mem[idx + 5:idx + msgsize_total], msgsize - 1,
-                    "peer init", conn)
+                    "peer init", conn.conn)
 
                 if msg is not None:
                     if self.peerinitclasses[msgtype] is PierceFireWall:
+                        log.add_conn("Received indirect connection attempt (PierceFireWall) with token %s", msg.token)
                         conn.piercefw = msg
+
+                        log.add_conn("List of stored PeerInit messages: %s", str(self._init_msgs))
+                        log.add_conn("Attempting to fetch PeerInit message for token %s", msg.token)
+
+                        conn.init = self._init_msgs.pop(msg.token, None)
+
+                        if conn.init is None:
+                            log.add_conn(("Indirect connection attempt with token %s previously expired, "
+                                          "closing connection"), msg.token)
+                            conn.ibuf = bytearray()
+                            self._callback_msgs.append(ConnClose(conn))
+                            self.close_connection(self._conns, conn.conn)
+                            return
+
+                        conn.init.conn = conn.conn
+                        self._out_indirect_conn_request_times.pop(conn.init, None)
+
+                        log.add_conn(("User %(user)s managed to connect to us indirectly (token %(token)s), "
+                                      "connection is established"), {
+                            "user": conn.init.target_user,
+                            "token": msg.token
+                        })
+
+                        self._queue.append(conn.init)
+                        self.process_conn_messages(conn.init)
 
                     elif self.peerinitclasses[msgtype] is PeerInit:
                         conn.init = msg
+
+                        log.add_conn("Received incoming direct connection of type %(type)s from user %(user)s", {
+                            'type': msg.conn_type,
+                            'user': msg.target_user
+                        })
+
+                        self.process_conn_messages(msg)
 
                     self._callback_msgs.append(msg)
 
@@ -925,8 +1246,10 @@ class SlskProtoThread(threading.Thread):
                             {'type': msgtype, 'size': msgsize - 1,
                              'msg_buffer': msg_buffer[idx + 5:idx + msgsize_total]})
 
-                    self._callback_msgs.append(ConnClose(conn.conn, conn.addr))
+                    conn.ibuf = bytearray()
+                    self._callback_msgs.append(ConnClose(conn))
                     self.close_connection(self._conns, conn.conn)
+                    return
 
                 break
 
@@ -938,7 +1261,7 @@ class SlskProtoThread(threading.Thread):
     def process_peer_init_output(self, msg_obj):
 
         if msg_obj.conn not in self._conns:
-            log.add_conn("Can't send the message over the closed connection: %(type)s %(msg_obj)s", {
+            log.add_conn("Cannot send the message over the closed connection: %(type)s %(msg_obj)s", {
                 'type': msg_obj.__class__,
                 'msg_obj': vars(msg_obj)
             })
@@ -980,8 +1303,12 @@ class SlskProtoThread(threading.Thread):
 
     def init_peer_conn(self, msg_obj):
 
+        conn_obj = None
+
         try:
             conn = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+            conn_obj = PeerConnectionInProgress(conn, msg_obj.addr, msg_obj.init)
+
             conn.setblocking(0)
 
             if self.bindip:
@@ -993,11 +1320,11 @@ class SlskProtoThread(threading.Thread):
             conn.connect_ex(msg_obj.addr)
 
             self.selector.register(conn, selectors.EVENT_READ | selectors.EVENT_WRITE)
-            self._connsinprogress[conn] = PeerConnectionInProgress(conn, msg_obj)
+            self._connsinprogress[conn] = conn_obj
             self._numsockets += 1
 
         except socket.error as err:
-            self._callback_msgs.append(ConnectError(msg_obj, err))
+            self.connect_error(err, conn_obj)
             conn.close()
 
     def process_peer_input(self, conn, msg_buffer):
@@ -1064,13 +1391,13 @@ class SlskProtoThread(threading.Thread):
             # Forcibly close peer connection. Only used after receiving a search result,
             # as we need to get rid of peer connections before they pile up.
 
-            self._callback_msgs.append(ConnClose(conn.conn, conn.addr))
+            self._callback_msgs.append(ConnClose(conn))
             self.close_connection(self._conns, conn.conn)
 
     def process_peer_output(self, msg_obj):
 
         if msg_obj.conn not in self._conns:
-            log.add_conn("Can't send the message over the closed connection: %(type)s %(msg_obj)s", {
+            log.add_conn("Cannot send the message over the closed connection: %(type)s %(msg_obj)s", {
                 'type': msg_obj.__class__,
                 'msg_obj': vars(msg_obj)
             })
@@ -1100,7 +1427,7 @@ class SlskProtoThread(threading.Thread):
 
         if conn.filereq is None:
             msgsize = 4
-            msg = self.unpack_network_message(FileRequest, msg_buffer[:msgsize], msgsize, "file", conn.conn)
+            msg = self.unpack_network_message(FileRequest, msg_buffer[:msgsize], msgsize, "file", conn)
 
             if msg is not None and msg.token is not None:
                 self._callback_msgs.append(msg)
@@ -1118,7 +1445,7 @@ class SlskProtoThread(threading.Thread):
 
                 except IOError as strerror:
                     self._callback_msgs.append(FileError(conn, conn.filedown.file, strerror))
-                    self._callback_msgs.append(ConnClose(conn.conn, conn.addr))
+                    self._callback_msgs.append(ConnClose(conn))
                     self.close_connection(self._conns, conn.conn)
 
                 except ValueError:
@@ -1136,7 +1463,7 @@ class SlskProtoThread(threading.Thread):
                 conn.lastcallback = current_time
 
             if finished:
-                self._callback_msgs.append(ConnClose(conn.conn, conn.addr))
+                self._callback_msgs.append(ConnClose(conn))
                 self.close_connection(self._conns, conn.conn)
 
             conn.filereadbytes += addedbyteslen
@@ -1153,7 +1480,7 @@ class SlskProtoThread(threading.Thread):
 
                 except IOError as strerror:
                     self._callback_msgs.append(FileError(conn, conn.fileupl.file, strerror))
-                    self._callback_msgs.append(ConnClose(conn.conn, conn.addr))
+                    self._callback_msgs.append(ConnClose(conn))
                     self.close_connection(self._conns, conn.conn)
 
                 except ValueError:
@@ -1169,7 +1496,7 @@ class SlskProtoThread(threading.Thread):
     def process_file_output(self, msg_obj):
 
         if msg_obj.conn not in self._conns:
-            log.add_conn("Can't send the message over the closed connection: %(type)s %(msg_obj)s", {
+            log.add_conn("Cannot send the message over the closed connection: %(type)s %(msg_obj)s", {
                 'type': msg_obj.__class__,
                 'msg_obj': vars(msg_obj)
             })
@@ -1236,9 +1563,11 @@ class SlskProtoThread(threading.Thread):
             else:
                 log.add("Distrib message type %(type)i size %(size)i contents %(msg_buffer)s unknown",
                         {'type': msgtype, 'size': msgsize - 1, 'msg_buffer': msg_buffer[idx + 5:idx + msgsize_total]})
-                self._callback_msgs.append(ConnClose(conn.conn, conn.addr))
+
+                conn.ibuf = bytearray()
+                self._callback_msgs.append(ConnClose(conn))
                 self.close_connection(self._conns, conn.conn)
-                break
+                return
 
             idx += msgsize_total
             buffer_len -= msgsize_total
@@ -1248,7 +1577,7 @@ class SlskProtoThread(threading.Thread):
     def process_distrib_output(self, msg_obj):
 
         if msg_obj.conn not in self._conns:
-            log.add_conn("Can't send the message over the closed connection: %(type)s %(msg_obj)s", {
+            log.add_conn("Cannot send the message over the closed connection: %(type)s %(msg_obj)s", {
                 'type': msg_obj.__class__,
                 'msg_obj': vars(msg_obj)
             })
@@ -1330,7 +1659,7 @@ class SlskProtoThread(threading.Thread):
             elif msg_class is ConnClose and msg_obj.conn in self._conns:
                 conn = msg_obj.conn
 
-                self._callback_msgs.append(ConnClose(conn, self._conns[conn].addr))
+                self._callback_msgs.append(ConnClose(self._conns[conn]))
                 self.close_connection(self._conns, conn)
 
             elif msg_class is ConnCloseIP:
@@ -1366,6 +1695,9 @@ class SlskProtoThread(threading.Thread):
 
                 self._upload_limit = msg_obj.limit * 1024
                 self._calc_upload_limit_function()
+
+            elif msg_obj.__class__ is SendNetworkMessage:
+                self.send_message_to_peer(msg_obj.user, msg_obj.message, msg_obj.login, msg_obj.addr)
 
     def read_data(self, conn_obj):
 
@@ -1438,7 +1770,7 @@ class SlskProtoThread(threading.Thread):
 
             except IOError as strerror:
                 self._callback_msgs.append(FileError(conn_obj, conn_obj.fileupl.file, strerror))
-                self._callback_msgs.append(ConnClose(connection, conn_obj.addr))
+                self._callback_msgs.append(ConnClose(conn_obj))
                 self.close_connection(self._conns, connection)
 
             except ValueError:
@@ -1529,7 +1861,7 @@ class SlskProtoThread(threading.Thread):
 
                         self._conns[incconn] = PeerConnection(conn=incconn, addr=incaddr, events=events)
                         self._numsockets += 1
-                        self._callback_msgs.append(IncConn(incconn, incaddr))
+                        log.add_conn("Incoming connection")
 
                         # Event flags are modified to include 'write' in subsequent loops, if necessary.
                         # Don't do it here, otherwise connections may break.
@@ -1544,12 +1876,10 @@ class SlskProtoThread(threading.Thread):
                     # Connection was removed, possibly disconnecting from the server
                     continue
 
-                msg_obj = conn_obj.msg_obj
-
                 if (current_time - conn_obj.lastactive) > self.IN_PROGRESS_STALE_AFTER:
                     # Connection failed
 
-                    self._callback_msgs.append(ConnectError(msg_obj, "Timed out"))
+                    self.connect_error("Timed out", conn_obj)
                     self.close_connection(self._connsinprogress, connection_in_progress)
                     continue
 
@@ -1559,36 +1889,70 @@ class SlskProtoThread(threading.Thread):
                         connection_in_progress.recv(1, socket.MSG_PEEK)
 
                 except socket.error as err:
-                    self._callback_msgs.append(ConnectError(msg_obj, err))
+                    self.connect_error(err, conn_obj)
                     self.close_connection(self._connsinprogress, connection_in_progress)
 
                 else:
                     if connection_in_progress in output_list:
                         # Connection has been established
 
-                        addr = msg_obj.addr
+                        addr = conn_obj.addr
                         events = selectors.EVENT_READ | selectors.EVENT_WRITE
 
                         if connection_in_progress is self.server_socket:
                             self._conns[self.server_socket] = Connection(
                                 conn=self.server_socket, addr=addr, events=events)
 
-                            self._callback_msgs.append(InitServerConn(self.server_socket, addr))
+                            log.add(
+                                _("Connected to server %(host)s:%(port)s, logging in…"), {
+                                    'host': addr[0],
+                                    'port': addr[1]
+                                }
+                            )
 
+                            self.server_address = addr
+                            self.server_timeout_value = -1
+                            login, password = conn_obj.login
+                            conn_obj.login = True
+
+                            self._queue.append(
+                                Login(
+                                    login, password,
+                                    # Soulseek client version
+                                    # NS and SoulseekQt use 157
+                                    # We use a custom version number for Nicotine+
+                                    160,
+
+                                    # Soulseek client minor version
+                                    # 17 stands for 157 ns 13c, 19 for 157 ns 13e
+                                    # SoulseekQt seems to go higher than this
+                                    # We use a custom minor version for Nicotine+
+                                    1
+                                )
+                            )
+
+                            if self.listenport is not None:
+                                self._queue.append(SetWaitPort(self.listenport))
                         else:
                             if self._network_filter.is_ip_blocked(addr[0]):
                                 log.add_conn("Ignoring connection request from blocked IP address %(ip)s:%(port)s", {
                                     "ip": addr[0],
                                     "port": addr[1]
                                 })
-                                self._callback_msgs.append(ConnectError(msg_obj, "Blocked IP address"))
                                 self.close_connection(self._connsinprogress, connection_in_progress)
                                 continue
 
-                            self._conns[connection_in_progress] = PeerConnection(
-                                conn=connection_in_progress, addr=addr, events=events, init=msg_obj.init)
+                            self._conns[connection_in_progress] = conn_obj = PeerConnection(
+                                conn=connection_in_progress, addr=addr, events=events, init=conn_obj.init)
 
-                            self._callback_msgs.append(InitPeerConn(connection_in_progress, addr))
+                            if not conn_obj.init.token:
+                                conn_obj.init.conn = connection_in_progress
+                                self._queue.append(conn_obj.init)
+                            else:
+                                self._queue.append(PierceFireWall(conn_obj.conn, conn_obj.init.token))
+
+                            log.add_conn("Connection established with user %s", conn_obj.init.target_user)
+                            self.process_conn_messages(conn_obj.init)
 
                         del self._connsinprogress[connection_in_progress]
 
@@ -1605,7 +1969,7 @@ class SlskProtoThread(threading.Thread):
                         and (current_time - conn_obj.lastactive) > self.CONNECTION_MAX_IDLE):
                     # No recent activity, peer connection is stale
 
-                    self._callback_msgs.append(ConnClose(connection, conn_obj.addr))
+                    self._callback_msgs.append(ConnClose(conn_obj))
                     self.close_connection(self._conns, connection)
                     continue
 
@@ -1616,7 +1980,7 @@ class SlskProtoThread(threading.Thread):
                     try:
                         if not self.read_data(conn_obj):
                             # No data received, socket was likely closed remotely
-                            self._callback_msgs.append(ConnClose(connection, conn_obj.addr))
+                            self._callback_msgs.append(ConnClose(conn_obj))
                             self.close_connection(self._conns, connection)
                             continue
 
@@ -1626,7 +1990,7 @@ class SlskProtoThread(threading.Thread):
                             "addr": conn_obj.addr,
                             "error": err
                         })
-                        self._callback_msgs.append(ConnClose(connection, conn_obj.addr))
+                        self._callback_msgs.append(ConnClose(conn_obj))
                         self.close_connection(self._conns, connection)
                         continue
 

--- a/pynicotine/slskproto.py
+++ b/pynicotine/slskproto.py
@@ -799,15 +799,7 @@ class SlskProtoThread(threading.Thread):
         """ A connection is established with the peer, time to queue up our peer
         messages for delivery """
 
-        username = init.target_user
         msgs = init.outgoing_msgs
-
-        if msgs is None:
-            return
-
-        log.add_conn("List of outgoing messages for user %(user)s: %(messages)s", {
-                     'user': username,
-                     'messages': msgs})
 
         for j in msgs:
             j.init = init
@@ -903,9 +895,10 @@ class SlskProtoThread(threading.Thread):
 
         self._queue.append(InitPeerConn(addr, init))
 
-        log.add_conn("Initialising direct connection of type %(type)s to user %(user)s", {
+        log.add_conn("Attempting direct connection of type %(type)s to user %(user)s %(addr)s", {
             'type': init.conn_type,
-            'user': user
+            'user': user,
+            'addr': addr
         })
 
     def connect_error(self, error, conn_obj):
@@ -1962,7 +1955,11 @@ class SlskProtoThread(threading.Thread):
                             else:
                                 self._queue.append(PierceFireWall(conn_obj.sock, conn_obj.init.token))
 
-                            log.add_conn("Connection established with user %s", conn_obj.init.target_user)
+                            log.add_conn(("Established connection with user %(user)s. List of outgoing "
+                                          "messages: %(messages)s"), {
+                                'user': conn_obj.init.target_user,
+                                'messages': conn_obj.init.outgoing_msgs
+                            })
                             self.process_conn_messages(conn_obj.init)
 
                         del self._connsinprogress[sock_in_progress]

--- a/pynicotine/slskproto.py
+++ b/pynicotine/slskproto.py
@@ -78,7 +78,6 @@ from pynicotine.slskmessages import GlobalRecommendations
 from pynicotine.slskmessages import GlobalUserList
 from pynicotine.slskmessages import HaveNoParent
 from pynicotine.slskmessages import InitPeerConn
-from pynicotine.slskmessages import InitServerConn
 from pynicotine.slskmessages import ItemRecommendations
 from pynicotine.slskmessages import ItemSimilarUsers
 from pynicotine.slskmessages import JoinPublicRoom
@@ -146,6 +145,8 @@ from pynicotine.slskmessages import SendConnectToken
 from pynicotine.slskmessages import SendDownloadSpeed
 from pynicotine.slskmessages import SendNetworkMessage
 from pynicotine.slskmessages import SendUploadSpeed
+from pynicotine.slskmessages import ServerConnect
+from pynicotine.slskmessages import ServerDisconnect
 from pynicotine.slskmessages import ServerMessage
 from pynicotine.slskmessages import ServerPing
 from pynicotine.slskmessages import ServerTimeout
@@ -176,24 +177,22 @@ from pynicotine.slskmessages import WishlistInterval
 from pynicotine.slskmessages import WishlistSearch
 
 
-""" Set the maximum number of open files to the hard limit reported by the OS.
-Our MAXSOCKETS value needs to be lower than the file limit, otherwise our open
-sockets in combination with other file activity can exceed the file limit,
-effectively halting the program. """
+# Set the maximum number of open files to the hard limit reported by the OS.
+# Our MAXSOCKETS value needs to be lower than the file limit, otherwise our open
+# sockets in combination with other file activity can exceed the file limit,
+# effectively halting the program.
 
 if sys.platform == "win32":
-
-    """ For Windows, FD_SETSIZE is set to 512 in the Python source.
-    This limit is hardcoded, so we'll have to live with it for now. """
+    # For Windows, FD_SETSIZE is set to 512 in the Python source.
+    # This limit is hardcoded, so we'll have to live with it for now.
 
     MAXSOCKETS = 512
 else:
     import resource  # pylint: disable=import-error
 
     if sys.platform == "darwin":
-
-        """ Maximum number of files a process can open is 10240 on macOS.
-        macOS reports INFINITE as hard limit, so we need this special case. """
+        # Maximum number of files a process can open is 10240 on macOS.
+        # macOS reports INFINITE as hard limit, so we need this special case.
 
         MAXFILELIMIT = 10240
     else:
@@ -205,9 +204,9 @@ else:
     except Exception as rlimit_error:
         log.add("Failed to set RLIMIT_NOFILE: %s", rlimit_error)
 
-    """ Set the maximum number of open sockets to a lower value than the hard limit,
-    otherwise we just waste resources.
-    The maximum is 1024, but can be lower if the file limit is too low. """
+    # Set the maximum number of open sockets to a lower value than the hard limit,
+    # otherwise we just waste resources.
+    # The maximum is 1024, but can be lower if the file limit is too low.
 
     MAXSOCKETS = min(max(int(MAXFILELIMIT * 0.75), 50), 1024)
 
@@ -217,22 +216,34 @@ DOUBLE_UINT_UNPACK = struct.Struct("<II").unpack
 UINT_PACK = struct.Struct("<I").pack
 
 
-class Connection:
-    """
-    Holds data about a connection. conn is a socket object,
-    addr is (ip, port) pair, ibuf and obuf are input and output msgBuffer,
-    init is a PeerInit object (see slskmessages docstrings).
-    """
+class ConnectionInProgress:
+    """ As all p2p connect()s are non-blocking, this class is used to
+    hold data about a connection that is not yet established """
 
-    __slots__ = ("conn", "addr", "ibuf", "obuf", "events", "init", "lastactive", "lastreadlength")
+    __slots__ = ("sock", "addr", "lastactive", "init", "login")
 
-    def __init__(self, conn=None, addr=None, events=None):
-        self.conn = conn
+    def __init__(self, sock=None, addr=None, init=None, login=None):
+        self.sock = sock
         self.addr = addr
+        self.init = init
+        self.login = login
+        self.lastactive = time.time()
+
+
+class Connection:
+    """ Holds data about a connection. sock is a socket object,
+    addr is (ip, port) pair, ibuf and obuf are input and output msgBuffer,
+    init is a PeerInit object (see slskmessages docstrings). """
+
+    __slots__ = ("sock", "addr", "init", "ibuf", "obuf", "events", "lastactive", "lastreadlength")
+
+    def __init__(self, sock=None, addr=None, events=None):
+        self.sock = sock
+        self.addr = addr
+        self.init = None
         self.events = events
         self.ibuf = bytearray()
         self.obuf = bytearray()
-        self.init = None
         self.lastactive = time.time()
         self.lastreadlength = 100 * 1024
 
@@ -241,30 +252,16 @@ class PeerConnection(Connection):
 
     __slots__ = ("filereq", "filedown", "fileupl", "filereadbytes", "bytestoread", "piercefw", "lastcallback")
 
-    def __init__(self, conn=None, addr=None, events=None, init=None):
-        Connection.__init__(self, conn, addr, events)
+    def __init__(self, sock=None, addr=None, events=None, init=None):
+        Connection.__init__(self, sock, addr, events)
+        self.init = init
         self.filereq = None
         self.filedown = None
         self.fileupl = None
         self.filereadbytes = 0
         self.bytestoread = 0
-        self.init = init
         self.piercefw = None
         self.lastcallback = time.time()
-
-
-class PeerConnectionInProgress:
-    """ As all p2p connect()s are non-blocking, this class is used to
-    hold data about a connection that is not yet established """
-
-    __slots__ = ("conn", "addr", "lastactive", "init", "login")
-
-    def __init__(self, conn=None, addr=None, init=None, login=None):
-        self.conn = conn
-        self.addr = addr
-        self.init = init
-        self.login = login
-        self.lastactive = time.time()
 
 
 class SlskProtoThread(threading.Thread):
@@ -272,9 +269,9 @@ class SlskProtoThread(threading.Thread):
     It sends data to the NicotineCore via a callback function and receives
     data via a deque object. """
 
-    """ Server and peers send each other small binary messages, that start
+    """ The server and peers send each other small binary messages that start
     with length and message code followed by the actual message data.
-    These are the codes."""
+    The codes are listed below. """
 
     servercodes = {
         Login: 1,
@@ -597,11 +594,11 @@ class SlskProtoThread(threading.Thread):
             self.server_timer.cancel()
             self.server_timer = None
 
-        for connection in self._conns.copy():
-            self.close_connection(self._conns, connection)
+        for sock in self._conns.copy():
+            self.close_connection(self._conns, sock)
 
-        for connection in self._connsinprogress.copy():
-            self.close_connection(self._connsinprogress, connection)
+        for sock in self._connsinprogress.copy():
+            self.close_connection(self._connsinprogress, sock)
 
         self._queue.clear()
         self._init_msgs.clear()
@@ -611,6 +608,7 @@ class SlskProtoThread(threading.Thread):
         self._out_indirect_conn_request_times.clear()
 
         if not self._want_abort:
+            self._callback_msgs.append(ServerDisconnect())
             self._callback_msgs.append(SetCurrentConnectionCount(0))
 
     def abort(self):
@@ -680,12 +678,12 @@ class SlskProtoThread(threading.Thread):
         else:
             self.current_cycle_loop_count = self.current_cycle_loop_count + 1
 
-    def set_conn_speed_limit(self, connection, limit, limits):
+    def set_conn_speed_limit(self, sock, limit, limits):
 
         limit = limit // (self.loops_per_second or 1)
 
         if limit > 0:
-            limits[connection] = limit
+            limits[sock] = limit
 
     """ Connections """
 
@@ -736,15 +734,15 @@ class SlskProtoThread(threading.Thread):
         log.add(_("The server seems to be down or not responding, retrying in %i seconds"),
                 self.server_timeout_value)
 
-    def socket_still_active(self, conn):
+    def socket_still_active(self, sock):
 
         try:
-            connection = self._conns[conn]
+            conn_obj = self._conns[sock]
 
         except KeyError:
             return False
 
-        return len(connection.obuf) > 0 or len(connection.ibuf) > 0
+        return len(conn_obj.obuf) > 0 or len(conn_obj.ibuf) > 0
 
     @staticmethod
     def pack_network_message(msg_obj):
@@ -782,7 +780,7 @@ class SlskProtoThread(threading.Thread):
     def modify_connection_events(self, conn_obj, events):
 
         if conn_obj.events != events:
-            self.selector.modify(conn_obj.conn, events)
+            self.selector.modify(conn_obj.sock, events)
             conn_obj.events = events
 
     def process_conn_messages(self, init):
@@ -800,14 +798,12 @@ class SlskProtoThread(threading.Thread):
                      'messages': msgs})
 
         for j in msgs:
-            j.conn = init.conn
+            j.init = init
             self._queue.append(j)
 
         msgs.clear()
 
     def send_message_to_peer(self, user, message, login, address=None):
-        """ Sends message to a peer. Used primarily when we know the username of a peer,
-        but don't have an active connection. """
 
         init = None
 
@@ -848,7 +844,7 @@ class SlskProtoThread(threading.Thread):
 
             init.outgoing_msgs.append(message)
 
-            if init.conn is not None:
+            if init.sock is not None:
                 # We have initiated a connection previously, and it's ready
                 self.process_conn_messages(init)
 
@@ -887,6 +883,7 @@ class SlskProtoThread(threading.Thread):
             })
 
         else:
+            init.addr = addr
             self.connect_to_peer_direct(user, addr, init)
 
     def connect_to_peer_direct(self, user, addr, init):
@@ -902,10 +899,12 @@ class SlskProtoThread(threading.Thread):
     def connect_error(self, error, conn_obj):
 
         if conn_obj.login:
+            server_address, port = conn_obj.addr
+
             log.add(
                 _("Cannot connect to server %(host)s:%(port)s: %(error)s"), {
-                    'host': conn_obj.addr[0],
-                    'port': conn_obj.addr[1],
+                    'host': server_address,
+                    'port': port,
                     'error': error
                 }
             )
@@ -947,13 +946,13 @@ class SlskProtoThread(threading.Thread):
             "error": error
         })
 
-    def close_connection(self, connection_list, connection):
+    def close_connection(self, connection_list, sock):
 
-        if connection not in connection_list:
+        if sock not in connection_list:
             # Already removed
             return
 
-        conn_obj = connection_list[connection]
+        conn_obj = connection_list[sock]
 
         if self._is_download(conn_obj):
             self.total_downloads -= 1
@@ -965,13 +964,13 @@ class SlskProtoThread(threading.Thread):
 
         # If we're shutting down, we've already closed the selector in abort()
         if not self._want_abort:
-            self.selector.unregister(connection)
+            self.selector.unregister(sock)
 
-        connection.close()
-        del connection_list[connection]
+        sock.close()
+        del connection_list[sock]
         self._numsockets -= 1
 
-        if connection is self.server_socket:
+        if sock is self.server_socket:
             # Disconnected from server, clean up connections and queue
             self.server_disconnect()
 
@@ -986,10 +985,10 @@ class SlskProtoThread(threading.Thread):
 
     def close_connection_by_ip(self, ip_address):
 
-        for connection in self._conns.copy():
-            conn_obj = self._conns.get(connection)
+        for sock in self._conns.copy():
+            conn_obj = self._conns.get(sock)
 
-            if not conn_obj or connection is self.server_socket:
+            if not conn_obj or sock is self.server_socket:
                 continue
 
             addr = conn_obj.addr
@@ -999,8 +998,8 @@ class SlskProtoThread(threading.Thread):
                     "ip": addr[0],
                     "port": addr[1]
                 })
-                self._callback_msgs.append(ConnClose(connection, addr))
-                self.close_connection(self._conns, connection)
+                self._callback_msgs.append(ConnClose(sock))
+                self.close_connection(self._conns, sock)
 
     """ Server Connection """
 
@@ -1031,9 +1030,9 @@ class SlskProtoThread(threading.Thread):
             server_socket.setsockopt(socket.IPPROTO_TCP, socket.TCP_KEEPALIVE, idle)  # pylint: disable=maybe-no-member
 
         elif hasattr(socket, 'SIO_KEEPALIVE_VALS'):
-            """ Windows fallback
-            Probe count is set to 10 on a system level, and can't be modified.
-            https://docs.microsoft.com/en-us/windows/win32/winsock/so-keepalive """
+            # Windows fallback
+            # Probe count is set to 10 on a system level, and can't be modified.
+            # https://docs.microsoft.com/en-us/windows/win32/winsock/so-keepalive
 
             server_socket.ioctl(
                 socket.SIO_KEEPALIVE_VALS,  # pylint: disable=maybe-no-member
@@ -1048,7 +1047,7 @@ class SlskProtoThread(threading.Thread):
 
         try:
             self.server_socket = server_socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-            conn_obj = PeerConnectionInProgress(server_socket, msg_obj.addr, login=msg_obj.login)
+            conn_obj = ConnectionInProgress(server_socket, msg_obj.addr, login=msg_obj.login)
 
             server_socket.setblocking(0)
 
@@ -1075,8 +1074,7 @@ class SlskProtoThread(threading.Thread):
     def process_server_input(self, conn, msg_buffer):
         """ Server has sent us something, this function retrieves messages
         from the msg_buffer, creates message objects and returns them and the rest
-        of the msg_buffer.
-        """
+        of the msg_buffer. """
 
         msg_buffer_mem = memoryview(msg_buffer)
         buffer_len = len(msg_buffer_mem)
@@ -1111,7 +1109,7 @@ class SlskProtoThread(threading.Thread):
                     conn_type = msg.conn_type
                     token = msg.token
 
-                    init = PeerInit(init_user=user, target_user=user, conn_type=conn_type, token=token)
+                    init = PeerInit(addr=addr, init_user=user, target_user=user, conn_type=conn_type, token=token)
                     self.connect_to_peer_direct(user, addr, init)
 
                 if self.serverclasses[msgtype] is GetUserStatus:
@@ -1136,6 +1134,7 @@ class SlskProtoThread(threading.Thread):
                         if init is not None:
                             # We now have the IP address for a user we previously didn't know,
                             # attempt a direct connection to the peer/user
+                            init.addr = addr
                             self.connect_to_peer_direct(msg.user, addr, init)
 
                     self.user_addresses[msg.user] = (msg.ip_address, msg.port)
@@ -1175,14 +1174,14 @@ class SlskProtoThread(threading.Thread):
 
     """ Peer Init """
 
-    def process_peer_init_input(self, conn, msg_buffer):
+    def process_peer_init_input(self, conn_obj, msg_buffer):
 
         msg_buffer_mem = memoryview(msg_buffer)
         buffer_len = len(msg_buffer_mem)
         idx = 0
 
         # Peer init messages are 8 bytes or greater in length
-        while buffer_len >= 8 and conn.init is None:
+        while buffer_len >= 8 and conn_obj.init is None:
             msgsize = UINT_UNPACK(msg_buffer_mem[idx:idx + 4])[0]
             msgsize_total = msgsize + 4
 
@@ -1196,40 +1195,41 @@ class SlskProtoThread(threading.Thread):
             if msgtype in self.peerinitclasses:
                 msg = self.unpack_network_message(
                     self.peerinitclasses[msgtype], msg_buffer_mem[idx + 5:idx + msgsize_total], msgsize - 1,
-                    "peer init", conn.conn)
+                    "peer init", conn_obj.sock)
 
                 if msg is not None:
                     if self.peerinitclasses[msgtype] is PierceFireWall:
                         log.add_conn("Received indirect connection attempt (PierceFireWall) with token %s", msg.token)
-                        conn.piercefw = msg
+                        conn_obj.piercefw = msg
 
                         log.add_conn("List of stored PeerInit messages: %s", str(self._init_msgs))
                         log.add_conn("Attempting to fetch PeerInit message for token %s", msg.token)
 
-                        conn.init = self._init_msgs.pop(msg.token, None)
+                        conn_obj.init = self._init_msgs.pop(msg.token, None)
 
-                        if conn.init is None:
+                        if conn_obj.init is None:
                             log.add_conn(("Indirect connection attempt with token %s previously expired, "
                                           "closing connection"), msg.token)
-                            conn.ibuf = bytearray()
-                            self._callback_msgs.append(ConnClose(conn))
-                            self.close_connection(self._conns, conn.conn)
+                            conn_obj.ibuf = bytearray()
+                            self._callback_msgs.append(ConnClose(conn_obj.sock))
+                            self.close_connection(self._conns, conn_obj.sock)
                             return
 
-                        conn.init.conn = conn.conn
-                        self._out_indirect_conn_request_times.pop(conn.init, None)
+                        conn_obj.init.sock = conn_obj.sock
+                        self._out_indirect_conn_request_times.pop(conn_obj.init, None)
 
                         log.add_conn(("User %(user)s managed to connect to us indirectly (token %(token)s), "
                                       "connection is established"), {
-                            "user": conn.init.target_user,
+                            "user": conn_obj.init.target_user,
                             "token": msg.token
                         })
 
-                        self._queue.append(conn.init)
-                        self.process_conn_messages(conn.init)
+                        self._queue.append(conn_obj.init)
+                        self.process_conn_messages(conn_obj.init)
 
                     elif self.peerinitclasses[msgtype] is PeerInit:
-                        conn.init = msg
+                        conn_obj.init = msg
+                        conn_obj.init.addr = conn_obj.addr
 
                         log.add_conn("Received incoming direct connection of type %(type)s from user %(user)s", {
                             'type': msg.conn_type,
@@ -1241,14 +1241,14 @@ class SlskProtoThread(threading.Thread):
                     self._callback_msgs.append(msg)
 
             else:
-                if conn.piercefw is None:
+                if conn_obj.piercefw is None:
                     log.add("Peer init message type %(type)i size %(size)i contents %(msg_buffer)s unknown",
                             {'type': msgtype, 'size': msgsize - 1,
                              'msg_buffer': msg_buffer[idx + 5:idx + msgsize_total]})
 
-                    conn.ibuf = bytearray()
-                    self._callback_msgs.append(ConnClose(conn))
-                    self.close_connection(self._conns, conn.conn)
+                    conn_obj.ibuf = bytearray()
+                    self._callback_msgs.append(ConnClose(conn_obj.sock))
+                    self.close_connection(self._conns, conn_obj.sock)
                     return
 
                 break
@@ -1256,11 +1256,11 @@ class SlskProtoThread(threading.Thread):
             idx += msgsize_total
             buffer_len -= msgsize_total
 
-        conn.ibuf = msg_buffer[idx:]
+        conn_obj.ibuf = msg_buffer[idx:]
 
     def process_peer_init_output(self, msg_obj):
 
-        if msg_obj.conn not in self._conns:
+        if msg_obj.sock not in self._conns:
             log.add_conn("Cannot send the message over the closed connection: %(type)s %(msg_obj)s", {
                 'type': msg_obj.__class__,
                 'msg_obj': vars(msg_obj)
@@ -1269,7 +1269,7 @@ class SlskProtoThread(threading.Thread):
 
         # Pack peer init messages
         if msg_obj.__class__ is PierceFireWall:
-            conn_obj = self._conns[msg_obj.conn]
+            conn_obj = self._conns[msg_obj.sock]
             msg = self.pack_network_message(msg_obj)
 
             if msg is None:
@@ -1282,7 +1282,7 @@ class SlskProtoThread(threading.Thread):
             conn_obj.obuf.extend(msg)
 
         elif msg_obj.__class__ is PeerInit:
-            conn_obj = self._conns[msg_obj.conn]
+            conn_obj = self._conns[msg_obj.sock]
             msg = self.pack_network_message(msg_obj)
 
             if msg is None:
@@ -1306,38 +1306,39 @@ class SlskProtoThread(threading.Thread):
         conn_obj = None
 
         try:
-            conn = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-            conn_obj = PeerConnectionInProgress(conn, msg_obj.addr, msg_obj.init)
+            sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+            conn_obj = ConnectionInProgress(sock, msg_obj.addr, msg_obj.init)
+            msg_obj.init.sock = sock
 
-            conn.setblocking(0)
+            sock.setblocking(0)
 
             if self.bindip:
-                conn.bind((self.bindip, 0))
+                sock.bind((self.bindip, 0))
 
             elif self.interface:
-                self.bind_to_network_interface(conn, self.interface)
+                self.bind_to_network_interface(sock, self.interface)
 
-            conn.connect_ex(msg_obj.addr)
+            sock.connect_ex(msg_obj.addr)
 
-            self.selector.register(conn, selectors.EVENT_READ | selectors.EVENT_WRITE)
-            self._connsinprogress[conn] = conn_obj
+            self.selector.register(sock, selectors.EVENT_READ | selectors.EVENT_WRITE)
+            self._connsinprogress[sock] = conn_obj
             self._numsockets += 1
 
         except socket.error as err:
             self.connect_error(err, conn_obj)
-            conn.close()
+            sock.close()
 
-    def process_peer_input(self, conn, msg_buffer):
+    def process_peer_input(self, conn_obj, msg_buffer):
         """ We have a "P" connection (p2p exchange), peer has sent us
         something, this function retrieves messages
         from the msg_buffer, creates message objects and returns them
-        and the rest of the msg_buffer.
-        """
+        and the rest of the msg_buffer. """
 
         msg_buffer_mem = memoryview(msg_buffer)
         buffer_len = len(msg_buffer_mem)
         idx = 0
         search_result_received = False
+        sock = conn_obj.sock
 
         # Peer messages are 8 bytes or greater in length
         while buffer_len >= 8:
@@ -1350,7 +1351,7 @@ class SlskProtoThread(threading.Thread):
                 if peer_class in (SharedFileList, UserInfoReply):
                     # Send progress to the main thread
                     self._callback_msgs.append(
-                        MessageProgress(conn.init.target_user, peer_class, buffer_len, msgsize_total))
+                        MessageProgress(conn_obj.init.target_user, peer_class, buffer_len, msgsize_total))
 
             except KeyError:
                 pass
@@ -1362,7 +1363,8 @@ class SlskProtoThread(threading.Thread):
             # Unpack peer messages
             if msgtype in self.peerclasses:
                 msg = self.unpack_network_message(
-                    self.peerclasses[msgtype], msg_buffer_mem[idx + 8:idx + msgsize_total], msgsize - 4, "peer", conn)
+                    self.peerclasses[msgtype], msg_buffer_mem[idx + 8:idx + msgsize_total], msgsize - 4,
+                    "peer", conn_obj.init)
 
                 if msg.__class__ is FileSearchResult:
                     search_result_received = True
@@ -1371,32 +1373,28 @@ class SlskProtoThread(threading.Thread):
                     self._callback_msgs.append(msg)
 
             else:
-                host = port = "unknown"
-
-                if conn.init.conn is not None and conn.addr is not None:
-                    host = conn.addr[0]
-                    port = conn.addr[1]
+                host, port = conn_obj.addr
 
                 log.add(("Peer message type %(type)s size %(size)i contents %(msg_buffer)s unknown, "
                          "from user: %(user)s, %(host)s:%(port)s"),
                         {'type': msgtype, 'size': msgsize - 4, 'msg_buffer': msg_buffer[idx + 8:idx + msgsize_total],
-                         'user': conn.init.target_user, 'host': host, 'port': port})
+                         'user': conn_obj.init.target_user, 'host': host, 'port': port})
 
             idx += msgsize_total
             buffer_len -= msgsize_total
 
-        conn.ibuf = msg_buffer[idx:]
+        conn_obj.ibuf = msg_buffer[idx:]
 
-        if search_result_received and not self.socket_still_active(conn.conn):
+        if search_result_received and not self.socket_still_active(sock):
             # Forcibly close peer connection. Only used after receiving a search result,
             # as we need to get rid of peer connections before they pile up.
 
-            self._callback_msgs.append(ConnClose(conn))
-            self.close_connection(self._conns, conn.conn)
+            self._callback_msgs.append(ConnClose(sock))
+            self.close_connection(self._conns, sock)
 
     def process_peer_output(self, msg_obj):
 
-        if msg_obj.conn not in self._conns:
+        if msg_obj.init.sock not in self._conns:
             log.add_conn("Cannot send the message over the closed connection: %(type)s %(msg_obj)s", {
                 'type': msg_obj.__class__,
                 'msg_obj': vars(msg_obj)
@@ -1409,7 +1407,7 @@ class SlskProtoThread(threading.Thread):
         if msg is None:
             return
 
-        conn_obj = self._conns[msg_obj.conn]
+        conn_obj = self._conns[msg_obj.init.sock]
         conn_obj.obuf.extend(UINT_PACK(len(msg) + 4))
         conn_obj.obuf.extend(UINT_PACK(self.peercodes[msg_obj.__class__]))
         conn_obj.obuf.extend(msg)
@@ -1418,35 +1416,34 @@ class SlskProtoThread(threading.Thread):
 
     """ File Connection """
 
-    def process_file_input(self, conn, msg_buffer):
+    def process_file_input(self, conn_obj, msg_buffer):
         """ We have a "F" connection (filetransfer), peer has sent us
         something, this function retrieves messages
         from the msg_buffer, creates message objects and returns them
-        and the rest of the msg_buffer.
-        """
+        and the rest of the msg_buffer. """
 
-        if conn.filereq is None:
+        if conn_obj.filereq is None:
             msgsize = 4
-            msg = self.unpack_network_message(FileRequest, msg_buffer[:msgsize], msgsize, "file", conn)
+            msg = self.unpack_network_message(FileRequest, msg_buffer[:msgsize], msgsize, "file", conn_obj.init)
 
             if msg is not None and msg.token is not None:
                 self._callback_msgs.append(msg)
-                conn.filereq = msg
+                conn_obj.filereq = msg
 
             msg_buffer = msg_buffer[msgsize:]
 
-        elif conn.filedown is not None:
-            leftbytes = conn.bytestoread - conn.filereadbytes
+        elif conn_obj.filedown is not None:
+            leftbytes = conn_obj.bytestoread - conn_obj.filereadbytes
             addedbytes = msg_buffer[:leftbytes]
 
             if leftbytes > 0:
                 try:
-                    conn.filedown.file.write(addedbytes)
+                    conn_obj.filedown.file.write(addedbytes)
 
                 except IOError as strerror:
-                    self._callback_msgs.append(FileError(conn, conn.filedown.file, strerror))
-                    self._callback_msgs.append(ConnClose(conn))
-                    self.close_connection(self._conns, conn.conn)
+                    self._callback_msgs.append(FileError(conn_obj.sock, conn_obj.filedown.file, strerror))
+                    self._callback_msgs.append(ConnClose(conn_obj.sock))
+                    self.close_connection(self._conns, conn_obj.sock)
 
                 except ValueError:
                     pass
@@ -1455,47 +1452,47 @@ class SlskProtoThread(threading.Thread):
             current_time = time.time()
             finished = ((leftbytes - addedbyteslen) == 0)
 
-            if finished or (current_time - conn.lastcallback) > 1:
+            if finished or (current_time - conn_obj.lastcallback) > 1:
                 # We save resources by not sending data back to the NicotineCore
                 # every time a part of a file is downloaded
 
-                self._callback_msgs.append(DownloadFile(conn.conn, conn.filedown.file))
-                conn.lastcallback = current_time
+                self._callback_msgs.append(DownloadFile(conn_obj.sock, conn_obj.filedown.file))
+                conn_obj.lastcallback = current_time
 
             if finished:
-                self._callback_msgs.append(ConnClose(conn))
-                self.close_connection(self._conns, conn.conn)
+                self._callback_msgs.append(ConnClose(conn_obj.sock))
+                self.close_connection(self._conns, conn_obj.sock)
 
-            conn.filereadbytes += addedbyteslen
+            conn_obj.filereadbytes += addedbyteslen
             msg_buffer = msg_buffer[leftbytes:]
 
-        elif conn.fileupl is not None and conn.fileupl.offset is None:
+        elif conn_obj.fileupl is not None and conn_obj.fileupl.offset is None:
             msgsize = 8
-            msg = self.unpack_network_message(FileOffset, msg_buffer[:msgsize], msgsize, "file", conn)
+            msg = self.unpack_network_message(FileOffset, msg_buffer[:msgsize], msgsize, "file", conn_obj.init)
 
             if msg is not None and msg.offset is not None:
                 try:
-                    conn.fileupl.file.seek(msg.offset)
-                    self.modify_connection_events(conn, selectors.EVENT_READ | selectors.EVENT_WRITE)
+                    conn_obj.fileupl.file.seek(msg.offset)
+                    self.modify_connection_events(conn_obj, selectors.EVENT_READ | selectors.EVENT_WRITE)
 
                 except IOError as strerror:
-                    self._callback_msgs.append(FileError(conn, conn.fileupl.file, strerror))
-                    self._callback_msgs.append(ConnClose(conn))
-                    self.close_connection(self._conns, conn.conn)
+                    self._callback_msgs.append(FileError(conn_obj.sock, conn_obj.fileupl.file, strerror))
+                    self._callback_msgs.append(ConnClose(conn_obj.sock))
+                    self.close_connection(self._conns, conn_obj.sock)
 
                 except ValueError:
                     pass
 
-                conn.fileupl.offset = msg.offset
-                self._callback_msgs.append(conn.fileupl)
+                conn_obj.fileupl.offset = msg.offset
+                self._callback_msgs.append(conn_obj.fileupl)
 
             msg_buffer = msg_buffer[msgsize:]
 
-        conn.ibuf = msg_buffer
+        conn_obj.ibuf = msg_buffer
 
     def process_file_output(self, msg_obj):
 
-        if msg_obj.conn not in self._conns:
+        if msg_obj.init.sock not in self._conns:
             log.add_conn("Cannot send the message over the closed connection: %(type)s %(msg_obj)s", {
                 'type': msg_obj.__class__,
                 'msg_obj': vars(msg_obj)
@@ -1509,7 +1506,7 @@ class SlskProtoThread(threading.Thread):
             if msg is None:
                 return
 
-            conn_obj = self._conns[msg_obj.conn]
+            conn_obj = self._conns[msg_obj.init.sock]
             conn_obj.filereq = msg_obj
             conn_obj.obuf.extend(msg)
 
@@ -1521,7 +1518,7 @@ class SlskProtoThread(threading.Thread):
             if msg is None:
                 return
 
-            conn_obj = self._conns[msg_obj.conn]
+            conn_obj = self._conns[msg_obj.init.sock]
             conn_obj.bytestoread = msg_obj.filesize - msg_obj.offset
             conn_obj.obuf.extend(msg)
 
@@ -1529,12 +1526,11 @@ class SlskProtoThread(threading.Thread):
 
     """ Distributed Connection """
 
-    def process_distrib_input(self, conn, msg_buffer):
+    def process_distrib_input(self, conn_obj, msg_buffer):
         """ We have a distributed network connection, parent has sent us
         something, this function retrieves messages
         from the msg_buffer, creates message objects and returns them
-        and the rest of the msg_buffer.
-        """
+        and the rest of the msg_buffer. """
 
         msg_buffer_mem = memoryview(msg_buffer)
         buffer_len = len(msg_buffer_mem)
@@ -1555,7 +1551,7 @@ class SlskProtoThread(threading.Thread):
             if msgtype in self.distribclasses:
                 msg = self.unpack_network_message(
                     self.distribclasses[msgtype], msg_buffer_mem[idx + 5:idx + msgsize_total], msgsize - 1,
-                    "distrib", conn)
+                    "distrib", conn_obj.init)
 
                 if msg is not None:
                     self._callback_msgs.append(msg)
@@ -1564,19 +1560,19 @@ class SlskProtoThread(threading.Thread):
                 log.add("Distrib message type %(type)i size %(size)i contents %(msg_buffer)s unknown",
                         {'type': msgtype, 'size': msgsize - 1, 'msg_buffer': msg_buffer[idx + 5:idx + msgsize_total]})
 
-                conn.ibuf = bytearray()
-                self._callback_msgs.append(ConnClose(conn))
-                self.close_connection(self._conns, conn.conn)
+                conn_obj.ibuf = bytearray()
+                self._callback_msgs.append(ConnClose(conn_obj.sock))
+                self.close_connection(self._conns, conn_obj.sock)
                 return
 
             idx += msgsize_total
             buffer_len -= msgsize_total
 
-        conn.ibuf = msg_buffer[idx:]
+        conn_obj.ibuf = msg_buffer[idx:]
 
     def process_distrib_output(self, msg_obj):
 
-        if msg_obj.conn not in self._conns:
+        if msg_obj.init.sock not in self._conns:
             log.add_conn("Cannot send the message over the closed connection: %(type)s %(msg_obj)s", {
                 'type': msg_obj.__class__,
                 'msg_obj': vars(msg_obj)
@@ -1589,7 +1585,7 @@ class SlskProtoThread(threading.Thread):
         if msg is None:
             return
 
-        conn_obj = self._conns[msg_obj.conn]
+        conn_obj = self._conns[msg_obj.init.sock]
         conn_obj.obuf.extend(UINT_PACK(len(msg) + 1))
         conn_obj.obuf.extend(bytes([self.distribcodes[msg_obj.__class__]]))
         conn_obj.obuf.extend(msg)
@@ -1622,7 +1618,7 @@ class SlskProtoThread(threading.Thread):
     def process_conn_output(self):
         """ Processes messages sent by the main thread. queue holds the messages,
         conns and connsinprogress are dictionaries holding Connection and
-        PeerConnectionInProgress messages. """
+        ConnectionInProgress messages. """
 
         msg_list = self._queue.copy()
         self._queue.clear()
@@ -1656,26 +1652,29 @@ class SlskProtoThread(threading.Thread):
             elif issubclass(msg_class, ServerMessage):
                 self.process_server_output(msg_obj)
 
-            elif msg_class is ConnClose and msg_obj.conn in self._conns:
-                conn = msg_obj.conn
+            elif msg_class is ConnClose and msg_obj.sock in self._conns:
+                sock = msg_obj.sock
 
-                self._callback_msgs.append(ConnClose(self._conns[conn]))
-                self.close_connection(self._conns, conn)
+                self._callback_msgs.append(ConnClose(sock))
+                self.close_connection(self._conns, sock)
 
             elif msg_class is ConnCloseIP:
                 self.close_connection_by_ip(msg_obj.addr)
 
-            elif msg_class is InitServerConn:
+            elif msg_class is ServerConnect:
                 if self._numsockets < MAXSOCKETS:
                     self.init_server_conn(msg_obj)
 
-            elif msg_class is DownloadFile and msg_obj.conn in self._conns:
-                self._conns[msg_obj.conn].filedown = msg_obj
+            elif msg_class is ServerDisconnect:
+                self.close_connection(self._conns, self.server_socket)
+
+            elif msg_class is DownloadFile and msg_obj.sock in self._conns:
+                self._conns[msg_obj.sock].filedown = msg_obj
                 self.total_downloads += 1
                 self._calc_download_limit()
 
-            elif msg_class is UploadFile and msg_obj.conn in self._conns:
-                self._conns[msg_obj.conn].fileupl = msg_obj
+            elif msg_class is UploadFile and msg_obj.sock in self._conns:
+                self._conns[msg_obj.sock].fileupl = msg_obj
                 self.total_uploads += 1
                 self._calc_upload_limit_function()
 
@@ -1701,16 +1700,16 @@ class SlskProtoThread(threading.Thread):
 
     def read_data(self, conn_obj):
 
-        connection = conn_obj.conn
+        sock = conn_obj.sock
 
         # Check for a download limit
-        if connection in self._dlimits:
-            limit = self._dlimits[connection]
+        if sock in self._dlimits:
+            limit = self._dlimits[sock]
         else:
             limit = None
 
         conn_obj.lastactive = time.time()
-        data = connection.recv(conn_obj.lastreadlength)
+        data = sock.recv(conn_obj.lastreadlength)
         conn_obj.ibuf.extend(data)
 
         if limit is None:
@@ -1729,10 +1728,10 @@ class SlskProtoThread(threading.Thread):
 
     def write_data(self, conn_obj):
 
-        connection = conn_obj.conn
+        sock = conn_obj.sock
 
-        if connection in self._ulimits:
-            limit = self._ulimits[connection]
+        if sock in self._ulimits:
+            limit = self._ulimits[sock]
         else:
             limit = None
 
@@ -1740,15 +1739,15 @@ class SlskProtoThread(threading.Thread):
 
         if conn_obj.obuf:
             if limit is None:
-                bytes_send = connection.send(conn_obj.obuf)
+                bytes_send = sock.send(conn_obj.obuf)
             else:
-                bytes_send = connection.send(conn_obj.obuf[:limit])
+                bytes_send = sock.send(conn_obj.obuf[:limit])
 
             conn_obj.obuf = conn_obj.obuf[bytes_send:]
         else:
             bytes_send = 0
 
-        if connection is self.server_socket:
+        if sock is self.server_socket:
             return
 
         if conn_obj.fileupl is not None and conn_obj.fileupl.offset is not None:
@@ -1769,9 +1768,9 @@ class SlskProtoThread(threading.Thread):
                         self.modify_connection_events(conn_obj, selectors.EVENT_READ | selectors.EVENT_WRITE)
 
             except IOError as strerror:
-                self._callback_msgs.append(FileError(conn_obj, conn_obj.fileupl.file, strerror))
-                self._callback_msgs.append(ConnClose(conn_obj))
-                self.close_connection(self._conns, connection)
+                self._callback_msgs.append(FileError(sock, conn_obj.fileupl.file, strerror))
+                self._callback_msgs.append(ConnClose(sock))
+                self.close_connection(self._conns, sock)
 
             except ValueError:
                 pass
@@ -1844,7 +1843,7 @@ class SlskProtoThread(threading.Thread):
             # Manage incoming connections to listen socket
             if self._numsockets < MAXSOCKETS and not self.server_disconnected and self.listen_socket in input_list:
                 try:
-                    incconn, incaddr = self.listen_socket.accept()
+                    incsock, incaddr = self.listen_socket.accept()
                 except Exception:
                     time.sleep(0.01)
                 else:
@@ -1853,24 +1852,24 @@ class SlskProtoThread(threading.Thread):
                             'ip': incaddr[0],
                             'port': incaddr[1]
                         })
-                        incconn.close()
+                        incsock.close()
 
                     else:
                         events = selectors.EVENT_READ
-                        incconn.setblocking(0)
+                        incsock.setblocking(0)
 
-                        self._conns[incconn] = PeerConnection(conn=incconn, addr=incaddr, events=events)
+                        self._conns[incsock] = PeerConnection(sock=incsock, addr=incaddr, events=events)
                         self._numsockets += 1
                         log.add_conn("Incoming connection")
 
                         # Event flags are modified to include 'write' in subsequent loops, if necessary.
                         # Don't do it here, otherwise connections may break.
-                        self.selector.register(incconn, events)
+                        self.selector.register(incsock, events)
 
             # Manage outgoing connections in progress
-            for connection_in_progress in self._connsinprogress.copy():
+            for sock_in_progress in self._connsinprogress.copy():
                 try:
-                    conn_obj = self._connsinprogress[connection_in_progress]
+                    conn_obj = self._connsinprogress[sock_in_progress]
 
                 except KeyError:
                     # Connection was removed, possibly disconnecting from the server
@@ -1880,28 +1879,28 @@ class SlskProtoThread(threading.Thread):
                     # Connection failed
 
                     self.connect_error("Timed out", conn_obj)
-                    self.close_connection(self._connsinprogress, connection_in_progress)
+                    self.close_connection(self._connsinprogress, sock_in_progress)
                     continue
 
                 try:
-                    if connection_in_progress in input_list:
+                    if sock_in_progress in input_list:
                         # Check if the socket has any data for us
-                        connection_in_progress.recv(1, socket.MSG_PEEK)
+                        sock_in_progress.recv(1, socket.MSG_PEEK)
 
                 except socket.error as err:
                     self.connect_error(err, conn_obj)
-                    self.close_connection(self._connsinprogress, connection_in_progress)
+                    self.close_connection(self._connsinprogress, sock_in_progress)
 
                 else:
-                    if connection_in_progress in output_list:
+                    if sock_in_progress in output_list:
                         # Connection has been established
 
                         addr = conn_obj.addr
                         events = selectors.EVENT_READ | selectors.EVENT_WRITE
 
-                        if connection_in_progress is self.server_socket:
+                        if sock_in_progress is self.server_socket:
                             self._conns[self.server_socket] = Connection(
-                                conn=self.server_socket, addr=addr, events=events)
+                                sock=self.server_socket, addr=addr, events=events)
 
                             log.add(
                                 _("Connected to server %(host)s:%(port)s, logging in…"), {
@@ -1939,49 +1938,49 @@ class SlskProtoThread(threading.Thread):
                                     "ip": addr[0],
                                     "port": addr[1]
                                 })
-                                self.close_connection(self._connsinprogress, connection_in_progress)
+                                self.close_connection(self._connsinprogress, sock_in_progress)
                                 continue
 
-                            self._conns[connection_in_progress] = conn_obj = PeerConnection(
-                                conn=connection_in_progress, addr=addr, events=events, init=conn_obj.init)
+                            self._conns[sock_in_progress] = conn_obj = PeerConnection(
+                                sock=sock_in_progress, addr=addr, events=events, init=conn_obj.init)
 
                             if not conn_obj.init.token:
-                                conn_obj.init.conn = connection_in_progress
+                                conn_obj.init.sock = sock_in_progress
                                 self._queue.append(conn_obj.init)
                             else:
-                                self._queue.append(PierceFireWall(conn_obj.conn, conn_obj.init.token))
+                                self._queue.append(PierceFireWall(conn_obj.sock, conn_obj.init.token))
 
                             log.add_conn("Connection established with user %s", conn_obj.init.target_user)
                             self.process_conn_messages(conn_obj.init)
 
-                        del self._connsinprogress[connection_in_progress]
+                        del self._connsinprogress[sock_in_progress]
 
             # Process read/write for active connections
-            for connection in self._conns.copy():
+            for sock in self._conns.copy():
                 try:
-                    conn_obj = self._conns[connection]
+                    conn_obj = self._conns[sock]
 
                 except KeyError:
                     # Connection was removed, possibly disconnecting from the server
                     continue
 
-                if (connection is not self.server_socket
+                if (sock is not self.server_socket
                         and (current_time - conn_obj.lastactive) > self.CONNECTION_MAX_IDLE):
                     # No recent activity, peer connection is stale
 
-                    self._callback_msgs.append(ConnClose(conn_obj))
-                    self.close_connection(self._conns, connection)
+                    self._callback_msgs.append(ConnClose(sock))
+                    self.close_connection(self._conns, sock)
                     continue
 
-                if connection in input_list:
+                if sock in input_list:
                     if self._is_download(conn_obj):
-                        self.set_conn_speed_limit(connection, self._download_limit_split, self._dlimits)
+                        self.set_conn_speed_limit(sock, self._download_limit_split, self._dlimits)
 
                     try:
                         if not self.read_data(conn_obj):
                             # No data received, socket was likely closed remotely
-                            self._callback_msgs.append(ConnClose(conn_obj))
-                            self.close_connection(self._conns, connection)
+                            self._callback_msgs.append(ConnClose(sock))
+                            self.close_connection(self._conns, sock)
                             continue
 
                     except socket.error as err:
@@ -1990,16 +1989,16 @@ class SlskProtoThread(threading.Thread):
                             "addr": conn_obj.addr,
                             "error": err
                         })
-                        self._callback_msgs.append(ConnClose(conn_obj))
-                        self.close_connection(self._conns, connection)
+                        self._callback_msgs.append(ConnClose(sock))
+                        self.close_connection(self._conns, sock)
                         continue
 
                 if conn_obj.ibuf:
-                    self.process_conn_input(connection, conn_obj)
+                    self.process_conn_input(sock, conn_obj)
 
-                if connection in output_list:
+                if sock in output_list:
                     if self._is_upload(conn_obj):
-                        self.set_conn_speed_limit(connection, self._upload_limit_split, self._ulimits)
+                        self.set_conn_speed_limit(sock, self._upload_limit_split, self._ulimits)
 
                     try:
                         self.write_data(conn_obj)
@@ -2009,8 +2008,8 @@ class SlskProtoThread(threading.Thread):
                             "addr": conn_obj.addr,
                             "error": err
                         })
-                        self._callback_msgs.append(ConnClose(connection, conn_obj.addr))
-                        self.close_connection(self._conns, connection)
+                        self._callback_msgs.append(ConnClose(sock))
+                        self.close_connection(self._conns, sock)
                         continue
 
             # Inform the main thread

--- a/pynicotine/transfers.py
+++ b/pynicotine/transfers.py
@@ -102,6 +102,7 @@ class Transfers:
         self.transfer_request_times = {}
         self.user_update_times = {}
         self.upload_speed = 0
+        self.token = 100
 
         self.downloads_file_name = os.path.join(self.config.data_dir, 'downloads.json')
         self.uploads_file_name = os.path.join(self.config.data_dir, 'uploads.json')
@@ -1627,7 +1628,8 @@ class Transfers:
             transfer.status = "User logged off"
 
         elif not locally_queued:
-            transfer.token = self.core.get_new_token()
+            self.token += 1
+            transfer.token = self.token
             transfer.status = "Getting status"
             self.transfer_request_times[transfer] = time.time()
 
@@ -1715,7 +1717,7 @@ class Transfers:
             return True
 
         try:
-            return self.core.users[user].status <= 0
+            return self.core.user_statuses[user] <= 0
 
         except (KeyError, TypeError):
             return False
@@ -2020,7 +2022,7 @@ class Transfers:
                     if (current_time - start_time) >= 30:
                         self.network_callback([slskmessages.TransferTimeout(transfer)])
 
-            if self.core.exit.wait(1):
+            if self.core.protothread.exit.wait(1):
                 # Event set, we're exiting
                 return
 
@@ -2029,7 +2031,7 @@ class Transfers:
         while True:
             self.network_callback([slskmessages.CheckUploadQueue()])
 
-            if self.core.exit.wait(10):
+            if self.core.protothread.exit.wait(10):
                 # Event set, we're exiting
                 return
 
@@ -2041,7 +2043,7 @@ class Transfers:
             self.download_queue_timer_count += 1
             self.network_callback([slskmessages.CheckDownloadQueue()])
 
-            if self.core.exit.wait(180):
+            if self.core.protothread.exit.wait(180):
                 # Event set, we're exiting
                 return
 

--- a/pynicotine/transfers.py
+++ b/pynicotine/transfers.py
@@ -1042,7 +1042,7 @@ class Transfers:
                 self._file_request_upload(msg, i)
                 return
 
-        self.queue.append(slskmessages.ConnClose(msg.sock))
+        self.queue.append(slskmessages.ConnClose(msg.init.sock))
 
     def _file_request_download(self, msg, i):
 

--- a/pynicotine/transfers.py
+++ b/pynicotine/transfers.py
@@ -52,9 +52,9 @@ from pynicotine.utils import write_file_and_backup
 
 
 class Transfer:
-    """ This class holds information about a single transfer. """
+    """ This class holds information about a single transfer """
 
-    __slots__ = ("conn", "user", "filename",
+    __slots__ = ("sock", "user", "filename",
                  "path", "token", "size", "file", "start_time", "last_update",
                  "current_byte_offset", "last_byte_offset", "speed", "time_elapsed",
                  "time_left", "modifier", "queue_position", "bitrate", "length",
@@ -74,7 +74,7 @@ class Transfer:
         self.bitrate = bitrate
         self.length = length
 
-        self.conn = None
+        self.sock = None
         self.modifier = None
         self.start_time = None
         self.last_update = None
@@ -601,9 +601,9 @@ class Transfers:
 
     def folder_contents_response(self, msg):
         """ When we got a contents of a folder, get all the files in it, but
-        skip the files in subfolders"""
+        skip the files in subfolders """
 
-        username = msg.conn.init.target_user
+        username = msg.init.target_user
         file_list = msg.list
 
         log.add_transfer("Received response for folder content request from user %s", username)
@@ -645,8 +645,7 @@ class Transfers:
         a TransferRequest with direction 0 (download request). We will initiate the upload of
         the queued file later. """
 
-        user = msg.conn.init.target_user
-        addr = msg.conn.addr[0]
+        user = msg.init.target_user
         real_path = self.core.shares.virtual2real(msg.file)
 
         if not self.file_is_upload_queued(user, msg.file):
@@ -659,21 +658,21 @@ class Transfers:
                 if friend:
                     limits = False
 
-            checkuser, reason = self.core.network_filter.check_user(user, addr)
+            checkuser, reason = self.core.network_filter.check_user(user, msg.init.addr)
 
             if not checkuser:
                 self.queue.append(
-                    slskmessages.UploadDenied(conn=msg.conn.conn, file=msg.file, reason=reason)
+                    slskmessages.UploadDenied(msg.init, msg.file, reason)
                 )
 
             elif limits and self.queue_limit_reached(user):
                 self.queue.append(
-                    slskmessages.UploadDenied(conn=msg.conn.conn, file=msg.file, reason="Too many megabytes")
+                    slskmessages.UploadDenied(msg.init, msg.file, "Too many megabytes")
                 )
 
             elif limits and self.file_limit_reached(user):
                 self.queue.append(
-                    slskmessages.UploadDenied(conn=msg.conn.conn, file=msg.file, reason="Too many files")
+                    slskmessages.UploadDenied(msg.init, msg.file, "Too many files")
                 )
 
             elif self.core.shares.file_is_shared(user, msg.file, real_path):
@@ -692,7 +691,7 @@ class Transfers:
 
             else:
                 self.queue.append(
-                    slskmessages.UploadDenied(conn=msg.conn.conn, file=msg.file, reason="File not shared.")
+                    slskmessages.UploadDenied(msg.init, msg.file, "File not shared.")
                 )
 
         log.add_transfer("QueueUpload request: User %(user)s, %(msg)s", {
@@ -702,8 +701,7 @@ class Transfers:
 
     def transfer_request(self, msg):
 
-        user = msg.conn.init.target_user
-        addr = msg.conn.addr[0]
+        user = msg.init.target_user
         response = None
 
         if msg.direction == 1:
@@ -713,7 +711,7 @@ class Transfers:
                 "user": user
             })
 
-            response = self.transfer_request_downloads(msg, user)
+            response = self.transfer_request_downloads(msg)
 
             log.add_transfer("Sending response to upload request %(request)s for file %(filename)s "
                              + "from user %(user)s: %(allowed)s", {
@@ -730,7 +728,7 @@ class Transfers:
                 "user": user
             })
 
-            response = self.transfer_request_uploads(msg, user, addr)
+            response = self.transfer_request_uploads(msg)
 
             log.add_transfer("Sending response to download request %(request)s for file %(filename)s "
                              + "from user %(user)s: %(allowed)s", {
@@ -742,8 +740,9 @@ class Transfers:
 
         self.core.send_message_to_peer(user, response)
 
-    def transfer_request_downloads(self, msg, user):
+    def transfer_request_downloads(self, msg):
 
+        user = msg.init.target_user
         filename = msg.file
         size = msg.filesize
 
@@ -766,10 +765,10 @@ class Transfers:
 
                 # Remote peer is signaling a transfer is ready, attempting to download it
 
-                """ If the file is larger than 2GB, the SoulseekQt client seems to
-                send a malformed file size (0 bytes) in the TransferRequest response.
-                In that case, we rely on the cached, correct file size we received when
-                we initially added the download. """
+                # If the file is larger than 2GB, the SoulseekQt client seems to
+                # send a malformed file size (0 bytes) in the TransferRequest response.
+                # In that case, we rely on the cached, correct file size we received when
+                # we initially added the download.
 
                 if msg.filesize > 0:
                     i.size = size
@@ -818,22 +817,23 @@ class Transfers:
 
         return response
 
-    def transfer_request_uploads(self, msg, user, addr):
+    def transfer_request_uploads(self, msg):
         """ Remote peer is requesting to download a file through your upload queue.
         Note that the QueueUpload peer message has replaced this method of requesting
         a download in most clients. """
 
-        response = self._transfer_request_uploads(msg, user, addr)
+        response = self._transfer_request_uploads(msg)
         log.add_transfer("Legacy TransferRequest upload request: %(req)s Response: %(resp)s", {
             'req': str(vars(msg)),
             'resp': response
         })
         return response
 
-    def _transfer_request_uploads(self, msg, user, addr):
+    def _transfer_request_uploads(self, msg):
 
         # Is user allowed to download?
-        checkuser, reason = self.core.network_filter.check_user(user, addr)
+        user = msg.init.target_user
+        checkuser, reason = self.core.network_filter.check_user(user, msg.init.addr)
 
         if not checkuser:
             return slskmessages.TransferResponse(None, 0, reason=reason, token=msg.token)
@@ -912,8 +912,7 @@ class Transfers:
         return response
 
     def transfer_response(self, msg):
-
-        """ Got a response to the file request from the peer."""
+        """ Received a response to the file request from the peer """
 
         log.add_transfer("Received response for transfer request %(request)s. Allowed: %(allowed)s. "
                          + "Reason: %(reason)s. Filesize: %(size)s", {
@@ -1006,7 +1005,7 @@ class Transfers:
 
         for i in self.downloads + self.uploads:
 
-            if i.conn != msg.conn.conn:
+            if i.sock != msg.sock:
                 continue
 
             self.abort_transfer(i)
@@ -1027,21 +1026,23 @@ class Transfers:
         """ Got an incoming file request. Could be an upload request or a
         request to get the file that was previously queued """
 
+        token = msg.token
+
         log.add_transfer("Received file request %(request)s", {
-            "request": msg.token
+            "request": token
         })
 
         for i in self.downloads:
-            if msg.token == i.token:
+            if token == i.token:
                 self._file_request_download(msg, i)
                 return
 
         for i in self.uploads:
-            if msg.token == i.token:
+            if token == i.token:
                 self._file_request_upload(msg, i)
                 return
 
-        self.queue.append(slskmessages.ConnClose(msg.conn))
+        self.queue.append(slskmessages.ConnClose(msg.sock))
 
     def _file_request_download(self, msg, i):
 
@@ -1054,8 +1055,8 @@ class Transfers:
         incompletedir = self.config.sections["transfers"]["incompletedir"]
         needupdate = True
 
-        if i.conn is None and i.size is not None:
-            i.conn = msg.conn
+        if i.sock is None and i.size is not None:
+            i.sock = msg.init.sock
             i.token = None
 
             if i in self.transfer_request_times:
@@ -1119,8 +1120,8 @@ class Transfers:
                     if i.size > offset:
                         i.status = "Transferring"
                         i.legacy_attempt = False
-                        self.queue.append(slskmessages.DownloadFile(i.conn, file_handle))
-                        self.queue.append(slskmessages.FileOffset(i.conn, i.size, offset))
+                        self.queue.append(slskmessages.DownloadFile(i.sock, file_handle))
+                        self.queue.append(slskmessages.FileOffset(msg.init, i.size, offset))
 
                         log.add_download(
                             _("Download started: user %(user)s, file %(file)s"), {
@@ -1145,7 +1146,7 @@ class Transfers:
                 'file': i.filename
             })
 
-            self.queue.append(slskmessages.ConnClose(msg.conn))
+            self.queue.append(slskmessages.ConnClose(msg.init.sock))
 
     def _file_request_upload(self, msg, i):
 
@@ -1156,8 +1157,8 @@ class Transfers:
         })
         needupdate = True
 
-        if i.conn is None:
-            i.conn = msg.conn
+        if i.sock is None:
+            i.sock = msg.init.sock
             i.token = None
             file_handle = None
 
@@ -1187,20 +1188,12 @@ class Transfers:
 
                 if i.size > offset:
                     i.status = "Transferring"
-                    self.queue.append(slskmessages.UploadFile(i.conn, file=file_handle, size=i.size))
-
-                    ip_address = None
-                    if i.conn is not None:
-                        try:
-                            ip_address = i.conn.getpeername()
-                        except OSError:
-                            # Connection already closed
-                            pass
+                    self.queue.append(slskmessages.UploadFile(i.sock, file=file_handle, size=i.size))
 
                     log.add_upload(
                         _("Upload started: user %(user)s, IP address %(ip)s, file %(file)s"), {
                             "user": i.user,
-                            "ip": ip_address,
+                            "ip": msg.init.addr[0],
                             "file": i.filename
                         }
                     )
@@ -1221,19 +1214,19 @@ class Transfers:
                 'file': i.filename
             })
 
-            self.queue.append(slskmessages.ConnClose(msg.conn))
+            self.queue.append(slskmessages.ConnClose(msg.init.sock))
 
     def upload_denied(self, msg):
 
-        user = msg.conn.init.target_user
+        user = msg.init.target_user
 
         for i in self.downloads:
             if i.user != user or i.filename != msg.file:
                 continue
 
             if msg.reason in ("File not shared.", "File not shared", "Remote file error") and not i.legacy_attempt:
-                """ The peer is possibly using an old client that doesn't support Unicode
-                (Soulseek NS). Attempt to request file name encoded as latin-1 once. """
+                # The peer is possibly using an old client that doesn't support Unicode
+                # (Soulseek NS). Attempt to request file name encoded as latin-1 once.
 
                 log.add_transfer("User %(user)s responded with reason '%(reason)s' for download request %(filename)s. "
                                  "Attempting to request file as latin-1.", {
@@ -1265,7 +1258,7 @@ class Transfers:
 
     def upload_failed(self, msg):
 
-        user = msg.conn.init.target_user
+        user = msg.init.target_user
 
         for i in self.downloads:
             if i.user != user or i.filename != msg.file:
@@ -1275,15 +1268,14 @@ class Transfers:
                 continue
 
             if not i.legacy_attempt:
-                """ Attempt to request file name encoded as latin-1 once. """
+                # Attempt to request file name encoded as latin-1 once
 
                 self.abort_transfer(i)
                 i.legacy_attempt = True
                 self.get_file(i.user, i.filename, i.path, i)
                 break
 
-            """ Already failed once previously, give up """
-
+            # Already failed once previously, give up
             i.status = "Remote file error"
 
             if self.downloadsview:
@@ -1296,13 +1288,13 @@ class Transfers:
             })
 
     def file_download(self, msg):
-        """ A file download is in progress"""
+        """ A file download is in progress """
 
         needupdate = True
 
         for i in self.downloads:
 
-            if i.conn != msg.conn:
+            if i.sock != msg.sock:
                 continue
 
             try:
@@ -1359,7 +1351,7 @@ class Transfers:
 
         for i in self.uploads:
 
-            if i.conn != msg.conn:
+            if i.sock != msg.sock:
                 continue
 
             if i in self.transfer_request_times:
@@ -1402,18 +1394,18 @@ class Transfers:
 
             break
 
-    def conn_close(self, conn):
-        """ The remote user has closed the connection either because
-        he logged off, or because there's a network problem. """
+    def conn_close(self, sock):
+        """ The remote user has closed the connection either because they logged off, or
+        because there's a network problem """
 
         for i in self.downloads:
-            if i.conn == conn:
+            if i.sock == sock:
                 self._conn_close(i, "download")
                 return
 
         # We need a copy due to upload auto-clearing modifying the deque during iteration
         for i in self.uploads.copy():
-            if i.conn == conn:
+            if i.sock == sock:
                 self._conn_close(i, "upload")
                 return
 
@@ -1435,10 +1427,9 @@ class Transfers:
                 else:
                     i.status = "Cancelled"
 
-                    """ Transfer ended abruptly. Tell the peer to re-queue the file. If the transfer was
-                    intentionally cancelled, the peer should ignore this message. """
-                    self.core.send_message_to_peer(
-                        i.user, slskmessages.UploadFailed(None, i.filename))
+                    # Transfer ended abruptly. Tell the peer to re-queue the file. If the transfer was
+                    # intentionally cancelled, the peer should ignore this message.
+                    self.core.send_message_to_peer(i.user, slskmessages.UploadFailed(None, i.filename))
 
                 auto_clear = True
 
@@ -1456,7 +1447,7 @@ class Transfers:
 
     def place_in_queue_request(self, msg):
 
-        user = msg.conn.init.target_user
+        user = msg.init.target_user
         privileged_user = self.is_privileged(user)
         queue_position = 0
         transfer = None
@@ -1494,7 +1485,7 @@ class Transfers:
                     break
 
         if queue_position > 0:
-            self.queue.append(slskmessages.PlaceInQueue(msg.conn.conn, msg.file, queue_position))
+            self.queue.append(slskmessages.PlaceInQueue(msg.init, msg.file, queue_position))
 
         if transfer is None:
             return
@@ -1506,9 +1497,9 @@ class Transfers:
             self.uploadsview.update(transfer)
 
     def place_in_queue(self, msg):
-        """ The server tells us our place in queue for a particular transfer."""
+        """ The peer tells us our place in queue for a particular transfer """
 
-        username = msg.conn.init.target_user
+        username = msg.init.target_user
         filename = msg.filename
 
         for i in self.downloads:
@@ -1750,7 +1741,7 @@ class Transfers:
 
             return maxupslots
 
-        lstlen = sum(1 for i in self.uploads if i.conn is not None)
+        lstlen = sum(1 for i in self.uploads if i.sock is not None)
 
         if self.allow_new_uploads():
             return lstlen + 1
@@ -1919,7 +1910,7 @@ class Transfers:
         i.current_byte_offset = i.size
         i.speed = None
         i.time_left = ""
-        i.conn = None
+        i.sock = None
 
         self.core.statistics.append_stat_value("completed_downloads", 1)
 
@@ -1955,9 +1946,9 @@ class Transfers:
         self.close_file(file_handle, i)
 
         ip_address = None
-        if i.conn is not None:
+        if i.sock is not None:
             try:
-                ip_address = i.conn.getpeername()
+                ip_address = i.sock.getpeername()
             except OSError:
                 # Connection already closed
                 pass
@@ -1966,7 +1957,7 @@ class Transfers:
         i.current_byte_offset = i.size
         i.speed = None
         i.time_left = ""
-        i.conn = None
+        i.sock = None
 
         self.user_update_times[i.user] = time.time()
 
@@ -2205,11 +2196,9 @@ class Transfers:
             return
 
     def ban_user(self, user, ban_message=None):
-        """
-        Ban a user, cancel all the user's uploads, send a 'Banned'
+        """ Ban a user, cancel all the user's uploads, send a 'Banned'
         message via the transfers, and clear the transfers from the
-        uploads list.
-        """
+        uploads list. """
 
         if ban_message:
             banmsg = "Banned (%s)" % ban_message
@@ -2289,9 +2278,9 @@ class Transfers:
         transfer.queue_position = 0
         transfer.time_left = ""
 
-        if transfer.conn is not None:
-            self.queue.append(slskmessages.ConnClose(transfer.conn))
-            transfer.conn = None
+        if transfer.sock is not None:
+            self.queue.append(slskmessages.ConnClose(transfer.sock))
+            transfer.sock = None
 
         if transfer in self.transfer_request_times:
             del self.transfer_request_times[transfer]

--- a/test/unit/protocol/test_slskproto.py
+++ b/test/unit/protocol/test_slskproto.py
@@ -28,7 +28,7 @@ from unittest.mock import Mock
 from unittest.mock import patch
 
 from pynicotine.slskproto import SlskProtoThread
-from pynicotine.slskmessages import InitServerConn, Login, SetWaitPort
+from pynicotine.slskmessages import ServerConnect, Login, SetWaitPort
 
 # Time (in s) needed for SlskProtoThread main loop to run at least once
 SLSKPROTO_RUN_TIME = 1.5
@@ -94,7 +94,7 @@ class SlskProtoTest(unittest.TestCase):
             mock_socket.set_data(LOGIN_DATAFILE)
             proto.server_connect()
 
-            queue.append(InitServerConn(addr=('0.0.0.0', 0)))
+            queue.append(ServerConnect(addr=('0.0.0.0', 0), login=('dummy', 'dummy')))
             sleep(SLSKPROTO_RUN_TIME)
 
             if hasattr(socket, 'TCP_KEEPIDLE'):
@@ -124,7 +124,7 @@ class SlskProtoTest(unittest.TestCase):
             eventprocessor=Mock()
         )
         proto.server_connect()
-        queue.append(InitServerConn(addr=('0.0.0.0', 0)))
+        queue.append(ServerConnect(addr=('0.0.0.0', 0), login=('username', 'password')))
 
         sleep(SLSKPROTO_RUN_TIME / 2)
 


### PR DESCRIPTION
This PR simplifies code related to the Soulseek protocol.

Some of the protocol logic existed in pynicotine.py for no good reason, introducing both overhead and unnecessary complexity due to constantly jumping between the network and main threads, and keeping track of separate connection objects in the main thread. Implement this logic in slskproto.py instead.

Also rename most of the confusing attributes in the code, mainly the "conn" attributes that could either point to a socket or a PeerConnection object depending on the context.

Since this is a rather large change, testing would be appreciated.