### PR TITLE
transfers.py: slot_limit_reached() Performance

### DIFF
--- a/pynicotine/transfers.py
+++ b/pynicotine/transfers.py
@@ -449,10 +449,10 @@ class Transfers:
 
     def slot_limit_reached(self):
 
-        maxupslots = self.config.sections["transfers"]["uploadslots"]
+        uploadslots = self.config.sections["transfers"]["uploadslots"]
 
-        if maxupslots <= 0:
-            maxupslots = 1
+        if uploadslots <= 0:
+            uploadslots = 1
 
         in_progress_count = 0
         current_time = time.time()
@@ -470,7 +470,7 @@ class Transfers:
                         or i.status == "Getting status"):
                     in_progress_count += 1
 
-            if in_progress_count >= maxupslots:
+            if in_progress_count >= uploadslots:
                 # slot_limit_reached, so stop iterating
                 return True
 

--- a/pynicotine/transfers.py
+++ b/pynicotine/transfers.py
@@ -455,14 +455,14 @@ class Transfers:
             maxupslots = 1
 
         in_progress_count = 0
-        now = time.time()
+        current_time = time.time()
 
-        for i in self.uploads:
+        for i in reversed(self.uploads):
             if i.conn is not None and i.speed is not None:
                 # Currently transferring
                 in_progress_count += 1
 
-            elif (now - i.last_status_change) < 30:
+            elif (current_time - i.last_status_change) < 30:  # ToDo: performance bottleneck
                 # Transfer initiating, changed within last 30 seconds
 
                 if (i.req is not None
@@ -470,7 +470,11 @@ class Transfers:
                         or i.status == "Getting status"):
                     in_progress_count += 1
 
-        return in_progress_count >= maxupslots
+            if in_progress_count >= maxupslots:
+                # slot_limit_reached, so stop iterating
+                return True
+
+        return False
 
     def bandwidth_limit_reached(self):
 


### PR DESCRIPTION
+ Added: As soon as `slot_limit_reached` is `True`, then break out of the loop, instead of iterating the entire `uploads` list
+ Changed: Iterate the uploads list in reverse, because active transfers are likely to be the most recent items
+ Changed: Local variable name '`now`' -> '`current_time`' in accordance with convention
+ Changed: Local variable name '`maxupslots`' -> '`uploadslots`' to match the name in config, it might as well be the same

- ToDo: Checking for `last_status_change` is slow, so it would be better to avoid doing this if possible