### PR TITLE
about.py: Credits headings and lines breaks

### DIFF
--- a/pynicotine/config.py
+++ b/pynicotine/config.py
@@ -62,9 +62,6 @@ class Config:
         self.application_name = "Nicotine+"
         self.application_id = "org.nicotine_plus.Nicotine"
         self.summary = _("Graphical client for the Soulseek peer-to-peer network")
-        self.copyright = """© 2001-2003 PySoulSeek Contributors
-© 2003-2004 Nicotine Team
-© 2004-2022 Nicotine+ Team"""
 
         self.website_url = "https://nicotine-plus.org/"
         self.privileges_url = "https://www.slsknet.org/userlogin.php?username=%s"

--- a/pynicotine/gtkgui/dialogs/about.py
+++ b/pynicotine/gtkgui/dialogs/about.py
@@ -28,7 +28,9 @@ from pynicotine.utils import open_uri
 
 class About:
 
-    AUTHORS = """Nicotine+ Contributors [active]
+    AUTHORS = """Nicotine+ Team
+
+Nicotine+ Contributors [active]
 
 &gt; Mat (mathiascode)
    - Maintainer
@@ -58,6 +60,7 @@ class About:
 &gt; slook
    - Tester
    - Accessibility improvements
+
 
 Nicotine+ Contributors [retired]
 
@@ -215,22 +218,25 @@ PySoulSeek Contributors [retired]
 
 Attributions
 
-- This product includes IP2Location LITE data
+- This program includes IP2Location LITE data
   available from:
   https://lite.ip2location.com
 
 - Country flags licensed under the MIT License.
   Copyright (c) 2016 Bowtie AB
-  Copyright (c) 2018 Jack Marsh
+  Copyright (c) 2018-2020 Jack Marsh
   https://github.com/jackiboy/flagpack
 
 - tinytag licensed under the MIT License.
-  Copyright (c) 2014-2018 Tom Wallroth
+  Copyright (c) 2014-2021 Tom Wallroth
   https://github.com/devsnd/tinytag/
+
 
 """
 
-    TRANSLATORS = """Dutch
+    TRANSLATORS = """Nicotine+ Translators
+
+Dutch
  - hboetes (2021-2022)
  - nince78 (2007)
  - hyriand
@@ -304,7 +310,8 @@ Swedish
  - alimony
 
 Turkish
- - Oğuz Ersen (2021-2022)"""
+ - Oğuz Ersen (2021-2022)
+"""
 
     def __init__(self, frame):
 

--- a/pynicotine/gtkgui/dialogs/about.py
+++ b/pynicotine/gtkgui/dialogs/about.py
@@ -1,4 +1,4 @@
-# COPYRIGHT (C) 2020-2021 Nicotine+ Team
+# COPYRIGHT (C) 2020-2022 Nicotine+ Team
 #
 # GNU GENERAL PUBLIC LICENSE
 #    Version 3, 29 June 2007
@@ -311,19 +311,24 @@ Swedish
 
 Turkish
  - Oğuz Ersen (2021-2022)
+
 """
+
+    COPYRIGHT = """© 2004-2022 Nicotine+ Team
+© 2003-2004 Nicotine Team
+© 2001-2003 PySoulSeek Contributors"""
 
     def __init__(self, frame):
 
         self.frame = frame
         self.dialog = Gtk.AboutDialog(
             comments=config.summary,
-            copyright=config.copyright,
+            copyright=self.COPYRIGHT,
             license_type=Gtk.License.GPL_3_0,
             version=config.version + "  •  GTK " + config.gtk_version,
             website=config.website_url,
             authors=self.AUTHORS.splitlines(),
-            translator_credits=self.TRANSLATORS
+            translator_credits=self.TRANSLATORS + config.translations_url
         )
         set_dialog_properties(self.dialog, frame.MainWindow)
         main_icon = get_icon("n")


### PR DESCRIPTION
+ Added: "Nicotine+ Team" top sub-heading
+ Added: Missing line breaks between each sub-section of Authors
+ Added: Link to translations URL below the Translators section

- Changed: "product" -> "program" in Attributions sub-section
- Changed: Copyright string from config.py moved into about.py, since it is not used anywhere else
- Changed: Copyright string in decending chronological order, with Nicotine+ Team at the top of the list 