### PR TITLE
notifications.py: Fix crash on Windows

### DIFF
--- a/pynicotine/gtkgui/widgets/notifications.py
+++ b/pynicotine/gtkgui/widgets/notifications.py
@@ -202,8 +202,8 @@ class WinNotify:
             # Tray icon was disabled by the user. Enable it temporarily to show a notification.
             self.tray_icon.show()
 
-        self.nid.sz_info_title = (title[:63].strip() + "…") if len(title) > 64 else title
-        self.nid.sz_info = (message[:255].strip() + "…") if len(message) > 256 else message
+        self.nid.sz_info_title = (title[:62].strip() + "…") if len(title) > 63 else title
+        self.nid.sz_info = (message[:254].strip() + "…") if len(message) > 255 else message
 
         windll.shell32.Shell_NotifyIconW(self.NIM_MODIFY, byref(self.nid))
         time.sleep(timeout)

--- a/pynicotine/gtkgui/widgets/notifications.py
+++ b/pynicotine/gtkgui/widgets/notifications.py
@@ -202,6 +202,7 @@ class WinNotify:
             # Tray icon was disabled by the user. Enable it temporarily to show a notification.
             self.tray_icon.show()
 
+        # Need to account for the null terminated character appended to the message length by Windows
         self.nid.sz_info_title = (title[:62].strip() + "…") if len(title) > 63 else title
         self.nid.sz_info = (message[:254].strip() + "…") if len(message) > 255 else message
 


### PR DESCRIPTION
+ Changed: Need to account for the null terminated character appended to the message length by Windows
+ Fixed: Crash on Windows if the message is exactly 256 or title is exactly 64 characters long

Fixes #1829

Ref: https://docs.microsoft.com/en-us/windows/win32/api/shellapi/ns-shellapi-notifyicondataw