### PR TITLE
Use significant decimals, rather than one decimal behind the dot.

### DIFF
--- a/pynicotine/utils.py
+++ b/pynicotine/utils.py
@@ -418,7 +418,7 @@ speed_suffixes = ['B/s', 'KiB/s', 'MiB/s', 'GiB/s', 'TiB/s', 'PiB/s', 'EiB/s', '
 def human_speed(filesize):
     try:
         step_unit = 1024
-        template = "%3.1f %s"
+        template = "%.3g %s"
 
         for index, suffix in enumerate(speed_suffixes):
             if filesize < step_unit:


### PR DESCRIPTION
Current -> Proposed:
1.2 Gb  -> 1.23 Gb

This provides sufficient precision without taking up too much space.