### PR TITLE
Human speed and size

### DIFF
--- a/pynicotine/utils.py
+++ b/pynicotine/utils.py
@@ -424,9 +424,7 @@ def human_speed(speed):
         for index, suffix in enumerate(speed_suffixes):
             if speed < step_unit:
                 if speed > carry:
-                    template = "%.2g %s"
-                    speed /= step_unit
-                    suffix = str(speed_suffixes[index + 1])
+                    template = "%.4g %s"
 
                 return template % (speed, suffix)
 

--- a/pynicotine/utils.py
+++ b/pynicotine/utils.py
@@ -393,52 +393,35 @@ def get_result_bitrate_length(filesize, attributes):
     return h_bitrate, bitrate, h_length, length
 
 
-size_suffixes = ['B', 'KiB', 'MiB', 'GiB', 'TiB', 'PiB', 'EiB', 'ZiB', 'YiB']
+suffixes = ['B', 'KiB', 'MiB', 'GiB', 'TiB', 'PiB', 'EiB', 'ZiB', 'YiB']
+step_unit = 1024
+carry = 999
 
 
-def human_size(filesize):
+def _human_speed_or_size(unit):
+    template = "%.3g %s"
     try:
-        step_unit = 1024
-        carry = 999
-        template = "%.3g %s"
-
-        for suffix in size_suffixes:
-            if filesize < step_unit:
-                if filesize > carry:
+        for suffix in suffixes:
+            if unit < step_unit:
+                if unit > carry:
                     template = "%.4g %s"
 
-                return template % (filesize, suffix)
+                return template % (unit, suffix)
 
-            filesize /= step_unit
+            unit /= step_unit
 
     except TypeError:
         pass
 
-    return filesize
-
-
-speed_suffixes = ['B/s', 'KiB/s', 'MiB/s', 'GiB/s', 'TiB/s', 'PiB/s', 'EiB/s', 'ZiB/s', 'YiB/s']
+    return unit
 
 
 def human_speed(speed):
-    try:
-        step_unit = 1024
-        carry = 999
-        template = "%.3g %s"
+    return _human_speed_or_size(speed) + "/s"
 
-        for suffix in speed_suffixes:
-            if speed < step_unit:
-                if speed > carry:
-                    template = "%.4g %s"
 
-                return template % (speed, suffix)
-
-            speed /= step_unit
-
-    except TypeError:
-        pass
-
-    return speed
+def human_size(filesize):
+    return _human_speed_or_size(filesize)
 
 
 def humanize(number):

--- a/pynicotine/utils.py
+++ b/pynicotine/utils.py
@@ -415,25 +415,27 @@ def human_size(filesize):
 speed_suffixes = ['B/s', 'KiB/s', 'MiB/s', 'GiB/s', 'TiB/s', 'PiB/s', 'EiB/s', 'ZiB/s', 'YiB/s']
 
 
-def human_speed(filesize):
+def human_speed(speed):
     try:
         step_unit = 1024
+        carry = 999
         template = "%.3g %s"
 
         for index, suffix in enumerate(speed_suffixes):
-            if filesize < step_unit:
-                if index <= 1:
-                    # Don't show decimals for KiB/s and B/s
-                    template = "%i %s"
+            if speed < step_unit:
+                if speed > carry:
+                    template = "%.2g %s"
+                    speed /= step_unit
+                    suffix = str(speed_suffixes[index+1])
 
-                return template % (filesize, suffix)
+                return template % (speed, suffix)
 
-            filesize /= step_unit
+            speed /= step_unit
 
     except TypeError:
         pass
 
-    return filesize
+    return speed
 
 
 def humanize(number):

--- a/pynicotine/utils.py
+++ b/pynicotine/utils.py
@@ -398,11 +398,16 @@ size_suffixes = ['B', 'KiB', 'MiB', 'GiB', 'TiB', 'PiB', 'EiB', 'ZiB', 'YiB']
 
 def human_size(filesize):
     try:
-        step_unit = 1024.0
+        step_unit = 1024
+        carry = 999
+        template = "%.3g %s"
 
-        for i in size_suffixes:
+        for suffix in size_suffixes:
             if filesize < step_unit:
-                return "%3.1f %s" % (filesize, i)
+                if filesize > carry:
+                    template = "%.4g %s"
+
+                return template % (filesize, suffix)
 
             filesize /= step_unit
 
@@ -421,7 +426,7 @@ def human_speed(speed):
         carry = 999
         template = "%.3g %s"
 
-        for index, suffix in enumerate(speed_suffixes):
+        for suffix in speed_suffixes:
             if speed < step_unit:
                 if speed > carry:
                     template = "%.4g %s"

--- a/pynicotine/utils.py
+++ b/pynicotine/utils.py
@@ -426,7 +426,7 @@ def human_speed(speed):
                 if speed > carry:
                     template = "%.2g %s"
                     speed /= step_unit
-                    suffix = str(speed_suffixes[index+1])
+                    suffix = str(speed_suffixes[index + 1])
 
                 return template % (speed, suffix)
 

--- a/pynicotine/utils.py
+++ b/pynicotine/utils.py
@@ -394,21 +394,19 @@ def get_result_bitrate_length(filesize, attributes):
 
 
 suffixes = ['B', 'KiB', 'MiB', 'GiB', 'TiB', 'PiB', 'EiB', 'ZiB', 'YiB']
-step_unit = 1024
-carry = 999
 
 
 def _human_speed_or_size(unit):
     template = "%.3g %s"
     try:
         for suffix in suffixes:
-            if unit < step_unit:
-                if unit > carry:
+            if unit < 1024:
+                if unit > 999:
                     template = "%.4g %s"
 
                 return template % (unit, suffix)
 
-            unit /= step_unit
+            unit /= 1024
 
     except TypeError:
         pass

--- a/pynicotine/utils.py
+++ b/pynicotine/utils.py
@@ -418,7 +418,7 @@ speed_suffixes = ['B/s', 'KiB/s', 'MiB/s', 'GiB/s', 'TiB/s', 'PiB/s', 'EiB/s', '
 def human_speed(filesize):
     try:
         step_unit = 1024
-        template = "%3.1f %s"
+        template = "%.3g %s"
 
         for index, suffix in enumerate(speed_suffixes):
             if filesize < step_unit:


### PR DESCRIPTION
Improve human_speed function
    
-    replace filesize with speed, which is the appropriate name
-    always use 3 digits of precision (not for 1.00)
-   print values between 1000 and 1024 as 0.98KiB/s
