### PR TITLE
Update control

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -15,7 +15,8 @@ Build-Depends:
     python3-gdbm,
     python3-gi (>= 3.18),
     python3-setuptools,
-    xvfb
+    xvfb,
+    python3-pytest-xvfb
 Vcs-Git: https://github.com/nicotine-plus/nicotine-plus.git
 Vcs-browser: https://github.com/nicotine-plus/nicotine-plus
 X-Python-Version: >= 3.5
@@ -41,4 +42,3 @@ Description: graphical client for Soulseek peer-to-peer network
  Nicotine+ aims to be a pleasant, free and open source (FOSS)
  alternative to the official Soulseek client, providing additional
  functionality while keeping current with the Soulseek protocol.
-


### PR DESCRIPTION
add python3-pytest-xvfb to build depends, needed to build in a Debian pbuilder schroot, may also be needed for Debian sbuild but I haven't tested that

once xvfb-run dh_auto_test is hit, it will fail with xvfb-run: error: xauth command not found