### PR TITLE
404.md: Download Nicotine+ link

### DIFF
--- a/404.md
+++ b/404.md
@@ -3,5 +3,5 @@ permalink: /404.html
 ---
 # Page Not Found
 This page doesn't exist. Perhaps you want to  
-- [Download Nicotine+](https://nicotine-plus.github.io/nicotine-plus/#download-nicotine)  
+- [Download Nicotine+](https://nicotine-plus.github.io/nicotine-plus/doc/DOWNLOADS)  
 - [Get involved](https://nicotine-plus.github.io/nicotine-plus/#getting-involved) in the Nicotine+ project


### PR DESCRIPTION
+ Changed: URL to '/doc/DOWNLOADS' because README.md no longer contains download links.