### PR TITLE
Links between DOWNLOADS.md and TESTING.md

### DIFF
--- a/doc/DOWNLOADS.md
+++ b/doc/DOWNLOADS.md
@@ -4,7 +4,7 @@ Download stable builds of Nicotine+ for your operating system.
 
 ## GNU/Linux, *BSD, Solaris
 
-If you have no need to modify the Nicotine+ source, you are strongly recommended to use packages for your distribution/operating system. This will save you time.
+If packages are available for your distribution/operating system, this will save you time.
 
 ### Ubuntu/Debian
 

--- a/doc/DOWNLOADS.md
+++ b/doc/DOWNLOADS.md
@@ -130,3 +130,7 @@ Once Homebrew is set up, run the following:
 ```sh
 brew install nicotine-plus
 ```
+
+## Testing Nicotine+
+
+If you want to download unstable builds and help test Nicotine+, see [TESTING.md](TESTING.md).

--- a/doc/DOWNLOADS.md
+++ b/doc/DOWNLOADS.md
@@ -1,8 +1,8 @@
 # Download Nicotine+
 
-Download stable builds of Nicotine+ for your operating system. For the release notes, see [NEWS.md](/NEWS.md).
+Download the current stable version of Nicotine+ for your operating system. For the release notes, see [NEWS.md](/NEWS.md).
 
-If you want to download unstable builds and help test Nicotine+, see [TESTING.md](TESTING.md).
+If you want to download the latest unstable build and help test Nicotine+, see [TESTING.md](TESTING.md).
 
 ## GNU/Linux, *BSD, Solaris
 

--- a/doc/DOWNLOADS.md
+++ b/doc/DOWNLOADS.md
@@ -6,8 +6,6 @@ If you want to download unstable builds and help test Nicotine+, see [TESTING.md
 
 ## GNU/Linux, *BSD, Solaris
 
-If packages are available for your distribution/operating system, this will save you time.
-
 ### Ubuntu/Debian
 
 To use [stable packages](https://launchpad.net/~nicotine-team/+archive/ubuntu/stable) on Ubuntu and Debian, add the stable Nicotine+ apt repository (PPA) by running the following:

--- a/doc/DOWNLOADS.md
+++ b/doc/DOWNLOADS.md
@@ -62,13 +62,13 @@ pkg install py-nicotine-plus
 
 ### pip
 
-If Nicotine+ is not available for your system, it can be installed using [pip](https://pip.pypa.io/). Ensure the [runtime dependencies](DEPENDENCIES.md) are installed, and run the following:
+If Nicotine+ is not packaged for your system, it can be installed using [pip](https://pip.pypa.io/). Ensure the [runtime dependencies](DEPENDENCIES.md) are installed, and run the following:
 
 ```sh
 pip3 install nicotine-plus
 ```
 
-Keep in mind that Nicotine+ will not auto-update. When a new release is available, run the following:
+Keep in mind that Nicotine+ will not update automatically. When a new release is available, run the following:
 
 ```sh
 pip3 install --upgrade nicotine-plus

--- a/doc/DOWNLOADS.md
+++ b/doc/DOWNLOADS.md
@@ -30,7 +30,7 @@ sudo dnf install nicotine+
 
 ### Flatpak
 
-If your distribution supports [Flatpak](https://www.flatpak.org/setup/), you can install [Nicotine+ from Flathub](https://flathub.org/apps/details/org.nicotine_plus.Nicotine), run the following:
+If your distribution supports [Flatpak](https://www.flatpak.org/setup/), you can install the current stable version of [Nicotine+ from Flathub](https://flathub.org/apps/details/org.nicotine_plus.Nicotine), run the following:
 
 ```sh
 flatpak install flathub org.nicotine_plus.Nicotine
@@ -62,7 +62,7 @@ pkg install py-nicotine-plus
 
 ### pip
 
-If Nicotine+ is not packaged for your system, it can be installed using [pip](https://pip.pypa.io/). Ensure the [runtime dependencies](DEPENDENCIES.md) are installed, and run the following:
+If Nicotine+ is not packaged for your system, the current stable version can be installed using [pip](https://pip.pypa.io/). Ensure the [runtime dependencies](DEPENDENCIES.md) are installed, and run the following:
 
 ```sh
 pip3 install nicotine-plus
@@ -76,19 +76,19 @@ pip3 install --upgrade nicotine-plus
 
 ## Windows
 
-### Official Builds
+### Official Release
 
 Stable Windows installers for Nicotine+ are available for download. Installing Nicotine+ requires administrator privileges.
 
-NOTE: The installer format has changed in Nicotine+ 3.2.0. If you are upgrading from Nicotine+ 3.1.1 or earlier, please uninstall Nicotine+ first (this will not remove your existing settings).
+*NOTE: The installer format has changed since Nicotine+ 3.2.0. If you are upgrading from Nicotine+ 3.1.1 or earlier, please uninstall Nicotine+ first (this will not remove your existing settings).*
 
-- [Download Nicotine+ 64-bit Windows Installer](https://github.com/nicotine-plus/nicotine-plus/releases/latest/download/windows-x86_64-installer.zip)  [[SHA256](https://github.com/nicotine-plus/nicotine-plus/releases/latest/download/windows-x86_64-installer.zip.sha256)]
-- [Download Nicotine+ 32-bit Windows Installer](https://github.com/nicotine-plus/nicotine-plus/releases/latest/download/windows-i686-installer.zip)  [[SHA256](https://github.com/nicotine-plus/nicotine-plus/releases/latest/download/windows-i686-installer.zip.sha256)]
+- [Download Nicotine+ 64-bit Windows Installer *(current stable version)*](https://github.com/nicotine-plus/nicotine-plus/releases/latest/download/windows-x86_64-installer.zip)  [[SHA256](https://github.com/nicotine-plus/nicotine-plus/releases/latest/download/windows-x86_64-installer.zip.sha256)]
+- [Download Nicotine+ 32-bit Windows Installer *current stable version)*](https://github.com/nicotine-plus/nicotine-plus/releases/latest/download/windows-i686-installer.zip)  [[SHA256](https://github.com/nicotine-plus/nicotine-plus/releases/latest/download/windows-i686-installer.zip.sha256)]
 
 Portable packages are also available. They can be run from your home directory, and do not require installation or administrator privileges.
 
-- [Download Nicotine+ 64-bit Windows Portable Package](https://github.com/nicotine-plus/nicotine-plus/releases/latest/download/windows-x86_64-package.zip)  [[SHA256](https://github.com/nicotine-plus/nicotine-plus/releases/latest/download/windows-x86_64-package.zip.sha256)]
-- [Download Nicotine+ 32-bit Windows Portable Package](https://github.com/nicotine-plus/nicotine-plus/releases/latest/download/windows-i686-package.zip)  [[SHA256](https://github.com/nicotine-plus/nicotine-plus/releases/latest/download/windows-i686-package.zip.sha256)]
+- [Download Nicotine+ 64-bit Windows Portable Package *(current stable version)*](https://github.com/nicotine-plus/nicotine-plus/releases/latest/download/windows-x86_64-package.zip)  [[SHA256](https://github.com/nicotine-plus/nicotine-plus/releases/latest/download/windows-x86_64-package.zip.sha256)]
+- [Download Nicotine+ 32-bit Windows Portable Package *(current stable version)*](https://github.com/nicotine-plus/nicotine-plus/releases/latest/download/windows-i686-package.zip)  [[SHA256](https://github.com/nicotine-plus/nicotine-plus/releases/latest/download/windows-i686-package.zip.sha256)]
 
 ### Scoop
 
@@ -115,19 +115,17 @@ choco install nicotine-plus
 
 ## macOS
 
-### Official Builds (Catalina/10.15 and newer)
+### Official Release (Catalina/10.15 and newer)
 
 A stable macOS installer for Nicotine+ is available on macOS version 10.15 (Catalina) and newer.
 
-- [Download Nicotine+ macOS Installer](https://github.com/nicotine-plus/nicotine-plus/releases/latest/download/macos-installer.zip)  [[SHA256](https://github.com/nicotine-plus/nicotine-plus/releases/latest/download/macos-installer.zip.sha256)]
+- [Download Nicotine+ macOS Installer *(current stable version)*](https://github.com/nicotine-plus/nicotine-plus/releases/latest/download/macos-installer.zip)  [[SHA256](https://github.com/nicotine-plus/nicotine-plus/releases/latest/download/macos-installer.zip.sha256)]
 
 ### Homebrew (Mojave/10.14 and newer)
 
-NOTE: If your Mac has an Apple M1 chip, please use the [official installer](#official-builds-catalina1015-and-newer) instead. Nicotine+ installed from Homebrew will currently not work on these devices due to issues in upstream dependencies.
+*NOTE: If your Mac has an Apple M1 chip, please use the [official macOS installer](https://github.com/nicotine-plus/nicotine-plus/releases/latest/download/macos-installer.zip) instead. Installing Nicotine+ from Homebrew will currently not work on Apple M1 devices due to issues in upstream dependencies.*
 
-On macOS version 10.14 (Mojave), the recommended approach is to install Nicotine+ using [Homebrew](https://brew.sh).
-
-Once Homebrew is set up, run the following:
+On macOS version 10.14 (Mojave), the recommended approach is to install Nicotine+ using [Homebrew](https://brew.sh), run the following:
 
 ```sh
 brew install nicotine-plus

--- a/doc/DOWNLOADS.md
+++ b/doc/DOWNLOADS.md
@@ -8,7 +8,7 @@ If you want to download the latest unstable build and help test Nicotine+, see [
 
 ### Ubuntu/Debian
 
-To use [stable packages](https://launchpad.net/~nicotine-team/+archive/ubuntu/stable) on Ubuntu and Debian, add the stable Nicotine+ apt repository (PPA) by running the following:
+To use [stable packages](https://launchpad.net/~nicotine-team/+archive/ubuntu/stable) on Ubuntu and Debian, add the *nicotine-team/stable* PPA repository by running the following:
 
 ```sh
 sudo apt install software-properties-common
@@ -18,7 +18,7 @@ sudo apt update
 sudo apt install nicotine
 ```
 
-If you prefer to install a .deb package directly, you can download one [here](http://ppa.launchpad.net/nicotine-team/stable/ubuntu/pool/main/n/nicotine/). Unlike the repository installation method, Nicotine+ will not update automatically; you need to download a .deb package each time a new release is available.
+If you prefer to install a .deb package directly, you can download one [here](http://ppa.launchpad.net/nicotine-team/stable/ubuntu/pool/main/n/nicotine/). Unlike the repository installation method, Nicotine+ will not update automatically unless you download and install it again each time a new release is available.
 
 ### Fedora
 
@@ -30,9 +30,11 @@ sudo dnf install nicotine+
 
 ### Flatpak
 
-If your distribution supports [Flatpak](https://www.flatpak.org/setup/), you can install Nicotine+ from Flathub.
+If your distribution supports [Flatpak](https://www.flatpak.org/setup/), you can install [Nicotine+ from Flathub](https://flathub.org/apps/details/org.nicotine_plus.Nicotine), run the following:
 
-- [Download Nicotine+ on Flathub](https://flathub.org/apps/details/org.nicotine_plus.Nicotine)
+```sh
+flatpak install flathub org.nicotine_plus.Nicotine
+```
 
 ### Arch Linux/Manjaro/Parabola
 
@@ -80,13 +82,13 @@ Stable Windows installers for Nicotine+ are available for download. Installing N
 
 NOTE: The installer format has changed in Nicotine+ 3.2.0. If you are upgrading from Nicotine+ 3.1.1 or earlier, please uninstall Nicotine+ first (this will not remove your existing settings).
 
-- [64-bit Installer](https://github.com/nicotine-plus/nicotine-plus/releases/latest/download/windows-x86_64-installer.zip)  [[SHA256](https://github.com/nicotine-plus/nicotine-plus/releases/latest/download/windows-x86_64-installer.zip.sha256)]
-- [32-bit Installer](https://github.com/nicotine-plus/nicotine-plus/releases/latest/download/windows-i686-installer.zip)  [[SHA256](https://github.com/nicotine-plus/nicotine-plus/releases/latest/download/windows-i686-installer.zip.sha256)]
+- [Download Nicotine+ 64-bit Windows Installer](https://github.com/nicotine-plus/nicotine-plus/releases/latest/download/windows-x86_64-installer.zip)  [[SHA256](https://github.com/nicotine-plus/nicotine-plus/releases/latest/download/windows-x86_64-installer.zip.sha256)]
+- [Download Nicotine+ 32-bit Windows Installer](https://github.com/nicotine-plus/nicotine-plus/releases/latest/download/windows-i686-installer.zip)  [[SHA256](https://github.com/nicotine-plus/nicotine-plus/releases/latest/download/windows-i686-installer.zip.sha256)]
 
 Portable packages are also available. They can be run from your home directory, and do not require installation or administrator privileges.
 
-- [64-bit Portable Package](https://github.com/nicotine-plus/nicotine-plus/releases/latest/download/windows-x86_64-package.zip)  [[SHA256](https://github.com/nicotine-plus/nicotine-plus/releases/latest/download/windows-x86_64-package.zip.sha256)]
-- [32-bit Portable Package](https://github.com/nicotine-plus/nicotine-plus/releases/latest/download/windows-i686-package.zip)  [[SHA256](https://github.com/nicotine-plus/nicotine-plus/releases/latest/download/windows-i686-package.zip.sha256)]
+- [Download Nicotine+ 64-bit Windows Portable Package](https://github.com/nicotine-plus/nicotine-plus/releases/latest/download/windows-x86_64-package.zip)  [[SHA256](https://github.com/nicotine-plus/nicotine-plus/releases/latest/download/windows-x86_64-package.zip.sha256)]
+- [Download Nicotine+ 32-bit Windows Portable Package](https://github.com/nicotine-plus/nicotine-plus/releases/latest/download/windows-i686-package.zip)  [[SHA256](https://github.com/nicotine-plus/nicotine-plus/releases/latest/download/windows-i686-package.zip.sha256)]
 
 ### Scoop
 
@@ -117,7 +119,7 @@ choco install nicotine-plus
 
 A stable macOS installer for Nicotine+ is available on macOS version 10.15 (Catalina) and newer.
 
-- [Download Installer](https://github.com/nicotine-plus/nicotine-plus/releases/latest/download/macos-installer.zip)  [[SHA256](https://github.com/nicotine-plus/nicotine-plus/releases/latest/download/macos-installer.zip.sha256)]
+- [Download Nicotine+ macOS Installer](https://github.com/nicotine-plus/nicotine-plus/releases/latest/download/macos-installer.zip)  [[SHA256](https://github.com/nicotine-plus/nicotine-plus/releases/latest/download/macos-installer.zip.sha256)]
 
 ### Homebrew (Mojave/10.14 and newer)
 

--- a/doc/DOWNLOADS.md
+++ b/doc/DOWNLOADS.md
@@ -1,6 +1,8 @@
 # Download Nicotine+
 
-Download stable builds of Nicotine+ for your operating system.
+Download stable builds of Nicotine+ for your operating system from here.
+
+If you want to download unstable builds and help test Nicotine+, see [TESTING.md](TESTING.md).
 
 ## GNU/Linux, *BSD, Solaris
 
@@ -130,7 +132,3 @@ Once Homebrew is set up, run the following:
 ```sh
 brew install nicotine-plus
 ```
-
-## Testing Nicotine+
-
-If you want to download unstable builds and help test Nicotine+, see [TESTING.md](TESTING.md).

--- a/doc/DOWNLOADS.md
+++ b/doc/DOWNLOADS.md
@@ -1,6 +1,6 @@
 # Download Nicotine+
 
-Download stable builds of Nicotine+ for your operating system from here.
+Download stable builds of Nicotine+ for your operating system. For the release notes, see [NEWS.md](/NEWS.md).
 
 If you want to download unstable builds and help test Nicotine+, see [TESTING.md](TESTING.md).
 
@@ -32,7 +32,7 @@ sudo dnf install nicotine+
 
 ### Flatpak
 
-If your distribution supports Flatpak, you can install Nicotine+ from Flathub.
+If your distribution supports [Flatpak](https://www.flatpak.org/setup/), you can install Nicotine+ from Flathub.
 
 - [Download Nicotine+ on Flathub](https://flathub.org/apps/details/org.nicotine_plus.Nicotine)
 
@@ -62,7 +62,7 @@ pkg install py-nicotine-plus
 
 ### pip
 
-If Nicotine+ is not available for your system, it can be installed using [pip](https://pip.pypa.io/en/stable/). Ensure the [runtime dependencies](DEPENDENCIES.md) are installed, and run the following:
+If Nicotine+ is not available for your system, it can be installed using [pip](https://pip.pypa.io/). Ensure the [runtime dependencies](DEPENDENCIES.md) are installed, and run the following:
 
 ```sh
 pip3 install nicotine-plus

--- a/doc/DOWNLOADS.md
+++ b/doc/DOWNLOADS.md
@@ -82,13 +82,13 @@ Stable Windows installers for Nicotine+ are available for download. Installing N
 
 *NOTE: The installer format has changed since Nicotine+ 3.2.0. If you are upgrading from Nicotine+ 3.1.1 or earlier, please uninstall Nicotine+ first (this will not remove your existing settings).*
 
-- [Download Nicotine+ 64-bit Windows Installer *(current stable version)*](https://github.com/nicotine-plus/nicotine-plus/releases/latest/download/windows-x86_64-installer.zip)  [[SHA256](https://github.com/nicotine-plus/nicotine-plus/releases/latest/download/windows-x86_64-installer.zip.sha256)]
-- [Download Nicotine+ 32-bit Windows Installer *current stable version)*](https://github.com/nicotine-plus/nicotine-plus/releases/latest/download/windows-i686-installer.zip)  [[SHA256](https://github.com/nicotine-plus/nicotine-plus/releases/latest/download/windows-i686-installer.zip.sha256)]
+- [Download Nicotine+ 64-bit Windows Installer](https://github.com/nicotine-plus/nicotine-plus/releases/latest/download/windows-x86_64-installer.zip)  [[SHA256](https://github.com/nicotine-plus/nicotine-plus/releases/latest/download/windows-x86_64-installer.zip.sha256)]
+- [Download Nicotine+ 32-bit Windows Installer](https://github.com/nicotine-plus/nicotine-plus/releases/latest/download/windows-i686-installer.zip)  [[SHA256](https://github.com/nicotine-plus/nicotine-plus/releases/latest/download/windows-i686-installer.zip.sha256)]
 
 Portable packages are also available. They can be run from your home directory, and do not require installation or administrator privileges.
 
-- [Download Nicotine+ 64-bit Windows Portable Package *(current stable version)*](https://github.com/nicotine-plus/nicotine-plus/releases/latest/download/windows-x86_64-package.zip)  [[SHA256](https://github.com/nicotine-plus/nicotine-plus/releases/latest/download/windows-x86_64-package.zip.sha256)]
-- [Download Nicotine+ 32-bit Windows Portable Package *(current stable version)*](https://github.com/nicotine-plus/nicotine-plus/releases/latest/download/windows-i686-package.zip)  [[SHA256](https://github.com/nicotine-plus/nicotine-plus/releases/latest/download/windows-i686-package.zip.sha256)]
+- [Download Nicotine+ 64-bit Windows Portable Package](https://github.com/nicotine-plus/nicotine-plus/releases/latest/download/windows-x86_64-package.zip)  [[SHA256](https://github.com/nicotine-plus/nicotine-plus/releases/latest/download/windows-x86_64-package.zip.sha256)]
+- [Download Nicotine+ 32-bit Windows Portable Package](https://github.com/nicotine-plus/nicotine-plus/releases/latest/download/windows-i686-package.zip)  [[SHA256](https://github.com/nicotine-plus/nicotine-plus/releases/latest/download/windows-i686-package.zip.sha256)]
 
 ### Scoop
 
@@ -119,7 +119,7 @@ choco install nicotine-plus
 
 A stable macOS installer for Nicotine+ is available on macOS version 10.15 (Catalina) and newer.
 
-- [Download Nicotine+ macOS Installer *(current stable version)*](https://github.com/nicotine-plus/nicotine-plus/releases/latest/download/macos-installer.zip)  [[SHA256](https://github.com/nicotine-plus/nicotine-plus/releases/latest/download/macos-installer.zip.sha256)]
+- [Download Nicotine+ macOS Installer](https://github.com/nicotine-plus/nicotine-plus/releases/latest/download/macos-installer.zip)  [[SHA256](https://github.com/nicotine-plus/nicotine-plus/releases/latest/download/macos-installer.zip.sha256)]
 
 ### Homebrew (Mojave/10.14 and newer)
 

--- a/doc/TESTING.md
+++ b/doc/TESTING.md
@@ -25,13 +25,13 @@ If you prefer to install a .deb package directly, you can download one [here](ht
 
 ### Flatpak
 
-Unstable Flatpak packages are generated after every commit to the master branch, and should only be used for testing.
+Unstable [Flatpak](https://www.flatpak.org/setup/) packages are generated after every commit to the master branch, and should only be used for testing.
 
 - [Download Package](https://nightly.link/nicotine-plus/nicotine-plus/workflows/packaging/master/flatpak-package.zip)
 
 ### pip
 
-To install the latest unstable build of Nicotine+ locally (no root required), run the following:
+To install the latest unstable build of Nicotine+ locally (no root required) with [pip](https://pip.pypa.io/en/stable/getting-started/), run the following:
 
 ```console
 pip install git+https://github.com/nicotine-plus/nicotine-plus.git

--- a/doc/TESTING.md
+++ b/doc/TESTING.md
@@ -31,7 +31,7 @@ Unstable [Flatpak](https://www.flatpak.org/setup/) packages are generated after 
 
 ### pip
 
-To install the latest unstable build of Nicotine+ locally (no root required) with [pip](https://pip.pypa.io/en/stable/getting-started/), run the following:
+To install the latest unstable build of Nicotine+ locally (no root required) using [pip](https://pip.pypa.io/), run the following:
 
 ```console
 pip install git+https://github.com/nicotine-plus/nicotine-plus.git

--- a/doc/TESTING.md
+++ b/doc/TESTING.md
@@ -1,12 +1,10 @@
 # Testing Nicotine+
 
-For those who like living on the bleeding edge and want to help testing the latest changes and bug fixes, you can run unstable builds of Nicotine+.
+For those who like living on the bleeding edge, you can run the latest unstable build of Nicotine+ and test the latest changes and bug fixes.
 
 If you want to download the current stable version of Nicotine+, see [DOWNLOADS.md](DOWNLOADS.md).
 
 ## GNU/Linux, *BSD, Solaris
-
-If you have no need to modify the Nicotine+ source, you should use packages for your distribution/operating system.
 
 ### Ubuntu/Debian
 
@@ -49,6 +47,25 @@ To uninstall Nicotine+, run:
 pip uninstall nicotine-plus
 ```
 
+### Git
+
+This is not particularly difficult, but may require some [dependancies](DEPENDENCIES.md) to be installed manually.
+
+To run Nicotine+ directly from a local [Git](https://git-scm.com/) folder, run the following:
+
+```console
+git clone https://github.com/nicotine-plus/nicotine-plus.git
+cd nicotine-plus
+./nicotine
+```
+
+To update to newer versions of Nicotine+, run the following:
+
+```console
+cd nicotine-plus
+git pull
+```
+
 ## Windows
 
 Unstable Windows packages are generated after every commit to the master branch, and should only be used for testing.
@@ -66,22 +83,3 @@ Portable packages are also available. They can be run from your home directory, 
 Unstable macOS installers are generated after every commit to the master branch, and should only be used for testing.
 
 - [Download Installer](https://nightly.link/nicotine-plus/nicotine-plus/workflows/packaging/master/macos-installer.zip)
-
-## Git
-
-This is not particularly difficult, but may require some dependancies to be installed manually, see [DEPENDENCIES.md](DEPENDENCIES.md).
-
-To run Nicotine+ directly from a local [Git](https://git-scm.com/) folder, run the following:
-
-```console
-git clone https://github.com/nicotine-plus/nicotine-plus.git
-cd nicotine-plus
-./nicotine
-```
-
-To update to newer versions of Nicotine+, run the following:
-
-```console
-cd nicotine-plus
-git pull
-```

--- a/doc/TESTING.md
+++ b/doc/TESTING.md
@@ -1,6 +1,6 @@
 # Testing Nicotine+
 
-For those who like living on the bleeding edge, you can run the latest unstable build of Nicotine+ and test the latest changes and bug fixes.
+For those who like living on the bleeding edge, you can run the latest unstable build of Nicotine+ and test recent changes and bug fixes.
 
 If you want to download the current stable version of Nicotine+, see [DOWNLOADS.md](DOWNLOADS.md).
 

--- a/doc/TESTING.md
+++ b/doc/TESTING.md
@@ -52,7 +52,7 @@ pip uninstall nicotine-plus
 
 ### Git
 
-To run Nicotine+ directly from a local Git folder, run the following:
+To run Nicotine+ directly from a local [Git](https://git-scm.com/) folder, run the following:
 
 ```console
 git clone https://github.com/nicotine-plus/nicotine-plus.git

--- a/doc/TESTING.md
+++ b/doc/TESTING.md
@@ -5,6 +5,8 @@ This is not particularly difficult, but may come with some additional required s
 
 ## GNU/Linux, *BSD, Solaris
 
+If you have no need to modify the Nicotine+ source, you should use packages for your distribution/operating system.
+
 ### Ubuntu/Debian
 
 The project builds [daily unstable snapshots](https://code.launchpad.net/~nicotine-team/+recipe/nicotine+-daily) in a separate [unstable PPA](https://code.launchpad.net/~nicotine-team/+archive/ubuntu/unstable). To use it, run the following:
@@ -48,7 +50,7 @@ pip uninstall nicotine-plus
 
 ### Git
 
-To run Nicotine+ directly from a folder, run the following:
+To run Nicotine+ directly from a local Git folder, run the following:
 
 ```console
 git clone https://github.com/nicotine-plus/nicotine-plus.git

--- a/doc/TESTING.md
+++ b/doc/TESTING.md
@@ -8,7 +8,7 @@ If you want to download the current stable version of Nicotine+, see [DOWNLOADS.
 
 ### Ubuntu/Debian
 
-The project builds [daily unstable snapshots](https://code.launchpad.net/~nicotine-team/+recipe/nicotine+-daily) in a separate [unstable PPA repository](https://code.launchpad.net/~nicotine-team/+archive/ubuntu/unstable). To use it, run the following:
+The project builds [daily unstable snapshots](https://code.launchpad.net/~nicotine-team/+recipe/nicotine+-daily) in a separate [unstable PPA repository](https://code.launchpad.net/~nicotine-team/+archive/ubuntu/unstable). To install the latest unstable build, run the following:
 
 ```sh
 sudo apt install software-properties-common
@@ -26,7 +26,7 @@ Unlike the repository installation method, Nicotine+ will not update automatical
 
 Unstable [Flatpak](https://www.flatpak.org/setup/) packages are generated after every commit to the master branch, and should only be used for testing.
 
-- [Download Nicotine+ Flatpak Package](https://nightly.link/nicotine-plus/nicotine-plus/workflows/packaging/master/flatpak-package.zip)
+- [Download Nicotine+ Flatpak Package *(latest unstable build)*](https://nightly.link/nicotine-plus/nicotine-plus/workflows/packaging/master/flatpak-package.zip)
 
 ### pip
 
@@ -38,7 +38,7 @@ pip install git+https://github.com/nicotine-plus/nicotine-plus.git
 
 Nicotine+ will now be available in your list of programs.
 
-To update to newer versions of Nicotine+, run the following command:
+To update your installation of Nicotine+, run the following command:
 
 ```console
 pip install --upgrade git+https://github.com/nicotine-plus/nicotine-plus.git
@@ -61,7 +61,7 @@ cd nicotine-plus
 ./nicotine
 ```
 
-To update to newer versions of Nicotine+, run the following:
+To update to the latest unstable build of Nicotine+, run the following:
 
 ```console
 cd nicotine-plus
@@ -72,16 +72,16 @@ git pull
 
 Unstable Windows packages are generated after every commit to the master branch, and should only be used for testing.
 
-- [Download Nicotine+ 64-bit Windows Installer](https://nightly.link/nicotine-plus/nicotine-plus/workflows/packaging/master/windows-x86_64-installer.zip)
-- [Download Nicotine+ 32-bit Windows Installer](https://nightly.link/nicotine-plus/nicotine-plus/workflows/packaging/master/windows-i686-installer.zip)
+- [Download Nicotine+ 64-bit Windows Installer *(latest unstable build)*](https://nightly.link/nicotine-plus/nicotine-plus/workflows/packaging/master/windows-x86_64-installer.zip)
+- [Download Nicotine+ 32-bit Windows Installer *(latest unstable build)*](https://nightly.link/nicotine-plus/nicotine-plus/workflows/packaging/master/windows-i686-installer.zip)
 
 Portable packages are also available. They can be run from your home directory, and do not require installation or administrator privileges.
 
-- [Download Nicotine+ 64-bit Windows Portable Package](https://nightly.link/nicotine-plus/nicotine-plus/workflows/packaging/master/windows-x86_64-package.zip)
-- [Download Nicotine+ 32-bit Windows Portable Package](https://nightly.link/nicotine-plus/nicotine-plus/workflows/packaging/master/windows-i686-package.zip)
+- [Download Nicotine+ 64-bit Windows Portable Package *(latest unstable build)*](https://nightly.link/nicotine-plus/nicotine-plus/workflows/packaging/master/windows-x86_64-package.zip)
+- [Download Nicotine+ 32-bit Windows Portable Package *(latest unstable build)*](https://nightly.link/nicotine-plus/nicotine-plus/workflows/packaging/master/windows-i686-package.zip)
 
 ## macOS (Catalina/10.15 and newer)
 
 Unstable macOS installers are generated after every commit to the master branch, and should only be used for testing.
 
-- [Download Nicotine+ macOS Installer](https://nightly.link/nicotine-plus/nicotine-plus/workflows/packaging/master/macos-installer.zip)
+- [Download Nicotine+ macOS Installer *(latest unstable build)*](https://nightly.link/nicotine-plus/nicotine-plus/workflows/packaging/master/macos-installer.zip)

--- a/doc/TESTING.md
+++ b/doc/TESTING.md
@@ -1,7 +1,6 @@
 # Testing Nicotine+
 
 For those who like living on the bleeding edge and want to help testing the latest changes and bug fixes, you can run unstable builds of Nicotine+.
-This is not particularly difficult, but may require some dependancies to be installed manually, see [DEPENDENCIES.md](DEPENDENCIES.md).
 
 If you want to download the current stable version of Nicotine+, see [DOWNLOADS.md](DOWNLOADS.md).
 
@@ -50,23 +49,6 @@ To uninstall Nicotine+, run:
 pip uninstall nicotine-plus
 ```
 
-### Git
-
-To run Nicotine+ directly from a local [Git](https://git-scm.com/) folder, run the following:
-
-```console
-git clone https://github.com/nicotine-plus/nicotine-plus.git
-cd nicotine-plus
-./nicotine
-```
-
-To update to newer versions of Nicotine+, run the following:
-
-```console
-cd nicotine-plus
-git pull
-```
-
 ## Windows
 
 Unstable Windows packages are generated after every commit to the master branch, and should only be used for testing.
@@ -84,3 +66,22 @@ Portable packages are also available. They can be run from your home directory, 
 Unstable macOS installers are generated after every commit to the master branch, and should only be used for testing.
 
 - [Download Installer](https://nightly.link/nicotine-plus/nicotine-plus/workflows/packaging/master/macos-installer.zip)
+
+## Git
+
+This is not particularly difficult, but may require some dependancies to be installed manually, see [DEPENDENCIES.md](DEPENDENCIES.md).
+
+To run Nicotine+ directly from a local [Git](https://git-scm.com/) folder, run the following:
+
+```console
+git clone https://github.com/nicotine-plus/nicotine-plus.git
+cd nicotine-plus
+./nicotine
+```
+
+To update to newer versions of Nicotine+, run the following:
+
+```console
+cd nicotine-plus
+git pull
+```

--- a/doc/TESTING.md
+++ b/doc/TESTING.md
@@ -1,7 +1,9 @@
 # Testing Nicotine+
 
 For those who like living on the bleeding edge and want to help testing the latest changes and bug fixes, you can run unstable builds of Nicotine+.
-This is not particularly difficult, but may come with some additional required skills, like managing changes in the database and the config files.
+This is not particularly difficult, but may require some dependancies to be installed manually, see [DEPENDENCIES.md](DEPENDENCIES.md).
+
+If you want to download the current stable version of Nicotine+, see [DOWNLOADS.md](DOWNLOADS.md).
 
 ## GNU/Linux, *BSD, Solaris
 
@@ -82,7 +84,3 @@ Portable packages are also available. They can be run from your home directory, 
 Unstable macOS installers are generated after every commit to the master branch, and should only be used for testing.
 
 - [Download Installer](https://nightly.link/nicotine-plus/nicotine-plus/workflows/packaging/master/macos-installer.zip)
-
-## Stable builds
-
-If you want to download the current stable version of Nicotine+, see [DOWNLOADS.md](DOWNLOADS.md).

--- a/doc/TESTING.md
+++ b/doc/TESTING.md
@@ -1,6 +1,6 @@
 # Testing Nicotine+
 
-For those who like living on the bleeding edge, you can run the latest unstable build of Nicotine+ and test recent changes and bug fixes.
+For those who like living on the bleeding edge, you can run the latest unstable build of Nicotine+ to test recent changes and bug fixes.
 
 If you want to download the current stable version of Nicotine+, see [DOWNLOADS.md](DOWNLOADS.md).
 
@@ -8,7 +8,7 @@ If you want to download the current stable version of Nicotine+, see [DOWNLOADS.
 
 ### Ubuntu/Debian
 
-The project builds [daily unstable snapshots](https://code.launchpad.net/~nicotine-team/+recipe/nicotine+-daily) in a separate [unstable PPA](https://code.launchpad.net/~nicotine-team/+archive/ubuntu/unstable). To use it, run the following:
+The project builds [daily unstable snapshots](https://code.launchpad.net/~nicotine-team/+recipe/nicotine+-daily) in a separate [unstable PPA repository](https://code.launchpad.net/~nicotine-team/+archive/ubuntu/unstable). To use it, run the following:
 
 ```sh
 sudo apt install software-properties-common
@@ -18,13 +18,15 @@ sudo apt update
 sudo apt install nicotine
 ```
 
-If you prefer to install a .deb package directly, you can download one [here](https://nightly.link/nicotine-plus/nicotine-plus/workflows/packaging/master/debian-package.zip). Unlike the repository installation method, Nicotine+ will not update automatically; you need to download a .deb package each time a new release is available.
+If you prefer to install a .deb package directly, you can download one [here](https://nightly.link/nicotine-plus/nicotine-plus/workflows/packaging/master/debian-package.zip).
+
+Unlike the repository installation method, Nicotine+ will not update automatically unless you download and install it again.
 
 ### Flatpak
 
 Unstable [Flatpak](https://www.flatpak.org/setup/) packages are generated after every commit to the master branch, and should only be used for testing.
 
-- [Download Package](https://nightly.link/nicotine-plus/nicotine-plus/workflows/packaging/master/flatpak-package.zip)
+- [Download Nicotine+ Flatpak Package](https://nightly.link/nicotine-plus/nicotine-plus/workflows/packaging/master/flatpak-package.zip)
 
 ### pip
 
@@ -70,16 +72,16 @@ git pull
 
 Unstable Windows packages are generated after every commit to the master branch, and should only be used for testing.
 
-- [64-bit Installer](https://nightly.link/nicotine-plus/nicotine-plus/workflows/packaging/master/windows-x86_64-installer.zip)
-- [32-bit Installer](https://nightly.link/nicotine-plus/nicotine-plus/workflows/packaging/master/windows-i686-installer.zip)
+- [Download Nicotine+ 64-bit Windows Installer](https://nightly.link/nicotine-plus/nicotine-plus/workflows/packaging/master/windows-x86_64-installer.zip)
+- [Download Nicotine+ 32-bit Windows Installer](https://nightly.link/nicotine-plus/nicotine-plus/workflows/packaging/master/windows-i686-installer.zip)
 
 Portable packages are also available. They can be run from your home directory, and do not require installation or administrator privileges.
 
-- [64-bit Portable Package](https://nightly.link/nicotine-plus/nicotine-plus/workflows/packaging/master/windows-x86_64-package.zip)
-- [32-bit Portable Package](https://nightly.link/nicotine-plus/nicotine-plus/workflows/packaging/master/windows-i686-package.zip)
+- [Download Nicotine+ 64-bit Windows Portable Package](https://nightly.link/nicotine-plus/nicotine-plus/workflows/packaging/master/windows-x86_64-package.zip)
+- [Download Nicotine+ 32-bit Windows Portable Package](https://nightly.link/nicotine-plus/nicotine-plus/workflows/packaging/master/windows-i686-package.zip)
 
 ## macOS (Catalina/10.15 and newer)
 
 Unstable macOS installers are generated after every commit to the master branch, and should only be used for testing.
 
-- [Download Installer](https://nightly.link/nicotine-plus/nicotine-plus/workflows/packaging/master/macos-installer.zip)
+- [Download Nicotine+ macOS Installer](https://nightly.link/nicotine-plus/nicotine-plus/workflows/packaging/master/macos-installer.zip)

--- a/doc/TESTING.md
+++ b/doc/TESTING.md
@@ -80,3 +80,7 @@ Portable packages are also available. They can be run from your home directory, 
 Unstable macOS installers are generated after every commit to the master branch, and should only be used for testing.
 
 - [Download Installer](https://nightly.link/nicotine-plus/nicotine-plus/workflows/packaging/master/macos-installer.zip)
+
+## Stable builds
+
+If you want to download the current stable version of Nicotine+, see [DOWNLOADS.md](DOWNLOADS.md).


### PR DESCRIPTION
+ Added: Link to TESTING.md, because this makes it easier to navigate around the website.
+ Added: Link to DOWNLOADS.md, incase website visitors get stuck on the wrong page.
+ Added: Link to DEPENDENCIES.md, this is useful and relevant in TESTING.md.

- Changed: Clarify "current stable version" and "latest unstable build" terminology to be more user-friendly.
- Changed: "Download Nicotine+" links to include SEO and user-friendly keywords.
- Changed: Plain text to hyperlinks for Flatpak, pip and Git, incase these tools need setup or config on the platform.
- Removed: Paragraph about source code from DOWNLOADS, it was an irrelevant statement of the obvious.