### PR TITLE
pynicotine.py: Add application executable and config path into debug log

### DIFF
--- a/pynicotine/pynicotine.py
+++ b/pynicotine/pynicotine.py
@@ -298,6 +298,7 @@ class NicotineCore:
 
         config.write_configuration()
 
+        log.add_debug("Saved configuration: %(file)s", {"file": config.filename})
         log.add(_("Quit %(program)s %(version)s, %(status)s!"), {
             "program": config.application_name,
             "version": config.version,

--- a/pynicotine/pynicotine.py
+++ b/pynicotine/pynicotine.py
@@ -223,10 +223,10 @@ class NicotineCore:
         self.network_callback = network_callback if network_callback else self.network_event
         script_dir = os.path.dirname(__file__)
 
+        log.add(_("Loading %(program)s %(version)s"), {"program": "Python", "version": config.python_version})
         log.add_debug("Using %(program)s executable: %(exe)s", {"program": "Python", "exe": str(sys.executable)})
         log.add_debug("Using %(program)s executable: %(exe)s", {"program": config.application_name, "exe": script_dir})
         log.add_debug("Using configuration: %(file)s", {"file": config.filename})
-        log.add(_("Loading %(program)s %(version)s"), {"program": "Python", "version": config.python_version})
         log.add(_("Loading %(program)s %(version)s"), {"program": config.application_name, "version": config.version})
 
         self.geoip = GeoIP(os.path.join(script_dir, "geoip/ipcountrydb.bin"))

--- a/pynicotine/pynicotine.py
+++ b/pynicotine/pynicotine.py
@@ -219,16 +219,17 @@ class NicotineCore:
 
     def start(self, ui_callback=None, network_callback=None):
 
-        log.add(_("Loading %(program)s %(version)s"), {"program": "Python", "version": config.python_version})
-        log.add(_("Loading %(program)s %(version)s"), {"program": config.application_name, "version": config.version})
-        log.add_debug("Using Python executable: %s", str(sys.executable))
-
         self.ui_callback = ui_callback
         self.network_callback = network_callback if network_callback else self.network_event
-
         script_dir = os.path.dirname(__file__)
-        self.geoip = GeoIP(os.path.join(script_dir, "geoip/ipcountrydb.bin"))
 
+        log.add_debug("Using %(program)s executable: %(exe)s", {"program": "Python", "exe": str(sys.executable)})
+        log.add_debug("Using %(program)s executable: %(exe)s", {"program": config.application_name, "exe": script_dir})
+        log.add_debug("Using configuration: %(file)s", {"file": config.filename})
+        log.add(_("Loading %(program)s %(version)s"), {"program": "Python", "version": config.python_version})
+        log.add(_("Loading %(program)s %(version)s"), {"program": config.application_name, "version": config.version})
+
+        self.geoip = GeoIP(os.path.join(script_dir, "geoip/ipcountrydb.bin"))
         self.notifications = Notifications(config, ui_callback)
         self.network_filter = NetworkFilter(self, config, self.queue, self.geoip)
         self.now_playing = NowPlaying(config)


### PR DESCRIPTION
+ Added: Nicotine+ executable to debug log, because this helps to avoid confusion when testing different dev versions
+ Added: Nicotine+ configuration file path to debug log, because this helps users to discover their profile path
+ Added: Nicotine+ configuration file path to debug log on quit, this could help users to troubleshoot errors or issues
+ Changed: Debug log string map for Python executable, because this follows the syntax of other log lines
+ Changed: The order of the startup debug lines and standard log lines, for better readability

```
04:08:55 Loading GTK 3.22.11
04:08:55 Loading Python 3.5.3 (default, Nov  4 2021, 15:29:10) 
[GCC 6.3.0 20170516]
04:08:55 [Misc] Using Python executable: /usr/bin/python3
04:08:55 [Misc] Using Nicotine+ executable: /home/user/Git/dev/nicotine-plus/pynicotine
04:08:55 [Misc] Using configuration: /home/user/.nicotine/config
04:08:55 Loading Nicotine+ 3.2.1.rc3
```
```
[2022-02-07 04:07:25] Quitting Nicotine+ 3.2.1.rc3, application closing…
[2022-02-07 04:07:25] [Misc] Saved configuration: /home/user/.nicotine/config
[2022-02-07 04:07:25] Quit Nicotine+ 3.2.1.rc3, done!
```
