### PR TITLE
transfers.py: Clean username subfolders for downloads

### DIFF
--- a/pynicotine/transfers.py
+++ b/pynicotine/transfers.py
@@ -1762,7 +1762,7 @@ class Transfers:
         # Check if username subfolders should be created for downloads
         if self.config.sections["transfers"]["usernamesubfolders"]:
             try:
-                downloaddir = os.path.join(downloaddir, user)
+                downloaddir = os.path.join(downloaddir, clean_file(user))
 
                 if not os.path.isdir(downloaddir):
                     os.makedirs(downloaddir)


### PR DESCRIPTION
+ Fixed: Usernames with illegal characters cause an error if 'Store completed downloads in username subfolders' is enabled.