### PR TITLE
Result Filters: Allow spaces and commas in Country Code filter entry string

### DIFF
--- a/pynicotine/gtkgui/search.py
+++ b/pynicotine/gtkgui/search.py
@@ -813,7 +813,7 @@ class Search(UserInterface):
         value = value.upper()
         allowed = False
 
-        for country_code in sfilter.split("|"):
+        for country_code in re.split('\|| |,|\+|&|and|or', sfilter):
             if country_code == value:
                 allowed = True
 

--- a/pynicotine/gtkgui/widgets/treeview.py
+++ b/pynicotine/gtkgui/widgets/treeview.py
@@ -466,7 +466,7 @@ def get_country_tooltip_text(column_value, strip_prefix):
 
     column_value = column_value[len(strip_prefix):]
     if column_value:
-        return GeoIP.country_code_to_name(column_value)
+        return GeoIP.country_code_to_name(column_value) + " (" + column_value + ")"
 
     return _("Earth")
 


### PR DESCRIPTION
+ Added: In addition to the "|" (or separator), also allow " " (space), "," (comma), "&", "+", "or", "and" in Country filter string
+ Added: In addition to the Country Name tooltip, also display the Country Code in brackets for ease of reference