### PR TITLE
Update debian copyright file to reference correct svg flag files.

### DIFF
--- a/debian/copyright
+++ b/debian/copyright
@@ -18,7 +18,7 @@ Files: pynicotine/geoip/ipcountrydb.bin
 Copyright: 2001-2018 Hexasoft Development Sdn. Bhd.
 License: CC-BY-SA-4.0
 
-Files: pynicotine/gtkgui/icons/flags/*
+Files: pynicotine/gtkgui/icons/hicolor/scalable/intl/nplus-flag-*.svg
 Copyright: 2016-2017 Bowtie AB
            2018-2020 Jack Marsh
 License: MIT


### PR DESCRIPTION
Between 3.2.0 and 3.2.1, the svg flag files have been moved from `pynicotine/gtkgui/icons/flags/` to `pynicotine/gtkgui/icons/hicolor/scalable/intl`.

This pull request updates the `debian/copyright` file to reference the new svg files.



