### PR TITLE
iconnotebook.py: Just set color without parsing

### DIFF
--- a/pynicotine/gtkgui/dialogs/preferences.py
+++ b/pynicotine/gtkgui/dialogs/preferences.py
@@ -1720,10 +1720,10 @@ class UserInterfaceFrame(UserInterface):
 
         if isinstance(widget, Gtk.Entry):
             rgba = Gdk.RGBA()
-            rgba.parse(widget.get_text())
 
-            color_button = getattr(self, Gtk.Buildable.get_name(widget).replace("Entry", "Pick"))
-            color_button.set_rgba(rgba)
+            if rgba.parse(widget.get_text()):
+                color_button = getattr(self, Gtk.Buildable.get_name(widget).replace("Entry", "Pick"))
+                color_button.set_rgba(rgba)
 
         self.theme_required = True
 

--- a/pynicotine/gtkgui/widgets/iconnotebook.py
+++ b/pynicotine/gtkgui/widgets/iconnotebook.py
@@ -21,6 +21,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import sys
+from html import escape
 
 from gi.repository import Gdk
 from gi.repository import Gtk
@@ -141,12 +142,9 @@ class TabLabel(Gtk.Box):
         if sys.platform != "darwin":
             self._add_close_button()
 
-    def _set_text_color(self, color):
+    def _set_text_color(self, color=None):
 
-        color_rgba = Gdk.RGBA()
-
-        if color_rgba.parse(color):
-            from html import escape
+        if color:
             self.label.set_markup("<span foreground=\"%s\">%s</span>" % (color, escape(self.text)))
             return
 


### PR DESCRIPTION
- Removed: Don't parse color with Gdk in Notebook, because at this point the config value should be correct
- Changed: Import html.escape module wide, because it is called too frequently to be imported on each chat message
+ Added: Parse for valid color when setting colors in Preferences (this might not be exactly the correct place?)

Aims to avoid recursion crash in #1889 