### PR TITLE
Show country code on flag tooltip and in File Properties

### DIFF
--- a/pynicotine/gtkgui/search.py
+++ b/pynicotine/gtkgui/search.py
@@ -1129,7 +1129,7 @@ class Search(UserInterface):
             virtual_path = self.resultsmodel.get_value(iterator, 11)
             directory, filename = virtual_path.rsplit('\\', 1)
             country_code = self.resultsmodel.get_value(iterator, 12)
-            country = "%s / %s" % (country_code, self.frame.np.geoip.country_code_to_name(country_code))
+            country = "%s (%s)" % (self.frame.np.geoip.country_code_to_name(country_code), country_code)
 
             data.append({
                 "user": self.resultsmodel.get_value(iterator, 1),

--- a/pynicotine/gtkgui/widgets/treeview.py
+++ b/pynicotine/gtkgui/widgets/treeview.py
@@ -464,9 +464,11 @@ def get_country_tooltip_text(column_value, strip_prefix):
     if not column_value.startswith(strip_prefix):
         return _("Unknown")
 
-    column_value = column_value[len(strip_prefix):]
-    if column_value:
-        return GeoIP.country_code_to_name(column_value)
+    country_code = column_value[len(strip_prefix):]
+
+    if country_code:
+        country = GeoIP.country_code_to_name(country_code)
+        return "%s (%s)" % (country, country_code)
 
     return _("Earth")
 


### PR DESCRIPTION
+ Added: Show country code on flag tooltip, because this helps for ease of reference when using the country filter
+ Changed: Use the same format for country code in search File Properties as in other modules