### PR TITLE
avoid using privileged ports

### DIFF
--- a/pynicotine/gtkgui/ui/settings/network.ui
+++ b/pynicotine/gtkgui/ui/settings/network.ui
@@ -2,14 +2,14 @@
 <interface>
   <requires lib="gtk+" version="3.0"/>
   <object class="GtkAdjustment" id="adjustment_FirstPort">
-    <property name="lower">1</property>
+    <property name="lower">1024</property>
     <property name="upper">65535</property>
     <property name="value">2234</property>
     <property name="step-increment">1</property>
     <property name="page-increment">10</property>
   </object>
   <object class="GtkAdjustment" id="adjustment_LastPort">
-    <property name="lower">1</property>
+    <property name="lower">1024</property>
     <property name="upper">65535</property>
     <property name="value">2239</property>
     <property name="step-increment">1</property>

--- a/test/unit/protocol/test_slskproto.py
+++ b/test/unit/protocol/test_slskproto.py
@@ -77,7 +77,7 @@ class SlskProtoTest(unittest.TestCase):
         queue = deque()
         proto = SlskProtoThread(
             core_callback=Mock(), queue=queue, interface='', bindip='',
-            port=None, port_range=(1, 65535), eventprocessor=Mock()
+            port=None, port_range=(1024, 65535), eventprocessor=Mock()
         )
 
         # Windows doesn't accept mock_socket in select() calls
@@ -112,7 +112,7 @@ class SlskProtoTest(unittest.TestCase):
         queue = deque()
         proto = SlskProtoThread(
             core_callback=Mock(), queue=queue, interface='', bindip='',
-            port=None, port_range=(1, 65535), eventprocessor=Mock()
+            port=None, port_range=(1024, 65535), eventprocessor=Mock()
         )
         proto.server_connect()
         queue.append(ServerConnect(addr=('0.0.0.0', 0), login=('username', 'password')))


### PR DESCRIPTION
The port-range 1-1023 is reserved for privileged processes and can only
be opened by the administrative user. Of course there is nothing stopping
users from running Nicotine+ as administrative user, but since it's not too
hard to figure out which port a user is using, it's also not too hard to
find users who do run n+ as admin.