### PR TITLE
Rename human

### DIFF
--- a/pynicotine/gtkgui/chatrooms.py
+++ b/pynicotine/gtkgui/chatrooms.py
@@ -529,7 +529,7 @@ class ChatRoom(UserInterface):
             h_speed = human_speed(avgspeed)
 
         files = userdata.files
-        h_files = humanize(files)
+        h_files = human_number(files)
 
         weight = Pango.Weight.NORMAL
         underline = Pango.Underline.NONE
@@ -867,7 +867,7 @@ class ChatRoom(UserInterface):
             h_speed = human_speed(avgspeed)
 
         self.usersmodel.set_value(iterator, 3, h_speed)
-        self.usersmodel.set_value(iterator, 4, humanize(files))
+        self.usersmodel.set_value(iterator, 4, human_number(files))
         self.usersmodel.set_value(iterator, 6, GObject.Value(GObject.TYPE_UINT, avgspeed))
         self.usersmodel.set_value(iterator, 7, GObject.Value(GObject.TYPE_UINT, files))
 

--- a/pynicotine/gtkgui/dialogs/fileproperties.py
+++ b/pynicotine/gtkgui/dialogs/fileproperties.py
@@ -120,7 +120,7 @@ class FileProperties(UserInterface):
         self.length_label.get_parent().set_visible(bool(length))
         self.length_value.get_parent().set_visible(bool(length))
 
-        self.queue_value.set_text(str(humanize(queue_position)))
+        self.queue_value.set_text(str(human_number(queue_position)))
         self.queue_label.get_parent().set_visible(bool(queue_position))
         self.queue_value.get_parent().set_visible(bool(queue_position))
 

--- a/pynicotine/gtkgui/dialogs/fileproperties.py
+++ b/pynicotine/gtkgui/dialogs/fileproperties.py
@@ -19,7 +19,7 @@
 from pynicotine.gtkgui.widgets.ui import UserInterface
 from pynicotine.gtkgui.widgets.dialogs import dialog_show
 from pynicotine.gtkgui.widgets.dialogs import generic_dialog
-from pynicotine.utils import human_length
+from pynicotine.utils import human_time
 from pynicotine.utils import human_size
 from pynicotine.utils import human_speed
 from pynicotine.utils import humanize
@@ -81,7 +81,7 @@ class FileProperties(UserInterface):
         if self.total_length:
             self.dialog.set_title(_("File Properties (%(num)i of %(total)i  /  %(size)s  /  %(length)s)") % {
                 'num': index, 'total': total_files, 'size': total_size,
-                'length': str(human_length(self.total_length))
+                'length': str(human_time(self.total_length))
             })
             return
 

--- a/pynicotine/gtkgui/interests.py
+++ b/pynicotine/gtkgui/interests.py
@@ -290,7 +290,7 @@ class Interests(UserInterface):
 
         for thing, rating in recommendations:
             self.recommendations_model.insert_with_valuesv(
-                -1, self.recommendations_column_numbers, [humanize(rating), thing, rating]
+                -1, self.recommendations_column_numbers, [human_number(rating), thing, rating]
             )
 
     def global_recommendations(self, msg):
@@ -357,7 +357,7 @@ class Interests(UserInterface):
             h_speed = human_speed(avgspeed)
 
         files = msg.files
-        h_files = humanize(msg.files)
+        h_files = human_number(msg.files)
 
         self.recommendation_users_model.set_value(iterator, 2, h_speed)
         self.recommendation_users_model.set_value(iterator, 3, h_files)

--- a/pynicotine/gtkgui/search.py
+++ b/pynicotine/gtkgui/search.py
@@ -314,7 +314,7 @@ class Search(UserInterface):
             str,                  # (6)  filename
             str,                  # (7)  h_size
             str,                  # (8)  h_bitrate
-            str,                  # (9)  h_length
+            str,                  # (9)  h_time
             GObject.TYPE_UINT,    # (10) bitrate
             str,                  # (11) fullpath
             str,                  # (12) country
@@ -566,7 +566,7 @@ class Search(UserInterface):
 
             size = result[2]
             h_size = human_size(size)
-            h_bitrate, bitrate, h_length, length = get_result_bitrate_length(size, result[4])
+            h_bitrate, bitrate, h_time, length = get_result_bitrate_length(size, result[4])
 
             if private:
                 name = _("[PRIVATE]  %s") % name
@@ -582,7 +582,7 @@ class Search(UserInterface):
                     name,
                     h_size,
                     h_bitrate,
-                    h_length,
+                    h_time,
                     GObject.Value(GObject.TYPE_UINT, bitrate),
                     fullpath,
                     country,
@@ -654,7 +654,7 @@ class Search(UserInterface):
 
     def add_row_to_model(self, row):
         (_counter, user, flag, h_speed, h_queue, directory, _filename, _h_size, _h_bitrate,
-            _h_length, _bitrate, fullpath, country, _size, speed, queue, _length, color) = row
+            _h_time, _bitrate, fullpath, country, _size, speed, queue, _length, color) = row
 
         expand_user = False
         expand_folder = False
@@ -1220,10 +1220,10 @@ class Search(UserInterface):
 
                 destination = self.frame.np.transfers.get_folder_destination(user, folder)
                 (_counter, user, _flag, _h_speed, _h_queue, _directory, _filename,
-                    _h_size, h_bitrate, h_length, _bitrate, fullpath, _country, size, _speed,
+                    _h_size, h_bitrate, h_time, _bitrate, fullpath, _country, size, _speed,
                     _queue, _length, _color) = row
                 visible_files.append(
-                    (user, fullpath, destination, size.get_uint64(), h_bitrate, h_length))
+                    (user, fullpath, destination, size.get_uint64(), h_bitrate, h_time))
 
             self.frame.np.search.request_folder_download(user, folder, visible_files)
 

--- a/pynicotine/gtkgui/search.py
+++ b/pynicotine/gtkgui/search.py
@@ -611,7 +611,7 @@ class Search(UserInterface):
             h_queue = ""
         else:
             inqueue = msg.inqueue or 1  # Ensure value is always >= 1
-            h_queue = humanize(inqueue)
+            h_queue = human_number(inqueue)
 
         h_speed = ""
         ulspeed = msg.ulspeed or 0

--- a/pynicotine/gtkgui/transferlist.py
+++ b/pynicotine/gtkgui/transferlist.py
@@ -44,7 +44,7 @@ from pynicotine.gtkgui.widgets.treeview import show_file_path_tooltip
 from pynicotine.gtkgui.widgets.treeview import verify_grouping_mode
 from pynicotine.gtkgui.widgets.ui import UserInterface
 from pynicotine.transfers import Transfer
-from pynicotine.utils import human_length
+from pynicotine.utils import human_time
 from pynicotine.utils import human_size
 from pynicotine.utils import human_speed
 
@@ -351,11 +351,11 @@ class TransferList(UserInterface):
 
     @staticmethod
     def get_helapsed(elapsed):
-        return human_length(elapsed) if elapsed >= 1 else ""
+        return human_time(elapsed) if elapsed >= 1 else ""
 
     @staticmethod
     def get_hleft(left):
-        return human_length(left) if left >= 1 else ""
+        return human_time(left) if left >= 1 else ""
 
     @staticmethod
     def get_percent(current_byte_offset, size):

--- a/pynicotine/gtkgui/userbrowse.py
+++ b/pynicotine/gtkgui/userbrowse.py
@@ -524,9 +524,9 @@ class UserBrowse(UserInterface):
             filename = file[1]
             size = file[2]
             selected_folder_size += size
-            h_bitrate, bitrate, h_length, length = get_result_bitrate_length(size, file[4])
+            h_bitrate, bitrate, h_time, length = get_result_bitrate_length(size, file[4])
 
-            file_row = [filename, human_size(size), h_bitrate, h_length,
+            file_row = [filename, human_size(size), h_bitrate, h_time,
                         GObject.Value(GObject.TYPE_UINT64, size),
                         GObject.Value(GObject.TYPE_UINT64, bitrate),
                         GObject.Value(GObject.TYPE_UINT64, length)]
@@ -580,11 +580,11 @@ class UserBrowse(UserInterface):
             for file_data in files:
                 virtualpath = "\\".join([folder, file_data[1]])
                 size = file_data[2]
-                h_bitrate, _bitrate, h_length, _length = get_result_bitrate_length(size, file_data[4])
+                h_bitrate, _bitrate, h_time, _length = get_result_bitrate_length(size, file_data[4])
 
                 self.frame.np.transfers.get_file(
                     self.user, virtualpath, destination,
-                    size=size, bitrate=h_bitrate, length=h_length)
+                    size=size, bitrate=h_bitrate, length=h_time)
 
         if not recurse:
             return
@@ -976,12 +976,12 @@ class UserBrowse(UserInterface):
 
             virtualpath = "\\".join([folder, file_data[1]])
             size = file_data[2]
-            h_bitrate, _bitrate, h_length, _length = get_result_bitrate_length(size, file_data[4])
+            h_bitrate, _bitrate, h_time, _length = get_result_bitrate_length(size, file_data[4])
 
             # Get the file
             self.frame.np.transfers.get_file(
                 self.user, virtualpath, prefix,
-                size=size, bitrate=h_bitrate, length=h_length)
+                size=size, bitrate=h_bitrate, length=h_time)
 
     def on_download_files_to_selected(self, selected, _data):
 
@@ -1089,12 +1089,12 @@ class UserBrowse(UserInterface):
                 filename = file_data[1]
                 file_size = file_data[2]
                 virtual_path = "\\".join([folder, filename])
-                h_bitrate, _bitrate, h_length, length = get_result_bitrate_length(file_size, file_data[4])
+                h_bitrate, _bitrate, h_time, length = get_result_bitrate_length(file_size, file_data[4])
                 selected_size += file_size
                 selected_length += length
 
                 data.append({"user": self.user, "fn": virtual_path, "filename": filename,
-                             "directory": folder, "size": file_size, "bitrate": h_bitrate, "length": h_length})
+                             "directory": folder, "size": file_size, "bitrate": h_bitrate, "length": h_time})
 
         else:
             model, paths = self.FileTreeView.get_selection().get_selected_rows()

--- a/pynicotine/gtkgui/userinfo.py
+++ b/pynicotine/gtkgui/userinfo.py
@@ -353,8 +353,8 @@ class UserInfo(UserInterface):
             self.descr_textview.clear()
             self.descr_textview.append_line(msg.descr, showstamp=False, scroll=False)
 
-        self.uploads.set_text(humanize(msg.totalupl))
-        self.queuesize.set_text(humanize(msg.queuesize))
+        self.uploads.set_text(human_number(msg.totalupl))
+        self.queuesize.set_text(human_number(msg.queuesize))
         self.slotsavail.set_text(_("Yes") if msg.slotsavail else _("No"))
 
         self.picture_data = None
@@ -368,8 +368,8 @@ class UserInfo(UserInterface):
         if msg.avgspeed > 0:
             self.speed.set_text(human_speed(msg.avgspeed))
 
-        self.filesshared.set_text(humanize(msg.files))
-        self.dirsshared.set_text(humanize(msg.dirs))
+        self.filesshared.set_text(human_number(msg.files))
+        self.dirsshared.set_text(human_number(msg.dirs))
 
     def set_user_country(self, country_code):
 

--- a/pynicotine/gtkgui/userlist.py
+++ b/pynicotine/gtkgui/userlist.py
@@ -375,7 +375,7 @@ class UserList(UserInterface):
             h_speed = human_speed(avgspeed)
 
         files = msg.files
-        h_files = humanize(files)
+        h_files = human_number(files)
 
         self.usersmodel.set_value(iterator, 3, h_speed)
         self.usersmodel.set_value(iterator, 4, h_files)

--- a/pynicotine/nowplaying.py
+++ b/pynicotine/nowplaying.py
@@ -25,7 +25,7 @@ import json
 from pynicotine.logfacility import log
 from pynicotine.utils import execute_command
 from pynicotine.utils import http_request
-from pynicotine.utils import human_length
+from pynicotine.utils import human_time
 
 
 class NowPlaying:
@@ -248,7 +248,7 @@ class NowPlaying:
 
         # The length is in microseconds, and be represented as a signed 64-bit integer.
         try:
-            self.title['length'] = human_length(metadata['mpris:length'] // 1000000)
+            self.title['length'] = human_time(metadata['mpris:length'] // 1000000)
         except KeyError:
             self.title['length'] = '?'
 

--- a/pynicotine/plugins/youtube_info/__init__.py
+++ b/pynicotine/plugins/youtube_info/__init__.py
@@ -22,7 +22,7 @@ import re
 
 from pynicotine.pluginsystem import BasePlugin
 from pynicotine.utils import http_request
-from pynicotine.utils import human_length
+from pynicotine.utils import human_time
 from pynicotine.utils import humanize
 
 
@@ -206,4 +206,4 @@ class Plugin(BasePlugin):
         for num, designator in re.findall(r'(\d+)([DHMS])', iso_8601_duration):
             seconds += intervals[designator] * int(num)
 
-        return human_length(seconds)
+        return human_time(seconds)

--- a/pynicotine/plugins/youtube_info/__init__.py
+++ b/pynicotine/plugins/youtube_info/__init__.py
@@ -173,10 +173,10 @@ class Plugin(BasePlugin):
             return None
 
         if likes != 'LIKES':
-            likes = humanize(int(likes))
+            likes = human_number(int(likes))
 
         if views != 'RESTRICTED':
-            views = humanize(int(views))
+            views = human_number(int(views))
 
         if live in ('live', 'upcoming'):
             duration = live.upper()

--- a/pynicotine/transfers.py
+++ b/pynicotine/transfers.py
@@ -658,11 +658,11 @@ class Transfers:
                 for file in files:
                     virtualpath = directory.rstrip('\\') + '\\' + file[1]
                     size = file[2]
-                    h_bitrate, _bitrate, h_length, _length = get_result_bitrate_length(size, file[4])
+                    h_bitrate, _bitrate, h_time, _length = get_result_bitrate_length(size, file[4])
 
                     self.get_file(
                         username, virtualpath, destination,
-                        size=size, bitrate=h_bitrate, length=h_length)
+                        size=size, bitrate=h_bitrate, length=h_time)
 
                 if directory in self.requested_folders.get(username, []):
                     del self.requested_folders[username][directory]

--- a/pynicotine/utils.py
+++ b/pynicotine/utils.py
@@ -403,7 +403,7 @@ def human_size(filesize):
     return _human_speed_or_size(filesize)
 
 
-def humanize(number):
+def human_number(number):
     return "{:n}".format(number)
 
 

--- a/pynicotine/utils.py
+++ b/pynicotine/utils.py
@@ -234,7 +234,7 @@ def make_version(version):
     return (major << 24) + (minor << 16) + (patch << 8) + stable
 
 
-def human_length(seconds):
+def human_time(seconds):
 
     minutes, seconds = divmod(seconds, 60)
     hours, minutes = divmod(minutes, 60)
@@ -278,7 +278,7 @@ def get_result_bitrate_length(filesize, attributes):
             h_bitrate = str(bitrate) + h_bitrate
 
             length = second
-            h_length = human_length(second)
+            h_length = human_time(second)
 
         # Sometimes the vbr indicator is in second position
         # Known clients: unknown (does this actually exist?)
@@ -291,14 +291,14 @@ def get_result_bitrate_length(filesize, attributes):
             h_bitrate = str(bitrate) + h_bitrate
 
             length = third
-            h_length = human_length(third)
+            h_length = human_time(third)
 
         # Lossless audio, length is in first position
         # Known clients: SoulseekQt 2015-6-12 and later
         elif third > 1:
 
             length = first
-            h_length = human_length(first)
+            h_length = human_time(first)
 
             # Bitrate = sample rate (Hz) * word length (bits) * channel count
             # Bitrate = 44100 * 16 * 2
@@ -338,7 +338,7 @@ def get_result_bitrate_length(filesize, attributes):
                 if bitrate > 0:
                     # Dividing the file size by the bitrate in Bytes should give us a good enough approximation
                     length = filesize / (bitrate * 125)
-                    h_length = human_length(length)
+                    h_length = human_time(length)
 
         # Lossless audio without length attribute
         # Known clients: SoulseekQt 2015-6-12 and later
@@ -352,7 +352,7 @@ def get_result_bitrate_length(filesize, attributes):
             if bitrate > 0:
                 # Dividing the file size by the bitrate in Bytes should give us a good enough approximation
                 length = filesize / (bitrate * 125)
-                h_length = human_length(length)
+                h_length = human_time(length)
 
         # Sometimes the bitrate is in first position and the length in second position
         # Known clients: SoulseekQt 2015-6-12 and later
@@ -362,7 +362,7 @@ def get_result_bitrate_length(filesize, attributes):
             h_bitrate = str(bitrate) + h_bitrate
 
             length = second
-            h_length = human_length(second)
+            h_length = human_time(second)
 
     # Ignore invalid values
     if bitrate <= 0:

--- a/pynicotine/utils.py
+++ b/pynicotine/utils.py
@@ -255,7 +255,7 @@ def get_result_bitrate_length(filesize, attributes):
     user browse files """
 
     h_bitrate = ""
-    h_length = ""
+    h_time = ""
 
     bitrate = 0
     length = 0
@@ -278,7 +278,7 @@ def get_result_bitrate_length(filesize, attributes):
             h_bitrate = str(bitrate) + h_bitrate
 
             length = second
-            h_length = human_time(second)
+            h_time = human_time(second)
 
         # Sometimes the vbr indicator is in second position
         # Known clients: unknown (does this actually exist?)
@@ -291,14 +291,14 @@ def get_result_bitrate_length(filesize, attributes):
             h_bitrate = str(bitrate) + h_bitrate
 
             length = third
-            h_length = human_time(third)
+            h_time = human_time(third)
 
         # Lossless audio, length is in first position
         # Known clients: SoulseekQt 2015-6-12 and later
         elif third > 1:
 
             length = first
-            h_length = human_time(first)
+            h_time = human_time(first)
 
             # Bitrate = sample rate (Hz) * word length (bits) * channel count
             # Bitrate = 44100 * 16 * 2
@@ -338,7 +338,7 @@ def get_result_bitrate_length(filesize, attributes):
                 if bitrate > 0:
                     # Dividing the file size by the bitrate in Bytes should give us a good enough approximation
                     length = filesize / (bitrate * 125)
-                    h_length = human_time(length)
+                    h_time = human_time(length)
 
         # Lossless audio without length attribute
         # Known clients: SoulseekQt 2015-6-12 and later
@@ -352,7 +352,7 @@ def get_result_bitrate_length(filesize, attributes):
             if bitrate > 0:
                 # Dividing the file size by the bitrate in Bytes should give us a good enough approximation
                 length = filesize / (bitrate * 125)
-                h_length = human_time(length)
+                h_time = human_time(length)
 
         # Sometimes the bitrate is in first position and the length in second position
         # Known clients: SoulseekQt 2015-6-12 and later
@@ -362,7 +362,7 @@ def get_result_bitrate_length(filesize, attributes):
             h_bitrate = str(bitrate) + h_bitrate
 
             length = second
-            h_length = human_time(second)
+            h_time = human_time(second)
 
     # Ignore invalid values
     if bitrate <= 0:
@@ -370,10 +370,10 @@ def get_result_bitrate_length(filesize, attributes):
         bitrate = 0
 
     if length < 0:
-        h_length = ""
+        h_time = ""
         length = 0
 
-    return h_bitrate, bitrate, h_length, length
+    return h_bitrate, bitrate, h_time, length
 
 
 def _human_speed_or_size(unit):


### PR DESCRIPTION
I propose renaming the following functions and variable, to make their function clearer:

humanize→human_number
human_length→human_time
h_length→h_time

Which I executed with the following commands:
```bash
cd pynicotine
sed -i 's|humanize(|human_number(|' $(ag -l humanize)
sed -i 's|human_length|human_time|' $(ag -l human_length)
sed -i 's|h_length|h_time|' $(ag -l h_length)
```
