### PR TITLE
Revert "Remove 'Clear Finished' buttons"

### DIFF
--- a/pynicotine/gtkgui/ui/downloads.ui
+++ b/pynicotine/gtkgui/ui/downloads.ui
@@ -141,6 +141,34 @@
             <property name="halign">end</property>
             <property name="hexpand">True</property>
             <child>
+              <object class="GtkButton">
+                <property name="visible">True</property>
+                <property name="tooltip-text" translatable="yes">Clear all finished and filtered downloads.</property>
+                <signal name="clicked" handler="on_clear_finished_filtered"/>
+                <child>
+                  <object class="GtkBox">
+                    <property name="visible">True</property>
+                    <property name="spacing">6</property>
+                    <child>
+                      <object class="GtkImage">
+                        <property name="visible">True</property>
+                        <property name="icon-name">edit-clear-symbolic</property>
+                      </object>
+                    </child>
+                    <child>
+                      <object class="GtkLabel">
+                        <property name="visible">True</property>
+                        <property name="label" translatable="yes">Clear Finished</property>
+                      </object>
+                    </child>
+                  </object>
+                </child>
+                <style>
+                  <class name="flat"/>
+                </style>
+              </object>
+            </child>
+            <child>
               <object class="GtkMenuButton" id="ClearTransfers">
                 <property name="visible">True</property>
                 <property name="direction">up</property>

--- a/pynicotine/gtkgui/ui/uploads.ui
+++ b/pynicotine/gtkgui/ui/uploads.ui
@@ -139,6 +139,34 @@
             <property name="halign">end</property>
             <property name="hexpand">True</property>
             <child>
+              <object class="GtkButton">
+                <property name="visible">True</property>
+                <property name="tooltip-text" translatable="yes">Clear all finished and cancelled uploads.</property>
+                <signal name="clicked" handler="on_clear_finished_aborted"/>
+                <child>
+                  <object class="GtkBox">
+                    <property name="visible">True</property>
+                    <property name="spacing">6</property>
+                    <child>
+                      <object class="GtkImage">
+                        <property name="visible">True</property>
+                        <property name="icon-name">edit-clear-symbolic</property>
+                      </object>
+                    </child>
+                    <child>
+                      <object class="GtkLabel">
+                        <property name="visible">True</property>
+                        <property name="label" translatable="yes">Clear Finished</property>
+                      </object>
+                    </child>
+                  </object>
+                </child>
+                <style>
+                  <class name="flat"/>
+                </style>
+              </object>
+            </child>
+            <child>
               <object class="GtkMenuButton" id="ClearTransfers">
                 <property name="visible">True</property>
                 <property name="direction">up</property>


### PR DESCRIPTION
Reverts nicotine-plus/nicotine-plus#1902

Perhaps we shouldn't remove this button until we can provide a way to do one-click clean-up of everything that's finished, such as with Ctrl+Click or suchlike.

https://github.com/nicotine-plus/nicotine-plus/commit/d121e9ca6c5233d3517849c54caa4b4d20664d5b#commitcomment-67978741