### PR TITLE
Preferences: Chats page icon

### DIFF
--- a/pynicotine/gtkgui/dialogs/preferences.py
+++ b/pynicotine/gtkgui/dialogs/preferences.py
@@ -2661,7 +2661,7 @@ class Preferences(UserInterface):
             ("Uploads", _("Uploads"), "emblem-shared-symbolic"),
             ("Searches", _("Searches"), "system-search-symbolic"),
             ("UserInfo", _("User Info"), "avatar-default-symbolic"),
-            ("Chats", _("Chats"), "user-available-symbolic"),
+            ("Chats", _("Chats"), "mail-unread-symbolic"),
             ("NowPlaying", _("Now Playing"), "folder-music-symbolic"),
             ("Logging", _("Logging"), "folder-documents-symbolic"),
             ("BannedUsers", _("Banned Users"), "action-unavailable-symbolic"),


### PR DESCRIPTION
+ Changed: Use the Private Chat icon instead of the Chat Rooms icon, because on Papirus themes the icon seems to be identical to the User Info icon

Before: ![image](https://user-images.githubusercontent.com/88614182/156945480-0263f7b5-86ea-4235-94b3-48df86743ce2.png)  - - - - After: ![image](https://user-images.githubusercontent.com/88614182/156945452-408b93d6-050d-4523-83e0-ddf6043241af.png)
