### PR TITLE
Chat Rooms: Speech self.room -> msg.room for the Public room feed

### DIFF
--- a/pynicotine/gtkgui/chatrooms.py
+++ b/pynicotine/gtkgui/chatrooms.py
@@ -786,14 +786,10 @@ class ChatRoom(UserInterface):
             )
 
             if self.Speech.get_active():
-
                 self.frame.np.notifications.new_tts(
-                    config.sections["ui"]["speechrooms"], {
-                        "room": self.room,
-                        "user": user,
-                        "message": speech
-                    }
+                    config.sections["ui"]["speechrooms"], {"room": msg.room, "user": user, "message": speech}
                 )
+
         else:
             self.chat_textview.append_line(
                 line, tag,


### PR DESCRIPTION
+ Fixed: Use `msg`.room instead of `self`.room for TTS, because otherwise all the rooms in the Public feed are "in room Public"