### PR TITLE
Chat Rooms: Fix broken string mentioned in action notification

### DIFF
--- a/pynicotine/gtkgui/chatrooms.py
+++ b/pynicotine/gtkgui/chatrooms.py
@@ -751,8 +751,6 @@ class ChatRoom(UserInterface):
         else:
             tag = self.tag_remote
 
-        self.show_notification(login_username, user, text, tag, public)
-
         if text.startswith("/me "):
             if public:
                 line = "%s | * %s %s" % (msg.room, user, text[4:])
@@ -799,6 +797,8 @@ class ChatRoom(UserInterface):
                 line, tag,
                 username=user, usertag=usertag, timestamp_format=timestamp_format
             )
+
+        self.show_notification(login_username, user, speech, tag, public)
 
     def echo_message(self, text, message_type):
 


### PR DESCRIPTION
+ Fixed: When mentioned in an action, `speech` is correctly sliced `text` without "/me " displayed in the notification popup
+ Changed: Show notification after appending line to chat TextView, to avoid the slight UI stutter upon mention

Suggest we could rename the `speech` variable to something more universally applicable such as `text_trimmed`