### PR TITLE
File Properties dialog: Also display filesize in Bytes

### DIFF
--- a/pynicotine/gtkgui/dialogs/fileproperties.py
+++ b/pynicotine/gtkgui/dialogs/fileproperties.py
@@ -98,7 +98,7 @@ class FileProperties(UserInterface):
 
         self.filename_value.set_text(str(properties["filename"]))
         self.folder_value.set_text(str(properties["directory"]))
-        self.filesize_value.set_text(str(human_size(properties["size"])))
+        self.filesize_value.set_text("%s (%s B)" % (human_size(properties["size"]), humanize(properties["size"])))
         self.username_value.set_text(str(properties["user"]))
 
         path = properties.get("path") or ""


### PR DESCRIPTION
+ Added: Display the filesize Bytes in brackets after factorized size, as is common for file management interfaces

![image](https://user-images.githubusercontent.com/88614182/157342664-7619e6ca-36fd-403e-8dc7-951cbc888ed8.png)

Helps with #1948 until perhaps some kind of options for customizing the filesize column can be implemented.