### PR TITLE
textentry.py: Show exit dialog (if set) on /quit /exit or /q command

### DIFF
--- a/pynicotine/gtkgui/widgets/textentry.py
+++ b/pynicotine/gtkgui/widgets/textentry.py
@@ -245,7 +245,7 @@ class ChatEntry:
             self.frame.on_away()
 
         elif cmd in ("/q", "/quit", "/exit"):
-            self.frame.np.quit()
+            self.frame.on_quit()
 
         elif cmd in ("/c", "/close"):
             self.frame.privatechat.pages[self.entity].on_close()


### PR DESCRIPTION
+ Changed: Respect the 'When closing Nicotine+' setting preference, instead of terminating unexpectedly when typing "`/q`"

A one letter command is too short for a function which kills the application when entering any string starting with "`/q `..."

Suggest the aliases could be split into different functions if anybody wants a way to do termination without prompt.

The dialog without the 'remember' toggle is shown, to avoid confusing the user's window close settings.