### PR TITLE
Preferences: Fix Critical Error on Chats page when TTS format string invalid

### DIFF
--- a/pynicotine/gtkgui/dialogs/preferences.py
+++ b/pynicotine/gtkgui/dialogs/preferences.py
@@ -1347,10 +1347,10 @@ class ChatsFrame(UserInterface):
 
         for i in ("%(user)s", "%(message)s"):
             if i not in config.sections["ui"]["speechprivate"]:
-                self.default_private(None)
+                self.on_default_private(None)
 
             if i not in config.sections["ui"]["speechrooms"]:
-                self.default_rooms(None)
+                self.on_default_rooms(None)
 
         for word, replacement in config.sections["words"]["autoreplaced"].items():
             self.replace_list_model.insert_with_valuesv(-1, self.column_numbers, [


### PR DESCRIPTION
+ Fixed: Critical Error on open Preferences Chats page after previously being allowed to set invalid TTS format string:

```
Error in sys.excepthook:
Traceback (most recent call last):
  File "/home/user/Git/dev/nicotine-plus/pynicotine/gtkgui/dialogs/preferences.py", line 3077, in on_switch_page
    page.set_settings()
  File "/home/user/Git/dev/nicotine-plus/pynicotine/gtkgui/dialogs/preferences.py", line 1350, in set_settings
    self.default_private(None)
AttributeError: 'ChatsFrame' object has no attribute 'default_private'
```

ToDo: Validate TTS format strings when changed to avoid crash in new_tts()