### PR TITLE
Chat Rooms: TTS off by default in Public feed

### DIFF
--- a/pynicotine/gtkgui/chatrooms.py
+++ b/pynicotine/gtkgui/chatrooms.py
@@ -506,6 +506,7 @@ class ChatRoom(UserInterface):
             self.RoomOptions.remove(widget)
             self.ChatEntryBox.add(widget)
 
+        self.Speech.set_active(False)  # Public feed is jibberish and too fast for TTS
         self.ChatEntry.set_sensitive(False)
         self.ChatEntryBox.set_halign(Gtk.Align.END)
 


### PR DESCRIPTION
+ Changed: Text-To-Speech off by default in Public feed, because messages are relentless and way too fast for TTS to keep up

Should a TTS user wish to enable Auto-join for the Public feed, then Speech always needs to be turned off at the start of every session, otherwise the speech message queue quickly becomes overwhelmed (it never catches up).