### PR TITLE
Document attribute combinations for Qt > 2015-6-12, slskd

### DIFF
--- a/doc/SLSKPROTOCOL.md
+++ b/doc/SLSKPROTOCOL.md
@@ -86,18 +86,18 @@ If you find any inconsistencies, errors or omissions in the documentation, pleas
 
 #### Used Attribute Combinations
 
-  - Soulseek NS, SoulseekQt (2015-2-21 and earlier), Nicotine+, Museek+, SoulSeeX:
+  - Soulseek NS, SoulseekQt (2015-2-21 and earlier), Nicotine+, Museek+, SoulSeeX, slskd (lossy formats):
       - {0: *bitrate*, 1: *length*, 2: *VBR*}
 
   - SoulseekQt (2015-2-21 and earlier):
       - {0: *bitrate*, 2: *VBR*}
 
-  - SoulseekQt (2015-6-12 and later):
+  - SoulseekQt (2015-6-12 and later), slskd (lossless formats):
       - {0: *bitrate*}
       - {1: *length*}
-      - {0: *bitrate*, 1: *length*}
+      - {0: *bitrate*, 1: *length*} (MP3, OGG)
       - {4: *sample rate*, 5: *bit depth*}
-      - {1: *length*, 4: *sample rate*, 5: *bit depth*}
+      - {1: *length*, 4: *sample rate*, 5: *bit depth*} (FLAC, WAV, APE)
 
 # Server Messages
 

--- a/doc/SLSKPROTOCOL.md
+++ b/doc/SLSKPROTOCOL.md
@@ -95,7 +95,7 @@ If you find any inconsistencies, errors or omissions in the documentation, pleas
   - SoulseekQt (2015-6-12 and later), slskd (lossless formats):
       - {0: *bitrate*}
       - {1: *length*}
-      - {0: *bitrate*, 1: *length*} (MP3, OGG)
+      - {0: *bitrate*, 1: *length*} (MP3, OGG, WMA, M4A)
       - {4: *sample rate*, 5: *bit depth*}
       - {1: *length*, 4: *sample rate*, 5: *bit depth*} (FLAC, WAV, APE)
 


### PR DESCRIPTION
I was able to confirm the attributes returned by Qt > 2015-6-12 for the most common lossless and lossy formats.  I tried an AIFF and it returned only bitrate and length, but from what I can tell there are both lossless and lossy versions so I'm reluctant to commit that to documentation at the moment.

For slskd I'm choosing to include the VBR attribute for lossy formats because NS and Nicotine+ both display it and I think there's some benefit for client-side filtering.  Interestingly, Qt doesn't display the VBR flag on the UI, but it does appear to work when filtering with `isvbr`.