### PR TITLE
gui/userbrowse.py: allow Refresh if connect failed

### DIFF
--- a/pynicotine/gtkgui/userbrowse.py
+++ b/pynicotine/gtkgui/userbrowse.py
@@ -478,18 +478,15 @@ class UserBrowse(UserInterface):
         else:
             self.progressbar1.set_fraction(0.5)
 
-        self.RefreshButton.set_sensitive(False)
-
     def message_progress(self, msg):
 
         if msg.total == 0 or msg.position == 0:
-            fraction = 0.0
+            self.progressbar1.set_fraction(0.0)
         elif msg.position >= msg.total:
-            fraction = 1.0
+            self.progressbar1.set_fraction(1.0)
         else:
-            fraction = float(msg.position) / msg.total
-
-        self.progressbar1.set_fraction(fraction)
+            self.progressbar1.set_fraction(float(msg.position) / msg.total)
+            self.RefreshButton.set_sensitive(False)
 
     def set_finished(self):
 


### PR DESCRIPTION
+ Changed: Wait until loading shares list is actually in progress before disabling the RefreshButton

In some cases of connection failure the button always remains disabled (greyed-out) because a time-out never triggers the error bar (which re-enables the button), such that if the remote shares has since become available then only the keyboard shortcut is possible to load the shares list, or else the Browse page must be closed and re-opened to initialize browsing.

The blocked UI leads mouse users into wrongly thinking that an initial error has persisted.

A different alternative fix might be possible by calling `show_connection_error()` in cases where all the associated connection attempts are finally stopped, refused or removed, but tracking this is more complex.