### PR TITLE
settings/userinterface.ui: clarify 'Prefer dark mode' tip

### DIFF
--- a/pynicotine/gtkgui/ui/settings/userinterface.ui
+++ b/pynicotine/gtkgui/ui/settings/userinterface.ui
@@ -34,7 +34,7 @@
                   <object class="GtkCheckButton" id="DarkMode">
                     <property name="label" translatable="yes">Prefer dark mode</property>
                     <property name="visible">True</property>
-                    <property name="tooltip_text" translatable="yes">Note that the operating system&apos;s theme may take precedence.</property>
+                    <property name="tooltip_text" translatable="yes">Nicotine+ can only ask GTK to enable the dark theme, it cannot force the light theme, and the operating system&apos;s theme may take precedence.</property>
                     <signal name="toggled" handler="on_theme_changed"/>
                   </object>
                 </child>


### PR DESCRIPTION
May close #1983

+ Changed: Tooltip text for 'Prefer dark mode' because the hit-and-miss nature of this option warrants a deeper explanation.