### PR TITLE
chatrooms.ui: add label to Room Wall button

### DIFF
--- a/pynicotine/gtkgui/chatrooms.py
+++ b/pynicotine/gtkgui/chatrooms.py
@@ -532,8 +532,7 @@ class ChatRoom(UserInterface):
         if self.room != "Public ":
             return
 
-        for widget in (self.activity_container, self.users_container, self.chat_entry,
-                       self.room_wall_button, self.help_button):
+        for widget in (self.activity_container, self.users_container, self.chat_entry, self.help_button):
             widget.hide()
 
         for widget in (self.auto_join_toggle, self.log_toggle):

--- a/pynicotine/gtkgui/ui/chatrooms.ui
+++ b/pynicotine/gtkgui/ui/chatrooms.ui
@@ -134,21 +134,6 @@
                           </object>
                         </child>
                         <child>
-                          <object class="GtkMenuButton" id="room_wall_button">
-                            <property name="visible">True</property>
-                            <property name="tooltip-text" translatable="yes">Room wall</property>
-                            <child>
-                              <object class="GtkImage">
-                                <property name="visible">True</property>
-                                <property name="icon-name">view-list-symbolic</property>
-                              </object>
-                            </child>
-                            <style>
-                              <class name="image-button"/>
-                            </style>
-                          </object>
-                        </child>
-                        <child>
                           <object class="GtkMenuButton" id="help_button">
                             <property name="visible">True</property>
                             <property name="tooltip-text" translatable="yes">Chat room command help</property>
@@ -240,15 +225,41 @@
                 <child>
                   <object class="GtkBox" id="room_options_container">
                     <property name="visible">True</property>
-                    <property name="orientation">vertical</property>
-                    <property name="margin-start">8</property>
+                    <property name="margin-start">12</property>
                     <property name="margin-end">6</property>
-                    <property name="margin-top">6</property>
-                    <property name="margin-bottom">6</property>
-                    <property name="spacing">4</property>
+                    <property name="margin-top">8</property>
+                    <property name="margin-bottom">8</property>
+                    <property name="spacing">6</property>
+                    <child>
+                      <object class="GtkMenuButton" id="room_wall_button">
+                        <property name="visible">True</property>
+                        <child>
+                          <object class="GtkBox">
+                            <property name="visible">True</property>
+                            <property name="spacing">6</property>
+                            <child>
+                              <object class="GtkImage">
+                                <property name="visible">True</property>
+                                <property name="icon-name">view-list-symbolic</property>
+                              </object>
+                            </child>
+                            <child>
+                              <object class="GtkLabel">
+                                <property name="visible">True</property>
+                                <property name="use-underline">True</property>
+                                <property name="label">Room _Wall</property>
+                              </object>
+                            </child>
+                          </object>
+                        </child>
+                        <style>
+                          <class name="image-button"/>
+                        </style>
+                      </object>
+                    </child>
                     <child>
                       <object class="GtkCheckButton" id="auto_join_toggle">
-                        <property name="label" translatable="yes">_Auto-join Room</property>
+                        <property name="label" translatable="yes">_Auto-join</property>
                         <property name="visible">True</property>
                         <property name="use-underline">True</property>
                         <signal name="toggled" handler="on_autojoin"/>

--- a/pynicotine/gtkgui/ui/chatrooms.ui
+++ b/pynicotine/gtkgui/ui/chatrooms.ui
@@ -247,7 +247,7 @@
                               <object class="GtkLabel">
                                 <property name="visible">True</property>
                                 <property name="use-underline">True</property>
-                                <property name="label">Room _Wall</property>
+                                <property name="label">R_oom Wall</property>
                               </object>
                             </child>
                           </object>


### PR DESCRIPTION
+ Added: Label for "R**o**om Wall" button, because the icon alone was not enough to clearly identify the feature and lacked accessibility.

+ Changed: Label for "Auto-join Room" -> "Auto-join" to save horizontal space because the nearby button label now mentions "Room".

+ Moved: Arrangement of 'room_options_container' widgets, which now appear more unified with the layout of Private Chat widgets.

![image](https://user-images.githubusercontent.com/88614182/166616084-48914d0d-9918-473f-b3a9-bf8ff47b8b1a.png)
