### PR TITLE
pynicotine.py: don't log new password string value after changing it

### DIFF
--- a/pynicotine/pynicotine.py
+++ b/pynicotine/pynicotine.py
@@ -920,7 +920,7 @@ class NicotineCore:
         config.sections["server"]["passw"] = password
         config.write_configuration()
 
-        log.add_important_info(_("Your password has been changed."))
+        log.add_important_info(_("Your password has been changed"))
 
     def private_room_add_operator(self, msg):
         """ Server code: 143 """

--- a/pynicotine/pynicotine.py
+++ b/pynicotine/pynicotine.py
@@ -920,8 +920,7 @@ class NicotineCore:
         config.sections["server"]["passw"] = password
         config.write_configuration()
 
-        log.add_important_info(
-            _("Your password has been changed. Password is %s"), password)
+        log.add_important_info(_("Your password has been changed."))
 
     def private_room_add_operator(self, msg):
         """ Server code: 143 """


### PR DESCRIPTION
Displaying and logging the value of this setting in clear text doesn't seem appropriate, because it could pose a security risk.

_Confirmation dialog:_
![image](https://user-images.githubusercontent.com/88614182/169103200-deac0856-3240-4d77-ab6c-79eca1d5d8ea.png)

_Log:_
`[2022-05-18 18:14:43] Your password has been changed.`