### PR TITLE
frame.py: show important log messages in log view

### DIFF
--- a/pynicotine/gtkgui/frame.py
+++ b/pynicotine/gtkgui/frame.py
@@ -1771,7 +1771,6 @@ class NicotineFrame(UserInterface):
         if level and level.startswith("important"):
             title = "Information" if level == "important_info" else "Error"
             MessageDialog(parent=self.application.get_active_window(), title=title, message=msg).show()
-            return False
 
         # Keep verbose debug messages out of statusbar to make it more useful
         if level not in ("transfer", "connection", "message", "miscellaneous"):


### PR DESCRIPTION
It doesn't make sense to hide 'important' level log messages from the Log Pane, since they are displayed in the console and to file, so why not show them in the interface too... This is handy after closing the dialog box to see what it said.