### PR TITLE
nicotine: Improve command line usage help description string

### DIFF
--- a/pynicotine/__init__.py
+++ b/pynicotine/__init__.py
@@ -40,7 +40,7 @@ def check_arguments():
     )
     parser.add_argument(
         "-u", "--user-data", metavar=_("dir"),
-        help=_("use non-default user data directory")
+         help=_("use non-default user data directory for e.g. list of downloads")
     )
     parser.add_argument(
         "-p", "--plugins", metavar=_("dir"),

--- a/pynicotine/__init__.py
+++ b/pynicotine/__init__.py
@@ -26,7 +26,7 @@ def check_arguments():
     from pynicotine.config import config
 
     parser = argparse.ArgumentParser(
-        description=config.summary, epilog="%s <%s>" % (config.author, config.website_url), add_help=False
+        description=config.summary, epilog=_("Website: %s") % config.website_url, add_help=False
     )
 
     # Visible arguments

--- a/pynicotine/__init__.py
+++ b/pynicotine/__init__.py
@@ -26,11 +26,14 @@ def check_arguments():
     from pynicotine.config import config
 
     parser = argparse.ArgumentParser(
-        description="%s %s - %s" % (config.application_name, config.version, config.summary),
-        epilog="%s <%s>" % (config.author, config.website_url)
+        description=config.summary, epilog="%s <%s>" % (config.author, config.website_url), add_help=False
     )
 
     # Visible arguments
+    parser.add_argument(
+        "-h", "--help", action="help",
+        help=_("show this help message and exit")
+    )
     parser.add_argument(
         "-c", "--config", metavar=_("file"),
         help=_("use non-default configuration file")

--- a/pynicotine/__init__.py
+++ b/pynicotine/__init__.py
@@ -40,7 +40,7 @@ def check_arguments():
     )
     parser.add_argument(
         "-u", "--user-data", metavar=_("dir"),
-         help=_("use non-default user data directory for e.g. list of downloads")
+        help=_("use non-default user data directory for e.g. list of downloads")
     )
     parser.add_argument(
         "-p", "--plugins", metavar=_("dir"),

--- a/pynicotine/__init__.py
+++ b/pynicotine/__init__.py
@@ -24,20 +24,20 @@ def check_arguments():
 
     import argparse
     from pynicotine.config import config
-    parser = argparse.ArgumentParser(description=_("Nicotine+ is a Soulseek client"), add_help=False)
+
+    parser = argparse.ArgumentParser(
+        description="%s %s - %s" % (config.application_name, config.version, config.summary),
+        epilog="%s <%s>" % (config.author, config.website_url)
+    )
 
     # Visible arguments
-    parser.add_argument(
-        "-h", "--help", action="help",
-        help=_("show this help message and exit")
-    )
     parser.add_argument(
         "-c", "--config", metavar=_("file"),
         help=_("use non-default configuration file")
     )
     parser.add_argument(
         "-u", "--user-data", metavar=_("dir"),
-        help=_("use non-default user data directory for e.g. list of downloads")
+        help=_("use non-default user data directory")
     )
     parser.add_argument(
         "-p", "--plugins", metavar=_("dir"),


### PR DESCRIPTION
- Removed: "Nicotine+ is a Soulseek client" string, in favour of the string defined in `config.summary`
+ Added: Footer epilog with `config.author` + `config.website_url` to match the `man nicotine` page

```
$ ./nicotine --help
usage: nicotine [-h] [-c file] [-u dir] [-p dir] [-t] [-d] [-s] [-b ip]
                [-l port] [-r] [-n] [-v]

Graphical client for the Soulseek peer-to-peer network

...

Nicotine+ Team <https://nicotine-plus.org/>
$ 
```

On most windowed posix terminals the URL <link> is clickable.