### PR TITLE
pynicotine: remove "-t" and "-d" command line options for Tray Icon

### DIFF
--- a/pynicotine/__init__.py
+++ b/pynicotine/__init__.py
@@ -44,14 +44,6 @@ def check_arguments():
         help=_("use non-default directory for plugins")
     )
     parser.add_argument(
-        "-t", "--enable-trayicon", action="store_true",
-        help=_("enable the tray icon")
-    )
-    parser.add_argument(
-        "-d", "--disable-trayicon", action="store_true",
-        help=_("disable the tray icon")
-    )
-    parser.add_argument(
         "-s", "--hidden", action="store_true",
         help=_("start the program without showing window")
     )
@@ -78,6 +70,11 @@ def check_arguments():
 
     # Disables critical error dialog; used for integration tests
     parser.add_argument("--ci-mode", action="store_true", help=argparse.SUPPRESS)
+
+    # Override config setting ["ui"]["trayicon"] for this session only
+    group_trayicon = parser.add_mutually_exclusive_group()
+    group_trayicon.add_argument("--enable-trayicon", action="store_true", help=argparse.SUPPRESS)   # deprecated "-t"
+    group_trayicon.add_argument("--disable-trayicon", action="store_true", help=argparse.SUPPRESS)  # deprecated "-d"
 
     args = parser.parse_args()
     trayicon = None

--- a/pynicotine/__init__.py
+++ b/pynicotine/__init__.py
@@ -71,11 +71,6 @@ def check_arguments():
     # Disables critical error dialog; used for integration tests
     parser.add_argument("--ci-mode", action="store_true", help=argparse.SUPPRESS)
 
-    # Override config setting ["ui"]["trayicon"] for this session only
-    group_trayicon = parser.add_mutually_exclusive_group()
-    group_trayicon.add_argument("--enable-trayicon", action="store_true", help=argparse.SUPPRESS)   # deprecated "-t"
-    group_trayicon.add_argument("--disable-trayicon", action="store_true", help=argparse.SUPPRESS)  # deprecated "-d"
-
     args = parser.parse_args()
     trayicon = None
     multi_instance = False
@@ -92,13 +87,7 @@ def check_arguments():
     if args.plugins:
         config.plugin_dir = args.plugins
 
-    if args.enable_trayicon:
-        trayicon = True
-
-    if args.disable_trayicon:
-        trayicon = False
-
-    return trayicon, args.headless, args.hidden, args.bindip, args.port, args.ci_mode, args.rescan, multi_instance
+    return args.headless, args.hidden, args.bindip, args.port, args.ci_mode, args.rescan, multi_instance
 
 
 def check_core_dependencies():
@@ -179,7 +168,7 @@ def run():
     from pynicotine.utils import rename_process
     rename_process(b"nicotine")
 
-    trayicon, headless, hidden, bindip, port, ci_mode, rescan, multi_instance = check_arguments()
+    headless, hidden, bindip, port, ci_mode, rescan, multi_instance = check_arguments()
     error = check_core_dependencies()
 
     if error:
@@ -204,7 +193,7 @@ def run():
     # Initialize GTK-based GUI
     if not headless:
         from pynicotine.gtkgui import run_gui
-        exit_code = run_gui(core, trayicon, hidden, ci_mode, multi_instance)
+        exit_code = run_gui(core, hidden, ci_mode, multi_instance)
 
         if exit_code is not None:
             return exit_code

--- a/pynicotine/__init__.py
+++ b/pynicotine/__init__.py
@@ -72,7 +72,6 @@ def check_arguments():
     parser.add_argument("--ci-mode", action="store_true", help=argparse.SUPPRESS)
 
     args = parser.parse_args()
-    trayicon = None
     multi_instance = False
 
     if args.config:

--- a/pynicotine/gtkgui/__init__.py
+++ b/pynicotine/gtkgui/__init__.py
@@ -81,7 +81,7 @@ def check_gui_dependencies():
     return None
 
 
-def run_gui(core, trayicon, hidden, ci_mode, multi_instance):
+def run_gui(core, hidden, ci_mode, multi_instance):
     """ Run Nicotine+ GTK GUI """
 
     from pynicotine.logfacility import log
@@ -98,4 +98,4 @@ def run_gui(core, trayicon, hidden, ci_mode, multi_instance):
         return None
 
     from pynicotine.gtkgui.application import Application
-    return Application(core, trayicon, hidden, ci_mode, multi_instance).run()
+    return Application(core, hidden, ci_mode, multi_instance).run()

--- a/pynicotine/gtkgui/application.py
+++ b/pynicotine/gtkgui/application.py
@@ -30,7 +30,7 @@ GTK_GUI_DIR = os.path.normpath(os.path.dirname(os.path.realpath(__file__)))
 
 class Application(Gtk.Application):
 
-    def __init__(self, core, tray_icon, start_hidden, ci_mode, multi_instance):
+    def __init__(self, core, start_hidden, ci_mode, multi_instance):
 
         super().__init__(application_id=config.application_id)
         GLib.set_application_name(config.application_name)
@@ -41,7 +41,6 @@ class Application(Gtk.Application):
 
         self.core = core
         self.frame = None
-        self.tray_icon = tray_icon
         self.start_hidden = start_hidden
         self.ci_mode = ci_mode
 
@@ -57,7 +56,7 @@ class Application(Gtk.Application):
         Gtk.Application.do_startup(self)
 
         from pynicotine.gtkgui.frame import NicotineFrame
-        self.frame = NicotineFrame(self, self.core, self.tray_icon, self.start_hidden, self.ci_mode)
+        self.frame = NicotineFrame(self, self.core, self.start_hidden, self.ci_mode)
         self.frame.on_startup()
 
     def do_activate(self):  # pylint:disable=arguments-differ

--- a/pynicotine/gtkgui/frame.py
+++ b/pynicotine/gtkgui/frame.py
@@ -76,7 +76,7 @@ from pynicotine.utils import open_uri
 
 class NicotineFrame(UserInterface):
 
-    def __init__(self, application, core, use_trayicon, start_hidden, ci_mode):
+    def __init__(self, application, core, start_hidden, ci_mode):
 
         if not ci_mode:
             # Show errors in the GUI from here on
@@ -262,7 +262,7 @@ class NicotineFrame(UserInterface):
 
         """ Tray Icon/Notifications """
 
-        self.tray_icon = TrayIcon(self, core, use_trayicon)
+        self.tray_icon = TrayIcon(self, core)
         self.notifications = Notifications(self, core)
         self.statistics = Statistics(self, core)
 

--- a/pynicotine/gtkgui/widgets/trayicon.py
+++ b/pynicotine/gtkgui/widgets/trayicon.py
@@ -425,26 +425,23 @@ class StatusIconImplementation(BaseImplementation):
 
 class TrayIcon:
 
-    def __init__(self, frame, core, use_trayicon):
+    def __init__(self, frame, core):
 
         self.frame = frame
         self.core = core
         self.available = True
         self.implementation = None
 
-        self.load(use_trayicon)
+        self.load()
 
-    def load(self, use_trayicon=None):
+    def load(self):
 
         if sys.platform == "win32":
-            # Always keep tray icon loaded for notification support
+            # Always keep tray icon loaded for Windows notification support
             pass
 
-        elif use_trayicon is None:
-            if not config.sections["ui"]["trayicon"]:
-                return
-
-        elif not use_trayicon:
+        elif not config.sections["ui"]["trayicon"]:
+            # No need to have tray icon loaded now (unless this is Windows)
             return
 
         if self.implementation is None:


### PR DESCRIPTION
The -t and -d command line options are not very useful and perhaps confusing to the user (as to this being a temporary state and not permanent config change). Also the command line arguments have no effect in certain modern environments such as macOS.

- Removed: Obsolete "-t" command line option and "--enable-trayicon" argument
- Removed: Obsolete "-d" command line option and "--disable-trayicon" argument

In the future the removed options could be better used for example:
+ `-d file` `--download file` specified by an slsk:// URL then exit (or stay running)
+ `-d folder` `--download folder` count the files and size of a remote folder and prompt to download it
+ `-t` print a list of currently active `--transfers` or do some `--terminal` console related function
+ `-t abort` stop and clear all active  transfers
+ `-t abort user` stop and clear active and queued transfers for a specified user
+ `-t pause` stop all active and queued transfers
+ `-t resume` start all paused transfers and retry all failed transfers