### PR TITLE
Update DOWNLOADS.md and TESTING.md

### DIFF
--- a/doc/DOWNLOADS.md
+++ b/doc/DOWNLOADS.md
@@ -60,20 +60,6 @@ To install Nicotine+ on FreeBSD, run the following:
 pkg install py-nicotine-plus
 ```
 
-### pip
-
-If Nicotine+ is not packaged for your system, the current stable version can be installed using [pip](https://pip.pypa.io/). Ensure the [runtime dependencies](DEPENDENCIES.md) are installed, and run the following:
-
-```sh
-pip3 install nicotine-plus
-```
-
-Keep in mind that Nicotine+ will not update automatically. When a new release is available, run the following:
-
-```sh
-pip3 install --upgrade nicotine-plus
-```
-
 ## Windows
 
 ### Official Release
@@ -128,3 +114,19 @@ A stable macOS installer for Nicotine+ is available on macOS Catalina 10.15 and 
 *NOTE: You have to follow [these instructions](https://support.apple.com/guide/mac-help/open-a-mac-app-from-an-unidentified-developer-mh40616/mac) the first time you open Nicotine+ on macOS.*
 
 - [Download Nicotine+ macOS Installer](https://github.com/nicotine-plus/nicotine-plus/releases/latest/download/macos-installer.zip)  [[SHA256](https://github.com/nicotine-plus/nicotine-plus/releases/latest/download/macos-installer.zip.sha256)]
+
+## Source
+
+### pip
+
+If Nicotine+ is not packaged for your system, the current stable version can be installed using [pip](https://pip.pypa.io/). Ensure the [runtime dependencies](DEPENDENCIES.md) are installed, and run the following:
+
+```sh
+pip3 install nicotine-plus
+```
+
+Keep in mind that Nicotine+ will not update automatically. When a new release is available, run the following:
+
+```sh
+pip3 install --upgrade nicotine-plus
+```

--- a/doc/TESTING.md
+++ b/doc/TESTING.md
@@ -18,7 +18,7 @@ sudo apt update
 sudo apt install nicotine
 ```
 
-If you prefer to install a .deb package directly, you can [download one here](https://nightly.link/nicotine-plus/nicotine-plus/workflows/packaging/master/debian-package.zip).
+If you prefer to install a .deb package directly, you can [download one here](https://nightly.link/nicotine-plus/nicotine-plus/workflows/packaging/master/debian-package.zip) [[Info](https://nightly.link/nicotine-plus/nicotine-plus/workflows/packaging/master/debian-package)].
 
 Unlike the repository installation method, you need to download and install Nicotine+ from the link above every time you want to update to the latest unstable build.
 
@@ -26,7 +26,27 @@ Unlike the repository installation method, you need to download and install Nico
 
 Unstable [Flatpak](https://www.flatpak.org/setup/) packages are built after every commit to the master branch.
 
-- [Download Unstable Flatpak Package](https://nightly.link/nicotine-plus/nicotine-plus/workflows/packaging/master/flatpak-package.zip)
+- [Download Unstable Flatpak Package](https://nightly.link/nicotine-plus/nicotine-plus/workflows/packaging/master/flatpak-package.zip) [[Info](https://nightly.link/nicotine-plus/nicotine-plus/workflows/packaging/master/flatpak-package)]
+
+## Windows
+
+Unstable Windows packages are built after every commit to the master branch.
+
+- [Download Unstable 64-bit Windows Installer](https://nightly.link/nicotine-plus/nicotine-plus/workflows/packaging/master/windows-x86_64-installer.zip) [[Info](https://nightly.link/nicotine-plus/nicotine-plus/workflows/packaging/master/windows-x86_64-installer)]
+- [Download Unstable 32-bit Windows Installer](https://nightly.link/nicotine-plus/nicotine-plus/workflows/packaging/master/windows-i686-installer.zip) [[Info](https://nightly.link/nicotine-plus/nicotine-plus/workflows/packaging/master/windows-i686-installer)]
+
+Portable packages are also available. They can be run from your home directory, and do not require installation or administrator privileges.
+
+- [Download Unstable 64-bit Windows Portable Package](https://nightly.link/nicotine-plus/nicotine-plus/workflows/packaging/master/windows-x86_64-package.zip) [[Info](https://nightly.link/nicotine-plus/nicotine-plus/workflows/packaging/master/windows-x86_64-package)]
+- [Download Unstable 32-bit Windows Portable Package](https://nightly.link/nicotine-plus/nicotine-plus/workflows/packaging/master/windows-i686-package.zip) [[Info](https://nightly.link/nicotine-plus/nicotine-plus/workflows/packaging/master/windows-i686-package)]
+
+## macOS (Catalina/10.15 and newer)
+
+Unstable macOS installers are built after every commit to the master branch.
+
+- [Download Unstable macOS Installer](https://nightly.link/nicotine-plus/nicotine-plus/workflows/packaging/master/macos-installer.zip) [[Info](https://nightly.link/nicotine-plus/nicotine-plus/workflows/packaging/master/macos-installer)]
+
+## Source
 
 ### pip
 
@@ -39,13 +59,10 @@ pip install git+https://github.com/nicotine-plus/nicotine-plus.git
 Nicotine+ will now be available in your list of programs.
 
 To update to the latest unstable build of Nicotine+, run the following:
-
 ```sh
 pip install --upgrade git+https://github.com/nicotine-plus/nicotine-plus.git
 ```
-
 To uninstall Nicotine+, run:
-
 ```sh
 pip uninstall nicotine-plus
 ```
@@ -66,21 +83,3 @@ To update to the latest unstable build of Nicotine+, run the following:
 cd nicotine-plus
 git pull
 ```
-
-## Windows
-
-Unstable Windows packages are built after every commit to the master branch.
-
-- [Download Unstable 64-bit Windows Installer](https://nightly.link/nicotine-plus/nicotine-plus/workflows/packaging/master/windows-x86_64-installer.zip)
-- [Download Unstable 32-bit Windows Installer](https://nightly.link/nicotine-plus/nicotine-plus/workflows/packaging/master/windows-i686-installer.zip)
-
-Portable packages are also available. They can be run from your home directory, and do not require installation or administrator privileges.
-
-- [Download Unstable 64-bit Windows Portable Package](https://nightly.link/nicotine-plus/nicotine-plus/workflows/packaging/master/windows-x86_64-package.zip)
-- [Download Unstable 32-bit Windows Portable Package](https://nightly.link/nicotine-plus/nicotine-plus/workflows/packaging/master/windows-i686-package.zip)
-
-## macOS (Catalina/10.15 and newer)
-
-Unstable macOS installers are built after every commit to the master branch.
-
-- [Download Unstable macOS Installer](https://nightly.link/nicotine-plus/nicotine-plus/workflows/packaging/master/macos-installer.zip)

--- a/doc/TESTING.md
+++ b/doc/TESTING.md
@@ -59,10 +59,13 @@ pip install git+https://github.com/nicotine-plus/nicotine-plus.git
 Nicotine+ will now be available in your list of programs.
 
 To update to the latest unstable build of Nicotine+, run the following:
+
 ```sh
 pip install --upgrade git+https://github.com/nicotine-plus/nicotine-plus.git
 ```
+
 To uninstall Nicotine+, run:
+
 ```sh
 pip uninstall nicotine-plus
 ```


### PR DESCRIPTION
The pip and Git sections were unnecessarily grouped under the GNU/Linux section as, if I'm not mistaken, both building via pip and Git apply to any platform. Both sections were moved to a "Source" parent section. Also, an info link was added to each of TESTING.md's download links to help find further details about each build.

Let me know if there any changes needed to be made.