### PR TITLE
SLSKPROTOCOL.md: Transfer Status Strings table and NS >2GB offset

### DIFF
--- a/doc/SLSKPROTOCOL.md
+++ b/doc/SLSKPROTOCOL.md
@@ -77,18 +77,18 @@ If you find any inconsistencies, errors or omissions in the documentation, pleas
 
 | String                | Comments                                    |
 | --------------------- | ------------------------------------------- |
-| Queued                |                                             |
-| Pending shutdown.     |                                             |
-| Disallowed extension  | Sent by Soulseek NS for filtered extensions |
-| Cancelled             |                                             |
-| Complete              |                                             |
 | Banned                |                                             |
 | Blocked country       |                                             |
-| Too many files        |                                             |
-| Too many megabytes    |                                             |
+| Cancelled             |                                             |
+| Complete              |                                             |
+| Disallowed extension  | Sent by Soulseek NS for filtered extensions |
 | File not shared       |                                             |
 | File not shared.      | Newer variant containing a dot              |
+| Pending shutdown.     |                                             |
+| Queued                |                                             |
 | Remote file error     |                                             |
+| Too many files        |                                             |
+| Too many megabytes    |                                             |
 
 ### File Attribute Types
 

--- a/doc/SLSKPROTOCOL.md
+++ b/doc/SLSKPROTOCOL.md
@@ -73,6 +73,31 @@ If you find any inconsistencies, errors or omissions in the documentation, pleas
 | 0    | Download from Peer |
 | 1    | Upload to Peer     |
 
+### Transfer Status Strings
+
+| String                | Comments                                    |
+| --------------------- | ------------------------------------------- |
+| Queued                |                                             |
+| Transferring          |                                             |
+| Connection timeout    |                                             |
+| Pending shutdown.     |                                             |
+| User logged off       |                                             |
+| Disallowed extension  | Sent by Soulseek NS for filtered extensions |
+| Aborted               |                                             |
+| Cancelled             |                                             |
+| Paused                |                                             |
+| Finished              |                                             |
+| Filtered              |                                             |
+| Banned                |                                             |
+| Blocked country       |                                             |
+| Too many files        |                                             |
+| Too many megabytes    |                                             |
+| File not shared       |                                             |
+| File not shared.      | Newer variant containing a dot              |
+| Download folder error |                                             |
+| Local file error      | Usually disk I/O, or Soulseek NS files >2GB |
+| Remote file error     |                                             |
+
 ### File Attribute Types
 
 | Code | Attribute (unit)   |
@@ -2204,13 +2229,13 @@ This message was formely used to send a download request (direction 0) as well, 
 ### Data Order
 
   - Send
-    1.  **uint32** <ins>direction</ins> **0 or 1** *see [Transfer Directions](#transfer-directions)*
+    1.  **uint32** <ins>direction</ins> **0 or 1** ; *see [Transfer Directions](#transfer-directions)*
     2.  **uint32** <ins>token</ins>
     3.  **string** <ins>filename</ins>
     4.  Check contents of <ins>direction</ins>
           - **uint64** <ins>filesize</ins> *if direction == 1 (upload)*
   - Receive
-    1.  **uint32** <ins>direction</ins> **0 or 1** *see [Transfer Directions](#transfer-directions)*
+    1.  **uint32** <ins>direction</ins> **0 or 1** ; *see [Transfer Directions](#transfer-directions)*
     2.  **uint32** <ins>token</ins>
     3.  **string** <ins>filename</ins>
     4.  Check contents of <ins>direction</ins>
@@ -2233,13 +2258,13 @@ We (or the other peer) either agrees, or tells the reason for rejecting the file
     2.  **bool** <ins>allowed</ins>
     3.  Check contents of <ins>allowed</ins>
           - **uint64** <ins>filesize</ins> *if allowed == 1*
-          - **string** <ins>reason</ins> *if allowed == 0*
+          - **string** <ins>reason</ins> *if allowed == 0* ; *see [Transfer Status Strings](#transfer-status-strings)*
   - Receive
     1.  **uint32** <ins>token</ins>
     2.  **bool** <ins>allowed</ins>
     3.  Check contents of <ins>allowed</ins>
           - **uint64** <ins>filesize</ins> *if allowed == 1*
-          - **string** <ins>reason</ins> *if allowed == 0*
+          - **string** <ins>reason</ins> *if allowed == 0* ; *see [Transfer Status Strings](#transfer-status-strings)*
 
 ## Peer Code 41 b
 
@@ -2255,12 +2280,12 @@ We (or the other peer) either agrees, or tells the reason for rejecting the file
     1.  **uint32** <ins>token</ins>
     2.  **bool** <ins>allowed</ins>
     3.  Check contents of <ins>allowed</ins>
-          - **string** <ins>reason</ins> *if allowed == 0*
+          - **string** <ins>reason</ins> *if allowed == 0* ; *see [Transfer Status Strings](#transfer-status-strings)*
   - Receive
     1.  **uint32** <ins>token</ins>
     2.  **bool** <ins>allowed</ins>
     3.  Check contents of <ins>allowed</ins>
-          - **string** <ins>reason</ins> *if allowed == 0*
+          - **string** <ins>reason</ins> *if allowed == 0* ; *see [Transfer Status Strings](#transfer-status-strings)*
 
 ## Peer Code 42
 
@@ -2326,10 +2351,10 @@ This message is sent to reject [QueueUpload](#peer-code-43) attempts and previou
 
   - Send
     1.  **string** <ins>filename</ins>
-    2.  **string** <ins>reason</ins>
+    2.  **string** <ins>reason</ins> *see [Transfer Status Strings](#transfer-status-strings)*
   - Receive
     1.  **string** <ins>filename</ins>
-    2.  **string** <ins>reason</ins>
+    2.  **string** <ins>reason</ins> *see [Transfer Status Strings](#transfer-status-strings)*
 
 ## Peer Code 51
 
@@ -2412,6 +2437,8 @@ We send this to a peer via a 'F' connection to tell them that we want to start u
 ### FileOffset
 
 We send this to the uploading peer at the beginning of a 'F' connection, to tell them how many bytes of the file we've previously downloaded. If none, the offset is 0.
+
+Soulseek NS fails to read the size of an incomplete file if more than 2 GB of the file has been downloaded by them, and their download pauses and later resumes. The legacy client then sends us an invalid file offset of -1.
 
 ### Data Order
 

--- a/doc/SLSKPROTOCOL.md
+++ b/doc/SLSKPROTOCOL.md
@@ -78,24 +78,16 @@ If you find any inconsistencies, errors or omissions in the documentation, pleas
 | String                | Comments                                    |
 | --------------------- | ------------------------------------------- |
 | Queued                |                                             |
-| Transferring          |                                             |
-| Connection timeout    |                                             |
 | Pending shutdown.     |                                             |
-| User logged off       |                                             |
 | Disallowed extension  | Sent by Soulseek NS for filtered extensions |
-| Aborted               |                                             |
 | Cancelled             |                                             |
-| Paused                |                                             |
-| Finished              |                                             |
-| Filtered              |                                             |
+| Complete              |                                             |
 | Banned                |                                             |
 | Blocked country       |                                             |
 | Too many files        |                                             |
 | Too many megabytes    |                                             |
 | File not shared       |                                             |
 | File not shared.      | Newer variant containing a dot              |
-| Download folder error |                                             |
-| Local file error      | Usually disk I/O, or Soulseek NS files >2GB |
 | Remote file error     |                                             |
 
 ### File Attribute Types
@@ -2229,13 +2221,13 @@ This message was formely used to send a download request (direction 0) as well, 
 ### Data Order
 
   - Send
-    1.  **uint32** <ins>direction</ins> **0 or 1** ; *see [Transfer Directions](#transfer-directions)*
+    1.  **uint32** <ins>direction</ins> **0 or 1** *see [Transfer Directions](#transfer-directions)*
     2.  **uint32** <ins>token</ins>
     3.  **string** <ins>filename</ins>
     4.  Check contents of <ins>direction</ins>
           - **uint64** <ins>filesize</ins> *if direction == 1 (upload)*
   - Receive
-    1.  **uint32** <ins>direction</ins> **0 or 1** ; *see [Transfer Directions](#transfer-directions)*
+    1.  **uint32** <ins>direction</ins> **0 or 1** *see [Transfer Directions](#transfer-directions)*
     2.  **uint32** <ins>token</ins>
     3.  **string** <ins>filename</ins>
     4.  Check contents of <ins>direction</ins>


### PR DESCRIPTION
Closes #1985

> It would be a good idea to add common transfer status messages to the Soulseek protocol documentation.

Please feel free to suggest what headers and content is required to populate the new table, or take it over as you deem appropriate.