### PR TITLE
transferlist.py: remove obsolete "Getting status"

### DIFF
--- a/pynicotine/gtkgui/transferlist.py
+++ b/pynicotine/gtkgui/transferlist.py
@@ -91,7 +91,6 @@ class TransferList(UserInterface):
             "Queued": _("Queued"),
             "Queued (prioritized)": _("Queued (prioritized)"),
             "Queued (privileged)": _("Queued (privileged)"),
-            "Getting status": _("Getting status"),
             "Transferring": _("Transferring"),
             "Connection timeout": _("Connection timeout"),
             "Pending shutdown.": _("Pending shutdown"),


### PR DESCRIPTION
... internal transfer status string not required anymore