### PR TITLE
transfers.py: prevent incomplete filename from exceeding 255 bytes

### DIFF
--- a/pynicotine/transfers.py
+++ b/pynicotine/transfers.py
@@ -1036,12 +1036,12 @@ class Transfers:
                     md5sum = md5()
                     md5sum.update((i.filename + i.user).encode('utf-8'))
 
-                    base_name, extension = os.path.splitext(clean_file(i.filename.replace('/', '\\').split('\\')[-1]))
+                    filename = i.filename.replace('/', '\\').split('\\')[-1]
                     prefix = "INCOMPLETE" + md5sum.hexdigest()
 
-                    # Ensure file name doesn't exceed 255 characters in length
+                    # Ensure filename doesn't exceed 255 bytes in length
                     incomplete_name = os.path.join(
-                        incompletedir, prefix + base_name[:255 - len(prefix) - len(extension)] + extension)
+                        incompletedir, prefix + filename.encode('utf-8')[:213].decode('utf-8', 'ignore'))
                     file_handle = open(incomplete_name.encode('utf-8'), 'ab+')  # pylint: disable=consider-using-with
 
                     try:

--- a/pynicotine/transfers.py
+++ b/pynicotine/transfers.py
@@ -1036,7 +1036,7 @@ class Transfers:
                     md5sum = md5()
                     md5sum.update((i.filename + i.user).encode('utf-8'))
 
-                    filename = i.filename.replace('/', '\\').split('\\')[-1]
+                    filename = clean_file(i.filename.replace('/', '\\').split('\\')[-1])
                     prefix = "INCOMPLETE" + md5sum.hexdigest()
 
                     # Ensure filename doesn't exceed 255 bytes in length


### PR DESCRIPTION
From the first commit:
>e86229103aef8ee95027e391b5989eee5ea3441e fixed an issue where
downloading a file with a filename of 255 characters would fail
because a prefix was added to its filename in the incomplete directory
which would create a filename over 255 characters, which isn't possible
on many systems.
The restriction on most systems is 255 bytes, not characters, so this
could still fail when multi-byte characters are present. Convert
the filename to bytes when truncating (prefix doesn't need this because
its byte length is known).

This will result in the extension being truncated if needed, unlike before. If we want the extension then we would need to truncate it as well otherwise a file with a filename containing a long extension can still fail to download. We could also try truncating the perfect amount to fill 255 bytes, but I don't care about both of these so haven't bothered doing them.