### PR TITLE
Chat Logs: increase default chat log read lines up to 200 old messages

### DIFF
--- a/pynicotine/config.py
+++ b/pynicotine/config.py
@@ -280,8 +280,8 @@ class Config:
                 "roomlogsdir": os.path.join(log_dir, "rooms"),
                 "privatelogsdir": os.path.join(log_dir, "private"),
                 "readroomlogs": True,
-                "readroomlines": 15,
-                "readprivatelines": 15,
+                "readroomlines": 200,
+                "readprivatelines": 200,
                 "rooms": []
             },
             "privatechat": {


### PR DESCRIPTION
... because showing 15 old messages is not very useful by modern standards.