### PR TITLE
Main Window: Show important log messages with InfoBar instead of MessageDialog

### DIFF
--- a/pynicotine/gtkgui/frame.py
+++ b/pynicotine/gtkgui/frame.py
@@ -52,6 +52,7 @@ from pynicotine.gtkgui.widgets.filechooser import FileChooser
 from pynicotine.gtkgui.widgets.iconnotebook import TabLabel
 from pynicotine.gtkgui.widgets.dialogs import MessageDialog
 from pynicotine.gtkgui.widgets.dialogs import OptionDialog
+from pynicotine.gtkgui.widgets.infobar import InfoBar
 from pynicotine.gtkgui.widgets.notifications import Notifications
 from pynicotine.gtkgui.widgets.popupmenu import PopupMenu
 from pynicotine.gtkgui.widgets.textentry import TextSearchBar
@@ -137,6 +138,7 @@ class NicotineFrame(UserInterface):
             self.header_menu,
             self.header_title,
             self.horizontal_paned,
+            self.info_bar,
             self.interests_container,
             self.interests_end,
             self.interests_page,
@@ -246,6 +248,7 @@ class NicotineFrame(UserInterface):
 
         self.log_view = TextView(self.log_view)
         self.log_search_bar = TextSearchBar(self.log_view.textview, self.log_search_bar, self.log_search_entry)
+        self.info_bar = InfoBar(self.info_bar, Gtk.MessageType.WARNING)  # "important_*" log level messages
 
         self.create_log_context_menu()
         log.add_listener(self.log_callback)
@@ -1764,15 +1767,17 @@ class NicotineFrame(UserInterface):
 
     def update_log(self, msg, level):
 
+        self.log_view.append_line(msg, find_urls=False)
+
         if level and level.startswith("important"):
             title = "Information" if level == "important_info" else "Error"
-            MessageDialog(parent=self.application.get_active_window(), title=title, message=msg).show()
+            self.show_important_message(title, msg)
+            return False
 
         # Keep verbose debug messages out of statusbar to make it more useful
         if level not in ("transfer", "connection", "message", "miscellaneous"):
             self.set_status_text(msg)
 
-        self.log_view.append_line(msg, find_urls=False)
         return False
 
     def on_popup_menu_log(self, menu, _textview):
@@ -1833,6 +1838,9 @@ class NicotineFrame(UserInterface):
         self.set_debug_level(action, state, "miscellaneous")
 
     """ Status Bar """
+
+    def show_important_message(self, title, message):
+        self.info_bar.show_message("%s: %s" % (title, message))
 
     def set_status_text(self, msg):
         self.status_label.set_text(msg)

--- a/pynicotine/gtkgui/ui/mainwindow.ui
+++ b/pynicotine/gtkgui/ui/mainwindow.ui
@@ -1683,29 +1683,15 @@
         <child>
           <object class="GtkBox">
             <property name="visible">True</property>
-            <property name="spacing">6</property>
+            <property name="hexpand">True</property>
+            <property name="orientation">vertical</property>
             <child>
-              <object class="GtkLabel" id="status_label">
+              <object class="GtkRevealer">
                 <property name="visible">True</property>
-                <property name="xalign">0</property>
-                <property name="hexpand">True</property>
-                <property name="margin-start">12</property>
-                <property name="margin-end">12</property>
-                <property name="ellipsize">end</property>
-                <property name="single-line-mode">True</property>
-              </object>
-            </child>
-            <child>
-              <object class="GtkBox">
-                <property name="visible">True</property>
-                <property name="spacing">18</property>
+                <property name="transition-type">slide-up</property>
                 <child>
-                  <object class="GtkProgressBar" id="scan_progress_bar">
-                    <property name="visible">False</property>
-                    <property name="valign">center</property>
-                    <property name="pulse-step">0.8</property>
-                    <property name="text" translatable="yes">Scanning Shares</property>
-                    <property name="show-text">True</property>
+                  <object class="GtkInfoBar" id="info_bar">
+                    <property name="visible">True</property>
                   </object>
                 </child>
               </object>
@@ -1713,161 +1699,193 @@
             <child>
               <object class="GtkBox">
                 <property name="visible">True</property>
-                <property name="margin-top">2</property>
-                <property name="margin-bottom">2</property>
-                <property name="margin-start">2</property>
-                <property name="margin-end">2</property>
                 <property name="spacing">6</property>
                 <child>
-                  <object class="GtkButton">
+                  <object class="GtkLabel" id="status_label">
                     <property name="visible">True</property>
-                    <property name="tooltip-text" translatable="yes">Connections</property>
-                    <property name="action-name">app.transferstatistics</property>
+                    <property name="xalign">0</property>
+                    <property name="hexpand">True</property>
+                    <property name="margin-start">12</property>
+                    <property name="margin-end">12</property>
+                    <property name="ellipsize">end</property>
+                    <property name="single-line-mode">True</property>
+                  </object>
+                </child>
+                <child>
+                  <object class="GtkBox">
+                    <property name="visible">True</property>
+                    <property name="spacing">18</property>
                     <child>
-                      <object class="GtkBox">
+                      <object class="GtkProgressBar" id="scan_progress_bar">
+                        <property name="visible">False</property>
+                        <property name="valign">center</property>
+                        <property name="pulse-step">0.8</property>
+                        <property name="text" translatable="yes">Scanning Shares</property>
+                        <property name="show-text">True</property>
+                      </object>
+                    </child>
+                  </object>
+                </child>
+                <child>
+                  <object class="GtkBox">
+                    <property name="visible">True</property>
+                    <property name="margin-top">2</property>
+                    <property name="margin-bottom">2</property>
+                    <property name="margin-start">2</property>
+                    <property name="margin-end">2</property>
+                    <property name="spacing">6</property>
+                    <child>
+                      <object class="GtkButton">
                         <property name="visible">True</property>
-                        <property name="spacing">6</property>
+                        <property name="tooltip-text" translatable="yes">Connections</property>
+                        <property name="action-name">app.transferstatistics</property>
                         <child>
-                          <object class="GtkImage">
+                          <object class="GtkBox">
                             <property name="visible">True</property>
-                            <property name="icon-name">network-wireless-symbolic</property>
+                            <property name="spacing">6</property>
+                            <child>
+                              <object class="GtkImage">
+                                <property name="visible">True</property>
+                                <property name="icon-name">network-wireless-symbolic</property>
+                              </object>
+                            </child>
+                            <child>
+                              <object class="GtkLabel" id="connections_label">
+                                <property name="visible">True</property>
+                                <property name="label">0</property>
+                                <attributes>
+                                  <attribute name="weight" value="normal"/>
+                                </attributes>
+                              </object>
+                            </child>
                           </object>
                         </child>
+                        <style>
+                          <class name="flat"/>
+                        </style>
+                      </object>
+                    </child>
+                    <child>
+                      <object class="GtkButton">
+                        <property name="visible">True</property>
+                        <property name="tooltip-text" translatable="yes">Downloading (speed / active users)</property>
+                        <signal name="clicked" handler="on_settings_downloads"/>
                         <child>
-                          <object class="GtkLabel" id="connections_label">
+                          <object class="GtkBox">
                             <property name="visible">True</property>
-                            <property name="label">0</property>
+                            <property name="spacing">6</property>
+                            <child>
+                              <object class="GtkImage">
+                                <property name="visible">True</property>
+                                <property name="icon-name">go-down-symbolic</property>
+                              </object>
+                            </child>
+                            <child>
+                              <object class="GtkLabel" id="download_status_label">
+                                <property name="visible">True</property>
+                                <attributes>
+                                  <attribute name="weight" value="normal"/>
+                                </attributes>
+                              </object>
+                            </child>
+                          </object>
+                        </child>
+                        <style>
+                          <class name="flat"/>
+                        </style>
+                      </object>
+                    </child>
+                    <child>
+                      <object class="GtkButton">
+                        <property name="visible">True</property>
+                        <property name="tooltip-text" translatable="yes">Uploading (speed / active users)</property>
+                        <signal name="clicked" handler="on_settings_uploads"/>
+                        <child>
+                          <object class="GtkBox">
+                            <property name="visible">True</property>
+                            <property name="spacing">6</property>
+                            <child>
+                              <object class="GtkImage">
+                                <property name="visible">True</property>
+                                <property name="icon-name">go-up-symbolic</property>
+                              </object>
+                            </child>
+                            <child>
+                              <object class="GtkLabel" id="upload_status_label">
+                                <property name="visible">True</property>
+                                <attributes>
+                                  <attribute name="weight" value="normal"/>
+                                </attributes>
+                              </object>
+                            </child>
+                          </object>
+                        </child>
+                        <style>
+                          <class name="flat"/>
+                        </style>
+                      </object>
+                    </child>
+                    <child>
+                      <object class="GtkButton" id="user_status_button">
+                        <property name="visible">True</property>
+                        <property name="action-name">win.away</property>
+                        <child>
+                          <object class="GtkLabel" id="user_status_label">
+                            <property name="visible">True</property>
+                            <property name="label" translatable="yes">Offline</property>
                             <attributes>
-                              <attribute name="weight" value="normal"/>
+                              <attribute name="weight" value="bold"/>
                             </attributes>
                           </object>
                         </child>
+                        <style>
+                          <class name="flat"/>
+                        </style>
                       </object>
                     </child>
-                    <style>
-                      <class name="flat"/>
-                    </style>
-                  </object>
-                </child>
-                <child>
-                  <object class="GtkButton">
-                    <property name="visible">True</property>
-                    <property name="tooltip-text" translatable="yes">Downloading (speed / active users)</property>
-                    <signal name="clicked" handler="on_settings_downloads"/>
                     <child>
-                      <object class="GtkBox">
+                      <object class="GtkToggleButton">
                         <property name="visible">True</property>
-                        <property name="spacing">6</property>
+                        <property name="tooltip-text" translatable="yes">Enable alternative download and upload speed limits</property>
+                        <property name="action-name">app.altspeedlimit</property>
+                        <child>
+                          <object class="GtkImage" id="alt_speed_icon">
+                            <property name="visible">True</property>
+                            <property name="icon-name">media-seek-backward-symbolic</property>
+                          </object>
+                        </child>
+                        <style>
+                          <class name="circular"/>
+                          <class name="flat"/>
+                          <class name="image-button"/>
+                        </style>
+                      </object>
+                    </child>
+                    <child>
+                      <object class="GtkToggleButton" id="log_history_button">
+                        <property name="visible">True</property>
+                        <property name="tooltip-text" translatable="yes">Show log history</property>
+                        <property name="action-name">win.showlog</property>
                         <child>
                           <object class="GtkImage">
                             <property name="visible">True</property>
-                            <property name="icon-name">go-down-symbolic</property>
+                            <property name="icon-name">view-more-symbolic</property>
                           </object>
                         </child>
-                        <child>
-                          <object class="GtkLabel" id="download_status_label">
-                            <property name="visible">True</property>
-                            <attributes>
-                              <attribute name="weight" value="normal"/>
-                            </attributes>
-                          </object>
-                        </child>
+                        <style>
+                          <class name="circular"/>
+                          <class name="flat"/>
+                          <class name="image-button"/>
+                        </style>
                       </object>
                     </child>
-                    <style>
-                      <class name="flat"/>
-                    </style>
                   </object>
                 </child>
-                <child>
-                  <object class="GtkButton">
-                    <property name="visible">True</property>
-                    <property name="tooltip-text" translatable="yes">Uploading (speed / active users)</property>
-                    <signal name="clicked" handler="on_settings_uploads"/>
-                    <child>
-                      <object class="GtkBox">
-                        <property name="visible">True</property>
-                        <property name="spacing">6</property>
-                        <child>
-                          <object class="GtkImage">
-                            <property name="visible">True</property>
-                            <property name="icon-name">go-up-symbolic</property>
-                          </object>
-                        </child>
-                        <child>
-                          <object class="GtkLabel" id="upload_status_label">
-                            <property name="visible">True</property>
-                            <attributes>
-                              <attribute name="weight" value="normal"/>
-                            </attributes>
-                          </object>
-                        </child>
-                      </object>
-                    </child>
-                    <style>
-                      <class name="flat"/>
-                    </style>
-                  </object>
-                </child>
-                <child>
-                  <object class="GtkButton" id="user_status_button">
-                    <property name="visible">True</property>
-                    <property name="action-name">win.away</property>
-                    <child>
-                      <object class="GtkLabel" id="user_status_label">
-                        <property name="visible">True</property>
-                        <property name="label" translatable="yes">Offline</property>
-                        <attributes>
-                          <attribute name="weight" value="bold"/>
-                        </attributes>
-                      </object>
-                    </child>
-                    <style>
-                      <class name="flat"/>
-                    </style>
-                  </object>
-                </child>
-                <child>
-                  <object class="GtkToggleButton">
-                    <property name="visible">True</property>
-                    <property name="tooltip-text" translatable="yes">Enable alternative download and upload speed limits</property>
-                    <property name="action-name">app.altspeedlimit</property>
-                    <child>
-                      <object class="GtkImage" id="alt_speed_icon">
-                        <property name="visible">True</property>
-                        <property name="icon-name">media-seek-backward-symbolic</property>
-                      </object>
-                    </child>
-                    <style>
-                      <class name="circular"/>
-                      <class name="flat"/>
-                      <class name="image-button"/>
-                    </style>
-                  </object>
-                </child>
-                <child>
-                  <object class="GtkToggleButton" id="log_history_button">
-                    <property name="visible">True</property>
-                    <property name="tooltip-text" translatable="yes">Show log history</property>
-                    <property name="action-name">win.showlog</property>
-                    <child>
-                      <object class="GtkImage">
-                        <property name="visible">True</property>
-                        <property name="icon-name">view-more-symbolic</property>
-                      </object>
-                    </child>
-                    <style>
-                      <class name="circular"/>
-                      <class name="flat"/>
-                      <class name="image-button"/>
-                    </style>
-                  </object>
-                </child>
+                <style>
+                  <class name="border-top"/>
+                </style>
               </object>
             </child>
-            <style>
-              <class name="border-top"/>
-            </style>
           </object>
         </child>
       </object>


### PR DESCRIPTION
- Removed: Don't use MessageDialog for such messages, because a UI obstruction is caused if they originate whilst another dialog is open (which is most likely since those messages are related mainly to login and password success / failures).
+ Added: InfoBar to display 'important_info' and 'important_error' log level messages relating to login and connection issues.
- Changed: Don't display a duplicate of an important message in the status bar (but still write it into the log file/console).

_For clarity, the code added to `mainwindow.ui` is as follows..._
```
        <!-- Status Bar -->
        <child>
          <object class="GtkBox">
            <property name="visible">True</property>
            <property name="hexpand">True</property>
            <property name="orientation">vertical</property>
            <child>
              <object class="GtkRevealer">
                <property name="visible">True</property>
                <property name="transition-type">slide-up</property>
                <child>
                  <object class="GtkInfoBar" id="info_bar">
                    <property name="visible">True</property>
                  </object>
                </child>
              </object>
            </child>
```
... then the entire Status Bar block is indented such that the InfoBar is nested above the Status Bar (it was not possible to add the InfoBar in it's own separate GtkBox container because then there is a 1px visual artifact line).

![image](https://user-images.githubusercontent.com/88614182/170011310-c5e1ee6a-8ab0-4754-8027-60f047f7995a.png)

In the future, it could be worthwhile adding option buttons to infobar.py in order to replace the Invalid Password dialog, and possible use for other serious connection errors or urgent issues that require immediate user intervention.