### PR TITLE
roomwall.py: add missing "> " character to new entry

### DIFF
--- a/pynicotine/gtkgui/popovers/roomwall.py
+++ b/pynicotine/gtkgui/popovers/roomwall.py
@@ -70,8 +70,8 @@ class RoomWall(UserInterface):
         self.core.queue.append(slskmessages.RoomTickerSet(self.room.room, entry_text))
 
         if entry_text:
-            login_username = self.core.login_username
-            self.room_wall_textview.append_line("[%s] %s" % (login_username, entry_text), showstamp=False, scroll=False)
+            user = self.core.login_username
+            self.room_wall_textview.append_line("> [%s] %s" % (user, entry_text), showstamp=False, scroll=False)
 
         self.update_message_list()
 


### PR DESCRIPTION
+ Fixed: Visual bug where a new Room Wall entry does not have the "`> `" prefix upon first being submitted

It was necessary to close and re-open the popover for our own recent entry into the top of the Room Wall text view to appear correctly.