### PR TITLE
README.md: "Nicotine+ is written in Python"...

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Nicotine+ is a graphical client for the [Soulseek](https://www.slsknet.org/) pee
 
 Nicotine+ aims to be a pleasant, free and open source (FOSS) alternative to the official Soulseek client, providing additional functionality while keeping current with the Soulseek protocol.
 
-Nicotine+ uses GTK for its graphical user interface, and is written in Python.
+Nicotine+ is written in Python and uses GTK for its graphical user interface.
 
 Check out the [screenshots](data/screenshots/SCREENSHOTS.md) and [source code](https://github.com/nicotine-plus/nicotine-plus).
 <br clear="right">


### PR DESCRIPTION
First and foremost (most interestingly), **_"Nicotine+ is written in Python"_**...

... and secondary to that (for those who are interested), it... **_"uses GTK for its graphical user interface."_**

- ~~"Nicotine+ uses GTK for its graphical user interface, and is written in Python."~~

+ **"Nicotine+ is written in Python and uses GTK for its graphical user interface."**

As well as being more grammatically correct (no comma required), this is also more factually correct, because pyNicotine has always been written in Python, but its various forks over the years haven't always used GTK for its GUI.

Perhaps the previous order was relevant years ago when the fork existed for the purpose of implementing a GTK GUI, but nowadays since the project is the only working fork in existence the use of GTK is inconsequential.