### PR TITLE
testreplier: don't allow sending a plugin command!

### DIFF
--- a/pynicotine/plugins/examplars/testreplier/__init__.py
+++ b/pynicotine/plugins/examplars/testreplier/__init__.py
@@ -46,4 +46,4 @@ class Plugin(BasePlugin):
 
         if self.throttle.ok_to_respond(room, user, line, 10):
             self.throttle.responded()
-            self.send_public(room, choice(self.settings['replies']))
+            self.send_public(room, choice(self.settings['replies']).lstrip("!"))


### PR DESCRIPTION
This PR removes any "!" from the start of reply strings before sending it, because it seems undesirable for this plugin to be able to trigger other user's plugin commands out-of-the-box.

Since it is not grammatically correct for a sentence to begin with an exclamation mark, then normal operation should not be affected for most use cases.