### PR TITLE
Remove link parsing of usernames that are links

### DIFF
--- a/pynicotine/gtkgui/widgets/textview.py
+++ b/pynicotine/gtkgui/widgets/textview.py
@@ -107,10 +107,10 @@ class TextView:
 
                 _append(buffer, section[:start], tag)
                 _append(buffer, username, usertag)
-                _append(buffer, section[end:], tag)
-                return
+                return section[end:]
 
             _append(buffer, section, tag)
+            return ""
 
         line = str(line).strip("\n")
         buffer = self.textbuffer
@@ -126,6 +126,9 @@ class TextView:
 
         if buffer.get_char_count() > 0:
             line = "\n" + line
+
+        if line:
+            line = _usertag(buffer, line)
 
         if find_urls and ("://" in line or "www." in line or "mailto:" in line):
             # Match first url
@@ -145,7 +148,7 @@ class TextView:
                 match = self.url_regex.search(line)
 
         if line:
-            _usertag(buffer, line)
+            _append(buffer, line, tag)
 
         if num_lines >= self.max_num_lines:
             # Limit number of lines in textview


### PR DESCRIPTION
If a username is an HTTP link or any other kind of link it should not be treated as such, as it can mislead or confuse people. You also don't get the user context menu when right-clicking, which makes it more of a hassle to do any user interactions. 

I don't know if this is the best approach. As this `append_line` method is used in quite a few contexts.

## Before: 
![image](https://user-images.githubusercontent.com/9467802/180622858-44795473-b4ca-4aa6-8cae-1ac17af28e26.png)
![image](https://user-images.githubusercontent.com/9467802/180622860-6185d606-51e7-4f44-ba8e-9fb396c08241.png)
In the wild:  ![image](https://user-images.githubusercontent.com/9467802/180622862-20f90133-581a-4447-929f-355658139873.png)


## After:
![image](https://user-images.githubusercontent.com/9467802/180622881-162aca86-94e7-4748-ae4d-15dbffa35b88.png)
![image](https://user-images.githubusercontent.com/9467802/180622883-85793b1b-f941-40c9-9f6a-3b8f327916d8.png)
