### PR TITLE
theme.py: Dim selected but unfocused list item in TreeViews

### DIFF
--- a/pynicotine/gtkgui/widgets/theme.py
+++ b/pynicotine/gtkgui/widgets/theme.py
@@ -218,6 +218,16 @@ def set_global_css():
         -GtkTreeView-vertical-separator: 5;
     }
 
+    treeview:selected {
+        /* Dim selected but unfocused list items */
+        background-color: alpha(@theme_selected_bg_color, 0.5);
+    }
+
+    treeview:selected:focus {
+        /* Highlight selected list item with focus */
+        background-color: @theme_selected_bg_color;
+    }
+
     filechooser treeview,
     fontchooser treeview {
         /* Restore default item spacing in GTK choosers */


### PR DESCRIPTION
Concept for an accessibility improvement for visually identifying the focused widget list item by means of dimming non-focused items by 50%.

It is useful for the dual view navigation in Browse Shares as well as doing multi-selections in any other TreeView, especially when using the keyboard to do selections...

![image](https://user-images.githubusercontent.com/88614182/180767911-775db579-c118-4f1c-ad64-209367a3b43a.png)

![image](https://user-images.githubusercontent.com/88614182/180767795-24fbb4c0-c027-4926-b03d-c49c18cef236.png)

Note: The highlighted selections auto-complete dropdown lists are also dimmed.