### PR TITLE
Only backup files once per session

### DIFF
--- a/pynicotine/config.py
+++ b/pynicotine/config.py
@@ -569,6 +569,11 @@ class Config:
         # Update config values from file
         self.set_config()
 
+        # Make a backup of the previous session if valid
+        if not self.need_config():
+            from pynicotine.utils import backup_file
+            backup_file(self.filename, protect=True)
+
         # Convert special download folder share to regular share
         if self.sections["transfers"].get("sharedownloaddir", False):
             shares = self.sections["transfers"]["shared"]
@@ -765,9 +770,9 @@ class Config:
             return
 
         from pynicotine.logfacility import log
-        from pynicotine.utils import write_file_and_backup
+        from pynicotine.utils import write_file
 
-        write_file_and_backup(self.filename, self.write_config_callback, protect=True)
+        write_file(self.filename, self.write_config_callback, protect=True)
         log.add_debug("Saved configuration: %(file)s", {"file": self.filename})
 
     def write_config_backup(self, filename):

--- a/pynicotine/transfers.py
+++ b/pynicotine/transfers.py
@@ -52,9 +52,10 @@ from pynicotine.utils import clean_path
 from pynicotine.utils import encode_path
 from pynicotine.utils import get_result_bitrate_length
 from pynicotine.utils import human_speed
-from pynicotine.utils import load_file
 from pynicotine.utils import truncate_string_byte
-from pynicotine.utils import write_file_and_backup
+from pynicotine.utils import load_file
+from pynicotine.utils import write_file
+from pynicotine.utils import backup_file
 
 
 class Transfer:
@@ -240,6 +241,9 @@ class Transfers:
 
         if transfer_type == "downloads" and not transfers_file.endswith("downloads.json"):
             load_func = self.load_legacy_transfers_file
+
+        # Make a backup of the previous session
+        backup_file(transfers_file, protect=True)
 
         return load_file(transfers_file, load_func)
 
@@ -2531,7 +2535,7 @@ class Transfers:
             callback = self.save_downloads_callback
 
         self.config.create_data_folder()
-        write_file_and_backup(transfers_file, callback)
+        write_file(transfers_file, callback)
 
     def server_disconnect(self):
 

--- a/pynicotine/transfers.py
+++ b/pynicotine/transfers.py
@@ -242,8 +242,7 @@ class Transfers:
         if transfer_type == "downloads" and not transfers_file.endswith("downloads.json"):
             load_func = self.load_legacy_transfers_file
 
-        # Make a backup of the previous session
-        backup_file(transfers_file, protect=True)
+        self.config.create_data_folder()
 
         return load_file(transfers_file, load_func)
 
@@ -256,8 +255,10 @@ class Transfers:
 
         if transfer_type == "uploads":
             transfer_list = self.uploads
+            backup_file(self.get_upload_list_file_name(), protect=True)
         else:
             transfer_list = self.downloads
+            backup_file(self.get_download_queue_file_name(), protect=True)
 
         for transfer_row in transfers:
             # User / filename / path
@@ -2534,7 +2535,6 @@ class Transfers:
             transfers_file = self.downloads_file_name
             callback = self.save_downloads_callback
 
-        self.config.create_data_folder()
         write_file(transfers_file, callback)
 
     def server_disconnect(self):

--- a/pynicotine/utils.py
+++ b/pynicotine/utils.py
@@ -601,25 +601,10 @@ def load_file(path, load_func, use_old_file=False):
     return None
 
 
-def write_file_and_backup(path, callback, protect=False):
+def write_file(path, callback, protect=False):
 
     path_encoded = encode_path(path)
     path_old_encoded = encode_path(path + ".old")
-
-    # Back up old file to path.old
-    try:
-        if os.path.exists(path_encoded) and os.stat(path_encoded).st_size > 0:
-            os.replace(path_encoded, path_old_encoded)
-
-            if protect:
-                os.chmod(path_old_encoded, 0o600)
-
-    except Exception as error:
-        log.add(_("Unable to back up file %(path)s: %(error)s"), {
-            "path": path,
-            "error": error
-        })
-        return
 
     # Save new file
     if protect:
@@ -652,6 +637,26 @@ def write_file_and_backup(path, callback, protect=False):
 
     if protect:
         os.umask(oldumask)
+
+
+def backup_file(path, protect=False):
+
+    path_encoded = encode_path(path)
+    path_old_encoded = encode_path(path + ".old")
+
+    # Back up old file to path.old
+    try:
+        if os.path.exists(path_encoded) and os.stat(path_encoded).st_size > 0:
+            os.replace(path_encoded, path_old_encoded)
+
+            if protect:
+                os.chmod(path_old_encoded, 0o600)
+
+    except Exception as error:
+        log.add(_("Unable to back up file %(path)s: %(error)s"), {
+            "path": path,
+            "error": error
+        })
 
 
 def http_request(url_scheme, base_url, path, request_type="GET", body="", headers=None, timeout=10, redirect_depth=0):


### PR DESCRIPTION
This way, at least it might be possible for a user to recover their old data from the previous session if something went wrong or the user made an error. Also never overwrite the 'config.old' file with config.defaults

Writing through the existing file without moving it beforehand seems to work fine (not tested on all systems).

TODO: Seperate `restore_file()` function, it seems that restoring the old data after a failed save will not be appropriate now.