### PR TITLE
Browse Shares: Indeterminate progress bar pulsing during initial connection phase

### DIFF
--- a/pynicotine/gtkgui/userbrowse.py
+++ b/pynicotine/gtkgui/userbrowse.py
@@ -552,7 +552,7 @@ class UserBrowse(UserInterface):
         if not indeterminate_progress:
             self.progress_bar.set_fraction(0.0)
         else:
-            self.progress_bar.set_fraction(0.5)
+            self.set_indeterminate_progress()
 
         self.refresh_button.set_sensitive(False)
 
@@ -567,8 +567,17 @@ class UserBrowse(UserInterface):
 
         self.progress_bar.set_fraction(fraction)
 
+    def set_indeterminate_progress(self):
+        self.progress_bar.pulse()
+        GLib.timeout_add(500, self.pulse_progress)
+
+    def pulse_progress(self):
+        if self.indeterminate_progress:
+            self.set_indeterminate_progress()
+
     def set_finished(self):
 
+        self.indeterminate_progress = False
         self.userbrowses.request_tab_hilite(self.container)
         self.progress_bar.set_fraction(1.0)
         self.refresh_button.set_sensitive(True)

--- a/pynicotine/userbrowse.py
+++ b/pynicotine/userbrowse.py
@@ -68,7 +68,7 @@ class UserBrowse:
         if self.ui_callback:
             self.ui_callback.remove_user(user)
 
-    def show_user(self, user, path=None, local_shares_type=None, indeterminate_progress=False, switch_page=True):
+    def show_user(self, user, path=None, local_shares_type=None, indeterminate_progress=True, switch_page=True):
 
         self.add_user(user)
 


### PR DESCRIPTION
+ Added: Show indeterminate progress bar pulse during initial connection attempt phase

The progress_bar indeterminate pulsing until the list of shared files starts loading, otherwise currently there is not any visual indication that a connection attempt is in progress, and the timeout is long.