### PR TITLE
mainwindow.ui: Room List -> Rooms

### DIFF
--- a/pynicotine/gtkgui/ui/mainwindow.ui
+++ b/pynicotine/gtkgui/ui/mainwindow.ui
@@ -1466,7 +1466,7 @@
                                                     <child>
                                                       <object class="GtkLabel">
                                                         <property name="visible">True</property>
-                                                        <property name="label" translatable="yes">_Room List</property>
+                                                        <property name="label" translatable="yes">_Rooms</property>
                                                         <property name="use-underline">True</property>
                                                         <property name="mnemonic-widget">room_list_button</property>
                                                       </object>


### PR DESCRIPTION
"Room List" is ambiguous with list of Users in a room.

The name of the user list is "Users", so the room list should be "Rooms"