### PR TITLE
mainwindow.ui: "Show Log History Pane"

### DIFF
--- a/pynicotine/gtkgui/ui/mainwindow.ui
+++ b/pynicotine/gtkgui/ui/mainwindow.ui
@@ -1873,7 +1873,7 @@
                 <child>
                   <object class="GtkToggleButton" id="_log_history_button">
                     <property name="visible">True</property>
-                    <property name="tooltip-text" translatable="yes">Show log history</property>
+                    <property name="tooltip-text" translatable="yes">Show Log History Pane</property>
                     <property name="action-name">win.show-log-history</property>
                     <child>
                       <object class="GtkImage">


### PR DESCRIPTION
GNOME HIG

Matches string in the main menu, so it can be backported to 3.2.x