### PR TITLE
"Result/File grouping mode" -> "File Grouping Mode"

### DIFF
--- a/pynicotine/gtkgui/ui/mainwindow.ui
+++ b/pynicotine/gtkgui/ui/mainwindow.ui
@@ -440,7 +440,7 @@
                                             <child>
                                               <object class="GtkMenuButton" id="downloads_grouping_button">
                                                 <property name="visible">True</property>
-                                                <property name="tooltip-text" translatable="yes">File grouping mode</property>
+                                                <property name="tooltip-text" translatable="yes">File Grouping Mode</property>
                                                 <child>
                                                   <object class="GtkImage">
                                                     <property name="visible">True</property>
@@ -683,7 +683,7 @@
                                             <child>
                                               <object class="GtkMenuButton" id="uploads_grouping_button">
                                                 <property name="visible">True</property>
-                                                <property name="tooltip-text" translatable="yes">File grouping mode</property>
+                                                <property name="tooltip-text" translatable="yes">File Grouping Mode</property>
                                                 <child>
                                                   <object class="GtkImage">
                                                     <property name="visible">True</property>

--- a/pynicotine/gtkgui/ui/search.ui
+++ b/pynicotine/gtkgui/ui/search.ui
@@ -137,7 +137,7 @@
                 <child>
                   <object class="GtkMenuButton" id="grouping_button">
                     <property name="visible">True</property>
-                    <property name="tooltip-text" translatable="yes">Result grouping mode</property>
+                    <property name="tooltip-text" translatable="yes">File Grouping Mode</property>
                     <child>
                       <object class="GtkImage">
                         <property name="visible">True</property>


### PR DESCRIPTION
Unify this tooltip string in Search Files, Downloads and Uploads.

Use header capitalization in (short) tooltips according to the new GNOME HIG: https://developer.gnome.org/hig/patterns/feedback/tooltips.html