### PR TITLE
settings/shares.ui: shorten explaination

### DIFF
--- a/pynicotine/gtkgui/ui/settings/shares.ui
+++ b/pynicotine/gtkgui/ui/settings/shares.ui
@@ -22,7 +22,7 @@
       <object class="GtkLabel">
         <property name="visible">True</property>
         <property name="xalign">0</property>
-        <property name="label" translatable="yes">Share folders with every Soulseek user or buddies, allowing contents to be downloaded directly from your device. Hidden files are never shared.</property>
+        <property name="label" translatable="yes">Share folders with every Soulseek user or buddies, allowing contents to be downloaded directly from your device.</property>
         <property name="selectable">True</property>
         <property name="wrap">True</property>
       </object>


### PR DESCRIPTION
The minor detail about "hidden files" is ambiguous with Soulseek 'private files' or buddy-only shares, it's confusing to mention this here.