### PR TITLE
settings/shares.ui: change explanation

### DIFF
--- a/pynicotine/gtkgui/ui/dialogs/fastconfigure.ui
+++ b/pynicotine/gtkgui/ui/dialogs/fastconfigure.ui
@@ -335,7 +335,7 @@
             <child>
               <object class="GtkLabel">
                 <property name="visible">True</property>
-                <property name="label" translatable="yes">Users on the Soulseek network will be able to download files from folders you share. Sharing files is crucial for the health of the Soulseek network.</property>
+                <property name="label" translatable="yes">Soulseek users will be able to download from your shares. Contribute to the Soulseek network by sharing your own collection and by resharing what you downloaded from other users.</property>
                 <property name="selectable">True</property>
                 <property name="xalign">0</property>
                 <property name="wrap">True</property>

--- a/pynicotine/gtkgui/ui/settings/shares.ui
+++ b/pynicotine/gtkgui/ui/settings/shares.ui
@@ -22,7 +22,7 @@
       <object class="GtkLabel">
         <property name="visible">True</property>
         <property name="xalign">0</property>
-        <property name="label" translatable="yes">Users on the Soulseek network will be able to download files from folders you share. Sharing files is crucial for the health of the Soulseek network.</property>
+        <property name="label" translatable="yes">Soulseek users will be able to download from your shares. Contribute to the Soulseek network by sharing your own collection and by resharing what you downloaded from other users.</property>
         <property name="selectable">True</property>
         <property name="wrap">True</property>
       </object>

--- a/pynicotine/gtkgui/ui/settings/shares.ui
+++ b/pynicotine/gtkgui/ui/settings/shares.ui
@@ -22,7 +22,7 @@
       <object class="GtkLabel">
         <property name="visible">True</property>
         <property name="xalign">0</property>
-        <property name="label" translatable="yes">Share folders with every Soulseek user or buddies, allowing contents to be downloaded directly from your device. Hidden files are never shared.</property>
+        <property name="label" translatable="yes">Users on the Soulseek network will be able to download files from folders you share. Sharing files is crucial for the health of the Soulseek network.</property>
         <property name="selectable">True</property>
         <property name="wrap">True</property>
       </object>


### PR DESCRIPTION
Matches the string in Setup Assistant

better alternative to #2204 , The minor detail about "hidden files" is ambiguous with Soulseek 'private files' or buddy-only shares, it's confusing to mention this here.
