### PR TITLE
Add separate Shift+Ctrl+H shortcut for Set Away Status

### DIFF
--- a/pynicotine/gtkgui/frame.py
+++ b/pynicotine/gtkgui/frame.py
@@ -537,9 +537,6 @@ class NicotineFrame(Window):
     def on_disconnect(self, *_args):
         self.core.disconnect()
 
-    def on_away(self, *_args):
-        self.core.set_away_mode(self.core.user_status != UserStatus.AWAY, save_state=True)
-
     def on_soulseek_privileges(self, *_args):
 
         import urllib.parse
@@ -783,12 +780,6 @@ class NicotineFrame(Window):
         self.application.add_action(self.disconnect_action)
         self.application.set_accels_for_action("app.disconnect", ["<Shift><Primary>d"])
 
-        state = config.sections["server"]["away"]
-        self.away_action = Gio.SimpleAction(name="away", state=GLib.Variant("b", state), enabled=False)
-        self.away_action.connect("change-state", self.on_away)
-        self.application.add_action(self.away_action)
-        self.application.set_accels_for_action("app.away", ["<Primary>h"])
-
         self.soulseek_privileges_action = Gio.SimpleAction(name="soulseek-privileges", enabled=False)
         self.soulseek_privileges_action.connect("activate", self.on_soulseek_privileges)
         self.application.add_action(self.soulseek_privileges_action)
@@ -960,13 +951,19 @@ class NicotineFrame(Window):
         action.connect("change-state", self.on_debug_miscellaneous)
         self.window.add_action(action)
 
-        # Status Bar
+        # Status Bar Buttons
 
         state = config.sections["transfers"]["usealtlimits"]
         self.alt_speed_action = Gio.SimpleAction(name="alternative-speed-limit", state=GLib.Variant("b", state))
         self.alt_speed_action.connect("change-state", self.on_alternative_speed_limit)
         self.application.add_action(self.alt_speed_action)
         self.update_alternative_speed_icon(state)
+
+        state = config.sections["server"]["away"]
+        self.away_action = Gio.SimpleAction(name="away", state=GLib.Variant("b", state), enabled=False)
+        self.away_action.connect("change-state", self.on_away)
+        self.application.add_action(self.away_action)
+        self.application.set_accels_for_action("app.away", ["<Primary>h"])
 
         # Window (system menu and events)
 
@@ -1540,6 +1537,9 @@ class NicotineFrame(Window):
         self.core.privatechats.update_completions()
 
     """ Away Mode """
+
+    def on_away(self, *_args):
+        self.core.set_away_mode(self.core.user_status != UserStatus.AWAY, save_state=True)
 
     def set_away_mode(self, _is_away):
         self.update_user_status()

--- a/pynicotine/gtkgui/frame.py
+++ b/pynicotine/gtkgui/frame.py
@@ -495,6 +495,8 @@ class NicotineFrame(Window):
         # Action status
         self.connect_action.set_enabled(not is_online)
         self.disconnect_action.set_enabled(is_online)
+        self.away_set_action.set_enabled(is_online)
+        self.away_unset_action.set_enabled(is_online)
         self.away_action.set_enabled(is_online)
         self.away_action.set_state(GLib.Variant("b", is_away))
         self.soulseek_privileges_action.set_enabled(is_online)
@@ -963,9 +965,18 @@ class NicotineFrame(Window):
         self.away_action = Gio.SimpleAction(name="away", state=GLib.Variant("b", state), enabled=False)
         self.away_action.connect("change-state", self.on_away)
         self.application.add_action(self.away_action)
-        self.application.set_accels_for_action("app.away", ["<Primary>h"])
 
-        # Window (system menu and events)
+        # Action Shortcuts
+
+        self.away_set_action = Gio.SimpleAction(name="away-set", enabled=False)
+        self.away_set_action.connect("activate", self.on_away_set_accelerator)
+        self.application.add_action(self.away_set_action)
+        self.application.set_accels_for_action("app.away-set", ["<Shift><Primary>h"])
+
+        self.away_unset_action = Gio.SimpleAction(name="away-unset", enabled=False)
+        self.away_unset_action.connect("activate", self.on_away_unset_accelerator)
+        self.application.add_action(self.away_unset_action)
+        self.application.set_accels_for_action("app.away-unset", ["<Primary>h"])
 
         action = Gio.SimpleAction(name="close")  # 'When closing Nicotine+'
         action.connect("activate", self.on_close_request)
@@ -1540,6 +1551,16 @@ class NicotineFrame(Window):
 
     def on_away(self, *_args):
         self.core.set_away_mode(self.core.user_status != UserStatus.AWAY, save_state=True)
+
+    def on_away_set_accelerator(self, *_args):
+        """ Shift+Ctrl+H: Set Away """
+
+        self.core.set_away_mode(True, save_state=True)
+
+    def on_away_unset_accelerator(self, *_args):
+        """ Ctrl+H: Unset Away (Return Home) """
+
+        self.core.set_away_mode(False, save_state=True)
 
     def set_away_mode(self, _is_away):
         self.update_user_status()

--- a/pynicotine/gtkgui/ui/dialogs/shortcuts.ui
+++ b/pynicotine/gtkgui/ui/dialogs/shortcuts.ui
@@ -30,8 +30,15 @@
             <child>
               <object class="GtkShortcutsShortcut">
                 <property name="visible">True</property>
-                <property name="action-name">app.away</property>
-                <property name="title" translatable="yes">Away</property>
+                <property name="action-name">app.away-set</property>
+                <property name="title" translatable="yes">Set Away Status</property>
+              </object>
+            </child>
+            <child>
+              <object class="GtkShortcutsShortcut">
+                <property name="visible">True</property>
+                <property name="action-name">app.away-unset</property>
+                <property name="title" translatable="yes">Set Online Status</property>
               </object>
             </child>
             <child>


### PR DESCRIPTION
+ Added: Shift+Ctrl+H key shortcut action for setting Away status
+ Changed: Ctrl+H key shortcut action for setting Online status, instead of toggling Away/Online
- Moved: Action declaration code within set_up_actions() since Away is not an item in the File menu anymore, also grouped Away Mode functions as appropriate.

The purpose of separating these shortcuts is to prevent a server ban for rapid Away/Online status toggling that was possible due to key-hold repeat of the current Away toggle shortcut key.