### PR TITLE
shares.py: Warning if share(s) cannot be accessed before a rescan

### DIFF
--- a/pynicotine/__init__.py
+++ b/pynicotine/__init__.py
@@ -118,6 +118,8 @@ def rescan_shares():
 
     config.load_config()
 
+    log.log_levels = set(["transfer"] + config.sections["logging"]["debugmodes"])
+
     shares = Shares(None, config, deque(), init_shares=False)
     error = shares.rescan_shares(use_thread=False)
 

--- a/pynicotine/cli/application.py
+++ b/pynicotine/cli/application.py
@@ -117,8 +117,8 @@ class Application:
         # Not implemented
         pass
 
-    def confirm_force_rescan(self, message, _unused):
-        log.add(f"Rescan aborted: {message}")
+    def confirm_force_rescan(self, message_text, _unused):
+        log.add(f"Rescan aborted: {message_text}")
         return False
 
     def invalid_password(self):

--- a/pynicotine/cli/application.py
+++ b/pynicotine/cli/application.py
@@ -117,8 +117,8 @@ class Application:
         # Not implemented
         pass
 
-    def confirm_force_rescan(self, message_text, _unused):
-        log.add(f"Rescan aborted: {message_text}")
+    def confirm_force_rescan(self, title, message, _unused):
+        log.add(f"{title}:\n\n{message}" + " " + "Rescan aborted" + "!")
         return False
 
     def invalid_password(self):

--- a/pynicotine/cli/application.py
+++ b/pynicotine/cli/application.py
@@ -118,7 +118,7 @@ class Application:
         pass
 
     def confirm_force_rescan(self, title, message, _unused):
-        log.add(f"{title}:\n\n{message} " + "Rescan aborted" + "!")
+        log.add(f"{title}:\n\n{message} " + _("Rescan aborted") + "!")
 
     def invalid_password(self):
         # Not implemented

--- a/pynicotine/cli/application.py
+++ b/pynicotine/cli/application.py
@@ -117,8 +117,8 @@ class Application:
         # Not implemented
         pass
 
-    def confirm_force_rescan(self, title, message, _unused):
-        log.add(f"{title}:\n\n{message} " + _("Rescan aborted") + "!")
+    def confirm_force_rescan(self, title, message, _show_retry, _show_force):
+        log.add(f"{title}:\n\n{message}\n" + _("Rescan aborted") + "!")
 
     def invalid_password(self):
         # Not implemented

--- a/pynicotine/cli/application.py
+++ b/pynicotine/cli/application.py
@@ -117,6 +117,10 @@ class Application:
         # Not implemented
         pass
 
+    def confirm_force_rescan(self, message, _unused):
+        log.add(f"Rescan aborted: {message}")
+        return False
+
     def invalid_password(self):
         # Not implemented
         pass

--- a/pynicotine/cli/application.py
+++ b/pynicotine/cli/application.py
@@ -118,8 +118,7 @@ class Application:
         pass
 
     def confirm_force_rescan(self, title, message, _unused):
-        log.add(f"{title}:\n\n{message}" + " " + "Rescan aborted" + "!")
-        return False
+        log.add(f"{title}:\n\n{message} " + "Rescan aborted" + "!")
 
     def invalid_password(self):
         # Not implemented

--- a/pynicotine/gtkgui/frame.py
+++ b/pynicotine/gtkgui/frame.py
@@ -729,7 +729,7 @@ class NicotineFrame(Window):
 
     def confirm_force_rescan(self, title, message, show_force):
 
-        def create_dialog(title, message_text, show_force):
+        def create_dialog(title, message, show_force):
             OptionDialog(
                 parent=self.window,
                 title=title,

--- a/pynicotine/gtkgui/frame.py
+++ b/pynicotine/gtkgui/frame.py
@@ -528,34 +528,6 @@ class NicotineFrame(Window):
         self.user_status_icon.set_property("icon-name", icon_name)
         self.user_status_label.set_text(status_text)
 
-    def confirm_force_rescan_response(self, _dialog, response_id, _data):
-
-        if response_id == 1:  # 'Retry'
-            self.core.shares.rescan_shares()
-
-        elif response_id == 2:  # 'Force Rescan'  # TODO: or 'Ignore'
-            self.core.shares.rescan_shares(force=True)
-
-        elif response_id == 3:  # 'Configure Shares' or 'Setup Assistant'
-            if config.need_config():
-                self.on_fast_configure()
-            else:
-                self.on_configure_shares()
-
-        return False
-
-    def confirm_force_rescan(self, message, show_force):
-
-        OptionDialog(
-            parent=self.window,
-            title=_("Failed to access shares"),
-            message=message,
-            first_button=_("_Retry"),
-            second_button=_("_Force Rescan") if show_force else None,  # _("_Ignore"),
-            third_button=_("_Configure Shares") if not config.need_config() else _("_Setup Assistant"),
-            callback=self.confirm_force_rescan_response
-        ).show()
-
     """ Action Callbacks """
 
     # File
@@ -736,6 +708,39 @@ class NicotineFrame(Window):
     @staticmethod
     def on_improve_translations(*_args):
         open_uri(config.translations_url)
+
+    """ Dialogs """
+
+    def confirm_force_rescan_response(self, _dialog, response_id, _data):
+
+        if response_id == 1:  # 'Retry'
+            self.core.shares.rescan_shares()
+
+        elif response_id == 2:  # 'Force Rescan'
+            self.core.shares.rescan_shares(force=True)
+
+        elif response_id == 4:  # 'Configure Shares' or 'Setup Assistant'
+            if config.need_config():
+                self.on_fast_configure()
+            else:
+                self.on_configure_shares()
+
+    def confirm_force_rescan(self, message_text, show_force):
+
+        def create_dialog(message_text, show_force):
+            OptionDialog(
+                parent=self.window,
+                title=_("Failed to access shares"),
+                message=message_text,
+                first_button=_("_Retry"),
+                second_button=_("_Force Rescan") if show_force else None,
+                third_button=_("_Ignore") if not show_force else None,
+                fourth_button=_("_Configure Shares") if not config.need_config() else _("_Setup Assistant"),
+                callback=self.confirm_force_rescan_response
+            ).show()
+
+        # Avoid dialog appearing deactive if invoked during rescan on startup
+        GLib.idle_add(create_dialog, message_text, show_force)
 
     def _on_check_latest_version(self):
 

--- a/pynicotine/gtkgui/frame.py
+++ b/pynicotine/gtkgui/frame.py
@@ -714,11 +714,9 @@ class NicotineFrame(Window):
     def confirm_force_rescan_response(self, _dialog, response_id, _data):
 
         if response_id == 1:  # 'Retry'
-            # Start the scan again from scratch
             self.core.shares.rescan_shares()
 
         elif response_id == 2:  # 'Force Rescan'
-            # Start the scan again and skip the check
             self.core.shares.rescan_shares(force=True)
 
         elif response_id == 4:  # 'Configure Shares' or 'Setup Assistant'
@@ -743,9 +741,6 @@ class NicotineFrame(Window):
 
         # Avoid dialog appearing deactive if invoked during rescan on startup
         GLib.idle_add(create_dialog, title, message, show_force)
-
-        # Continue initializing shares, but without doing the rescan for now
-        return False
 
     def _on_check_latest_version(self):
 

--- a/pynicotine/gtkgui/frame.py
+++ b/pynicotine/gtkgui/frame.py
@@ -528,12 +528,12 @@ class NicotineFrame(Window):
         self.user_status_icon.set_property("icon-name", icon_name)
         self.user_status_label.set_text(status_text)
 
-    def confirm_rescan_dialog_response(self, _dialog, response_id, _data):
+    def confirm_force_rescan_response(self, _dialog, response_id, _data):
 
         if response_id == 1:  # 'Retry'
             self.core.shares.rescan_shares()
 
-        elif response_id == 2:  # 'Force Rescan'
+        elif response_id == 2:  # 'Force Rescan'  # TODO: or 'Ignore'
             self.core.shares.rescan_shares(force=True)
 
         elif response_id == 3:  # 'Configure Shares' or 'Setup Assistant'
@@ -544,16 +544,16 @@ class NicotineFrame(Window):
 
         return False
 
-    def confirm_rescan_dialog(self, message, show_force):
+    def confirm_force_rescan(self, message, show_force):
 
         OptionDialog(
             parent=self.window,
             title=_("Failed to access shares"),
             message=message,
             first_button=_("_Retry"),
-            second_button=_("_Force Rescan") if show_force else None,
+            second_button=_("_Force Rescan") if show_force else None,  # _("_Ignore"),
             third_button=_("_Configure Shares") if not config.need_config() else _("_Setup Assistant"),
-            callback=self.confirm_rescan_dialog_response
+            callback=self.confirm_force_rescan_response
         ).show()
 
     """ Action Callbacks """

--- a/pynicotine/gtkgui/frame.py
+++ b/pynicotine/gtkgui/frame.py
@@ -535,20 +535,20 @@ class NicotineFrame(Window):
         elif response_id == 2:  # 'Force Rescan'
             self.core.shares.rescan_shares(force=True)
 
-        elif response_id == 3:  # 'Configure Shares'
-            self.on_configure_shares()
+        elif response_id == 3:  # 'Configure Shares' or 'Setup Assistant'
+            self.on_configure_shares() if not config.need_config() else self.on_fast_configure()
 
         return False
 
-    def confirm_rescan_dialog(self, message):
+    def confirm_rescan_dialog(self, message, show_force):
 
         OptionDialog(
             parent=self.window,
             title=_("Failed to access shares"),
             message=message,
             first_button=_("_Retry"),
-            second_button=_("_Force Rescan"),
-            third_button=_("_Configure Shares"),
+            second_button=_("_Force Rescan") if show_force else None,
+            third_button=_("_Configure Shares") if not config.need_config() else _("_Setup Assistant"),
             callback=self.confirm_rescan_dialog_response
         ).show()
 

--- a/pynicotine/gtkgui/frame.py
+++ b/pynicotine/gtkgui/frame.py
@@ -540,11 +540,11 @@ class NicotineFrame(Window):
 
         return False
 
-    def confirm_rescan_dialog(self, title, message):
+    def confirm_rescan_dialog(self, message):
 
         OptionDialog(
             parent=self.window,
-            title=title,
+            title=_("Failed to access shares"),
             message=message,
             first_button=_("_Retry"),
             second_button=_("_Force Rescan"),

--- a/pynicotine/gtkgui/frame.py
+++ b/pynicotine/gtkgui/frame.py
@@ -727,13 +727,13 @@ class NicotineFrame(Window):
             else:
                 self.on_configure_shares()
 
-    def confirm_force_rescan(self, message_text, show_force):
+    def confirm_force_rescan(self, title, message, show_force):
 
-        def create_dialog(message_text, show_force):
+        def create_dialog(title, message_text, show_force):
             OptionDialog(
                 parent=self.window,
-                title=_("Failed to access shares"),
-                message=message_text,
+                title=title,
+                message=message,
                 first_button=_("_Retry"),
                 second_button=_("_Force Rescan") if show_force else None,
                 third_button=_("_Ignore") if not show_force else None,
@@ -742,7 +742,7 @@ class NicotineFrame(Window):
             ).show()
 
         # Avoid dialog appearing deactive if invoked during rescan on startup
-        GLib.idle_add(create_dialog, message_text, show_force)
+        GLib.idle_add(create_dialog, title, message, show_force)
 
         # Continue initializing shares, but without doing the rescan for now
         return False

--- a/pynicotine/gtkgui/frame.py
+++ b/pynicotine/gtkgui/frame.py
@@ -527,6 +527,31 @@ class NicotineFrame(Window):
         self.user_status_icon.set_property("icon-name", icon_name)
         self.user_status_label.set_text(status_text)
 
+    def confirm_rescan_dialog_response(self, _dialog, response_id, _data):
+
+        if response_id == 1:  # 'Retry'
+            self.core.shares.rescan_shares()
+
+        elif response_id == 2:  # 'Force Rescan'
+            self.core.shares.rescan_shares(force=True)
+
+        elif response_id == 3:  # 'Configure Shares'
+            self.on_configure_shares()
+
+        return False
+
+    def confirm_rescan_dialog(self, title, message):
+
+        OptionDialog(
+            parent=self.window,
+            title=title,
+            message=message,
+            first_button=_("_Retry"),
+            second_button=_("_Force Rescan"),
+            third_button=_("_Configure Shares"),
+            callback=self.confirm_rescan_dialog_response
+        ).show()
+
     """ Action Callbacks """
 
     # File

--- a/pynicotine/gtkgui/frame.py
+++ b/pynicotine/gtkgui/frame.py
@@ -714,9 +714,11 @@ class NicotineFrame(Window):
     def confirm_force_rescan_response(self, _dialog, response_id, _data):
 
         if response_id == 1:  # 'Retry'
+            # Start the scan again from scratch
             self.core.shares.rescan_shares()
 
         elif response_id == 2:  # 'Force Rescan'
+            # Start the scan again and skip the check
             self.core.shares.rescan_shares(force=True)
 
         elif response_id == 4:  # 'Configure Shares' or 'Setup Assistant'
@@ -741,6 +743,9 @@ class NicotineFrame(Window):
 
         # Avoid dialog appearing deactive if invoked during rescan on startup
         GLib.idle_add(create_dialog, message_text, show_force)
+
+        # Continue initializing shares, but without doing the rescan for now
+        return False
 
     def _on_check_latest_version(self):
 

--- a/pynicotine/gtkgui/frame.py
+++ b/pynicotine/gtkgui/frame.py
@@ -725,22 +725,22 @@ class NicotineFrame(Window):
             else:
                 self.on_configure_shares()
 
-    def confirm_force_rescan(self, title, message, show_force):
+    def confirm_force_rescan(self, title, message, show_retry, show_force):
 
-        def create_dialog(title, message, show_force):
+        def create_dialog():
             OptionDialog(
                 parent=self.window,
                 title=title,
                 message=message,
-                first_button=_("_Retry"),
-                second_button=_("_Force Rescan") if show_force else None,
-                third_button=_("_Ignore") if not show_force else None,
+                first_button=_("_Retry") if show_retry else None,  # hide if 0 shares configured
+                second_button=_("_Force Rescan") if show_force else None,  # hide if 0 shares ready
+                third_button=_("_Ignore") if not show_force else None,  # don't offer to completely wipe out the index
                 fourth_button=_("_Configure Shares") if not config.need_config() else _("_Setup Assistant"),
                 callback=self.confirm_force_rescan_response
             ).show()
 
         # Avoid dialog appearing deactive if invoked during rescan on startup
-        GLib.idle_add(create_dialog, title, message, show_force)
+        GLib.idle_add(create_dialog)
 
     def _on_check_latest_version(self):
 

--- a/pynicotine/gtkgui/frame.py
+++ b/pynicotine/gtkgui/frame.py
@@ -536,7 +536,10 @@ class NicotineFrame(Window):
             self.core.shares.rescan_shares(force=True)
 
         elif response_id == 3:  # 'Configure Shares' or 'Setup Assistant'
-            self.on_configure_shares() if not config.need_config() else self.on_fast_configure()
+            if config.need_config():
+                self.on_fast_configure()
+            else:
+                self.on_configure_shares()
 
         return False
 

--- a/pynicotine/gtkgui/widgets/dialogs.py
+++ b/pynicotine/gtkgui/widgets/dialogs.py
@@ -294,7 +294,7 @@ class EntryDialog(MessageDialog):
 class OptionDialog(MessageDialog):
 
     def __init__(self, parent, title, message, callback, callback_data=None, option_label="", option_value=False,
-                 first_button=_("_No"), second_button=_("_Yes"), third_button=""):
+                 first_button=_("_No"), second_button=_("_Yes"), third_button="", fourth_button=""):
 
         buttons = []
 
@@ -306,6 +306,9 @@ class OptionDialog(MessageDialog):
 
         if third_button:
             buttons.append((third_button, 3))
+
+        if fourth_button:
+            buttons.append((fourth_button, 4))
 
         super().__init__(parent=parent, title=title, message=message, message_type=Gtk.MessageType.OTHER,
                          callback=callback, callback_data=callback_data, buttons=buttons)

--- a/pynicotine/shares.py
+++ b/pynicotine/shares.py
@@ -834,38 +834,65 @@ class Shares:
         return False
 
     @staticmethod
+    def count_shares(shared_folders):
+        """ Return the total number of configured shared folders """
+
+        num_shares = 0
+
+        for shares in shared_folders:
+            for virtual, folder, *_unused in shares:
+                num_shares += 1
+
+        return num_shares
+
+    @staticmethod
     def check_shares(shared_folders):
         """ Return shared folder paths that are inaccessible """
 
         errors = []
 
-        for virtual, folder, *_unused in shared_folders[1]:
-            if not os.access(str(folder), os.R_OK):
-                errors.append(f"Cannot access share {virtual} with real path {folder}")
+        for shares in shared_folders:
+            for virtual, folder, *_unused in shares:
+                if not os.access(str(folder), os.R_OK):
+                    errors.append(f"Cannot access share {virtual} with real path {folder}")
 
         return errors
+
+    def confirm_rescan(self, shared_folders):
+        """ Verify if all shares are mounted before continuing to rescan """
+
+        errors = self.check_shares(shared_folders)
+
+        if not errors:
+            return True
+
+        num_errors, num_shares = len(errors), self.count_shares(shared_folders)
+        title = f"Failed to access {num_errors} of {num_shares} configured shares"
+        message = '\n'.join(errors)
+
+        log.add(message)
+
+        if num_errors >= 2:
+            log.add(title)
+
+        if self.ui_callback:
+            # Prompt to retry or force rescan
+            return self.ui_callback.confirm_rescan_dialog(title, message)
+
+        return False
 
     def rescan_shares(self, init=False, rescan=True, rebuild=False, use_thread=True, force=False):
 
         if self.rescanning:
             return None
 
-        self.rescanning = True
         shared_folders = self.get_shared_folders()
-        errors = self.check_shares(shared_folders)
 
-        if errors:
-            log.add('\n'.join(errors))
+        if not force:
+            rescan = (rescan and self.confirm_rescan(shared_folders))
 
-            if len(errors) >= 2:
-                log.add(f"Failed to access {len(errors)} shares")
-
-            if not force and rescan and self.ui_callback:
-                pass  # TODO: Confirm abort/retry/continue (force rescan)
-
-            rescan = (force and rescan)
-            
         # Hand over database control to the scanner process
+        self.rescanning = True
         self.close_shares(self.share_dbs)
 
         scanner, scanner_queue = self.build_scanner_process(shared_folders, init, rescan, rebuild)

--- a/pynicotine/shares.py
+++ b/pynicotine/shares.py
@@ -858,26 +858,26 @@ class Shares:
         return False
 
     def list_shares(self, group=None):
-        """ Returns ONE list with all readable shares and missing shares.
-        group specifies which shares to check: "normal", "buddy", etc """
+        """ Returns ONE string with all readable shares and missing shares.
+        group specifies which shares to list: "normal", "buddy", etc. """
         # TODO: Unused, need new command in core_commands to run this
 
         reads, fails = self.check_shares(shares=None, group=group)
         num_reads = len(reads)
         num_fails = len(fails)
         num_total = num_reads + num_fails
+        total_shares_line = "0 " + _("shares") + " " + _("configured")
 
         if not num_total:
-            head_line = "No configured shares"
-            fails.insert(0, head_line)
+            fails.insert(0, total_shares_line)
 
-        # Coalesce all "Ready " and "Missing " items toegether
-        all_shares = '\n\n'.join(reads) + "\n" + '\n\n'.join(fails)
+        # Coalesce the summary line toegether with all "Ready " and "Missing " items
+        all_shares = total_shares_line + ":\n\n" + '\n\n'.join(reads) + "\n" + '\n\n'.join(fails)
 
         return all_shares
 
     def check_shares(self, shares=None, group=None):
-        """ Returns TWO lists of: readable shares, and missing shares.
+        """ Returns TWO lists of strings: readable shares, and missing shares.
         group specifies which shares to check: "normal", "buddy", etc. """
 
         if shares is None:
@@ -892,9 +892,9 @@ class Shares:
 
             for virtual, folder, *_unused in table:
                 if os.access(folder, os.R_OK):
-                    reads.append(f"Ready {group_name} share \"{virtual}\" at:\n{folder}")
+                    reads.append(_(f"Ready {group_name} share \"{virtual}\" at:\n{folder}"))
                 else:
-                    fails.append(f"Missing {group_name} share \"{virtual}\" at:\n{folder}")
+                    fails.append(_(f"Missing {group_name} share \"{virtual}\" at:\n{folder}"))
 
             if group is not None:
                 # Only check a specific group (ie just "normal" or "buddy" shares, etc)
@@ -913,13 +913,13 @@ class Shares:
         num_fails = len(fails)
         num_total = num_reads + num_fails
 
-        reads_shares_word = "share" if num_reads == 1 else "shares"
-        fails_shares_word = "share" if num_fails == 1 else "shares"
-        total_shares_word = "share" if num_total == 1 else "shares"
+        reads_shares_word = _("share") if num_reads == 1 else _("shares")
+        fails_shares_word = _("share") if num_fails == 1 else _("shares")
+        total_shares_word = _("share") if num_total == 1 else _("shares")
 
-        total_shares_line = f"{num_total} {total_shares_word} configured"
-        reads_shares_line = f"{num_reads} {reads_shares_word} ready to scan"
-        fails_shares_line = f"{num_fails} {fails_shares_word} cannot be found"
+        total_shares_line = f"{num_total} {total_shares_word} " + _("configured")
+        reads_shares_line = f"{num_reads} {reads_shares_word} " + _("ready to scan")
+        fails_shares_line = f"{num_fails} {fails_shares_word} " + _("cannot be found")
 
         log.add(total_shares_line)
 
@@ -941,7 +941,7 @@ class Shares:
         fails_text = '\n\n'.join(fails)
 
         log.add_transfer(f"{fails_shares_line}:\n\n{fails_text}\n\n")
-        log.add("Rescan aborted" + ": " + (fails_text.replace(":\n", " ") if num_fails == 1 else fails_shares_line))
+        log.add(_("Rescan aborted") + ": " + (fails_text.replace(":\n", " ") if num_fails == 1 else fails_shares_line))
 
         if self.ui_callback:
             if num_fails > 5:
@@ -949,13 +949,13 @@ class Shares:
                 fails_text = '\n\n'.join(fails[:5]) + "\n\n…\n"
 
             if num_reads:
-                bottom_line = f"Retry to check again, or use force to exclude {num_fails} {fails_shares_word}."
+                bottom_line = _(f"Retry to check again, or use force to exclude {num_fails} {fails_shares_word}.")
                 show_force = True
             else:
-                bottom_line = "Nothing to scan" + "."
+                bottom_line = _("Nothing to scan") + "."
                 show_force = False  # don't offer to totally wipe out all share indexes
 
-            title_text = "Rescan aborted" + ": " + (fails_shares_line if num_total else total_shares_line)
+            title_text = _("Rescan aborted") + ": " + (fails_shares_line if num_total else total_shares_line)
             summary_line = f"{reads_shares_line}" + " " + f"(out of {total_shares_line})"
             message_text = f"{fails_text}\n\n{summary_line}\n\n{bottom_line}"
 
@@ -976,7 +976,7 @@ class Shares:
             # Verify all shares are mounted before allowing destructive rescan
             rescan = (rescan and self.confirm_force_rescan(shared_folders))
         else:
-            log.add("Shared folder checks skipped using force rescan")
+            log.add(_("Shared folder checks skipped, using force rescan"))
 
         # Hand over database control to the scanner process (it needs to initialize in any case)
         self.rescanning = True

--- a/pynicotine/shares.py
+++ b/pynicotine/shares.py
@@ -935,7 +935,7 @@ class Shares:
             fails.insert(0, total_shares_line)
 
         if reads:
-            reads_text = '\n\n'.join(reads) + "\n"
+            reads_text = '\n\n'.join(reads)
             log.add_transfer(f"{reads_shares_line}:\n\n{reads_text}\n")
 
         if reads and not fails:
@@ -943,8 +943,9 @@ class Shares:
             return True
 
         fails_text = '\n\n'.join(fails)
+        summary_line = _(f"{reads_shares_line} (out of {total_shares_line})")
 
-        log.add_transfer(f"{fails_shares_line}:\n\n{fails_text}\n\n")
+        log.add_transfer(f"{fails_shares_line}:\n\n{fails_text}\n\n{summary_line}")
         log.add(_("Rescan aborted") + ": " + (fails_text.replace(":\n", " ") if num_fails == 1 else fails_shares_line))
 
         if self.ui_callback:
@@ -961,7 +962,6 @@ class Shares:
                 bottom_line = _("Nothing to scan") + ". " + (bottom_line if num_total else "")
 
             title_text = _("Rescan aborted") + ": " + (fails_shares_line if num_total else total_shares_line)
-            summary_line = f"{reads_shares_line}" + " " + f"(out of {total_shares_line})"
             message_text = f"{fails_text}\n\n{summary_line}\n\n{bottom_line}"
 
             # Prompt with retry/force rescan options only offered if relevant and appropriate

--- a/pynicotine/shares.py
+++ b/pynicotine/shares.py
@@ -856,10 +856,10 @@ class Shares:
         num_ok, num_shares, errors = self.check_shares(shared_folders)
         num_errors = len(errors)
 
-        log.add(f"Located {num_ok} of {num_shares} configured shares")
+        log.add(f"{num_ok} shares available" + " / " + f"{num_shares} shares configured")
 
-        if not num_ok:
-            errors.insert(0, "No shares available" if num_shares else "No shares configured")
+        if not num_ok or not num_shares:
+            errors.insert(0, f"{num_ok} shares available" if num_shares else f"{num_shares} shares configured")
 
         if not errors:
             return True

--- a/pynicotine/shares.py
+++ b/pynicotine/shares.py
@@ -856,10 +856,10 @@ class Shares:
         num_ok, num_shares, errors = self.check_shares(shared_folders)
         num_errors = len(errors)
 
-        if num_shares:
-            log.add(f"Located {num_ok} of {num_shares} configured shares")
-        elif not num_ok:
-            errors.append("No configured shares")
+        log.add(f"Located {num_ok} of {num_shares} configured shares")
+
+        if not num_ok:
+            errors.insert(0, "No shares available" if num_shares else "No shares configured")
 
         if not errors:
             return True
@@ -875,7 +875,7 @@ class Shares:
             message = summary + ":\n\n" + ('\n\n'.join(errors) if num_errors <= 5
                                            else '\n\n'.join(errors[:5]) + "\n\n…")
             # Prompt retry/force rescan
-            return self.ui_callback.confirm_rescan_dialog(message)
+            return self.ui_callback.confirm_rescan_dialog(message, num_ok)
 
         return False
 

--- a/pynicotine/shares.py
+++ b/pynicotine/shares.py
@@ -858,12 +858,10 @@ class Shares:
 
         return False
 
-    def list_shares(self, group=None):
-        """ Returns ONE string with all readable shares and missing shares.
-        group specifies which shares to list: "normal", "buddy", etc. """
-        # TODO: Unused, need new command in core_commands to run this
+    def list_shares(self):
+        """ Returns ONE string with all readable shares and missing shares """
 
-        reads, fails = self.check_shares(shares=None, group=group)
+        reads, fails = self.check_shares()
 
         num_reads = len(reads)
         num_fails = len(fails)
@@ -875,8 +873,10 @@ class Shares:
         if not num_total:
             fails.insert(0, total_shares_line)
 
-        # Coalesce the summary line toegether with all "Ready " and "Missing " items
-        all_shares = total_shares_line + ":\n\n" + '\n\n'.join(reads) + "\n" + '\n\n'.join(fails)
+        # Coalesce the summary line toegether with all "ready" and "not found" items
+        all_shares = total_shares_line
+        all_shares += "\n\n" + '\n\n'.join(reads) if reads else ""
+        all_shares += "\n\n" + '\n\n'.join(fails) if fails else ""
 
         return all_shares
 

--- a/pynicotine/shares.py
+++ b/pynicotine/shares.py
@@ -933,7 +933,8 @@ class Shares:
 
         if self.ui_callback:
             if num_reads:
-                bottom_line = f"Retry to check again, or use force to exclude {num_fails} shares."
+                shares_word = "shares" if num_fails > 1 else "share"
+                bottom_line = f"Retry to check again, or use force to exclude {num_fails} {shares_word}."
             else:
                 bottom_line = "No accessible shares" if num_total else ""  # "No configured shares"
 
@@ -957,7 +958,7 @@ class Shares:
             # Verify all shares are mounted before allowing destructive rescan
             rescan = (rescan and self.confirm_force_rescan(shared_folders))
         else:
-            log.add("Shares check skipped (force rescan)")
+            log.add("Shared folder checks skipped using force rescan")
 
         # Hand over database control to the scanner process (it needs to initialize in any case)
         self.rescanning = True

--- a/pynicotine/shares.py
+++ b/pynicotine/shares.py
@@ -854,7 +854,7 @@ class Shares:
         for shares in shared_folders:
             for virtual, folder, *_unused in shares:
                 if not os.access(str(folder), os.R_OK):
-                    errors.append(f"Cannot access share {virtual} with real path {folder}")
+                    errors.append(f"Cannot access share {virtual} at {folder}")
 
         return errors
 

--- a/pynicotine/shares.py
+++ b/pynicotine/shares.py
@@ -840,7 +840,7 @@ class Shares:
         num_shares = 0
 
         for shares in shared_folders:
-            for virtual, folder, *_unused in shares:
+            for _virtual, _folder, *_unused in shares:
                 num_shares += 1
 
         return num_shares

--- a/pynicotine/shares.py
+++ b/pynicotine/shares.py
@@ -858,27 +858,42 @@ class Shares:
 
         return False
 
-    def list_shares(self):
-        """ Returns ONE string with all readable shares and missing shares """
+    def count_shares(self, shares=None, group=None, logging=True):
+        """ Check if any shares are missing and log counts """
 
-        reads, fails = self.check_shares()
+        reads, fails = self.check_shares(shares=shares, group=group)
 
         num_reads = len(reads)
         num_fails = len(fails)
         num_total = num_reads + num_fails
 
-        total_shares_line = (_(f"{num_total} share configured") if num_total == 1 else
-                             _(f"{num_total} shares configured"))
+        summary_total = _(f"{num_total} shares configured")
+        summary_reads = _(f"{num_reads} shares ready")
+        summary_fails = _(f"{num_fails} shares not found")
 
-        if not num_total:
-            fails.insert(0, total_shares_line)
+        reads_text = '\n\n'.join(reads)
+        fails_text = '\n\n'.join(fails)
 
-        # Coalesce the summary line toegether with all "ready" and "not found" items
-        all_shares = total_shares_line
-        all_shares += "\n\n" + '\n\n'.join(reads) if reads else ""
-        all_shares += "\n\n" + '\n\n'.join(fails) if fails else ""
+        if logging:
+            log.add(summary_total)
 
-        return all_shares
+            if num_total:
+                log.add(summary_reads)
+                if num_fails:
+                    log.add(summary_fails)
+            else:
+                fails.insert(0, summary_total)
+
+            if reads:
+                log.add_transfer(f"{summary_reads}:\n\n{reads_text}\n")
+
+            if fails and num_total:
+                log.add_transfer(f"{summary_fails}:\n\n{fails_text}\n")
+
+            log.add_transfer(_(f"{summary_reads} out of {summary_total}"))
+
+        return (num_reads, num_fails, num_total, summary_total,
+                summary_reads, summary_fails, reads_text, fails_text, fails)
 
     def check_shares(self, shares=None, group=None):
         """ Returns TWO lists of strings: readable shares, and missing shares.
@@ -909,61 +924,30 @@ class Shares:
         return reads, fails
 
     def confirm_force_rescan(self, shares):
-        """ Check if any shares are missing, if so then show a prompt """
 
-        reads, fails = self.check_shares(shares)
+        # Check if any shares are missing and log counts
+        (num_reads, num_fails, num_total, summary_total,
+         summary_reads, summary_fails, _reads_text, fails_text, fails) = self.count_shares(shares)
 
-        num_reads = len(reads)
-        num_fails = len(fails)
-        num_total = num_reads + num_fails
-
-        total_shares = (_(f"{num_total} share configured") if num_total == 1 else
-                        _(f"{num_total} shares configured"))
-
-        reads_shares = (_(f"{num_reads} share ready") if num_reads == 1 else
-                        _(f"{num_reads} shares ready"))
-
-        fails_shares = (_(f"{num_fails} share not found") if num_fails == 1 else
-                        _(f"{num_fails} shares not found"))
-
-        log.add(total_shares)
-
-        if num_total:
-            log.add(reads_shares)
-            if num_fails:
-                log.add(fails_shares)
-        else:
-            fails.insert(0, total_shares)
-
-        if reads:
-            reads_text = '\n\n'.join(reads)
-            log.add_transfer(f"{reads_shares}:\n\n{reads_text}\n")
-
-        if reads and not fails:
+        if num_reads and not num_fails:
             # Continue initializing shares, and do the rescan now
             return True
 
-        fails_text = '\n\n'.join(fails)
-        summary = _(f"{reads_shares} out of {total_shares}")
-
-        log.add_transfer(f"{fails_shares}:\n\n{fails_text}\n\n{summary}")
-        log.add(_("Rescan aborted") + ": " + (fails_text.replace(":\n", " ") if num_fails == 1 else fails_shares))
+        log.add(_("Rescan aborted") + ": " + (fails_text.replace(":\n", " ") if num_fails == 1 else summary_fails))
 
         if self.ui_callback:
+            title_text = _("Rescan aborted") + ": " + (summary_fails if num_total else summary_total)
+            summary = _(f"{summary_reads} out of {summary_total}")
+
+            # TODO: This string doesn't currently make sense in the CLI until '/rescan force' is implemented
+            summary += ("\n" + _(f"Force rescan will exclude {num_fails} shares") if num_reads else
+                        "\n" + _("Nothing to scan"))
+
             if num_fails > 5:
                 # Abbreviate message_text, the dialog may get too tall if there's many fails!
                 fails_text = '\n\n'.join(fails[:5]) + "\n\n…\n"
 
-            epilog = _("Verify disk(s) are accessible then retry to check again")
-
-            if num_reads:
-                # TODO: This string doesn't currently make sense in the CLI until '/rescan force' is implemented
-                summary += ",\n" + (_(f"using force will exclude {num_fails} share") + "." if num_fails == 1 else
-                                    _(f"using force will exclude {num_fails} shares") + ".")
-            else:
-                epilog = _("Nothing to scan") + ". " + (epilog if num_total else "")
-
-            title_text = _("Rescan aborted") + ": " + (fails_shares if num_total else total_shares)
+            epilog = _("Verify disk(s) are accessible then retry to check again") if num_total else ""
             message_text = f"{fails_text}\n\n{summary}\n\n{epilog}"
 
             # Prompt with retry/force rescan options only offered if relevant and appropriate

--- a/pynicotine/shares.py
+++ b/pynicotine/shares.py
@@ -921,9 +921,6 @@ class Shares:
         reads_shares_line = f"{num_reads} {reads_shares_word} ready to scan"
         fails_shares_line = f"{num_fails} {fails_shares_word} cannot be found"
 
-        reads_text = '\n\n'.join(reads) + "\n"
-
-        log.add_transfer(f"{reads_shares_line}:\n\n{reads_text}\n")
         log.add(total_shares_line)
 
         if num_total:
@@ -938,6 +935,10 @@ class Shares:
             head_line = fails_shares_line
         else:
             head_line = reads_shares_line
+
+        reads_text = '\n\n'.join(reads) + "\n"
+
+        log.add_transfer(f"{reads_shares_line}:\n\n{reads_text}\n")
 
         if reads and not fails:
             # Continue initializing shares, and do the rescan now
@@ -954,7 +955,7 @@ class Shares:
             if num_reads:
                 bottom_line = f"Retry to check again, or use force to exclude {num_fails} {fails_shares_word}."
             else:
-                bottom_line = reads_shares_line if num_total and num_reads else "Rescan aborted"
+                bottom_line = reads_shares_line if num_total and num_reads else "Nothing to scan" + "."
 
             if num_fails > 5:
                 # Abbreviate message_text, as dialog may get too tall if there's many fails!

--- a/pynicotine/shares.py
+++ b/pynicotine/shares.py
@@ -928,17 +928,11 @@ class Shares:
             if num_fails:
                 log.add(fails_shares_line)
         else:
-            head_line = total_shares_line
             fails.insert(0, total_shares_line)
 
-        if num_reads < num_total:
-            head_line = fails_shares_line
-        else:
-            head_line = reads_shares_line
-
-        reads_text = '\n\n'.join(reads) + "\n"
-
-        log.add_transfer(f"{reads_shares_line}:\n\n{reads_text}\n")
+        if reads:
+            reads_text = '\n\n'.join(reads) + "\n"
+            log.add_transfer(f"{reads_shares_line}:\n\n{reads_text}\n")
 
         if reads and not fails:
             # Continue initializing shares, and do the rescan now

--- a/test/integration/test_startup.py
+++ b/test/integration/test_startup.py
@@ -54,13 +54,13 @@ class StartupTest(unittest.TestCase):
         output = subprocess.check_output(["python3", "-m", "pynicotine", "--help"], timeout=3)
         self.assertTrue(str(output).find("--help") > -1)
 
-        # Check for " 0 folders found after rescan" in output. Text strings are translatable,
-        # so we can't match them directly.
+        # Look for ' 1 of 1 configured shares' in output. Text strings are translatable,
+        # so we can't match an entire line directly.
         output = subprocess.check_output(
             ["python3", "-m", "pynicotine", "--config=" + CONFIG_FILE, "--user-data=" + USER_DATA, "--rescan"],
             timeout=10
         )
-        self.assertTrue(str(output).find(" 0 ") > -1)
+        self.assertTrue(str(output).find(" 1 ") > -1)
 
         output = subprocess.check_output(["python3", "-m", "pynicotine", "--version"], timeout=3)
         self.assertTrue(str(output).find("Nicotine+") > -1)

--- a/test/integration/test_startup.py
+++ b/test/integration/test_startup.py
@@ -54,13 +54,13 @@ class StartupTest(unittest.TestCase):
         output = subprocess.check_output(["python3", "-m", "pynicotine", "--help"], timeout=3)
         self.assertTrue(str(output).find("--help") > -1)
 
-        # Look for ' 1 of 1 configured shares' in output. Text strings are translatable,
-        # so we can't match an entire line directly.
+        # Check for " 0 folders found after rescan" in output. Text strings are translatable,
+        # so we can't match them directly.
         output = subprocess.check_output(
             ["python3", "-m", "pynicotine", "--config=" + CONFIG_FILE, "--user-data=" + USER_DATA, "--rescan"],
             timeout=10
         )
-        self.assertTrue(str(output).find(" 1 ") > -1)
+        self.assertTrue(str(output).find(" 0 ") > -1)
 
         output = subprocess.check_output(["python3", "-m", "pynicotine", "--version"], timeout=3)
         self.assertTrue(str(output).find("Nicotine+") > -1)


### PR DESCRIPTION
This would close #1698

+ Added: Log warning if share(s) cannot be accessed before a rescan wipes out the shares database
+ Added: Option dialog prompt for "Retry", "Force Rescan" or "Configure Shares"


Implementation of a confirmation dialog as discussed in #1698

_If no shares are accessible:_
![Screenshot_2022-10-19_20-00-10](https://user-images.githubusercontent.com/88614182/196780430-90a1d974-58d0-4ccb-a438-6b0c8129028b.png)

.
.

_If one share cannot be found:_
```
2022-10-19 20:05:38 2 shares configured
2022-10-19 20:05:38 1 share ready
2022-10-19 20:05:38 1 share not found
2022-10-19 20:05:38 Rescan aborted: Missing public share "PLAY" at /media/user/PLAY
```
![Screenshot_2022-10-19_20-01-25](https://user-images.githubusercontent.com/88614182/196780654-8496eb94-384a-4d87-8bae-24932a4bb8fb.png)

,
.

If more than one share**s** are not accessible::
```
2022-10-19 20:08:20 3 shares configured
2022-10-19 20:08:20 1 share ready
2022-10-19 20:08:20 2 shares not found
2022-10-19 20:08:20 Rescan aborted: 2 shares not found
```
![Screenshot_2022-10-19_20-08-37](https://user-images.githubusercontent.com/88614182/196782043-1c5f2c62-9994-4c68-9b6a-4946bed76e9c.png)

.
.
_On "Retry" after the missing shares are mounted:_
```
2022-10-19 20:11:39 3 shares configured
2022-10-19 20:11:39 3 shares ready
2022-10-19 20:11:39 Rescanning shares…
2022-10-19 20:11:39 276 folders found before rescan, rebuilding…
2022-10-19 20:11:40 Rescan complete: 276 folders found
```

It seems to be successful at preventing inadvertent database loss, but it is quite obnoxious because the box doesn't have a close (X) or cancel button. However, if there are no ready (or no configured) shares to scan then "Ignore" is offered instead of "Force Rescan", allowing the dialog to be easily dismissed if the user doesn't wish to share anything.

The "Force Rescan" button changes to "Ignore" if there a no available shares to scan then it seems pointless to allow a force scan which would result is zeroing out the database.

The future intention is to integrate the shares checking mechanism into the `/listshares` command which would require some sort of output, and  also there is some long-winded experimental code which aims to provide inspiration for improved flexibility as to how multiple share "groups" (i.e. share_type) could potentially be addressed in a more logical way.