### PR TITLE
config.py: move "Unknown config option" into debug log

### DIFF
--- a/pynicotine/config.py
+++ b/pynicotine/config.py
@@ -660,13 +660,13 @@ class Config:
 
                 # Check if config section exists in defaults
                 if i not in self.defaults and i not in self.removed_options:
-                    log.add(_("Unknown config section '%s'"), i)
+                    log.add_debug("Unknown config section '%s'", i)
 
                 # Check if config option exists in defaults
                 elif (j not in self.defaults.get(i, {}) and j not in self.removed_options.get(i, {})
                         and i != "plugins" and j != "filter"):
-                    log.add(_("Unknown config option '%(option)s' in section '%(section)s'"),
-                            {'option': j, 'section': i})
+                    log.add_debug("Unknown config option '%(option)s' in section '%(section)s'",
+                                  {'option': j, 'section': i})
 
                 else:
                     """ Attempt to get the default value for a config option. If there's no default


### PR DESCRIPTION
Closes #2228 

It might be a good idea to move this log entry into the debug log, since it is not really an important enough problem for it to be in the standard log.