### PR TITLE
Capitalize Short Tooltips

### DIFF
--- a/pynicotine/gtkgui/ui/mainwindow.ui
+++ b/pynicotine/gtkgui/ui/mainwindow.ui
@@ -425,7 +425,7 @@
                                             <child>
                                               <object class="GtkToggleButton" id="downloads_expand_button">
                                                 <property name="visible">True</property>
-                                                <property name="tooltip-text" translatable="yes">Expand / Collapse all</property>
+                                                <property name="tooltip-text" translatable="yes">Expand / Collapse All</property>
                                                 <child>
                                                   <object class="GtkImage" id="downloads_expand_icon">
                                                     <property name="visible">True</property>
@@ -668,7 +668,7 @@
                                             <child>
                                               <object class="GtkToggleButton" id="uploads_expand_button">
                                                 <property name="visible">True</property>
-                                                <property name="tooltip-text" translatable="yes">Expand / Collapse all</property>
+                                                <property name="tooltip-text" translatable="yes">Expand / Collapse All</property>
                                                 <child>
                                                   <object class="GtkImage" id="uploads_expand_icon">
                                                     <property name="visible">True</property>

--- a/pynicotine/gtkgui/ui/mainwindow.ui
+++ b/pynicotine/gtkgui/ui/mainwindow.ui
@@ -86,7 +86,7 @@
                                         <child>
                                           <object class="GtkMenuButton" id="search_mode_button">
                                             <property name="visible">True</property>
-                                            <property name="tooltip-text" translatable="yes">Search scope</property>
+                                            <property name="tooltip-text" translatable="yes">Search Scope</property>
                                             <child>
                                               <object class="GtkBox">
                                                 <property name="visible">True</property>

--- a/pynicotine/gtkgui/ui/search.ui
+++ b/pynicotine/gtkgui/ui/search.ui
@@ -376,7 +376,7 @@
                                 <child>
                                   <object class="GtkToggleButton" id="filter_free_slot_button">
                                     <property name="visible">True</property>
-                                    <property name="tooltip-text" translatable="yes">Free slot</property>
+                                    <property name="tooltip-text" translatable="yes">Free Slot</property>
                                     <signal name="toggled" handler="on_refilter"/>
                                     <child>
                                       <object class="GtkImage">

--- a/pynicotine/gtkgui/ui/search.ui
+++ b/pynicotine/gtkgui/ui/search.ui
@@ -121,7 +121,7 @@
                 <property name="visible">True</property>
                 <child>
                   <object class="GtkToggleButton" id="expand_button">
-                    <property name="tooltip-text" translatable="yes">Expand / Collapse all</property>
+                    <property name="tooltip-text" translatable="yes">Expand / Collapse All</property>
                     <signal name="toggled" handler="on_toggle_expand_all"/>
                     <child>
                       <object class="GtkImage" id="expand_icon">

--- a/pynicotine/gtkgui/ui/settings/network.ui
+++ b/pynicotine/gtkgui/ui/settings/network.ui
@@ -163,7 +163,7 @@
                                     <property name="adjustment">adjustment_FirstPort</property>
                                     <property name="numeric">True</property>
                                     <property name="max-width-chars">6</property>
-                                    <property name="tooltip-text" translatable="yes">First port</property>
+                                    <property name="tooltip-text" translatable="yes">First Port</property>
                                   </object>
                                 </child>
                               </object>
@@ -190,7 +190,7 @@
                                         <property name="adjustment">adjustment_LastPort</property>
                                         <property name="numeric">True</property>
                                         <property name="max-width-chars">6</property>
-                                        <property name="tooltip-text" translatable="yes">Last port</property>
+                                        <property name="tooltip-text" translatable="yes">Last Port</property>
                                       </object>
                                     </child>
                                   </object>

--- a/pynicotine/gtkgui/ui/userbrowse.ui
+++ b/pynicotine/gtkgui/ui/userbrowse.ui
@@ -195,7 +195,7 @@
                                 <child>
                                   <object class="GtkToggleButton" id="expand_button">
                                     <property name="visible">True</property>
-                                    <property name="tooltip-text" translatable="yes">Expand / Collapse all</property>
+                                    <property name="tooltip-text" translatable="yes">Expand / Collapse All</property>
                                     <signal name="toggled" handler="on_expand"/>
                                     <child>
                                       <object class="GtkImage" id="expand_icon">

--- a/pynicotine/gtkgui/ui/userbrowse.ui
+++ b/pynicotine/gtkgui/ui/userbrowse.ui
@@ -179,7 +179,7 @@
                                 <child>
                                   <object class="GtkButton" id="refresh_button">
                                     <property name="visible">True</property>
-                                    <property name="tooltip-text" translatable="yes">Refresh files</property>
+                                    <property name="tooltip-text" translatable="yes">Refresh Files</property>
                                     <signal name="clicked" handler="on_refresh"/>
                                     <child>
                                       <object class="GtkImage">


### PR DESCRIPTION
Use header capitalization in (short) tooltips according to the new GNOME HIG: https://developer.gnome.org/hig/patterns/feedback/tooltips.html

That's most of the obvious ones in the main interface done now.