### PR TITLE
Result Filters: Match usernames

### DIFF
--- a/pynicotine/gtkgui/search.py
+++ b/pynicotine/gtkgui/search.py
@@ -941,10 +941,10 @@ class Search:
             if filter_id == "filtercc" and not self.check_country(filter_value, row[12].upper()):
                 return False
 
-            if filter_id == "filterin" and not filter_value.search(row[11]):
+            if filter_id == "filterin" and not filter_value.search(row[11] + row[1]):
                 return False
 
-            if filter_id == "filterout" and filter_value.search(row[11]):
+            if filter_id == "filterout" and filter_value.search(row[11] + row[1]):
                 return False
 
             if filter_id == "filterslot" and row[15].get_value() > 0:

--- a/pynicotine/gtkgui/search.py
+++ b/pynicotine/gtkgui/search.py
@@ -941,10 +941,10 @@ class Search:
             if filter_id == "filtercc" and not self.check_country(filter_value, row[12].upper()):
                 return False
 
-            if filter_id == "filterin" and not filter_value.search(row[11] + row[1]):
+            if filter_id == "filterin" and not filter_value.search(row[11]) and not filter_value.fullmatch(row[1]):
                 return False
 
-            if filter_id == "filterout" and filter_value.search(row[11] + row[1]):
+            if filter_id == "filterout" and (filter_value.search(row[11]) or filter_value.fullmatch(row[1])):
                 return False
 
             if filter_id == "filterslot" and row[15].get_value() > 0:

--- a/pynicotine/gtkgui/ui/popovers/searchfilterhelp.ui
+++ b/pynicotine/gtkgui/ui/popovers/searchfilterhelp.ui
@@ -92,7 +92,7 @@
                     <property name="visible">True</property>
                     <property name="xalign">0</property>
                     <property name="margin-start">12</property>
-                    <property name="label" translatable="yes">Files and folders containing this text will be shown.</property>
+                    <property name="label" translatable="yes">Files, folders and usernames containing this text will be shown.</property>
                     <property name="selectable">True</property>
                     <property name="wrap">True</property>
                   </object>
@@ -136,7 +136,7 @@
                 <property name="visible">True</property>
                 <property name="xalign">0</property>
                 <property name="margin-start">12</property>
-                <property name="label" translatable="yes">As above, but files and folders are filtered out if the text matches.</property>
+                <property name="label" translatable="yes">As above, but files, folders and usernames are filtered out if the text matches.</property>
                 <property name="selectable">True</property>
                 <property name="wrap">True</property>
               </object>


### PR DESCRIPTION
+ Added: Enable matching of usernames in the Include and Exclude search result filters

Only entire username strings are exact-matched such that it is unlikely to interfere with path string searching.

As the future intention of #1887 is to integrate filters into the wishlist for the purpose of ignoring unwanted results, then excluding usernames will be key data for that purpose, and filtering by username could be useful in any case.