### PR TITLE
[3.2.x] privatechat.py: remove call to non-exist module

### DIFF
--- a/pynicotine/gtkgui/privatechat.py
+++ b/pynicotine/gtkgui/privatechat.py
@@ -345,7 +345,6 @@ class PrivateChat(UserInterface):
 
         if response_id == 2:
             delete_log(config.sections["logging"]["privatelogsdir"], self.user)
-            self.chats.history.remove_user(self.user)
             self.chat_view.clear()
 
     def on_delete_chat_log(self, *_args):


### PR DESCRIPTION
Fix #2247 "Delete chat log... >> Value: 'PrivateChats' object has no attribute"

+ Fixed: Regression caused by backport commit b5423cd1c: "chatrooms.ui: use snake case widget names"
+ Checked: No other instances of `chat.history` are found in the 3.2.x branch tree

```
gtkgui/privatechat.py L348 | b5423cd1c (2022-04-09 02:56:58 +0300 348)             self.chats.history.remove_user(self.user)
```

- **TODO: Bump to 3.2.7 before merging this fix.**