### PR TITLE
Bump version to 4.0.0.dev1

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,8 +1,8 @@
-nicotine (3.3.0-dev4) jammy; urgency=medium
+nicotine (4.0.0-dev1) jammy; urgency=medium
 
   * Development version.
 
- -- Mat <mail@mathias.is>  Fri, 25 Nov 2022 21:05:54 +0300
+ -- Mat <mail@mathias.is>  Sat, 26 Nov 2022 12:02:15 +0300
 
 nicotine (3.2.6-1) jammy; urgency=medium
 

--- a/pynicotine/config.py
+++ b/pynicotine/config.py
@@ -55,7 +55,7 @@ class Config:
 
         config_dir, self.data_dir = self.get_user_directories()
         self.filename = os.path.join(config_dir, "config")
-        self.version = "3.3.0.dev4"
+        self.version = "4.0.0.dev1"
         self.python_version = platform.python_version()
         self.gtk_version = ""
 


### PR DESCRIPTION
Due to the move to GTK 4 by default (which is essentially completely different than GTK 3 due to various rewrites and the move to GPU rendering), larger changes in the Nicotine+ core, new plugin command system, and other planned changes, I think bumping the major version would be a good idea: https://semver.org/