### PR TITLE
show sys.platform in critical error dialog

### DIFF
--- a/pynicotine/gtkgui/application.py
+++ b/pynicotine/gtkgui/application.py
@@ -774,7 +774,7 @@ class Application:
 
         loop = GLib.MainLoop()
         error = (f"Nicotine+ Version: {config.version}\nGTK Version: {config.gtk_version}\n"
-                 f"Python Version: {config.python_version}\n\n"
+                 f"Python Version: {config.python_version} ({sys.platform})\n\n"
                  f"Type: {exc_type}\nValue: {exc_value}\nTraceback: {''.join(format_tb(exc_traceback))}")
 
         OptionDialog(


### PR DESCRIPTION
+ Added: Raw system platform identifier in Critical Error message

In some cases it is useful to know which platform a reported error occurred.

Example output on "linux" platform:
```
Nicotine+ Version: 3.3.0.dev4
GTK Version: 3.24.24
Python Version: 3.9.2 (linux)
```