### PR TITLE
userlist.py: Buddy Status notification title

### DIFF
--- a/pynicotine/userlist.py
+++ b/pynicotine/userlist.py
@@ -237,4 +237,4 @@ class UserList:
             status_text = _("%(user)s is offline")
 
         log.add(status_text, {"user": user})
-        core.notifications.show_text_notification(status_text % {"user": user}, title=_("Buddy Online Status"))
+        core.notifications.show_text_notification(status_text % {"user": user}, title=_("Buddy Status"))


### PR DESCRIPTION
- Changed: String to disambiguate "Online" status of buddy who could be "offline"

Having the word "Online" appearing in the title of message is confusing if the buddy is going offline.