### PR TITLE
preferences.py: default server text entry button

### DIFF
--- a/pynicotine/gtkgui/dialogs/preferences.py
+++ b/pynicotine/gtkgui/dialogs/preferences.py
@@ -213,6 +213,10 @@ class NetworkPage:
     def on_toggle_upnp(self, widget, *_args):
         self.portmap_required = widget.get_active()
 
+    def on_default_server(self, *_args):
+        server_address, server_port = config.defaults["server"]["server"]
+        self.Server.set_text(f"{server_address}:{server_port}")
+
 
 class DownloadsPage:
 

--- a/pynicotine/gtkgui/ui/settings/network.ui
+++ b/pynicotine/gtkgui/ui/settings/network.ui
@@ -382,6 +382,9 @@
                 <property name="visible">True</property>
                 <property name="valign">center</property>
                 <property name="width-chars">16</property>
+                <property name="secondary-icon-name">edit-undo-symbolic</property>
+                <property name="secondary-icon-tooltip-text" translatable="yes">Default</property>
+                <signal name="icon-press" handler="on_default_server"/>
               </object>
             </child>
           </object>


### PR DESCRIPTION
+ Added: Icon button in 'Soulseek server' text entry to allow setting to default soulseek server.

![image](https://user-images.githubusercontent.com/88614182/207189600-8a98a00c-de97-4139-b45f-2f0103a84b21.png)

Without this feature there is not any accessible means of restoring an inadvertent network configuration change.