### PR TITLE
networkfilter.py: support explicit ip addresses and handle offline users

### DIFF
--- a/pynicotine/gtkgui/dialogs/preferences.py
+++ b/pynicotine/gtkgui/dialogs/preferences.py
@@ -858,22 +858,13 @@ class IgnoredUsersPage:
 
         ip_address = dialog.get_entry_value()
 
-        if not ip_address or ip_address.count(".") != 3:
+        if not core.network_filter.is_ip_address(ip_address):
             return
 
-        for chars in ip_address.split("."):
-            if chars == "*":
-                continue
-
-            if not chars.isdigit():
-                return
-
-            if int(chars) > 255:
-                return
-
         if ip_address not in self.ignored_ips:
-            self.ignored_ips[ip_address] = ""
-            self.ignored_ips_list_view.add_row([ip_address, ""])
+            user = core.network_filter.get_known_username(ip_address) or ""
+            self.ignored_ips[ip_address] = user
+            self.ignored_ips_list_view.add_row([ip_address, user])
 
     def on_add_ignored_ip(self, *_args):
 
@@ -1010,22 +1001,13 @@ class BannedUsersPage:
 
         ip_address = dialog.get_entry_value()
 
-        if not ip_address or ip_address.count(".") != 3:
+        if not core.network_filter.is_ip_address(ip_address):
             return
 
-        for chars in ip_address.split("."):
-            if chars == "*":
-                continue
-
-            if not chars.isdigit():
-                return
-
-            if int(chars) > 255:
-                return
-
         if ip_address not in self.banned_ips:
-            self.banned_ips[ip_address] = ""
-            self.banned_ips_list_view.add_row([ip_address, ""])
+            user = core.network_filter.get_known_username(ip_address) or ""
+            self.banned_ips[ip_address] = user
+            self.banned_ips_list_view.add_row([ip_address, user])
             self.ip_ban_required = True
 
     def on_add_banned_ip(self, *_args):

--- a/pynicotine/gtkgui/widgets/textentry.py
+++ b/pynicotine/gtkgui/widgets/textentry.py
@@ -176,7 +176,7 @@ class ChatEntry:
 
         elif cmd == "/ignoreip":
             if args:
-                core.network_filter.ignore_ip(args)
+                core.network_filter.ignore_user_ip(ip_address=args)
 
         elif cmd == "/unban":
             if args:

--- a/pynicotine/networkfilter.py
+++ b/pynicotine/networkfilter.py
@@ -39,15 +39,12 @@ class NetworkFilter:
         self.ip_ban_requested.clear()
         self.ip_ignore_requested.clear()
 
-    """ General """
+    """ IP Filter List Management """
 
-    def _request_ip(self, user, action, list_type):
-        """ Ask for the IP address of a user. Once a GetPeerAddress response arrives,
-        either ban_unban_user_ip_callback or ignore_unignore_user_ip_callback
-        is called. """
-
-        if user in core.user_addresses:
-            return False
+    def _request_ip(self, user, action, list_type, online=True):
+        """ Ask for the IP address of an unknown user. Once a GetPeerAddress
+         response arrives, either ban_unban_user_ip_callback or
+         ignore_unignore_user_ip_callback is called. """
 
         if list_type == "ban":
             request_list = self.ip_ban_requested
@@ -57,59 +54,83 @@ class NetworkFilter:
         if user not in request_list:
             request_list[user] = action
 
-        core.queue.append(slskmessages.GetPeerAddress(user))
-        return True
+        if not online:
+            # We already know this user is probably offline
+            return
 
-    def _add_user_ip_to_list(self, user, list_type):
-        """ Add the current IP of a user to a list. """
+        core.queue.append(slskmessages.GetPeerAddress(user))
+
+    def _add_user_ip_to_list(self, list_type, user, ip_address):
+        """ Add the current IP address and username of a user to a list """
 
         if list_type == "ban":
             ip_list = config.sections["server"]["ipblocklist"]
         else:
             ip_list = config.sections["server"]["ipignorelist"]
 
-        if self._request_ip(user, "add", list_type):
-            return None
+        if self.is_ip_address(ip_address, allow_zero=False) and not user:
+            # Try to get a username from currently active connections
+            user = self.get_known_username(ip_address) or ""
 
-        ip_address, _port = core.user_addresses[user]
+        elif user and not self.is_ip_address(ip_address, allow_zero=False):
+            # Try to get an address from currently active connections
+            ip_address = self.get_known_ip_address(user)
 
-        if ip_address not in ip_list or ip_list[ip_address] != user:
+            if not self.is_ip_address(ip_address, allow_zero=False):
+                cached_ip = self._get_cached_user_ip(user, ip_list) or ""
+                offline = cached_ip.startswith("?.?.?.?") or cached_ip == "0.0.0.0"
+
+                # Queue a callback to update the filter, only try one time
+                self._request_ip(user, "add", list_type, online=not offline)
+
+                # Add a unique dummy entry for now, so it can be updated later
+                ip_address = f"?.?.?.? [{user}]"
+
+        if ip_address not in ip_list or ip_list[ip_address] != user != "":
             ip_list[ip_address] = user
             config.write_configuration()
 
+        # Close connection and print output as confirmation on CLI
         return ip_address
 
-    def _remove_user_ip_from_list(self, user, list_type):
-        """ Attempt to remove the previously saved IP address of a user from a list. """
+    def _remove_user_ip_from_list(self, list_type, user, ip_address):
+        """ Remove the previously saved IP address of a user from a list """
 
         if list_type == "ban":
-            cached_ip = self.get_cached_banned_user_ip(user)
             ip_list = config.sections["server"]["ipblocklist"]
         else:
-            cached_ip = self.get_cached_ignored_user_ip(user)
             ip_list = config.sections["server"]["ipignorelist"]
 
-        if cached_ip is not None:
-            del ip_list[cached_ip]
-            config.write_configuration()
-            return
+        if user and not ip_address or ip_address is None:
+            # Try to get an address from currently active connections
+            cached_ip = self._get_cached_user_ip(user, ip_list) or ""
+            ip_address = cached_ip or self.get_known_ip_address(user)
 
-        if self._request_ip(user, "remove", list_type):
-            return
+            if ip_address.startswith("?.?.?.?") or ip_address == "0.0.0.0":
+                # Allow deleting dummy entries (the offline default IP
+                # "0.0.0.0" entry is not saved in filters since 3.3.0)
+                pass
 
-        ip_address, _port = core.user_addresses[user]
+            elif not self.is_ip_address(ip_address, allow_zero=False):
+                # IP unknown, queue a callback to remove the filter later
+                self._request_ip(user, "remove", list_type, online=True)
+
+                # Print output as confirmation on CLI also do username list
+                return user
 
         if ip_address in ip_list:
             del ip_list[ip_address]
             config.write_configuration()
 
-    def _get_cached_user_ip(self, user, list_type):
-        """ Retrieve the IP address of a user previously saved in a list. """
+        # Print output as confirmation on CLI
+        return ip_address
 
-        if list_type == "ban":
-            ip_list = config.sections["server"]["ipblocklist"]
-        else:
-            ip_list = config.sections["server"]["ipignorelist"]
+    """ IP List Lookup Functions """
+
+    @staticmethod
+    def _get_cached_user_ip(user, ip_list):
+        """ Retrieve IP address of a user previously saved in an IP list, for
+        setting Ban/Ignore IP Address check buttons in user actions menus """
 
         for ip_address, username in ip_list.items():
             if user == username:
@@ -117,17 +138,64 @@ class NetworkFilter:
 
         return None
 
-    def _is_ip_in_list(self, address, list_type):
+    @staticmethod
+    def get_known_ip_address(user):
+        """ Try to lookup an address from watched known connections,
+        for updating an IP list item if the address is unspecified """
+
+        user_address = core.user_addresses.get(user)
+
+        if not user_address:
+            # User is offline
+            return None
+
+        user_ip_address, _user_port = user_address
+
+        return user_ip_address
+
+    @staticmethod
+    def get_known_username(ip_address):
+        """ Try to match a username from watched and known connections,
+        for updating an IP list item if the username is unspecified """
+
+        for (user_name, user_address) in core.user_addresses.items():
+            if ip_address == user_address[0]:
+                return user_name
+
+        return None
+
+    @staticmethod
+    def is_ip_address(ip_address, allow_zero=True, allow_wildcard=True):
+        """ Check if the given value is an IPv4 address or not """
+
+        if not ip_address or ip_address is None or ip_address.count(".") != 3:
+            return False
+
+        if not allow_zero and ip_address == "0.0.0.0":
+            # User is offline if ip_address "0.0.0.0" (not None!)
+            return False
+
+        for part in ip_address.split("."):
+            if allow_wildcard and part == "*":
+                continue
+
+            if not part.isdigit():
+                return False
+
+            if int(part) > 255:
+                return False
+
+        return True
+
+    """ IP Filter Rule Processing """
+
+    @staticmethod
+    def _is_ip_in_list(address, ip_list):
         """ Check if an IP address exists in a list, disregarding the username
         the address is paired with. """
 
         if address is None:
             return True
-
-        if list_type == "ban":
-            ip_list = config.sections["server"]["ipblocklist"]
-        else:
-            ip_list = config.sections["server"]["ipignorelist"]
 
         s_address = address.split(".")
 
@@ -152,10 +220,10 @@ class NetworkFilter:
 
                 # Last time around
                 if seg == 4:
-                    # Wildcard ban
+                    # Wildcard filter
                     return True
 
-        # Not banned
+        # Not filtered
         return False
 
     def check_user(self, user, ip_address):
@@ -200,41 +268,46 @@ class NetworkFilter:
         """ Close all connections whose IP address exists in the ban list """
 
         for ip_address in config.sections["server"]["ipblocklist"]:
+            if not self.is_ip_address(ip_address, allow_wildcard=False, allow_zero=False):
+                # We can't close wildcard patterns nor dummy (zero) addresses
+                continue
+
             core.queue.append(slskmessages.CloseConnectionIP(ip_address))
 
-    def update_saved_user_ip_filters(self, user):
-        """ When we know a user's IP address has changed, we call this function to
-        update the IP saved in lists. """
+    """ Callbacks """
 
-        user_address = core.user_addresses.get(user)
+    def _update_saved_user_ip_address(self, user, new_ip):
+        """ Check if a user's IP address has changed and update the lists """
 
-        if not user_address:
-            # User is offline
-            return
-
-        new_ip, _new_port = user_address
         cached_banned_ip = self.get_cached_banned_user_ip(user)
 
         if cached_banned_ip is not None and cached_banned_ip != new_ip:
-            self.unban_user_ip(user)
-            self.ban_user_ip(user)
+            self.unban_user_ip(user, cached_banned_ip)
+            self.ban_user_ip(user, new_ip)
 
         cached_ignored_ip = self.get_cached_ignored_user_ip(user)
 
         if cached_ignored_ip is not None and cached_ignored_ip != new_ip:
-            self.unignore_user_ip(user)
-            self.ignore_user_ip(user)
+            self.unignore_user_ip(user, cached_ignored_ip)
+            self.ignore_user_ip(user, new_ip)
 
     def _get_peer_address(self, msg):
         """ Server code: 3 """
 
+        ip_address = msg.ip_address
+
+        if not self.is_ip_address(ip_address, allow_zero=False):
+            # User is offline if ip_address "0.0.0.0" (not None!)
+            return
+
         user = msg.user
 
         # If the IP address changed, make sure our IP ban/ignore list reflects this
-        self.update_saved_user_ip_filters(user)
+        self._update_saved_user_ip_address(user, ip_address)
 
-        self.ban_unban_user_ip_callback(user)
-        self.ignore_unignore_user_ip_callback(user)
+        # Check pending "add" and "remove" requests for IP-based filtering of previously offline users
+        self._ban_unban_user_ip_callback(user, ip_address)
+        self._ignore_unignore_user_ip_callback(user, ip_address)
 
     """ Banning """
 
@@ -259,41 +332,39 @@ class NetworkFilter:
 
         events.emit("unban-user", user)
 
-    def ban_user_ip(self, user):
-        ip_address = self._add_user_ip_to_list(user, "ban")
+    def ban_user_ip(self, user=None, ip_address=None):
 
-        if ip_address:
-            core.queue.append(slskmessages.CloseConnectionIP(ip_address))
+        banned_ip_address = self._add_user_ip_to_list("ban", user, ip_address)
 
-    def unban_user_ip(self, user):
-        self._remove_user_ip_from_list(user, "ban")
+        if self.is_ip_address(banned_ip_address, allow_wildcard=False, allow_zero=False):
+            # We can't close wildcard patterns nor dummy (zero) address entries
+            core.queue.append(slskmessages.CloseConnectionIP(banned_ip_address))
 
-    def ban_unban_user_ip_callback(self, user):
+        return banned_ip_address
+
+    def unban_user_ip(self, user=None, ip_address=None):
+        return self._remove_user_ip_from_list("ban", user, ip_address)
+
+    def _ban_unban_user_ip_callback(self, user, ip_address):
 
         request = self.ip_ban_requested.pop(user, None)
 
         if request is None:
-            return False
-
-        if user not in core.user_addresses:
-            # User is offline
-            return False
+            return
 
         if request == "remove":
-            self.unban_user_ip(user)
+            self.unban_user_ip(user, ip_address)
         else:
-            self.ban_user_ip(user)
-
-        return True
+            self.ban_user_ip(user, ip_address)
 
     def get_cached_banned_user_ip(self, user):
-        return self._get_cached_user_ip(user, "ban")
+        return self._get_cached_user_ip(user, config.sections["server"]["ipblocklist"])
 
     def is_user_banned(self, user):
         return user in config.sections["server"]["banlist"]
 
     def is_ip_banned(self, address):
-        return self._is_ip_in_list(address, "ban")
+        return self._is_ip_in_list(address, config.sections["server"]["ipblocklist"])
 
     """ Ignoring """
 
@@ -317,49 +388,32 @@ class NetworkFilter:
 
         events.emit("unignore-user", user)
 
-    def ignore_ip(self, ip_address):
+    def ignore_user_ip(self, user=None, ip_address=None):
+        return self._add_user_ip_to_list("ignore", user, ip_address)
 
-        if not ip_address or ip_address.count(".") != 3:
-            return
+    def unignore_user_ip(self, user=None, ip_address=None):
+        return self._remove_user_ip_from_list("ignore", user, ip_address)
 
-        ip_ignore_list = config.sections["server"]["ipignorelist"]
-
-        if ip_address not in ip_ignore_list:
-            ip_ignore_list[ip_address] = ""
-            config.write_configuration()
-
-    def ignore_user_ip(self, user):
-        self._add_user_ip_to_list(user, "ignore")
-
-    def unignore_user_ip(self, user):
-        self._remove_user_ip_from_list(user, "ignore")
-
-    def ignore_unignore_user_ip_callback(self, user):
+    def _ignore_unignore_user_ip_callback(self, user, ip_address):
 
         request = self.ip_ignore_requested.pop(user, None)
 
         if request is None:
-            return False
-
-        if user not in core.user_addresses:
-            # User is offline
-            return False
+            return
 
         if request == "remove":
-            self.unignore_user_ip(user)
+            self.unignore_user_ip(user, ip_address)
         else:
-            self.ignore_user_ip(user)
-
-        return True
+            self.ignore_user_ip(user, ip_address)
 
     def get_cached_ignored_user_ip(self, user):
-        return self._get_cached_user_ip(user, "ignore")
+        return self._get_cached_user_ip(user, config.sections["server"]["ipignorelist"])
 
     def is_user_ignored(self, user):
         return user in config.sections["server"]["ignorelist"]
 
     def is_ip_ignored(self, address):
-        return self._is_ip_in_list(address, "ignore")
+        return self._is_ip_in_list(address, config.sections["server"]["ipignorelist"])
 
     def is_user_ip_ignored(self, user):
 


### PR DESCRIPTION
This PR includes what is needed to support the user filtering related CLI core_commands being developed in #2281

+ Added: Support for adding IP addresses directly into the IP Ban/Ignore filters, without needing to know a username
+ Added: Try to establish a username, if known, whilst adding a IP ban/ignore filter in the Preferences or `/ignoreip` command

As a result of the intended implementation, it has been necessary to address the following issues:

+ Changed: Prefer locally stored `core.user_addresses` where possible to avoid unnecessary excessive GetPeerAddress() calls
+ Fixed: Several issues that made it impossible to reliably ban/ignore more than one offline user at a time
+ Fixed: Prevent duplicate username lookups for improved performance when getting and setting cached ban/ignore states
+ Fixed: Don't replace a valid filter with zero `0.0.0.0` IP address or `""` empty username data if the user is offline
+ Fixed: Don't try to close zero 0.0.0.0 IP connections when adding an IP-ban for an offline user, or closing Preferences dialog
+ Fixed: Avoid core error when attempting to close newly added banned IP address containing `*` wildcard characters