### PR TITLE
Fix bug where path is null for certain downloads

### DIFF
--- a/pynicotine/transfers.py
+++ b/pynicotine/transfers.py
@@ -2034,6 +2034,7 @@ class Transfers:
         transfer.current_byte_offset = transfer.size
         transfer.sock = None
         transfer.token = None
+        transfer.path = folder
 
         core.statistics.append_stat_value("completed_downloads", 1)
 


### PR DESCRIPTION
On 3.3.0-dev4, there is a bug where the transfer.path is only set when one uses the "Download Files / Folders to..." option.  If one does not, then the transfer.path will be None.  This causes a problem where, when right clicking on a transfer > "Open in File Manager" it opens to the root download folder (rather than the downloaded folder name or the username if the 'store completed to username subfolders' setting is on).

The fix I have made for this is to set the transfer.path to the final saved folder that we move the transfer to when it finishes downloading.  If the path is already set (in the case of "Download Files / Folders to..." option) it changes nothing.

Please feel free to modify or discard this pull request if there is a different fix in mind.