### PR TITLE
Prioritize user profiles in user actions

### DIFF
--- a/TRANSLATORS.md
+++ b/TRANSLATORS.md
@@ -19,9 +19,9 @@
  - Ingmar K. Steen (Hyriand) (2003–2004)
 
 ## English
- - slook (2021–2022)
- - Han Boetes (hboetes) (2021–2022)
- - Mat (mathiascode) (2020–2022)
+ - slook (2021–2023)
+ - Han Boetes (hboetes) (2021–2023)
+ - Mat (mathiascode) (2020–2023)
  - Michael Labouebe (gfarmerfr) (2016)
  - daelstorm (2004–2009)
  - Ingmar K. Steen (Hyriand) (2003–2004)

--- a/pynicotine/gtkgui/application.py
+++ b/pynicotine/gtkgui/application.py
@@ -1,4 +1,4 @@
-# COPYRIGHT (C) 2020-2022 Nicotine+ Contributors
+# COPYRIGHT (C) 2020-2023 Nicotine+ Contributors
 #
 # GNU GENERAL PUBLIC LICENSE
 #    Version 3, 29 June 2007
@@ -320,8 +320,8 @@ class Application:
         action.connect("activate", self.on_configure_ignored_users)
         self.add_action(action)
 
-        action = Gio.SimpleAction(name="update-user-info")
-        action.connect("activate", self.on_update_user_info)
+        action = Gio.SimpleAction(name="update-user-profile")
+        action.connect("activate", self.on_update_user_profile)
         self.add_action(action)
 
         # Notifications
@@ -733,8 +733,8 @@ class Application:
     def on_configure_uploads(self, *_args):
         self.on_preferences(page_id="uploads")
 
-    def on_update_user_info(self, *_args):
-        self.on_preferences(page_id="user-info")
+    def on_update_user_profile(self, *_args):
+        self.on_preferences(page_id="user-profile")
 
     def on_configure_ignored_users(self, *_args):
         self.on_preferences(page_id="ignored-users")

--- a/pynicotine/gtkgui/chatrooms.py
+++ b/pynicotine/gtkgui/chatrooms.py
@@ -1,4 +1,4 @@
-# COPYRIGHT (C) 2020-2022 Nicotine+ Contributors
+# COPYRIGHT (C) 2020-2023 Nicotine+ Contributors
 # COPYRIGHT (C) 2016-2017 Michael Labouebe <gfarmerfr@free.fr>
 # COPYRIGHT (C) 2016 Mutnick <muhing@yahoo.com>
 # COPYRIGHT (C) 2008-2011 quinox <quinox@users.sf.net>
@@ -756,7 +756,7 @@ class ChatRoom:
         user = self.get_selected_username(treeview)
 
         if user is not None:
-            core.privatechat.show_user(user)
+            core.userinfo.show_user(user)
 
     def on_popup_menu_user(self, menu, treeview):
         user = self.get_selected_username(treeview)

--- a/pynicotine/gtkgui/dialogs/about.py
+++ b/pynicotine/gtkgui/dialogs/about.py
@@ -1,4 +1,4 @@
-# COPYRIGHT (C) 2020-2022 Nicotine+ Contributors
+# COPYRIGHT (C) 2020-2023 Nicotine+ Contributors
 #
 # GNU GENERAL PUBLIC LICENSE
 #    Version 3, 29 June 2007
@@ -204,8 +204,8 @@ Inactive
 
 >> <b>English</b>
    - slook (2021–2023)
-   - Han Boetes (hboetes) (2021–2022)
-   - Mat (mathiascode) (2020–2022)
+   - Han Boetes (hboetes) (2021–2023)
+   - Mat (mathiascode) (2020–2023)
    - Michael Labouebe (gfarmerfr) (2016)
    - daelstorm (2004–2009)
    - Ingmar K. Steen (Hyriand) (2003–2004)

--- a/pynicotine/gtkgui/dialogs/preferences.py
+++ b/pynicotine/gtkgui/dialogs/preferences.py
@@ -1,4 +1,4 @@
-# COPYRIGHT (C) 2020-2022 Nicotine+ Contributors
+# COPYRIGHT (C) 2020-2023 Nicotine+ Contributors
 # COPYRIGHT (C) 2016-2017 Michael Labouebe <gfarmerfr@free.fr>
 # COPYRIGHT (C) 2016 Mutnick <muhing@yahoo.com>
 # COPYRIGHT (C) 2008-2011 quinox <quinox@users.sf.net>
@@ -730,7 +730,7 @@ class UploadsPage:
         }
 
 
-class UserInfoPage:
+class UserProfilePage:
 
     def __init__(self, application):
 
@@ -2367,7 +2367,7 @@ class Preferences(Dialog):
             ("downloads", _("Downloads"), "document-save-symbolic"),
             ("uploads", _("Uploads"), "emblem-shared-symbolic"),
             ("searches", _("Searches"), "system-search-symbolic"),
-            ("user-info", _("User Info"), "avatar-default-symbolic"),
+            ("user-profile", _("User Profile"), "avatar-default-symbolic"),
             ("chats", _("Chats"), "insert-text-symbolic"),
             ("now-playing", _("Now Playing"), "folder-music-symbolic"),
             ("logging", _("Logging"), "folder-documents-symbolic"),

--- a/pynicotine/gtkgui/mainwindow.py
+++ b/pynicotine/gtkgui/mainwindow.py
@@ -1,4 +1,4 @@
-# COPYRIGHT (C) 2020-2022 Nicotine+ Contributors
+# COPYRIGHT (C) 2020-2023 Nicotine+ Contributors
 # COPYRIGHT (C) 2016-2017 Michael Labouebe <gfarmerfr@free.fr>
 # COPYRIGHT (C) 2016-2018 Mutnick <mutnick@techie.com>
 # COPYRIGHT (C) 2008-2011 quinox <quinox@users.sf.net>
@@ -952,7 +952,7 @@ class MainWindow(Window):
             ("downloads", _("Downloads"), "document-save-symbolic"),
             ("uploads", _("Uploads"), "emblem-shared-symbolic"),
             ("userbrowse", _("Browse Shares"), "folder-symbolic"),
-            ("userinfo", _("User Info"), "avatar-default-symbolic"),
+            ("userinfo", _("User Profiles"), "avatar-default-symbolic"),
             ("private", _("Private Chat"), "mail-unread-symbolic"),
             ("userlist", _("Buddies"), "contact-new-symbolic"),
             ("chatrooms", _("Chat Rooms"), "user-available-symbolic"),
@@ -1200,8 +1200,8 @@ class MainWindow(Window):
 
     """ User Info """
 
-    def on_get_user_info(self, *_args):
-        self.userinfo.on_get_user_info()
+    def on_show_user_profile(self, *_args):
+        self.userinfo.on_show_user_profile()
 
     """ Shares """
 

--- a/pynicotine/gtkgui/ui/mainwindow.ui
+++ b/pynicotine/gtkgui/ui/mainwindow.ui
@@ -958,7 +958,7 @@
                         </child>
                       </object>
                     </child>
-                    <!-- User Info -->
+                    <!-- User Profile -->
                     <child>
                       <object class="GtkBox" id="userinfo_page">
                         <property name="visible">False</property>
@@ -997,8 +997,8 @@
                                                 <property name="placeholder-text" translatable="yes">Username…</property>
                                                 <property name="tooltip-text" translatable="yes">Enter the username of the person whose information you want to see</property>
                                                 <property name="primary-icon-name">avatar-default-symbolic</property>
-                                                <signal name="activate" handler="on_get_user_info"/>
-                                                <signal name="icon-press" handler="on_get_user_info"/>
+                                                <signal name="activate" handler="on_show_user_profile"/>
+                                                <signal name="icon-press" handler="on_show_user_profile"/>
                                               </object>
                                             </child>
                                             <style>
@@ -1014,9 +1014,9 @@
                                         <property name="spacing">6</property>
                                         <property name="valign">center</property>
                                         <child>
-                                          <object class="GtkButton" id="_update_info_button">
+                                          <object class="GtkButton" id="_update_profile_button">
                                             <property name="visible">True</property>
-                                            <property name="action-name">app.update-user-info</property>
+                                            <property name="action-name">app.update-user-profile</property>
                                             <child>
                                               <object class="GtkBox">
                                                 <property name="visible">True</property>
@@ -1030,9 +1030,9 @@
                                                 <child>
                                                   <object class="GtkLabel">
                                                     <property name="visible">True</property>
-                                                    <property name="label" translatable="yes">Update I_nfo</property>
+                                                    <property name="label" translatable="yes">_Update Profile</property>
                                                     <property name="use-underline">True</property>
-                                                    <property name="mnemonic-widget">_update_info_button</property>
+                                                    <property name="mnemonic-widget">_update_profile_button</property>
                                                   </object>
                                                 </child>
                                               </object>
@@ -1085,7 +1085,7 @@
                                         <child>
                                           <object class="GtkLabel">
                                             <property name="visible">True</property>
-                                            <property name="label" translatable="yes">User Info</property>
+                                            <property name="label" translatable="yes">User Profiles</property>
                                             <property name="justify">center</property>
                                             <property name="wrap">True</property>
                                             <style>

--- a/pynicotine/gtkgui/ui/settings/userinterface.ui
+++ b/pynicotine/gtkgui/ui/settings/userinterface.ui
@@ -239,7 +239,7 @@
                             <property name="can-focus">False</property>
                             <child>
                               <object class="GtkCheckButton" id="EnableUserInfoTab">
-                                <property name="label" translatable="yes">User Info</property>
+                                <property name="label" translatable="yes">User Profiles</property>
                                 <property name="visible">True</property>
                               </object>
                             </child>

--- a/pynicotine/gtkgui/userinfo.py
+++ b/pynicotine/gtkgui/userinfo.py
@@ -1,4 +1,4 @@
-# COPYRIGHT (C) 2020-2022 Nicotine+ Contributors
+# COPYRIGHT (C) 2020-2023 Nicotine+ Contributors
 # COPYRIGHT (C) 2016-2017 Michael Labouebe <gfarmerfr@free.fr>
 # COPYRIGHT (C) 2008-2010 quinox <quinox@users.sf.net>
 # COPYRIGHT (C) 2006-2009 daelstorm <daelstorm@gmail.com>
@@ -79,7 +79,7 @@ class UserInfos(IconNotebook):
         ):
             events.connect(event_name, callback)
 
-    def on_get_user_info(self, *_args):
+    def on_show_user_profile(self, *_args):
 
         username = self.window.userinfo_entry.get_text().strip()
 

--- a/pynicotine/gtkgui/widgets/popupmenu.py
+++ b/pynicotine/gtkgui/widgets/popupmenu.py
@@ -1,4 +1,4 @@
-# COPYRIGHT (C) 2020-2022 Nicotine+ Contributors
+# COPYRIGHT (C) 2020-2023 Nicotine+ Contributors
 # COPYRIGHT (C) 2016-2017 Michael Labouebe <gfarmerfr@free.fr>
 # COPYRIGHT (C) 2008-2009 quinox <quinox@users.sf.net>
 # COPYRIGHT (C) 2006-2009 daelstorm <daelstorm@gmail.com>
@@ -346,11 +346,11 @@ class UserPopupMenu(PopupMenu):
             ("", None)
         )
 
+        if page != "userinfo":
+            self.add_items(("#" + _("View User _Profile"), self.on_user_profile))
+
         if page != "privatechat":
             self.add_items(("#" + _("Send M_essage"), self.on_send_message))
-
-        if page != "userinfo":
-            self.add_items(("#" + _("Show User I_nfo"), self.on_get_user_info))
 
         if page != "userbrowse":
             self.add_items(("#" + _("_Browse Files"), self.on_browse_user))
@@ -453,7 +453,7 @@ class UserPopupMenu(PopupMenu):
     def on_show_ip_address(self, *_args):
         core.request_ip_address(self.user)
 
-    def on_get_user_info(self, *_args):
+    def on_user_profile(self, *_args):
         core.userinfo.show_user(self.user)
 
     def on_browse_user(self, *_args):

--- a/pynicotine/gtkgui/widgets/trayicon.py
+++ b/pynicotine/gtkgui/widgets/trayicon.py
@@ -1,4 +1,4 @@
-# COPYRIGHT (C) 2020-2022 Nicotine+ Contributors
+# COPYRIGHT (C) 2020-2023 Nicotine+ Contributors
 #
 # GNU GENERAL PUBLIC LICENSE
 #    Version 3, 29 June 2007
@@ -102,8 +102,8 @@ class BaseImplementation:
         self.create_item()
 
         self.send_message_item = self.create_item(_("Send Message"), self.on_open_private_chat)
-        self.lookup_info_item = self.create_item(_("Request User's Info"), self.on_get_a_users_info)
-        self.lookup_shares_item = self.create_item(_("Request User's Shares"), self.on_get_a_users_shares)
+        self.lookup_info_item = self.create_item(_("View User Profile"), self.on_get_a_users_info)
+        self.lookup_shares_item = self.create_item(_("Browse Shares"), self.on_get_a_users_shares)
 
         self.create_item()
 
@@ -232,8 +232,8 @@ class BaseImplementation:
 
         EntryDialog(
             parent=self.application.window,
-            title=_("Request User Info"),
-            message=_('Enter the name of the user whose info you want to see:'),
+            title=_("View User Profile"),
+            message=_('Enter the name of the user whose profile you want to see:'),
             callback=self.on_get_a_users_info_response,
             droplist=sorted(core.userlist.buddies)
         ).show()
@@ -252,7 +252,7 @@ class BaseImplementation:
 
         EntryDialog(
             parent=self.application.window,
-            title=_("Request Shares List"),
+            title=_("Browse Shares"),
             message=_('Enter the name of the user whose shares you want to see:'),
             callback=self.on_get_a_users_shares_response,
             droplist=sorted(core.userlist.buddies)

--- a/pynicotine/userinfo.py
+++ b/pynicotine/userinfo.py
@@ -1,4 +1,4 @@
-# COPYRIGHT (C) 2021-2022 Nicotine+ Contributors
+# COPYRIGHT (C) 2021-2023 Nicotine+ Contributors
 #
 # GNU GENERAL PUBLIC LICENSE
 #    Version 3, 29 June 2007
@@ -118,7 +118,7 @@ class UserInfo:
         self.requested_info_times[user] = request_time
 
         if core.login_username != user:
-            log.add(_("User %(user)s is reading your user info"), {'user': user})
+            log.add(_("User %(user)s is viewing your profile"), {'user': user})
 
         status, reason = core.network_filter.check_user(user, ip_address)
 


### PR DESCRIPTION
The idea is that the user description becomes more prominent, in order to learn more about a user before interacting with them. User profiles contain buttons to then perform various actions, like sending a private message.

- Move user profile item to the top of user menus
- Double-clicking usernames in chatroom list opens user profile
- Rename user info -> user profile
