### PR TITLE
fastconfigure.py: continue adding shared folders

### DIFF
--- a/pynicotine/gtkgui/dialogs/fastconfigure.py
+++ b/pynicotine/gtkgui/dialogs/fastconfigure.py
@@ -128,7 +128,7 @@ class FastConfigure(Dialog):
                 continue
 
             if folder_path in (x[1] for x in shared_folders + buddy_shared_folders):
-                return
+                continue
 
             self.rescan_required = True
 


### PR DESCRIPTION
+ Fixed: Allow adding all the other multiple selected folders even if one of them is already shared

Otherwise, it appears baffling as to why the attempted Add operation was only partially successful, especially if the existing share is a buddy-only share which are not shown in this list. The silent fail makes the interface frustrating to use in this scenario.

In future, we should consider moving the duplicated shares-related code from fastconfigure.py and preferences.py into shares.py (perhaps an _apply_config_ boolean flag can be used to determine if the config file is updated straight away or not, and _mapping_ can be returned to populate the calling list).