### PR TITLE
Use GTK 4 in Windows builds

### DIFF
--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -53,8 +53,8 @@ jobs:
     strategy:
       matrix:
         include:
-          - { msystem: MINGW64, arch: x86_64, gtk: 3, libadwaita: 0 }
-          - { msystem: MINGW32, arch: i686, gtk: 3, libadwaita: 0 }
+          - { msystem: MINGW64, arch: x86_64, gtk: 4, libadwaita: 1 }
+          - { msystem: MINGW32, arch: i686, gtk: 4, libadwaita: 1 }
     defaults:
       run:
         shell: msys2 {0}


### PR DESCRIPTION
Tray icon and notification support isn't present yet, but I still want to start testing GTK 4 in time.