### PR TITLE
mainwindow.py: avoid continuous "size-allocate" signal calls on GTK 3

### DIFF
--- a/pynicotine/gtkgui/mainwindow.py
+++ b/pynicotine/gtkgui/mainwindow.py
@@ -351,7 +351,6 @@ class MainWindow(Window):
         else:
             self.window.connect("delete-event", self.on_close_request)
 
-            self.window.connect("size-allocate", self.on_window_size_changed)
             self.window.connect("notify::is-maximized", self.on_window_property_changed, "maximized")
 
         self.application.add_window(self.window)
@@ -372,12 +371,18 @@ class MainWindow(Window):
 
         self.application.notifications.set_urgency_hint(False)
 
+        # Moving/reszing does trigger notify::is-active on GTK 3
+        self.save_window_size(window)
+
     @staticmethod
     def on_window_property_changed(window, param, config_property):
         config.sections["ui"][config_property] = window.get_property(param.name)
 
     @staticmethod
-    def on_window_size_changed(window, _allocation):
+    def save_window_size(window):
+
+        if GTK_API_VERSION >= 4:
+            return
 
         if config.sections["ui"]["maximized"]:
             return


### PR DESCRIPTION
+ Fixed: An issue where the "size-allocate" signal continuously calls many times per second on Xfce causing some excess resource usage in Xorg.

Moving/reszing does trigger the `"notify::is-active"` signal on GTK 3 so we can use that instead in order to save the window size and position only when needed.

Not tested on other window managers, working on Xfce 4.16, GTK 3.24.24... it might be an idea to also make a call `on_shutdown()` using `self.window` (but there might be a risk that the window object is not realized).