### PR TITLE
port_checker: move port command to core_commands

### DIFF
--- a/pynicotine/plugins/examplars/port_checker/PLUGININFO
+++ b/pynicotine/plugins/examplars/port_checker/PLUGININFO
@@ -1,4 +1,4 @@
-Version = "2021-09-16r00"
+Version = "2023-01-18r00"
 Authors = ["Nicotine+"]
 Name = "Port Checker"
 Description = "By examining chatroom messages this plugin tries to find people that have a potential firewall/router problem, and if found tests their port. If a closed port is encountered a message will be sent to him/her."

--- a/pynicotine/plugins/examplars/port_checker/__init__.py
+++ b/pynicotine/plugins/examplars/port_checker/__init__.py
@@ -1,4 +1,4 @@
-# COPYRIGHT (C) 2020-2022 Nicotine+ Contributors
+# COPYRIGHT (C) 2020-2023 Nicotine+ Contributors
 # COPYRIGHT (C) 2008-2011 quinox <quinox@users.sf.net>
 #
 # GNU GENERAL PUBLIC LICENSE
@@ -44,8 +44,14 @@ class Plugin(BasePlugin):
                 'type': 'int'
             }
         }
-        self.__publiccommands__ = self.__privatecommands__ = [('port', self.port_checker_command)]
-
+        self.commands = {
+            "port": {
+                "callback": self.port_checker_command,
+                "description": "Check firewall state of user",
+                "usage": ["<user>"],
+                "usage_private_chat": ["[user]"]
+            }
+        }
         self.throttle = ResponseThrottle(self.core, self.human_name)
         self.checkroom = "nicotine"
         self.pending_user = ""
@@ -111,9 +117,9 @@ class Plugin(BasePlugin):
 
         return 'closed'
 
-    def port_checker_command(self, _, user):
+    def port_checker_command(self, args, user=None, **_room):
 
-        if user:
-            self.resolve(user, False)
-        else:
-            self.log("Provide a user name as parameter.")
+        if args:
+            user = args
+
+        self.resolve(user, False)


### PR DESCRIPTION
+ Changed: `/port` command to use new core_commands system, with syntax usage and help description etc.