### PR TITLE
core_commands: join and leave chat room commands

### DIFF
--- a/pynicotine/gtkgui/widgets/textentry.py
+++ b/pynicotine/gtkgui/widgets/textentry.py
@@ -148,16 +148,6 @@ class ChatEntry:
             if args:
                 core.search.do_search(args, "buddies")
 
-        elif cmd in ("/j", "/join"):
-            if args:
-                core.chatrooms.show_room(args)
-
-        elif cmd in ("/l", "/leave", "/p", "/part"):
-            if args:
-                core.chatrooms.remove_room(args)
-            else:
-                core.chatrooms.remove_room(self.entity)
-
         elif cmd in ("/ad", "/add", "/buddy"):
             if args:
                 core.userlist.add_buddy(args)

--- a/pynicotine/plugins/core_commands/__init__.py
+++ b/pynicotine/plugins/core_commands/__init__.py
@@ -60,6 +60,23 @@ class Plugin(BasePlugin):
                 "usage": ["<choice1|choice2>", "<something..>"],
                 "usage_chatroom": ["<choice55|choice2>"]
             },
+            "join": {
+                "aliases": ["j"],
+                "callback": self.join_command,
+                "description": _("Join chat room"),
+                "disable": ["cli"],
+                "group": _("Chat Rooms"),
+                "usage": ["<room>"]
+            },
+            "leave": {
+                "aliases": ["l"],
+                "callback": self.leave_command,
+                "description": _("Leave chat room"),
+                "disable": ["cli"],
+                "group": _("Chat Rooms"),
+                "usage": ["<room>"],
+                "usage_chatroom": ["[room]"]
+            },
             "rescan": {
                 "callback": self.rescan_command,
                 "description": _("Rescan shares"),
@@ -147,6 +164,23 @@ class Plugin(BasePlugin):
 
     def sample_command(self, _args, **_unused):
         self.output("Hello")
+        return True
+
+    """ Chat Rooms """
+
+    def join_command(self, args, **_unused):
+        self.core.chatrooms.show_room(args)
+
+    def leave_command(self, args, room=None, **_unused):
+
+        if args:
+            room = args
+
+        if room not in self.core.chatrooms.joined_rooms:
+            self.output(_("Not joined in room %s") % room)
+            return False
+
+        self.core.chatrooms.remove_room(room)
         return True
 
     """ Configure Shares """


### PR DESCRIPTION
- Moved: `/join` command into core_commands plugin, no functional changes.
- Moved: `/leave` into core_commands plugin, Added error message if specified chat room is not joined.
- Removed: `/p` and `/part` aliases from the `/leave` chat room command