### PR TITLE
core_commands: me command

### DIFF
--- a/pynicotine/gtkgui/widgets/textentry.py
+++ b/pynicotine/gtkgui/widgets/textentry.py
@@ -77,8 +77,8 @@ class ChatEntry:
         is_double_slash_cmd = text.startswith("//")
         is_single_slash_cmd = (text.startswith("/") and not is_double_slash_cmd)
 
-        if not is_single_slash_cmd or text.startswith("/me"):
-            # Regular chat message (/me is sent as plain text)
+        if not is_single_slash_cmd:
+            # Regular chat message
 
             self.widget.set_text("")
 

--- a/pynicotine/plugins/core_commands/__init__.py
+++ b/pynicotine/plugins/core_commands/__init__.py
@@ -41,6 +41,13 @@ class Plugin(BasePlugin):
                 "group": self.main_group_name,
                 "usage": ["[-force]"]
             },
+            "me": {
+                "callback": self.me_command,
+                "description": _("Say something in the third-person"),
+                "disable": ["cli"],
+                "group": _("Chat"),
+                "usage": ["<something..>"]
+            },
             "close": {
                 "description": "Close private chat",
                 "aliases": ["c"],
@@ -130,7 +137,12 @@ class Plugin(BasePlugin):
 
         return True
 
-    """ Private Chats """
+    """ Chat """
+
+    def me_command(self, args, **_unused):
+        self.send_message("/me " + args)  # /me is sent as plain text
+
+    """ Private Chat """
 
     def close_command(self, args, user=None, **_unused):
 


### PR DESCRIPTION
+ Moved: `/me` command into core_commands plugin, no functional changes.
