### PR TITLE
core_commands: search rsearch bsearch commands

### DIFF
--- a/pynicotine/gtkgui/widgets/textentry.py
+++ b/pynicotine/gtkgui/widgets/textentry.py
@@ -130,23 +130,11 @@ class ChatEntry:
                     core.privatechat.show_user(user)
                     core.privatechat.send_message(user, msg)
 
-        elif cmd in ("/s", "/search"):
-            if args:
-                core.search.do_search(args, "global")
-
         elif cmd in ("/us", "/usearch"):
             args_split = args.split(" ", maxsplit=1)
 
             if len(args_split) == 2:
                 core.search.do_search(args_split[1], "user", user=args_split[0])
-
-        elif cmd in ("/rs", "/rsearch"):
-            if args:
-                core.search.do_search(args, "rooms")
-
-        elif cmd in ("/bs", "/bsearch"):
-            if args:
-                core.search.do_search(args, "buddies")
 
         elif cmd in ("/j", "/join"):
             if args:

--- a/pynicotine/plugins/core_commands/__init__.py
+++ b/pynicotine/plugins/core_commands/__init__.py
@@ -72,6 +72,30 @@ class Plugin(BasePlugin):
                 "description": _("List shares"),
                 "group": _("Configure Shares"),
                 "usage": ["[public]", "[buddy]"]
+            },
+            "search": {
+                "aliases": ["s"],
+                "callback": self.search_command,
+                "description": _("Start global file search"),
+                "disable": ["cli"],
+                "group": _("Search Files"),
+                "usage": ["<query>"]
+            },
+            "rsearch": {
+                "aliases": ["rs"],
+                "callback": self.search_rooms_command,
+                "description": _("Search files in joined rooms"),
+                "disable": ["cli"],
+                "group": _("Search Files"),
+                "usage": ["<query>"]
+            },
+            "bsearch": {
+                "aliases": ["bs"],
+                "callback": self.search_buddies_command,
+                "description": _("Search files of all buddies"),
+                "disable": ["cli"],
+                "group": _("Search Files"),
+                "usage": ["<query>"]
             }
         }
 
@@ -183,3 +207,14 @@ class Plugin(BasePlugin):
             num_listed += num_shares
 
         self.output("\n" + f"{num_listed} shares listed ({num_total} configured)")
+
+    """ Search Files """
+
+    def search_command(self, args, **_unused):
+        self.core.search.do_search(args, "global")
+
+    def search_rooms_command(self, args, **_unused):
+        self.core.search.do_search(args, "rooms")
+
+    def search_buddies_command(self, args, **_unused):
+        self.core.search.do_search(args, "buddies")


### PR DESCRIPTION
+ Moved: `/search` command into core_commands plugin, no functional changes.
+ Moved: `/rsearch` command into core_commands plugin, no functional changes.
+ Moved: `/bsearch` command into core_commands plugin, no functional changes.

`/usearch` command requires _shlex_ syntax parsing to support usernames that contain spaces, so it will follow in a separate PR.