### PR TITLE
pluginsystem.py: give core_commands a human_name

### DIFF
--- a/pynicotine/plugins/core_commands/PLUGININFO
+++ b/pynicotine/plugins/core_commands/PLUGININFO
@@ -1,0 +1,3 @@
+Version = "2023-01-23r00"
+Authors = ["Nicotine+"]
+Name = _("Nicotine+ Commands")

--- a/pynicotine/plugins/core_commands/__init__.py
+++ b/pynicotine/plugins/core_commands/__init__.py
@@ -25,20 +25,17 @@ class Plugin(BasePlugin):
 
         super().__init__(*args, **kwargs)
 
-        self.main_group_name = _("%s Commands") % self.config.application_name
         self.commands = {
             "help": {
                 "aliases": ["?"],
                 "callback": self.help_command,
                 "description": _("List available commands"),
-                "group": self.main_group_name,
                 "usage": ["[query]"]
             },
             "quit": {
                 "aliases": ["q", "exit"],
                 "callback": self.quit_command,
                 "description": _("Quit Nicotine+"),
-                "group": self.main_group_name,
                 "usage": ["[-force]"]
             },
             "me": {
@@ -66,7 +63,6 @@ class Plugin(BasePlugin):
             },
             "sample": {
                 "description": "Sample command description",
-                "group": self.main_group_name,
                 "aliases": ["demo"],
                 "disable": ["private_chat"],
                 "callback": self.sample_command,

--- a/pynicotine/pluginsystem.py
+++ b/pynicotine/pluginsystem.py
@@ -546,8 +546,7 @@ class PluginHandler:
             self.enabled_plugins[plugin_name] = plugin
             plugin.loaded_notification()
 
-            if plugin_name != "core_commands":
-                log.add(_("Loaded plugin %s"), plugin.human_name)
+            log.add(_("Loaded plugin %s"), plugin.human_name)
 
         except Exception:
             from traceback import format_exc
@@ -654,7 +653,7 @@ class PluginHandler:
         plugin_info = {}
         plugin_path = self.get_plugin_path(plugin_name)
 
-        if plugin_path is None or plugin_name == "core_commands":
+        if plugin_path is None:
             return plugin_info
 
         info_path = os.path.join(plugin_path, "PLUGININFO")


### PR DESCRIPTION
+ Added: Human name of "core_commands" plugin to application_name + "Commands", i.e: "Nicotine+ Commands"

The string appears for the main group in the `/help` output as well as for the title of `self.log` messages.

Without a `human_name` value, the plugin log function is not really usable, if we were to ever want to use that.