### PR TITLE
pluginsystem.py: always enable core_commands

### DIFF
--- a/pynicotine/pluginsystem.py
+++ b/pynicotine/pluginsystem.py
@@ -389,13 +389,12 @@ class PluginHandler:
 
     def _start(self):
 
-        enable = config.sections["plugins"]["enable"]
+        self.enable_plugin("core_commands")
 
-        if not enable:
+        if not config.sections["plugins"]["enable"]:
             return
 
         log.add(_("Loading plugin system"))
-        self.enable_plugin("core_commands")
 
         to_enable = config.sections["plugins"]["enabled"]
         log.add_debug(f"Enabled plugin(s): {', '.join(to_enable)}")


### PR DESCRIPTION
+ Fixed: Always enable the core_commands plugin, even if the user has disabled the plugin system.

The core_commands plugin cannot be disabled whilst the application is running, but if the application was restarted after disabling the plugin system then the entire command system is unavailable, which totally bricks the headless mode CLI and the command help popover is blank.