### PR TITLE
core_commands: escape tab in help message output

### DIFF
--- a/pynicotine/plugins/core_commands/__init__.py
+++ b/pynicotine/plugins/core_commands/__init__.py
@@ -162,7 +162,7 @@ class Plugin(BasePlugin):
             output_text += f"\n\n{group_name}:"
 
             for command_usage, description in commands:
-                output_text += f"\n	{command_usage}  -  {description}"
+                output_text += f"\n\t{command_usage}  -  {description}"
 
         if not search_query:
             output_text += "\n\n" + _("Type %(command)s to list similar commands") % {"command": "/help [query]"}


### PR DESCRIPTION
+ Changed: Escape invisible alternate whitespace with `\t`

Otherwise my text editor wants to convert it into a space every time the file is saved.