### PR TITLE
core_commands: msg command and shlex split

### DIFF
--- a/pynicotine/gtkgui/widgets/textentry.py
+++ b/pynicotine/gtkgui/widgets/textentry.py
@@ -113,19 +113,6 @@ class ChatEntry:
             if arg_self:
                 core.request_ip_address(arg_self)
 
-        elif cmd in ("/m", "/msg"):
-            if args:
-                args_split = args.split(" ", maxsplit=1)
-                user = args_split[0]
-                msg = None
-
-                if len(args_split) == 2:
-                    msg = args_split[1]
-
-                if msg:
-                    core.privatechat.show_user(user)
-                    core.privatechat.send_message(user, msg)
-
         elif cmd in ("/us", "/usearch"):
             args_split = args.split(" ", maxsplit=1)
 

--- a/pynicotine/plugins/core_commands/__init__.py
+++ b/pynicotine/plugins/core_commands/__init__.py
@@ -61,6 +61,14 @@ class Plugin(BasePlugin):
                 "usage_chatroom": ["<user>"],
                 "usage_private_chat": ["[user]"]
             },
+            "msg": {
+                "aliases": ["m"],
+                "callback": self.msg_command,
+                "description": _("Send private message to user"),
+                "disable": ["cli"],
+                "group": _("Private Chat"),
+                "usage": ["<user>", "<message..>"]
+            },
             "pm": {
                 "callback": self.pm_command,
                 "description": _("Open private chat"),
@@ -219,6 +227,16 @@ class Plugin(BasePlugin):
 
         self.output(f"Closing private chat of user {user}")
         self.core.privatechat.remove_user(user)
+        return True
+
+    def msg_command(self, args, **_unused):
+
+        user, text = self.split_args(args, 2)
+
+        if not text:
+            return False
+
+        self.send_private(user, text, show_ui=True, switch_page=False)
         return True
 
     def pm_command(self, args, **_unused):

--- a/pynicotine/pluginsystem.py
+++ b/pynicotine/pluginsystem.py
@@ -267,6 +267,77 @@ class BasePlugin:
     def output(self, text):
         self.echo_message(text, message_type="command")
 
+    def split_args(self, args, num_required_args, quiet=False):
+        """ Split command line arguments string into a list, supporting quoted
+        "long arguments" containing spaces, quotes optional where possible """
+
+        arg_list = []
+        quoted_positions = []
+
+        if '"' not in args and "'" not in args:
+            # Standard split by spaces, only last argument can contain spaces,
+            # which is okay for most arguments like single-word usernames etc.
+            arg_list = args.split(maxsplit=(num_required_args - 1))
+
+            if not num_required_args or len(arg_list) == num_required_args:
+                return arg_list
+
+        else:
+            # Support "long arguments" containing spaces, surrounded with quotes
+            from shlex import split
+
+            try:
+                # Preserve quotation marks for now
+                arg_list = split(args, posix=False)
+
+            except ValueError as error:
+                # Mismatched quotes etc
+                if not quiet:
+                    self.output(error)
+
+            # Identify "long arguments", and strip quotes
+            for i, arg in enumerate(arg_list):
+                if (arg.startswith('"') and arg.endswith('"')) or (arg.startswith("'") and arg.endswith("'")):
+                    quoted_positions.append(i)
+                    arg_list[i] = arg[1:-1]
+
+        # Find non-quoted items that should be merged together, this makes
+        # using quotes optional for first or last arguments. For example:
+        #     /msg "user name" "message text"
+        #     /msg user name "message text"
+        #     /msg "user name" message text
+        #     /usearch "user name" 'Artist Name "Song Title"'
+        # (all of the above examples are treated as having two arguments)
+        for i in reversed(range(len(arg_list))):
+            if not num_required_args or len(arg_list) <= num_required_args:
+                break
+
+            if i == 0:
+                if not quiet:
+                    self.output(_("Too many arguments, %(num_required_args)i required, "
+                                "%(num_given_args)i given (%(num_quoted_args)i quoted)") % {
+                        "num_required_args": int(num_required_args),
+                        "num_given_args": len(arg_list),
+                        "num_quoted_args": len(quoted_positions)
+                    })
+
+                # Wipe out all ambiguous arguments to avoid mismatching
+                arg_list = [arg_list[0]]
+                break
+
+            if i in quoted_positions or i - 1 in quoted_positions:
+                continue
+
+            # Merge the previous argument with this non-quoted argument
+            removed_arg = arg_list.pop(i)
+            arg_list[i - 1] += " " + removed_arg
+
+        # Always return correct number of arguments, even if error
+        while len(arg_list) < num_required_args:
+            arg_list.append(False)
+
+        return arg_list
+
 
 class ResponseThrottle:
 
@@ -815,7 +886,7 @@ class PluginHandler:
                     command_found = True
                     rejection_message = None
                     usage = data.get(f"usage_{command_interface}", data.get("usage", []))
-                    args_split = args.split()
+                    args_split = plugin.split_args(args, 0)
                     num_args = len(args_split)
                     num_required_args = 0
 


### PR DESCRIPTION
+ Moved: `/msg` command into core_commands plugin
+ Added: Accept "long strings with spaces" as quoted arguments, but don't require quotes if arguments are unambiguous
+ Changed: Don't switch to the tab on entering `/msg` command, because that's what the /pm command is for

Lexical (shell-like) argument splitting allows support for quoted "user names". Quotes are not mandatory if the argument is the first or last one, nor if the username is a single word, i.e; the following inputs all validate into 2 arguments:

`/msg "user name" "message text"`  <- both arguments quoted, ok.
`/msg user name "message text"`  <- only final argument quoted, ok.
`/msg "user name" message text`  <- only first argument quoted, ok.
`/msg username message text`  <- no quotes required for single-word usernames, ok.

_Review/testing points:_

- 3 or more `num_required_args` are tested working with the new `split_args()` function. The `/msg` only needs to accept two arguments, but other commands might need more. A helpful error message is shown on the interface in the case of a mismatch, such as "Too many arguments". Setting `num_required_args=0` returns unlimited splits.

- It is very likely that the `<user>` argument will contain spaces, because many users have such long names. Some commands are useless without support for arguments that contain spaces.

- The proposed implementation is a useful utility that should be available to plugin developers to process any string in the way they want, with any amount of required arguments (such as perhaps from secondary input() prompt or another source).

- Closer integration for argument parsing might be considered into the pluginsystem core, but caution is needed to ensure that optional arguments don't throw an error that prevents the plugin command from being triggered.

- Strings containing `'`_inline `"`quotes`"` can be `"`protected`"` with alternate quotation marks_`'`, and other features (but unfortunately there is no _maxsplit_ feature). See [shlex module Python docs](https://docs.python.org/3.8/library/shlex.html#shlex.split) for details.