### PR TITLE
core_commands: ip command

### DIFF
--- a/pynicotine/gtkgui/widgets/textentry.py
+++ b/pynicotine/gtkgui/widgets/textentry.py
@@ -109,10 +109,6 @@ class ChatEntry:
             if arg_self:
                 core.userbrowse.browse_user(arg_self)
 
-        elif cmd == "/ip":
-            if arg_self:
-                core.request_ip_address(arg_self)
-
         elif cmd in ("/m", "/msg"):
             if args:
                 args_split = args.split(" ", maxsplit=1)

--- a/pynicotine/networkfilter.py
+++ b/pynicotine/networkfilter.py
@@ -139,7 +139,7 @@ class NetworkFilter:
         return None
 
     @staticmethod
-    def get_known_ip_address(user):
+    def get_online_user_ip_address(user):
         """ Try to lookup an address from watched known connections,
         for updating an IP list item if the address is unspecified """
 
@@ -150,17 +150,16 @@ class NetworkFilter:
             return None
 
         user_ip_address, _user_port = user_address
-
         return user_ip_address
 
     @staticmethod
-    def get_known_username(ip_address):
+    def get_online_username(ip_address):
         """ Try to match a username from watched and known connections,
         for updating an IP list item if the username is unspecified """
 
-        for (user_name, user_address) in core.user_addresses.items():
+        for username, user_address in core.user_addresses.items():
             if ip_address == user_address[0]:
-                return user_name
+                return username
 
         return None
 

--- a/pynicotine/plugins/core_commands/__init__.py
+++ b/pynicotine/plugins/core_commands/__init__.py
@@ -94,6 +94,13 @@ class Plugin(BasePlugin):
                 "usage": ["<room>"],
                 "usage_chatroom": ["[room]"]
             },
+            "ip": {
+                "callback": self.ip_address_command,
+                "description": _("Show IP address or username"),
+                "group": _("Network Filters"),
+                "usage": ["<user or ip>"],
+                "usage_private_chat": ["[user]", "[ip]"]
+            },
             "rescan": {
                 "callback": self.rescan_command,
                 "description": _("Rescan shares"),
@@ -244,6 +251,25 @@ class Plugin(BasePlugin):
 
         self.core.chatrooms.remove_room(room)
         return True
+
+    """ Network Filters """
+
+    def ip_address_command(self, args, user=None, **_unused):
+
+        if self.core.network_filter.is_ip_address(args):
+            self.output(self.core.network_filter.get_online_username(args))
+            return
+
+        if args:
+            user = args
+
+        online_ip_address = self.core.network_filter.get_online_user_ip_address(user)
+
+        if not online_ip_address:
+            self.core.request_ip_address(user)
+            return
+
+        self.output(online_ip_address)
 
     """ Configure Shares """
 


### PR DESCRIPTION
+ Moved: `/ip` command into core_commands plugin
+ Changed: `/ip` command get address from core and print to output if available, fallback to request only if user is unknown
+ Added: `/ip` command can accept IPv4 address as argument for looking up an online address to output associated username

There is no text around the raw output strings, which makes copy & paste nice and easy when working with the network filters in a terminal, but it could be debated as to if more verbosity could be desirable.

- The future plan is to also output the Online/Offline status and Banned/Ignored states, as well as listing any stored IP addresses/usernames associated with a particular user/address.

-  For now this PR brings all the functionality that is required to replace the existing `/ip` command.