### PR TITLE
networkfilter.py: fix AttributeError if IP address is None

### DIFF
--- a/pynicotine/networkfilter.py
+++ b/pynicotine/networkfilter.py
@@ -103,8 +103,8 @@ class NetworkFilter:
 
         if user and not ip_address or ip_address is None:
             # Try to get an address from currently active connections
-            cached_ip = self._get_cached_user_ip(user, ip_list) or ""
-            ip_address = cached_ip or self.get_known_ip_address(user)
+            cached_ip = self._get_cached_user_ip(user, ip_list)
+            ip_address = cached_ip or self.get_known_ip_address(user) or ""
 
             if ip_address.startswith("?.?.?.?") or ip_address == "0.0.0.0":
                 # Allow deleting dummy entries (the offline default IP


### PR DESCRIPTION
+ Fixed: Possible AttributeError when attempting to remove a non-existant IP filter of a user who isn;t banned or ignored nor has never been seen online

Regression since https://github.com/nicotine-plus/nicotine-plus/pull/2287

It is not clear if we are supposed to use `"0.0.0.0"` or `None` or `""` or something else for expressing the address unknown/offline users throughout different parts of the application. It is awkward handling variables that may contain different data-types.