### PR TITLE
core_commands: ban unban ignore unignore commands

### DIFF
--- a/pynicotine/gtkgui/widgets/textentry.py
+++ b/pynicotine/gtkgui/widgets/textentry.py
@@ -140,26 +140,6 @@ class ChatEntry:
             if args:
                 core.userlist.remove_buddy(args)
 
-        elif cmd == "/ban":
-            if args:
-                core.network_filter.ban_user(args)
-
-        elif cmd == "/ignore":
-            if args:
-                core.network_filter.ignore_user(args)
-
-        elif cmd == "/ignoreip":
-            if args:
-                core.network_filter.ignore_user_ip(ip_address=args)
-
-        elif cmd == "/unban":
-            if args:
-                core.network_filter.unban_user(args)
-
-        elif cmd == "/unignore":
-            if args:
-                core.network_filter.unignore_user(args)
-
         elif cmd == "/ctcpversion":
             if arg_self:
                 core.privatechat.show_user(arg_self)

--- a/pynicotine/plugins/core_commands/__init__.py
+++ b/pynicotine/plugins/core_commands/__init__.py
@@ -94,6 +94,36 @@ class Plugin(BasePlugin):
                 "usage": ["<room>"],
                 "usage_chatroom": ["[room]"]
             },
+            "ban": {
+                "callback": self.ban_command,
+                "description": _("Block connections from user or IP address"),
+                "group": _("Network Filters"),
+                "usage": ["<user or ip>"],
+                "usage_private_chat": ["[user]", "[ip]"]
+            },
+            "unban": {
+                "callback": self.unban_command,
+                "description": _("Remove user or IP address from ban lists"),
+                "group": _("Network Filters"),
+                "usage": ["<user or ip>"],
+                "usage_private_chat": ["[user]", "[ip]"]
+            },
+            "ignore": {
+                "callback": self.ignore_command,
+                "description": _("Silence messages from user or IP address"),
+                "disable": ["cli"],
+                "group": _("Network Filters"),
+                "usage": ["<user or ip>"],
+                "usage_private_chat": ["[user]", "[ip]"]
+            },
+            "unignore": {
+                "callback": self.unignore_command,
+                "description": _("Remove user or IP address from ignore lists"),
+                "disable": ["cli"],
+                "group": _("Network Filters"),
+                "usage": ["<user or ip>"],
+                "usage_private_chat": ["[user]", "[ip]"]
+            },
             "rescan": {
                 "callback": self.rescan_command,
                 "description": _("Rescan shares"),
@@ -244,6 +274,66 @@ class Plugin(BasePlugin):
 
         self.core.chatrooms.remove_room(room)
         return True
+
+    """ Network Filters """
+
+    def ban_command(self, args, user=None, **_unused):
+
+        if self.core.network_filter.is_ip_address(args):
+            banned_ip_address = self.core.network_filter.ban_user_ip(ip_address=args)
+        else:
+            if args:
+                user = args
+
+            banned_ip_address = None
+            self.core.network_filter.ban_user(user)
+
+        self.output(_("Banned %s") % (banned_ip_address or user))
+
+    def unban_command(self, args, user=None, **_unused):
+
+        if self.core.network_filter.is_ip_address(args):
+            unbanned_ip_addresses = self.core.network_filter.unban_user_ip(ip_address=args)
+
+            self.core.network_filter.unban_user(
+                self.core.network_filter.get_known_username(unbanned_ip_address) or unbanned_ip_address)
+        else:
+            if args:
+                user = args
+
+            unbanned_ip_addresses = self.core.network_filter.unban_user_ip(user)
+            self.core.network_filter.unban_user(user)
+
+        self.output(_("Unbanned %s") % (" & ".join(unbanned_ip_addresses) or user))
+
+    def ignore_command(self, args, user=None, **_unused):
+
+        if self.core.network_filter.is_ip_address(args):
+            ignored_ip_address = self.core.network_filter.ignore_user_ip(ip_address=args)
+        else:
+            if args:
+                user = args
+
+            ignored_ip_address = None
+            self.core.network_filter.ignore_user(user)
+
+        self.output(_("Ignored %s") % (ignored_ip_address or user))
+
+    def unignore_command(self, args, user=None, **_unused):
+
+        if self.core.network_filter.is_ip_address(args):
+            unignored_ip_addresses = self.core.network_filter.unignore_user_ip(ip_address=args)
+
+            self.core.network_filter.unignore_user(
+                self.core.network_filter.get_known_username(unignored_ip_address) or unignored_ip_address)
+        else:
+            if args:
+                user = args
+
+            unignored_ip_addresses = self.core.network_filter.unignore_user_ip(user)
+            self.core.network_filter.unignore_user(user)
+
+        self.output(_("Unignored %s") % (" & ".join(unignored_ip_addresses) or user))
 
     """ Configure Shares """
 


### PR DESCRIPTION
+ Moved: `/ban` `/unban` `/ignore` `/unignore` commands into core_commands plugin
+ Changed: `/ban` and `/ignore` commands can accept either username or IPv4 address as argument to add appropriate filter
+ Changed: `/unban` and `/unignore` commands removes both username-based and IP-based filters at the same time
+ Added: Echo output of added/removed filter item(s)
- Removed: `/ignoreip` command (was undocumented, Changed: `/ignore` command to also accept an IPv4 address instead)