### PR TITLE
core_commands: msg command

### DIFF
--- a/pynicotine/gtkgui/widgets/textentry.py
+++ b/pynicotine/gtkgui/widgets/textentry.py
@@ -109,19 +109,6 @@ class ChatEntry:
             if arg_self:
                 core.userbrowse.browse_user(arg_self)
 
-        elif cmd in ("/m", "/msg"):
-            if args:
-                args_split = args.split(" ", maxsplit=1)
-                user = args_split[0]
-                msg = None
-
-                if len(args_split) == 2:
-                    msg = args_split[1]
-
-                if msg:
-                    core.privatechat.show_user(user)
-                    core.privatechat.send_message(user, msg)
-
         elif cmd in ("/us", "/usearch"):
             args_split = args.split(" ", maxsplit=1)
 

--- a/pynicotine/plugins/core_commands/__init__.py
+++ b/pynicotine/plugins/core_commands/__init__.py
@@ -61,6 +61,14 @@ class Plugin(BasePlugin):
                 "usage_chatroom": ["<user>"],
                 "usage_private_chat": ["[user]"]
             },
+            "msg": {
+                "aliases": ["m"],
+                "callback": self.msg_command,
+                "description": _("Send private message to user"),
+                "disable": ["cli"],
+                "group": _("Private Chat"),
+                "usage": ["<user>", "<message..>"]
+            },
             "pm": {
                 "callback": self.pm_command,
                 "description": _("Open private chat"),
@@ -257,6 +265,13 @@ class Plugin(BasePlugin):
         self.output(f"Closing private chat of user {user}")
         self.core.privatechat.remove_user(user)
         return True
+
+    def msg_command(self, args, **_unused):
+
+        args_split = args.split(maxsplit=1)
+        user, text = args_split[0], args_split[1]
+
+        self.send_private(user, text, show_ui=True, switch_page=False)
 
     def pm_command(self, args, **_unused):
         self.core.privatechat.show_user(args)


### PR DESCRIPTION
+ Moved: `/msg` command into core_commands plugin
+ Changed: Don't switch to the tab on entering `/msg` command, because that's what the /pm command is for

Tab switching is not desirable because that defeats the purpose of a having command which gives the ability to send a message to a user other than the current tab window.

_Note: The current /msg command cannot send messages to "user names" that contain spaces. For a suggested working solution to that problem see PR #2344, meanwhile this PR can be merged as it retains the functionality of the existing command._