### PR TITLE
core_commands: usearch command

### DIFF
--- a/pynicotine/gtkgui/widgets/textentry.py
+++ b/pynicotine/gtkgui/widgets/textentry.py
@@ -109,12 +109,6 @@ class ChatEntry:
             if arg_self:
                 core.userbrowse.browse_user(arg_self)
 
-        elif cmd in ("/us", "/usearch"):
-            args_split = args.split(" ", maxsplit=1)
-
-            if len(args_split) == 2:
-                core.search.do_search(args_split[1], "user", user=args_split[0])
-
         elif cmd in ("/ad", "/add", "/buddy"):
             if args:
                 core.userlist.add_buddy(args)

--- a/pynicotine/plugins/core_commands/__init__.py
+++ b/pynicotine/plugins/core_commands/__init__.py
@@ -175,6 +175,14 @@ class Plugin(BasePlugin):
                 "disable": ["cli"],
                 "group": _("Search Files"),
                 "usage": ["<query>"]
+            },
+            "usearch": {
+                "aliases": ["us"],
+                "callback": self.search_user_command,
+                "description": _("Search a user's shared files"),
+                "disable": ["cli"],
+                "group": _("Search Files"),
+                "usage": ["<user>", "<query>"]
             }
         }
 
@@ -415,3 +423,10 @@ class Plugin(BasePlugin):
 
     def search_buddies_command(self, args, **_unused):
         self.core.search.do_search(args, "buddies")
+
+    def search_user_command(self, args, user=None, **_unused):
+
+        args_split = args.split(maxsplit=1)
+        user, query = args_split[0], args_split[1]
+
+        self.core.search.do_search(query, "user", user=user)


### PR DESCRIPTION
+ Moved: `/usearch` command into core_commands plugin, no functional changes.

_Note: The positional `<user>` argument has to be mandatory even in private chat, because otherwise it is ambiguous with the first word of the `<query>` argument. Only single-word usernames are supported, this is the same way as the original command works._

In future we could support parsing quoted arguments to improve this, but that isn't needed for our purposes right now. This PR completes the full suite of existing commands as is in the "Search Files" category.