### PR TITLE
core_commands: say command

### DIFF
--- a/pynicotine/plugins/core_commands/__init__.py
+++ b/pynicotine/plugins/core_commands/__init__.py
@@ -102,6 +102,13 @@ class Plugin(BasePlugin):
                 "usage": ["<room>"],
                 "usage_chatroom": ["[room]"]
             },
+            "say": {
+                "callback": self.say_command,
+                "description": _("Say message in specified chat room"),
+                "disable": ["cli"],
+                "group": _("Chat Rooms"),
+                "usage": ["<room>", "<message..>"]
+            },
             "ip": {
                 "callback": self.ip_address_command,
                 "description": _("Show IP address or username"),
@@ -295,6 +302,18 @@ class Plugin(BasePlugin):
             return False
 
         self.core.chatrooms.remove_room(room)
+        return True
+
+    def say_command(self, args, **_unused):
+
+        args_split = args.split(maxsplit=1)
+        room, text = args_split[0], args_split[1]
+
+        if room not in self.core.chatrooms.joined_rooms:
+            self.output(_("Not joined in room %s") % room)
+            return False
+
+        self.send_public(room, text)
         return True
 
     """ Network Filters """


### PR DESCRIPTION
+ Added: `/say` command into core_commands plugin, as it was traditionally in previous versions of Nicotine
+ Added: Don't attempt to send chat room message unless joined, fail with error message if not

_Note: Only single-word room names are currently supported._ 

If we don't want to include this command in the project right now, then it can be excluded with the `"disabled"` property, (or perhaps be placed into a hidden help group, or an optional plugin?). rather than it being omitted entirely.