### PR TITLE
core_commands: browse command

### DIFF
--- a/pynicotine/gtkgui/widgets/textentry.py
+++ b/pynicotine/gtkgui/widgets/textentry.py
@@ -105,10 +105,6 @@ class ChatEntry:
             if arg_self:
                 core.userinfo.show_user(arg_self)
 
-        elif cmd in ("/b", "/browse"):
-            if arg_self:
-                core.userbrowse.browse_user(arg_self)
-
         elif cmd in ("/us", "/usearch"):
             args_split = args.split(" ", maxsplit=1)
 

--- a/pynicotine/plugins/core_commands/__init__.py
+++ b/pynicotine/plugins/core_commands/__init__.py
@@ -102,6 +102,15 @@ class Plugin(BasePlugin):
                 "usage": ["<room>"],
                 "usage_chatroom": ["[room]"]
             },
+            "browse": {
+                "aliases": ["b"],
+                "callback": self.browse_user_command,
+                "description": _("Browse files of user"),
+                "disable": ["cli"],
+                "group": _("Users"),
+                "usage": ["<user>"],
+                "usage_private_chat": ["[user]"]
+            },
             "ip": {
                 "callback": self.ip_address_command,
                 "description": _("Show IP address or username"),
@@ -296,6 +305,15 @@ class Plugin(BasePlugin):
 
         self.core.chatrooms.remove_room(room)
         return True
+
+    """ Users """
+
+    def browse_user_command(self, args, user=None, **_unused):
+
+        if args:
+            user = args
+
+        self.core.userbrowse.browse_user(user)
 
     """ Network Filters """
 


### PR DESCRIPTION
+ Moved: `/browse` command into core_commands plugin
+ Added: Enable usage from chat rooms or other private chat windows with the `<user>` argument