### PR TITLE
core_commands: add buddy rem unbuddy commands

### DIFF
--- a/pynicotine/gtkgui/widgets/textentry.py
+++ b/pynicotine/gtkgui/widgets/textentry.py
@@ -115,14 +115,6 @@ class ChatEntry:
             if len(args_split) == 2:
                 core.search.do_search(args_split[1], "user", user=args_split[0])
 
-        elif cmd in ("/ad", "/add", "/buddy"):
-            if args:
-                core.userlist.add_buddy(args)
-
-        elif cmd in ("/rem", "/unbuddy"):
-            if args:
-                core.userlist.remove_buddy(args)
-
         elif cmd == "/ctcpversion":
             if arg_self:
                 core.privatechat.show_user(arg_self)

--- a/pynicotine/plugins/core_commands/__init__.py
+++ b/pynicotine/plugins/core_commands/__init__.py
@@ -102,6 +102,22 @@ class Plugin(BasePlugin):
                 "usage": ["<room>"],
                 "usage_chatroom": ["[room]"]
             },
+            "add": {
+                "aliases": ["buddy"],
+                "callback": self.add_buddy_command,
+                "description": _("Add user to buddy list"),
+                "group": _("Users"),
+                "usage": ["<user>"],
+                "usage_private_chat": ["[user]"]
+            },
+            "rem": {
+                "aliases": ["unbuddy"],
+                "callback": self.remove_buddy_command,
+                "description": _("Remove buddy from buddy list"),
+                "group": _("Users"),
+                "usage": ["<buddy>"],
+                "usage_private_chat": ["[buddy]"]
+            },
             "ip": {
                 "callback": self.ip_address_command,
                 "description": _("Show IP address or username"),
@@ -296,6 +312,22 @@ class Plugin(BasePlugin):
 
         self.core.chatrooms.remove_room(room)
         return True
+
+    """ Users """
+
+    def add_buddy_command(self, args, user=None, **_unused):
+
+        if args:
+            user = args
+
+        self.core.userlist.add_buddy(user)
+
+    def remove_buddy_command(self, args, user=None, **_unused):
+
+        if args:
+            user = args
+
+        self.core.userlist.remove_buddy(user)
 
     """ Network Filters """
 


### PR DESCRIPTION
+ Moved: `/add` and `/rem` (alias `/buddy` and `/unbuddy`) commands into core_commands plugin, no functional changes.
- Removed: `/ad` alias from the `/add` buddy command, because it seems useless clutter in the help.

There is no output to confirm the requested operation was successful or not. That might belong better in userlist.py as standard logging.