### PR TITLE
pluginsystem.py: "to list available commands"

### DIFF
--- a/pynicotine/plugins/core_commands/__init__.py
+++ b/pynicotine/plugins/core_commands/__init__.py
@@ -263,6 +263,8 @@ class Plugin(BasePlugin):
 
         if not search_query:
             output_text += "\n\n" + _("Type %(command)s to list similar commands") % {"command": "/help [query]"}
+        elif not num_commands:
+            output_text += "\n" + _("Type %(command)s to list available commands") % {"command": "/help"}
 
         self.output(output_text)
         return True

--- a/pynicotine/pluginsystem.py
+++ b/pynicotine/pluginsystem.py
@@ -874,7 +874,7 @@ class PluginHandler:
                 break
 
         if plugin:
-            plugin.output(f"Unknown command: {'/' + command}. Type /help for a list of commands.")
+            plugin.output(f"Unknown command: {'/' + command}. Type /help to list available commands.")
 
         self.command_source = None
         return is_successful


### PR DESCRIPTION
+ Changed: Unknown command string "for a list of commands" -> "to list available commands"
+ Added: Help command output string if there are no matching results for the given argument

The word "to" is more to the point than using "for", "a" and "of" in the sentence:
```
Unknown command: /tfgyuhjio. Type /help to list available commands.
```
The word "available" matches how it is used in the other descriptions:
```
/help uyighuihuh
Listing 0 available commands matching "uyighuihuh":
Type /help to list available commands
/help
Listing 25 available commands:

Nicotine+ Commands:
	/help, /? [query]  -  List available commands
...
```