### PR TITLE
core_commands: away command

### DIFF
--- a/pynicotine/gtkgui/widgets/textentry.py
+++ b/pynicotine/gtkgui/widgets/textentry.py
@@ -106,9 +106,6 @@ class ChatEntry:
                 core.privatechat.show_user(arg_self)
                 core.privatechat.send_message(arg_self, core.privatechat.CTCP_VERSION)
 
-        elif cmd in ("/a", "/away"):
-            core.set_away_mode(core.user_status != UserStatus.AWAY, save_state=True)
-
         elif cmd == "/now":
             core.now_playing.display_now_playing(
                 callback=lambda np_message: self.send_message(self.entity, np_message))

--- a/pynicotine/plugins/core_commands/__init__.py
+++ b/pynicotine/plugins/core_commands/__init__.py
@@ -17,6 +17,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 from pynicotine.pluginsystem import BasePlugin
+from pynicotine.slskmessages import UserStatus
 
 
 class Plugin(BasePlugin):
@@ -31,6 +32,11 @@ class Plugin(BasePlugin):
                 "callback": self.help_command,
                 "description": _("List available commands"),
                 "usage": ["[query]"]
+            },
+            "away": {
+                "aliases": ["a"],
+                "callback": self.away_command,
+                "description": _("Toggle away status"),
             },
             "quit": {
                 "aliases": ["q", "exit"],
@@ -268,6 +274,15 @@ class Plugin(BasePlugin):
 
         self.output(output_text)
         return True
+
+    def away_command(self, _args, **_unused):
+
+        if self.core.user_status == UserStatus.OFFLINE:
+            self.output(_("Offline"))
+            return
+
+        self.core.set_away_mode(self.core.user_status != UserStatus.AWAY, save_state=True)
+        self.output(_("Online") if self.core.user_status == UserStatus.ONLINE else _("Away"))
 
     def quit_command(self, args, **_unused):
 


### PR DESCRIPTION
+ Moved: `/away` command into core_commands plugin
+ Added: Print output to state current online status

It would be better if the core had a toggle_away_status() function, to avoid needing the UserStatus import, also perhaps that logged status change similar to that of a buddy status notification.