### PR TITLE
pylint: disable no-member in Plugin modules

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -399,7 +399,8 @@ ignored-classes=optparse.Values,thread._local,_thread._local
 # (useful for modules/projects where namespaces are manipulated during runtime
 # and thus existing member attributes cannot be deduced by static analysis). It
 # supports qualified module names, as well as Unix pattern matching.
-ignored-modules=
+ignored-modules=pynicotine.pluginsystem,
+                pynicotine.plugins.*
 
 # Show a hint with possible names when a member name was not found. The aspect
 # of finding the hint is based on edit distance.

--- a/pynicotine/plugins/core_commands/__init__.py
+++ b/pynicotine/plugins/core_commands/__init__.py
@@ -241,7 +241,7 @@ class Plugin(BasePlugin):
             command_interface = "cli"
 
         search_query = " ".join(args.lower().split(" ", maxsplit=1))
-        command_groups = self.parent.get_command_descriptions(  # pylint: disable=no-member
+        command_groups = self.parent.get_command_descriptions(
             command_interface, search_query=search_query
         )
         num_commands = sum(len(command_groups[x]) for x in command_groups)

--- a/pynicotine/pluginsystem.py
+++ b/pynicotine/pluginsystem.py
@@ -235,11 +235,11 @@ class BasePlugin:
         """ Convenience function to send a message to the same user/room
         a plugin command runs for """
 
-        if self.parent.command_source is None:  # pylint: disable=no-member
+        if self.parent.command_source is None:
             # Function was not called from a command
             return
 
-        command_interface, source = self.parent.command_source  # pylint: disable=no-member
+        command_interface, source = self.parent.command_source
 
         if command_interface == "cli":
             return
@@ -251,11 +251,11 @@ class BasePlugin:
         """ Convenience function to display a raw message the same window
         a plugin command runs from """
 
-        if self.parent.command_source is None:  # pylint: disable=no-member
+        if self.parent.command_source is None:
             # Function was not called from a command
             return
 
-        command_interface, source = self.parent.command_source  # pylint: disable=no-member
+        command_interface, source = self.parent.command_source
 
         if command_interface == "cli":
             print(text)


### PR DESCRIPTION
Disable the `no-member` check for plugin modules where namespaces are manipulated during runtime and thus existing member attributes cannot be deduced by static analysis.

Allows the use of `self.parent` reference in core Plugin modules, as documented:
https://github.com/nicotine-plus/nicotine-plus/blob/23180d9623e9c98f5cb2ad2d4adf877d07e6d7f0/pynicotine/pluginsystem.py#L56

May suggest this might also be appropriate for the `pynicotine.widgets.dialogs` module.

- Alternatively, it looks like we could specify the PluginHandler and Plugin Class in the setting above.

Afaik these only affect membership-related tests.