### PR TITLE
DOWNLOADS.md: add MX Linux package

### DIFF
--- a/doc/DOWNLOADS.md
+++ b/doc/DOWNLOADS.md
@@ -17,6 +17,7 @@ If you are using any of the operating systems listed, you can install Nicotine+ 
 | [Fedora](https://packages.fedoraproject.org/pkgs/nicotine+/nicotine+/)                  | `nicotine+`         |
 | [Gentoo](https://packages.gentoo.org/packages/net-p2p/nicotine+)                        | `net-p2p/nicotine+` |
 | [Manjaro](https://software.manjaro.org/package/nicotine+)                               | `nicotine+`         |
+| [MX Linux](https://mxrepo.com)                                                          | `nicotine`          |
 | [NixOS](https://search.nixos.org/packages?show=nicotine-plus)                           | `nicotine-plus`     |
 | [OpenBSD](https://openports.pl/path/net/nicotine-plus)                                  | `net/nicotine-plus` |
 | [Parabola](https://www.parabola.nu/packages/community/x86_64/nicotine+/)                | `nicotine+`         |


### PR DESCRIPTION
+ Added: MX Linux package `nicotine`

Not sure URL link to use it's all on one page for each MX release, nicotine-plus 3.2.5 is listed on https://mxrepo.com/MX21packages.html

3.2.5 https://mxrepo.com/mx/repo/pool/main/n/nicotine-plus/
3.2.6 https://mxrepo.com/mx/testrepo/pool/test/n/nicotine/
3.2.2 https://mxrepo.com/mx/testrepo/pool/test/n/nicotine-plus/ (needs to be removed)

It is called `nicotine-plus` at the moment (for 3.2.5) but 3.2.6 onwards is called `nicotine` in their testing repo to match future Debian upstream, see see forum discussion https://forum.mxlinux.org/viewtopic.php?p=700566&hilit=nicotine#p700566

This PR can wait until @stevenpusser has properly updated it to the correct `nicotine` package name in the MX `main` repo.