### PR TITLE
nowplaying.py: remove "Playing now" string in $n

### DIFF
--- a/pynicotine/nowplaying.py
+++ b/pynicotine/nowplaying.py
@@ -153,7 +153,7 @@ class NowPlaying:
             self.title["artist"] = artist = lastplayed["artist"]["#text"]
             self.title["title"] = title = lastplayed["name"]
             self.title["album"] = album = lastplayed["album"]["#text"]
-            self.title["nowplaying"] = f"{_('Last played')}: {artist} - {album} - {title}"
+            self.title["nowplaying"] = f"{artist} - {album} - {title}"
 
         except Exception:
             log.add(_("Last.fm: Could not get recent track from Audioscrobbler: %(error)s"),
@@ -283,7 +283,7 @@ class NowPlaying:
             self.title["artist"] = artist = track["artist_name"]
             self.title["title"] = title = track["track_name"]
             self.title["album"] = album = track["release_name"]
-            self.title["nowplaying"] = f"{_('Playing now')}: {artist} - {album} - {title}"
+            self.title["nowplaying"] = f"{artist} - {album} - {title}"
 
             return True
 


### PR DESCRIPTION
- Removed: Intro text from the `$n` string output.

User reports that otherwise it prevents Now Playing Search from working properly. If the intro text is wanted for use in chat it will have to be added somewhere else.

Fixes https://github.com/nicotine-plus/nicotine-plus/discussions/2380 discussion