### PR TITLE
now_playing_sender: now command

### DIFF
--- a/pynicotine/gtkgui/widgets/textentry.py
+++ b/pynicotine/gtkgui/widgets/textentry.py
@@ -103,10 +103,6 @@ class ChatEntry:
                 core.privatechat.show_user(arg_self)
                 core.privatechat.send_message(arg_self, core.privatechat.CTCP_VERSION)
 
-        elif cmd == "/now":
-            core.now_playing.display_now_playing(
-                callback=lambda np_message: self.send_message(self.entity, np_message))
-
         elif self.is_chatroom:
             if not core.pluginhandler.trigger_chatroom_command_event(self.entity, cmd[1:], args):
                 return

--- a/pynicotine/nowplaying.py
+++ b/pynicotine/nowplaying.py
@@ -153,7 +153,7 @@ class NowPlaying:
             self.title["artist"] = artist = lastplayed["artist"]["#text"]
             self.title["title"] = title = lastplayed["name"]
             self.title["album"] = album = lastplayed["album"]["#text"]
-            self.title["nowplaying"] = f"{_('Last played')}: {artist} - {album} - {title}"
+            self.title["nowplaying"] = f"{artist} - {album} - {title}"
 
         except Exception:
             log.add(_("Last.fm: Could not get recent track from Audioscrobbler: %(error)s"),
@@ -283,7 +283,7 @@ class NowPlaying:
             self.title["artist"] = artist = track["artist_name"]
             self.title["title"] = title = track["track_name"]
             self.title["album"] = album = track["release_name"]
-            self.title["nowplaying"] = f"{_('Playing now')}: {artist} - {album} - {title}"
+            self.title["nowplaying"] = f"{artist} - {album} - {title}"
 
             return True
 

--- a/pynicotine/plugins/core_commands/__init__.py
+++ b/pynicotine/plugins/core_commands/__init__.py
@@ -66,7 +66,7 @@ class Plugin(BasePlugin):
                 "aliases": ["q", "exit"],
                 "callback": self.quit_command,
                 "description": _("Quit Nicotine+"),
-                "usage": ["[-force]"]
+                "usage": ["[-force]", ""]
             },
             "clear": {
                 "aliases": ["cl"],
@@ -74,6 +74,7 @@ class Plugin(BasePlugin):
                 "description": _("Clear chat window"),
                 "disable": ["cli"],
                 "group": _CommandGroup.CHAT,
+                "usage": [""]
             },
             "me": {
                 "callback": self.me_command,
@@ -205,7 +206,7 @@ class Plugin(BasePlugin):
                 "callback": self.rescan_command,
                 "description": _("Rescan shares"),
                 "group": _CommandGroup.SHARES,
-                "usage": ["[-force]"]
+                "usage": ["[-force]", ""]
             },
             "shares": {
                 "aliases": ["ls"],

--- a/pynicotine/plugins/now_playing_sender/PLUGININFO
+++ b/pynicotine/plugins/now_playing_sender/PLUGININFO
@@ -1,4 +1,4 @@
-Version = "2020-11-08r00"
+Version = "2023-02-13r00"
 Authors = ["Nicotine+"]
-Name = "MPRIS Now Playing Sender"
-Description = "Whenever your media player starts playing a new song, this plugin automatically sends the song name in specified chat rooms, when joined. The plugin makes use of the 'Now Playing'-feature, which can be configured in the chat-related settings.\n\nOnly MPRIS is supported as a player source!"
+Name = "Now Playing Sender"
+Description = "The plugin makes use of the 'Now Playing' feature, as configured in preferences.\n\nWhenever your MPRIS* compatible media player starts playing a new song, this plugin automatically sends the song name in joined chat rooms as specified in the plugin settings.\n\nThe /now command has the following options:\n- local : Test the output locally\n- broadcast : Announce to chat rooms\n\nIf no option is specified, the /now command sends to current chat by default.\n\nWhen the plugin is used in headless mode the chat sending functions are unavailable.\n\nThe /now command is supported on all platforms for manual message sending.\n\n* MPRIS is only supported on GNU/Linux to enable automatic message sending."

--- a/pynicotine/pluginsystem.py
+++ b/pynicotine/pluginsystem.py
@@ -437,10 +437,6 @@ class PluginHandler:
 
     def _import_plugin_instance(self, plugin_name):
 
-        if sys.platform in ("win32", "darwin") and plugin_name == "now_playing_sender":
-            # MPRIS is not available on Windows and macOS
-            return None
-
         try:
             # Import builtin plugin
             from importlib import import_module
@@ -565,10 +561,6 @@ class PluginHandler:
                     file_path = entry.name.decode("utf-8", "replace")
 
                     if file_path == "core_commands":
-                        continue
-
-                    if sys.platform in ("win32", "darwin") and file_path == "now_playing_sender":
-                        # MPRIS is not available on Windows and macOS
                         continue
 
                     if entry.is_dir() and file_path not in plugin_list:
@@ -836,7 +828,12 @@ class PluginHandler:
                             rejection_message = f"Missing {arg} argument"
                             break
 
-                        if "|" not in arg:
+                        if num_args > i and arg == "":
+                            # Empty string "" in usage denotes End Of Line, enforce maximum arguments
+                            rejection_message = f"Too many arguments, {num_args} entered, {i} allowed"
+                            break
+
+                        if num_args <= i or "|" not in arg:
                             continue
 
                         choices = arg[1:-1].split("|")


### PR DESCRIPTION
+ Moved: `/now` command into now_playing_sender plugin
+ Added: Optional `local` or `broadcast` argument, if there is no argument then send to current chat by default
+ Added: Ability to print the `/now` command output in headless CLI echo (chat functions are unavailable, local echo only)
+ Added: Support for maximum plugin command arguments to be limited by terminating `usage` with empty string `""` (the `local` and `broadcast` choice argument is not relevant in the `cli` interface)
+ Fixed: Support for a single plugin command choice argument to be optional
+ Changed: PLUGININFO Name to remove reference to MPRIS as it is no longer mandatory for "Now Playing Sender" because the /now command provides functionality even for non-MPRIS users
+ Fixed: Only get the now playing string once, rather than recursing in the loop for each listed chat room
- Removed: Special exclusion for Windows and macOS, the plugin might partially operate by using the `/now` command, since platform specific functions are bypassed within the plugin itself.
- Removed: Intro text from `$n` output, any additional text should be added by customizing the message in preferences.