### PR TITLE
pluginsystem.py: fix IndexError on no choice argument

### DIFF
--- a/pynicotine/pluginsystem.py
+++ b/pynicotine/pluginsystem.py
@@ -836,7 +836,7 @@ class PluginHandler:
                             rejection_message = f"Missing {arg} argument"
                             break
 
-                        if "|" not in arg:
+                        if num_args <= i or "|" not in arg:
                             continue
 
                         choices = arg[1:-1].split("|")


### PR DESCRIPTION
+ Fixed: An IndexError is encountered if the final or only argument in `usage` is an [optional] choice but no choice is entered.

The intention is to allow the possibility for a choice argument to be optional, but a crash occurs.

Allow usage, for example `"[option2|option3]"` (where implicit 'option1' is considered to be the default if no choice is entered).

If a positional required argument is missing then it will be already be picked up by the "Missing {arg} argument" condition.
