### PR TITLE
portmapper.py: repeat NAT-PMP requests with increasing timeout

### DIFF
--- a/pynicotine/portmapper.py
+++ b/pynicotine/portmapper.py
@@ -129,9 +129,8 @@ class NATPMP(BaseImplementation):
             sock.bind((self.local_ip_address, 0))
             request = self.PortmapRequest(public_port, private_port, lease_duration)
             timeout = self.REQUEST_INIT_TIMEOUT
-            i = 1
 
-            while i <= self.REQUEST_ATTEMPTS:
+            for i in range(1, self.REQUEST_ATTEMPTS + 1):
                 sock.settimeout(timeout)
                 request.sendto(sock, self._gateway_address, self.REQUEST_PORT, i)
 
@@ -141,7 +140,6 @@ class NATPMP(BaseImplementation):
 
                 except socket.timeout:
                     timeout *= 2
-                    i += 1
 
         log.add_debug(f"NAT-PMP: Giving up, all {self.REQUEST_ATTEMPTS} portmap requests timed out")
 

--- a/pynicotine/portmapper.py
+++ b/pynicotine/portmapper.py
@@ -85,10 +85,10 @@ class NATPMP(BaseImplementation):
             self._private_port = private_port
             self._lease_duration = lease_duration
 
-        def sendto(self, sock, addr, port, num_attempt):
+        def sendto(self, sock, addr, num_attempt):
 
             msg = bytes(self)
-            sock.sendto(msg, (addr, port))
+            sock.sendto(msg, addr)
 
             log.add_debug(f"NAT-PMP: Portmap request attempt {num_attempt} of {NATPMP.REQUEST_ATTEMPTS}: {msg}")
 
@@ -132,7 +132,7 @@ class NATPMP(BaseImplementation):
 
             for i in range(1, self.REQUEST_ATTEMPTS + 1):
                 sock.settimeout(timeout)
-                request.sendto(sock, self._gateway_address, self.REQUEST_PORT, i)
+                request.sendto(sock, (self._gateway_address, self.REQUEST_PORT), i)
 
                 try:
                     response = self.PortmapResponse(message=sock.recv(16))

--- a/pynicotine/portmapper.py
+++ b/pynicotine/portmapper.py
@@ -51,9 +51,9 @@ class NATPMP(BaseImplementation):
 
     NAME = "NAT-PMP"
     REQUEST_PORT = 5351
+    REQUEST_ATTEMPTS = 2  # spec says 9, but 2 should be enough
+    REQUEST_INIT_TIMEOUT = 0.250  # seconds
     SUCCESS_RESULT = 0
-    REQUEST_ATTEMPTS = 2 # spec says 9, but 2 should be enough
-    REQUEST_INIT_TIMEOUT = 0.250 # seconds
 
     class PortmapResponse:
 

--- a/pynicotine/portmapper.py
+++ b/pynicotine/portmapper.py
@@ -85,10 +85,10 @@ class NATPMP(BaseImplementation):
             self._private_port = private_port
             self._lease_duration = lease_duration
 
-        def sendto(self, sock, addr, num_attempt):
+        def sendto(self, sock, addr, port, num_attempt):
 
             msg = bytes(self)
-            sock.sendto(msg, addr)
+            sock.sendto(msg, (addr, port))
 
             log.add_debug(f"NAT-PMP: Portmap request attempt {num_attempt} of {NATPMP.REQUEST_ATTEMPTS}: {msg}")
 
@@ -133,7 +133,7 @@ class NATPMP(BaseImplementation):
 
             while i <= self.REQUEST_ATTEMPTS:
                 sock.settimeout(timeout)
-                request.sendto(sock, (self._gateway_address, self.REQUEST_PORT), i)
+                request.sendto(sock, self._gateway_address, self.REQUEST_PORT, i)
 
                 try:
                     response = self.PortmapResponse(message=sock.recv(16))


### PR DESCRIPTION
As per discussion in #2408, *send with retry* mechanism was implemented for NAT-PMP port-mapping requests. The maximum number of retry attempts was set to 2, which should be enough (the spec says 9).