### PR TITLE
gtkgui/search.py: use correct fullpath column index

### DIFF
--- a/pynicotine/gtkgui/search.py
+++ b/pynicotine/gtkgui/search.py
@@ -1276,7 +1276,7 @@ class Search:
         selected_length = 0
 
         for iterator in self.selected_results.values():
-            virtual_path = self.resultsmodel.get_value(iterator, 11)
+            virtual_path = self.resultsmodel.get_value(iterator, 12)
             directory, filename = virtual_path.rsplit("\\", 1)
             file_size = self.resultsmodel.get_value(iterator, 14)
             selected_size += file_size


### PR DESCRIPTION
Resolve #2415.
Commit [d14494ac](https://github.com/nicotine-plus/nicotine-plus/commit/d14494ac316f3813abdc835df6ac2e5187c306ce) introduced a new column -- file type icon, which shifted some columns, changing their index. Therefore, the `fullpath` column is now at `12`. This change was reflect in a number of places in the code, but the one causing this bug was missed.