### PR TITLE
treeview.py: new expand_root_rows() method implemented for Browse Shares

### DIFF
--- a/pynicotine/gtkgui/userbrowse.py
+++ b/pynicotine/gtkgui/userbrowse.py
@@ -421,7 +421,7 @@ class UserBrowse:
         if self.expand_button.get_active():
             self.folder_tree_view.expand_all_rows()
         else:
-            self.folder_tree_view.collapse_all_rows()
+            self.folder_tree_view.expand_root_rows()
 
         # Select first row
         self.folder_tree_view.select_row()

--- a/pynicotine/gtkgui/widgets/treeview.py
+++ b/pynicotine/gtkgui/widgets/treeview.py
@@ -487,6 +487,16 @@ class TreeView:
     def collapse_all_rows(self):
         self.widget.collapse_all()
 
+    def expand_root_rows(self):
+
+        model = self.model
+        iterator = model.get_iter_first()
+
+        while iterator:
+            path = model.get_path(iterator)
+            self.widget.expand_to_path(path)
+            iterator = model.iter_next(iterator)
+
     def get_focused_column(self):
         _path, column = self.widget.get_cursor()
         return column.get_title()
@@ -737,7 +747,7 @@ def collapse_treeview(treeview, grouping_mode):
     treeview.collapse_all()
 
     if grouping_mode == "folder_grouping":
-        # Group by folder
+        # Group by folder; expand_root_rows()
 
         model = treeview.get_model()
         iterator = model.get_iter_first()


### PR DESCRIPTION
Resolves https://github.com/nicotine-plus/nicotine-plus/discussions/1881#discussioncomment-3263521

+ Added: Expand into first level upon initial loading of Browse Shares list, instead of fully collapsed.

The required functionality already exists for `"folder_grouping"` view mode, the new method can be used for that as well, as commented in the legacy function.

The Expand / Collapse All button function is unaffected, it is still useful to remember the expand preference if desired.