### PR TITLE
gtkgui/userbrowse.py: remember selection after refresh

### DIFF
--- a/pynicotine/gtkgui/userbrowse.py
+++ b/pynicotine/gtkgui/userbrowse.py
@@ -487,10 +487,12 @@ class UserBrowse:
         iterator = self.file_list_view.iterators.get(filename)
 
         if not iterator:
+            self.folder_tree_view.grab_focus()
             return
 
-        # Scroll to the requested file and grab focus to it
-        self.file_list_view.select_row(iterator, should_expand=True)
+        # Scroll to the requested file
+        self.file_list_view.select_row(iterator)
+        self.file_list_view.grab_focus()
 
     def shared_file_list(self, msg):
 

--- a/pynicotine/gtkgui/userbrowse.py
+++ b/pynicotine/gtkgui/userbrowse.py
@@ -781,7 +781,7 @@ class UserBrowse:
 
     def on_copy_folder_path(self, *_args):
         folder_path = self.get_selected_folder_path()
-        copy_text(f"{self.user}\\{folder_path}")
+        copy_text(folder_path)
 
     def on_copy_dir_url(self, *_args):
         folder_path = self.get_selected_folder_path()
@@ -1048,7 +1048,7 @@ class UserBrowse:
 
     def on_copy_file_path(self, *_args):
         file_path = self.get_selected_file_path()
-        copy_text(f"{self.user}\\{file_path}")
+        copy_text(file_path)
 
     def on_copy_url(self, *_args):
         file_path = self.get_selected_file_path()

--- a/pynicotine/gtkgui/userbrowse.py
+++ b/pynicotine/gtkgui/userbrowse.py
@@ -616,7 +616,7 @@ class UserBrowse:
 
     def get_selected_file_path(self):
         selected_folder = self.get_selected_folder_path()
-        selected_file = next(iter(self.selected_files)) if self.selected_files else ""
+        selected_file = next(iter(self.selected_files), "")
         return f"{selected_folder}{selected_file}"
 
     """ Search """

--- a/pynicotine/gtkgui/widgets/treeview.py
+++ b/pynicotine/gtkgui/widgets/treeview.py
@@ -463,6 +463,7 @@ class TreeView:
 
             if should_expand:
                 self.widget.expand_to_path(path)
+                self.widget.grab_focus()
 
             self.widget.set_cursor(path)
             self.widget.scroll_to_cell(path, column=None, use_align=True, row_align=0.5, col_align=0.5)

--- a/pynicotine/gtkgui/widgets/treeview.py
+++ b/pynicotine/gtkgui/widgets/treeview.py
@@ -463,7 +463,6 @@ class TreeView:
 
             if should_expand:
                 self.widget.expand_to_path(path)
-                self.widget.grab_focus()
 
             self.widget.set_cursor(path)
             self.widget.scroll_to_cell(path, column=None, use_align=True, row_align=0.5, col_align=0.5)


### PR DESCRIPTION
If the file and/or folder still exists in the refreshed shares, then it was frustrating that the selection is lost after doing a refresh operation, because finding the desired item again can be difficult if the shares are large, as there are no location history features.

+ Added: Return to the currently selected location (file and/or folder) after doing a Refresh
+ Changed: Add a trailing slash onto to the end of folder path copy to clipboard string
+ Fixed: Grab the focus onto the relevant list view widget when entering a URL even if the tab is already open

The clipboard copy code is slightly repurposed for this. The new getter functions are designed to be useful for other purposes too, such as for storing location history, status text, tooltips, etc.

If the selected file doesn't exist anymore, then the folder is selected at least. Only a single file selection is recalled (upper-most).