### PR TITLE
gtkgui/userbrowse.py: fix ValueError in browse_queued_path()

### DIFF
--- a/pynicotine/userbrowse.py
+++ b/pynicotine/userbrowse.py
@@ -309,11 +309,22 @@ class UserBrowse:
         import urllib.parse
 
         try:
-            user, file_path = urllib.parse.unquote(url[7:]).split("/", 1)
-            self.browse_user(user, path=file_path.replace("/", "\\"))
+            user, path = urllib.parse.unquote(url[7:]).split("/", 1)
+            split_path = path.split("/")
+
+            # Allow URL to a root share path with no trailing slash
+            file_path = "\\".join(split_path) if len(split_path) >= 2 else f"{split_path[0]}\\"
+
+        except ValueError:
+            # Allow URL with only a username
+            user, file_path = urllib.parse.unquote(url[7:]), None
 
         except Exception:
+            # Unreachable code?
             log.add(_("Invalid Soulseek URL: %s"), url)
+            return
+
+        self.browse_user(user, path=file_path)
 
     def _shared_file_list_response(self, msg):
 


### PR DESCRIPTION
+ Fixed: Crash on entering an invalid Soulseek URL that only contains a root path, for example `slsk://user/folder`

```
Nicotine+ Version: 3.3.0.dev4
GTK Version: 3.24.24
Python Version: 3.9.2 (linux)

Type: <class 'ValueError'>
Value: not enough values to unpack (expected 2, got 1)
Traceback:   File "/home/user/Git/nicotine-plus/pynicotine/gtkgui/application.py", line 783, in on_process_thread_events
    events.process_thread_events()
  File "/home/user/Git/nicotine-plus/pynicotine/events.py", line 256, in process_thread_events
    self.emit(event_name, *args, **kwargs)
  File "/home/user/Git/nicotine-plus/pynicotine/events.py", line 226, in emit
    function(*args, **kwargs)
  File "/home/user/Git/nicotine-plus/pynicotine/gtkgui/userbrowse.py", line 149, in shared_file_list
    page.shared_file_list(msg)
  File "/home/user/Git/nicotine-plus/pynicotine/gtkgui/userbrowse.py", line 501, in shared_file_list
    self.browse_queued_path()
  File "/home/user/Git/nicotine-plus/pynicotine/gtkgui/userbrowse.py", line 476, in browse_queued_path
    folder, filename = self.queued_path.rsplit("\\", 1)
```

```
Nicotine+ Version: 3.2.9
GTK Version: 3.22.11
Python Version: 3.5.3 (default, Nov  4 2021, 15:29:10) 
[GCC 6.3.0 20170516]

Type: <class 'ValueError'>
Value: not enough values to unpack (expected 2, got 1)
Traceback:   File "/home/user/Git/nicotine-plus/3.2.x/pynicotine/gtkgui/userbrowse.py", line 147, in _shared_file_list
    self.pages[user].shared_file_list(msg)
  File "/home/user/Git/nicotine-plus/3.2.x/pynicotine/gtkgui/userbrowse.py", line 523, in shared_file_list
    self.browse_queued_path()
  File "/home/user/Git/nicotine-plus/3.2.x/pynicotine/gtkgui/userbrowse.py", line 493, in browse_queued_path
    folder, filename = self.queued_path.rsplit("\\", 1)
```

or `slsk://user/` will also do it, either text entry or link click handler. -- Edit: Fixed.

@mathiascode Critical Error (master; 3.2.x)