### PR TITLE
userbrowse.py: cleanup browse_local_shares()

### DIFF
--- a/pynicotine/gtkgui/application.py
+++ b/pynicotine/gtkgui/application.py
@@ -625,10 +625,10 @@ class Application:
         core.shares.rescan_shares()
 
     def on_browse_public_shares(self, *_args):
-        core.userbrowse.browse_local_public_shares(new_request=True)
+        core.userbrowse.browse_local_shares(shares_type="normal", new_request=True)
 
     def on_browse_buddy_shares(self, *_args):
-        core.userbrowse.browse_local_buddy_shares(new_request=True)
+        core.userbrowse.browse_local_shares(shares_type="buddy", new_request=True)
 
     def on_load_shares_from_disk_selected(self, selected, _data):
         for filename in selected:

--- a/pynicotine/gtkgui/application.py
+++ b/pynicotine/gtkgui/application.py
@@ -625,10 +625,10 @@ class Application:
         core.shares.rescan_shares()
 
     def on_browse_public_shares(self, *_args):
-        core.userbrowse.browse_local_shares(shares_type="normal", new_request=True)
+        core.userbrowse.browse_local_shares(share_type="normal", new_request=True)
 
     def on_browse_buddy_shares(self, *_args):
-        core.userbrowse.browse_local_shares(shares_type="buddy", new_request=True)
+        core.userbrowse.browse_local_shares(share_type="buddy", new_request=True)
 
     def on_load_shares_from_disk_selected(self, selected, _data):
         for filename in selected:

--- a/pynicotine/shares.py
+++ b/pynicotine/shares.py
@@ -745,13 +745,10 @@ class Shares:
         if self.should_compress_shares:
             self.rescan_shares(init=True, rescan=False)
 
-        if share_type == "normal":
-            return self.compressed_shares_normal
-
         if share_type == "buddy":
             return self.compressed_shares_buddy
 
-        return None
+        return self.compressed_shares_normal
 
     @staticmethod
     def close_shares(share_dbs):

--- a/pynicotine/userbrowse.py
+++ b/pynicotine/userbrowse.py
@@ -72,7 +72,7 @@ class UserBrowse:
         del self.user_shares[user]
         events.emit("user-browse-remove-user", user)
 
-    def parse_local_shares(self, username, msg):
+    def _parse_local_shares(self, username, msg):
         """ Parse a local shares list and show it in the UI """
 
         built = msg.make_network_message()
@@ -81,31 +81,22 @@ class UserBrowse:
 
         events.emit_main_thread("shared-file-list-response", msg)
 
-    def browse_local_public_shares(self, path=None, new_request=None):
-        """ Browse your own public shares """
+    def browse_local_shares(self, path=None, shares_type=None, new_request=False):
+        """ Browse your own shares """
 
         username = config.sections["server"]["login"] or "Default"
 
         if username not in self.user_shares or new_request:
-            msg = core.shares.get_compressed_shares_message("normal")
+            msg = core.shares.get_compressed_shares_message(shares_type)
+
             Thread(
-                target=self.parse_local_shares, args=(username, msg), name="LocalShareParser", daemon=True
+                target=self._parse_local_shares,
+                args=(username, msg),
+                name="LocalShareParser",
+                daemon=True
             ).start()
 
-        self._show_user(username, path=path, local_shares_type="normal")
-
-    def browse_local_buddy_shares(self, path=None, new_request=False):
-        """ Browse your own buddy shares """
-
-        username = config.sections["server"]["login"] or "Default"
-
-        if username not in self.user_shares or new_request:
-            msg = core.shares.get_compressed_shares_message("buddy")
-            Thread(
-                target=self.parse_local_shares, args=(username, msg), name="LocalBuddyShareParser", daemon=True
-            ).start()
-
-        self._show_user(username, path=path, local_shares_type="buddy")
+        self._show_user(username, path=path, local_shares_type=shares_type)
 
     def browse_user(self, username, path=None, local_shares_type=None, new_request=False, switch_page=True):
         """ Browse a user's shares """
@@ -119,11 +110,7 @@ class UserBrowse:
             user_share.clear()
 
         if username == (config.sections["server"]["login"] or "Default"):
-            if local_shares_type == "normal":
-                self.browse_local_public_shares(path, new_request)
-                return
-
-            self.browse_local_buddy_shares(path, new_request)
+            self.browse_local_shares(path, local_shares_type or "buddy", new_request)
             return
 
         self._show_user(username, path=path, switch_page=switch_page)

--- a/pynicotine/userbrowse.py
+++ b/pynicotine/userbrowse.py
@@ -81,22 +81,18 @@ class UserBrowse:
 
         events.emit_main_thread("shared-file-list-response", msg)
 
-    def browse_local_shares(self, path=None, shares_type=None, new_request=False):
+    def browse_local_shares(self, path=None, share_type=None, new_request=False):
         """ Browse your own shares """
 
         username = config.sections["server"]["login"] or "Default"
 
         if username not in self.user_shares or new_request:
-            msg = core.shares.get_compressed_shares_message(shares_type)
-
+            msg = core.shares.get_compressed_shares_message(share_type)
             Thread(
-                target=self._parse_local_shares,
-                args=(username, msg),
-                name="LocalShareParser",
-                daemon=True
+                target=self._parse_local_shares, args=(username, msg), name="LocalShareParser", daemon=True
             ).start()
 
-        self._show_user(username, path=path, local_shares_type=shares_type)
+        self._show_user(username, path=path, local_shares_type=share_type)
 
     def browse_user(self, username, path=None, local_shares_type="buddy", new_request=False, switch_page=True):
         """ Browse a user's shares """

--- a/pynicotine/userbrowse.py
+++ b/pynicotine/userbrowse.py
@@ -98,7 +98,7 @@ class UserBrowse:
 
         self._show_user(username, path=path, local_shares_type=shares_type)
 
-    def browse_user(self, username, path=None, local_shares_type=None, new_request=False, switch_page=True):
+    def browse_user(self, username, path=None, local_shares_type="buddy", new_request=False, switch_page=True):
         """ Browse a user's shares """
 
         if not username:
@@ -110,7 +110,7 @@ class UserBrowse:
             user_share.clear()
 
         if username == (config.sections["server"]["login"] or "Default"):
-            self.browse_local_shares(path, local_shares_type or "buddy", new_request)
+            self.browse_local_shares(path, local_shares_type, new_request)
             return
 
         self._show_user(username, path=path, switch_page=switch_page)


### PR DESCRIPTION
Code cleanup. No functional changes.

userbrowse.py: A single method can handle any local share group without hard-coding the share group name.

shares.py: If the share group name does not exist (for example "public"), then fall back to "normal".