### PR TITLE
core_commands: rescan force rebuild optional choices

### DIFF
--- a/pynicotine/plugins/core_commands/__init__.py
+++ b/pynicotine/plugins/core_commands/__init__.py
@@ -205,7 +205,7 @@ class Plugin(BasePlugin):
                 "callback": self.rescan_command,
                 "description": _("Rescan shares"),
                 "group": _CommandGroup.SHARES,
-                "usage": ["[-force]"]
+                "usage": ["[force|rebuild]"]
             },
             "shares": {
                 "aliases": ["ls"],
@@ -484,8 +484,11 @@ class Plugin(BasePlugin):
     """ Configure Shares """
 
     def rescan_command(self, args, **_unused):
-        force = (args.lstrip("- ") in ("force", "f"))
-        self.core.shares.rescan_shares(force=force)
+
+        rebuild = (args == "rebuild")
+        force = (args == "force") or rebuild
+
+        self.core.shares.rescan_shares(rebuild=rebuild, force=force)
 
     def list_shares_command(self, args, **_unused):
 

--- a/pynicotine/shares.py
+++ b/pynicotine/shares.py
@@ -140,9 +140,9 @@ class Scanner(Process):
             if self.rescan:
                 start_num_folders = len(list(self.share_dbs.get("buddyfiles", {})))
 
-                self.queue.put((_("Rescanning shares…"), None, LogLevel.DEFAULT))
-                self.queue.put((_("%(num)s folders found before rescan, rebuilding…"),
-                               {"num": start_num_folders}, LogLevel.DEFAULT))
+                self.queue.put((_("%(num)s folders found before rescan"), {"num": start_num_folders}, LogLevel.DEFAULT))
+                self.queue.put((_("Rebuilding shares…") if self.rebuild else _("Rescanning shares…"),
+                               None, LogLevel.DEFAULT))
 
                 new_mtimes, new_files, new_streams = self.rescan_dirs("public", rebuild=self.rebuild)
                 _new_mtimes, new_files, _new_streams = self.rescan_dirs("buddy", new_mtimes, new_files,


### PR DESCRIPTION
Provides a workaround for issues like #2447 and #2472 , whereby it is desired to force an entire rebuild of the database regardless of the folder mtimes.

+ Added: Optional `rebuild` choice argument for the /rescan command
+ Changed: Optional `force` flag argument into choice argument
+ Added: New string in shares to log the mode of rescan/rebuild
+ Changed: swap the order of initial log strings, and remove superfluous word from before folder count string.

"rebuild" also implies "force", otherwise if the rescan is interrupted by the Shares Not Available dialog prompt, then the rebuild option flag would be ineffectual.