### PR TITLE
FilePopupMenu: selected files human count and size

### DIFF
--- a/pynicotine/gtkgui/search.py
+++ b/pynicotine/gtkgui/search.py
@@ -59,9 +59,10 @@ from pynicotine.gtkgui.widgets.treeview import show_file_type_tooltip
 from pynicotine.logfacility import log
 from pynicotine.shares import FileTypes
 from pynicotine.utils import factorize
-from pynicotine.utils import humanize
 from pynicotine.utils import human_size
 from pynicotine.utils import human_speed
+from pynicotine.utils import humanize
+from pynicotine.utils import pluralize
 
 
 class Searches(IconNotebook):
@@ -1297,7 +1298,7 @@ class Search:
 
         self.select_results()
         self.populate_popup_menu_users()
-        menu.set_num_selected_files(len(self.selected_results))
+        menu.set_num_selected_files(pluralize(len(self.selected_results), "files-selected"))
 
     def on_browse_folder(self, *_args):
 
@@ -1369,7 +1370,8 @@ class Search:
 
         FolderChooser(
             parent=self.window,
-            title=_("Select Destination Folder for File(s)"),
+            title=(_("Select Destination To Download %(selection)s")
+                   % {"selection": pluralize(len(self.selected_results))}),
             callback=self.on_download_files_to_selected,
             initial_folder=config.sections["transfers"]["downloaddir"]
         ).show()
@@ -1421,7 +1423,7 @@ class Search:
 
         FolderChooser(
             parent=self.window,
-            title=_("Select Destination Folder"),
+            title=_("Select Destination To Download %(selection)s") % {"selection": _("Folder")},
             callback=self.on_download_folders_to_selected,
             initial_folder=config.sections["transfers"]["downloaddir"]
         ).show()

--- a/pynicotine/gtkgui/transferlist.py
+++ b/pynicotine/gtkgui/transferlist.py
@@ -52,6 +52,7 @@ from pynicotine.utils import human_length
 from pynicotine.utils import human_size
 from pynicotine.utils import human_speed
 from pynicotine.utils import humanize
+from pynicotine.utils import pluralize
 
 
 class TransferList:
@@ -784,7 +785,7 @@ class TransferList:
     def on_popup_menu(self, menu, _widget):
 
         self.select_transfers()
-        menu.set_num_selected_files(len(self.selected_transfers))
+        menu.set_num_selected_files(pluralize(len(self.selected_transfers), "files-selected"))
 
         self.populate_popup_menu_users()
 

--- a/pynicotine/gtkgui/widgets/popupmenu.py
+++ b/pynicotine/gtkgui/widgets/popupmenu.py
@@ -323,10 +323,10 @@ class PopupMenu:
 
 class FilePopupMenu(PopupMenu):
 
-    def set_num_selected_files(self, num_files):
+    def set_num_selected_files(self, text):
 
         self.actions["selected_files"].set_enabled(False)
-        self.items["selected_files"].set_label(_("%s File(s) Selected") % num_files)
+        self.items["selected_files"].set_label(text)
         self.model.remove(0)
         self.model.prepend_item(self.items["selected_files"])
 

--- a/pynicotine/utils.py
+++ b/pynicotine/utils.py
@@ -131,6 +131,21 @@ def humanize(number):
     return f"{number:n}"
 
 
+def pluralize(items, item_type="files"):
+    """ Convert a raw numeric digit into a human readable string describing the quantity of items """
+
+    pluralization = {
+        "files": ["0 Files", _("1 File"), _("%s Files")],
+        "files-selected": ["0 Files Selected", _("1 File Selected"), _("%s Files Selected")]
+    }
+    zero, singular, plural = pluralization.get(item_type, ["No Items", "1 Item", "%s Items"])
+
+    if not items:
+        return zero
+
+    return singular if items == 1 else plural % humanize(items)
+
+
 def factorize(filesize, base=1024):
     """ Converts filesize string with a given unit into raw integer size,
         defaults to binary for "k", "m", "g" suffixes (KiB, MiB, GiB) """


### PR DESCRIPTION
+ Added: Display total size of "File Selected" or "Files Selected" in files popup context menus in Browse Shares
+ Added: Display total Files count and size of selected "File" or "Files" in Upload Files To... and Download Files To... dialogs
+ Added: Display total size of "File" or "Files" in folder in Upload Folder To... and Download Folder To... dialogs
+ Added: New strings to implement pluralization for "1 File", "%i Files", "1 File Selected" and "%i Files Selected"
+ Removed: "File(s) Selected" string and several download/upload dialog strings that are not needed any more
+ Fixed: Implementation of `self.selected_folder_size` set to `0` when setting an empty folder

Note: In userbrowse.py `self.selected_folder_size` was already present but was not implemented, as was the case for the stored "filesize" data as values in `self.selected_files`. This PR makes use of those data which already exist, as such there is not much additional processing overhead other than for `sum(self.selected_files.values())` on context menu activate.

Counting files in folders is not implemented because there is not a method to calculate without additional subfolder recursion, and the number displayed would not be clear what selection items it refers to. Rather than count simply "Folder" string is used.

In the search module however, the selected_files data values instead contain `iterator`, storing that data would not seem to be useful in the userbrowse module, but this PR might lead to an inconsistent implementation, because a different approach to display the total size shall be required in search. Never the less, identical strings are designed for flexible use in any case.

The numeric digit is explicitly included in the "1 File" and "1 File Selected" strings in the hope that it will ease translation, but since language pluralization is not my area of expertise, I would appreciate review as to if this approach is suitable or not?

_x Files Selected_
![image](https://user-images.githubusercontent.com/88614182/227773090-6326fce8-3cdd-47f7-b9ee-e29b82d404ea.png)

_1 File Selected_
![image](https://user-images.githubusercontent.com/88614182/227752714-91f0ecf9-ed49-4db7-acce-d3d544a0b380.png)

_Download File(s) To..._
![image](https://user-images.githubusercontent.com/88614182/227766372-2b60aad1-f4a0-4b59-9c7c-8ca27250aca4.png)
![image](https://user-images.githubusercontent.com/88614182/227766400-067c9624-500c-4d42-a71b-018ca86c5016.png)

_Download Folder To..._
![image](https://user-images.githubusercontent.com/88614182/227766426-e83e7002-fa36-43ed-b8bd-8877be7d6766.png)

_Download Folder & Subfolders To..._
![image](https://user-images.githubusercontent.com/88614182/227766451-ec71673c-608c-4dcc-9fa1-695362f9ad01.png)

_Upload File(s) To..._
![image](https://user-images.githubusercontent.com/88614182/227766546-52ea392c-216d-4aa9-bab2-7aa428b227b6.png)

_Upload Folder To..._
![image](https://user-images.githubusercontent.com/88614182/227766496-ac01d6d4-2adc-4b47-aa04-4ca7e30fcd1f.png)

_Upload Folder & Subfolders To..._
![image](https://user-images.githubusercontent.com/88614182/227786793-28fb5ffe-e218-4b9c-a15f-d697a3734dfe.png)
