### PR TITLE
filechooser.py: folder chooser "Select" button label

### DIFF
--- a/pynicotine/gtkgui/widgets/filechooser.py
+++ b/pynicotine/gtkgui/widgets/filechooser.py
@@ -133,6 +133,8 @@ class FolderChooser(FileChooser):
 
         super().__init__(parent, callback, callback_data, title, initial_folder, select_multiple=select_multiple)
 
+        self.file_chooser.set_accept_label(_("_Select"))
+
         if not self.using_new_api:
             self.file_chooser.set_action(Gtk.FileChooserAction.SELECT_FOLDER)
             return


### PR DESCRIPTION
+ Changed: Accept button label "_Open" -> "_Select" when selecting a folder

In all cases the default "Open" label was inappropriate for the folder chooser dialog.

![image](https://user-images.githubusercontent.com/88614182/227796423-19c57930-bb4b-4a3f-9f57-02306dca6cd1.png)

The label setter function should work on both FileChooserNative and FileDialog GTK >= 4.10. Only tested on GTK 3.24.24.