### PR TITLE
gtkgui/search.py: update active filter counter with filter widgets

### DIFF
--- a/pynicotine/gtkgui/search.py
+++ b/pynicotine/gtkgui/search.py
@@ -601,6 +601,8 @@ class Search:
             if presets:
                 widget.set_row_separator_func(self.on_combobox_check_separator)
 
+        self.update_filter_counter(self.active_filter_count)
+
         if self.filters_undo == self.FILTERS_EMPTY:
             tooltip_text = _("Clear Filters")
             icon_name = "edit-clear-symbolic"
@@ -1106,7 +1108,6 @@ class Search:
 
         # Update number of results
         self.update_result_counter()
-        self.update_filter_counter(self.active_filter_count)
 
         if sort_column is not None and sort_type is not None:
             self.resultsmodel.set_sort_column_id(sort_column, sort_type)


### PR DESCRIPTION
Code cleanup, minor performance.

+ Changed: Update number of active filters counter label when the number of active filters change, instead of when the number of visible results change.

+ ~Changed: Render the filter combobox list separator in sequence, while the list is short, before adding filter history items~

The update_filter_counter() call was in the wrong place. While incoming search results are being received or refiltered, the number of visible search results is unrelated to any interactions that would change which result filters are currently active.

~Draft: Slight bug exists where Undo icon does not change to Clear icon if the a filter's most recent history item is selected again.~ _Edit: Turns out that bug existed before and is not caused by this Pr._