### PR TITLE
FilePopupMenu: human count selected files

### DIFF
--- a/pynicotine/gtkgui/widgets/popupmenu.py
+++ b/pynicotine/gtkgui/widgets/popupmenu.py
@@ -32,7 +32,7 @@ from pynicotine.gtkgui.widgets import clipboard
 from pynicotine.gtkgui.widgets.accelerator import Accelerator
 from pynicotine.gtkgui.widgets.dialogs import EntryDialog
 from pynicotine.utils import TRANSLATE_PUNCTUATION
-from pynicotine.utils import pluralize
+from pynicotine.utils import human_count
 
 
 """ Popup/Context Menu """
@@ -327,7 +327,7 @@ class FilePopupMenu(PopupMenu):
     def set_num_selected_files(self, num_files):
 
         self.actions["selected_files"].set_enabled(False)
-        self.items["selected_files"].set_label(pluralize(num_files, "selected_files"))
+        self.items["selected_files"].set_label(human_count(num_files, "selected_files"))
         self.model.remove(0)
         self.model.prepend_item(self.items["selected_files"])
 

--- a/pynicotine/gtkgui/widgets/popupmenu.py
+++ b/pynicotine/gtkgui/widgets/popupmenu.py
@@ -32,6 +32,7 @@ from pynicotine.gtkgui.widgets import clipboard
 from pynicotine.gtkgui.widgets.accelerator import Accelerator
 from pynicotine.gtkgui.widgets.dialogs import EntryDialog
 from pynicotine.utils import TRANSLATE_PUNCTUATION
+from pynicotine.utils import pluralize
 
 
 """ Popup/Context Menu """
@@ -326,7 +327,7 @@ class FilePopupMenu(PopupMenu):
     def set_num_selected_files(self, num_files):
 
         self.actions["selected_files"].set_enabled(False)
-        self.items["selected_files"].set_label(_("%s File(s) Selected") % num_files)
+        self.items["selected_files"].set_label(pluralize(num_files, "selected_files"))
         self.model.remove(0)
         self.model.prepend_item(self.items["selected_files"])
 

--- a/pynicotine/utils.py
+++ b/pynicotine/utils.py
@@ -131,6 +131,15 @@ def humanize(number):
     return f"{number:n}"
 
 
+def pluralize(number, label):
+
+    pluralization = {
+        "selected_files": ["0 Files Selected", _("1 File Selected"), _("%s Files Selected")],
+    }
+
+    return pluralization[label][number] if number < 2 else pluralization[label][2] % humanize(number)
+
+
 def factorize(filesize, base=1024):
     """ Converts filesize string with a given unit into raw integer size,
         defaults to binary for "k", "m", "g" suffixes (KiB, MiB, GiB) """

--- a/pynicotine/utils.py
+++ b/pynicotine/utils.py
@@ -86,6 +86,28 @@ def encode_path(path, prefix=True):
     return path.encode("utf-8")
 
 
+def human_count(number, label):
+
+    pluralization_labels = {
+        "selected_files": ["0 Files Selected", _("1 File Selected"), _("%s Files Selected")],
+    }
+    zero, singular, plural = pluralization_labels.get(label, ["No Items", "Item", "%i Items"])
+
+    if not number:
+        return zero.replace("%s", "0").replace("%i", "0")
+
+    if number == 1:
+        return singular.replace("%s", "1").replace("%i", "1")
+
+    if "%s" in plural:
+        return plural % humanize(number)
+
+    if "%i" in plural:
+        return plural % number
+
+    return plural
+
+
 def human_length(seconds):
 
     minutes, seconds = divmod(int(seconds), 60)
@@ -129,15 +151,6 @@ def human_size(filesize):
 
 def humanize(number):
     return f"{number:n}"
-
-
-def pluralize(number, label):
-
-    pluralization = {
-        "selected_files": ["0 Files Selected", _("1 File Selected"), _("%s Files Selected")],
-    }
-
-    return pluralization[label][number] if number < 2 else pluralization[label][2] % humanize(number)
 
 
 def factorize(filesize, base=1024):


### PR DESCRIPTION
+ Added: "1 File Selected" or "n Files Selected" translatable strings for the file popup menus or any purpose
- Removed: "n File(s) Selected" translatable string

This is an alternative to Pr #2466, this more complex version allows much greater flexibility if a number is specified in any of the translatable strings whether or not a digit is desired, such as "No Files" "%i Folder" or just the word "Subfolders" without a number, for example.

Also humanization of the number can be disabled by using %i instead of %s, and the plural digit can be omitted entirely. _(idea:, perhaps if _number_ is a boolean then the digit replacer could be stripped from the string)_

It is intended for menu items and any other strings which to be available from any part of the program (including headless mode).