### PR TITLE
gtkgui/search.py: correctly Restore/Clear Filters

### DIFF
--- a/pynicotine/gtkgui/search.py
+++ b/pynicotine/gtkgui/search.py
@@ -650,7 +650,6 @@ class Search:
             combobox.get_child().set_text(h_value)
 
         self.populating_filters = False
-        self.filters_undo = self.filters
 
         self.on_refilter()
 
@@ -1620,8 +1619,11 @@ class Search:
             # Filters have not changed, no need to refilter
             return
 
-        if filters not in (self.FILTERS_EMPTY, self.filters_undo):
-            # Filters changed while we had undo history
+        if self.filters and filters == self.FILTERS_EMPTY:
+            # Filters cleared, enable Restore Filters
+            self.filters_undo = self.filters
+        else:
+            # Filters active, enable Clear Filters
             self.filters_undo = self.FILTERS_EMPTY
 
         self.active_filter_count = 0


### PR DESCRIPTION
+ Fixed: Slight bug where Undo icon does not change to Clear icon if a single filter's most recent history item is selected again

The button got confused if the field value is manually set to the same value as is stored in the undo.

This PR simplifies the undo mechanism by consolidating the setting of it into one place. The Restore Filters button now becomes enabled even if the only active filter entry is cleared manually.