### PR TITLE
This formulation is easier to translate.

### DIFF
--- a/pynicotine/gtkgui/userbrowse.py
+++ b/pynicotine/gtkgui/userbrowse.py
@@ -522,8 +522,8 @@ class UserBrowse:
 
         self.retry_button.set_visible(True)
         self.info_bar.show_message(
-            _("Unable to request shared files from user. Either the user is offline, you both have "
-              "a closed listening port, or there's a temporary connectivity issue."),
+            _("Unable to request shared files from user. Either the user is offline, the listening ports "
+              "are closed on both sides, or there is a temporary connectivity issue."),
             message_type=Gtk.MessageType.ERROR
         )
 


### PR DESCRIPTION
The current sentence is hard to properly translate:

> you both have a closed listening port

will result in the following automatic translation:

> Sie haben beide einen geschlossenen Empfangsport

Which doesn't make sense since the translation engine does not understand the difference of you singular and you plural, but:

> the listening ports are closed on both sides

Will result in

> die Empfangsporten sind beidseitig geschlossen

Which is spot on.

I generally would try to avoid `you`, because of this ambiguity. Consider

> Do you really want to clear all uploads?

and the shorter:

> Really clear all uploads?