### PR TITLE
textentry.py: fix chat entry dropdown without tab completion

### DIFF
--- a/pynicotine/gtkgui/chatrooms.py
+++ b/pynicotine/gtkgui/chatrooms.py
@@ -1218,7 +1218,7 @@ class ChatRoom:
 
     def set_completion_list(self, completion_list):
 
-        if not config.sections["words"]["tab"]:
+        if not config.sections["words"]["tab"] and not config.sections["words"]["dropdown"]:
             return
 
         # We want to include users for this room only

--- a/pynicotine/gtkgui/privatechat.py
+++ b/pynicotine/gtkgui/privatechat.py
@@ -564,10 +564,10 @@ class PrivateChat:
 
     def set_completion_list(self, completion_list):
 
-        if not config.sections["words"]["tab"]:
+        if not config.sections["words"]["tab"] and not config.sections["words"]["dropdown"]:
             return
 
-        # Tab-complete the recipient username
+        # We want to include the recipient username
         completion_list.append(self.user)
 
         # No duplicates


### PR DESCRIPTION
+ **Fixed: Possible KeyError crash if a user leaves a joined room after chat completion preferences are altered:**
The KeyError was caused by attempting to remove a non-existant dropdown list item, if the option was previously disabled.

+ **Fixed: Allow chat entry dropdown-completion even if tab-completion is not enabled:**
The dropdown list was prevented from being populated, and thereby was not shown if the 'Enable tab-key completion' config setting was off, yet those two features are supposed to be independent of each-other.