### PR TITLE
config: exact_file_sizes -> file_size_units

### DIFF
--- a/pynicotine/config.py
+++ b/pynicotine/config.py
@@ -404,7 +404,7 @@ class Config:
                 "urgencyhint": True,
                 "file_path_tooltips": True,
                 "reverse_file_paths": True,
-                "exact_file_sizes": False
+                "file_size_units": ""
             },
             "private_rooms": {
                 "rooms": {}
@@ -500,7 +500,8 @@ class Config:
                 "notexists",
                 "roomlistcollapsed",
                 "showaway",
-                "decimalsep"
+                "decimalsep",
+                "exact_file_sizes"  # TODO: remove in 3.3.0 (was only in 3.3.0.dev)
             ),
             "columns": (
                 "downloads",
@@ -729,6 +730,16 @@ class Config:
                         use_speed_limit = "unlimited"
 
                     self.sections[section][option] = use_speed_limit
+                    continue
+
+                # Migrate file size units (TODO: remove as only in 3.3.0.dev)
+                if option == "file_size_units" and section == "ui":
+                    if self.sections[section].get("exact_file_sizes", False):
+                        file_size_units = "B"
+                    else:
+                        file_size_units = ""
+
+                    self.sections[section][option] = file_size_units
                     continue
 
                 # Set default value

--- a/pynicotine/gtkgui/dialogs/preferences.py
+++ b/pynicotine/gtkgui/dialogs/preferences.py
@@ -1468,7 +1468,7 @@ class UserInterfacePage:
             self.color_url_entry,
             self.container,
             self.dark_mode_toggle,
-            self.exact_file_sizes_toggle,
+            self.file_size_units_combobox,
             self.font_browse_button,
             self.font_browse_clear_button,
             self.font_chat_button,
@@ -1568,6 +1568,9 @@ class UserInterfacePage:
             combobox.append("Left", _("Left"))
             combobox.append("Right", _("Right"))
 
+        self.file_size_units_combobox.append("", _("Automatic"))
+        self.file_size_units_combobox.append("B", _("B (Bytes)"))
+
         icon_list = [
             (USER_STATUS_ICON_NAMES[slskmessages.UserStatus.ONLINE], _("Online"), 16, ("colored-icon", "user-status")),
             (USER_STATUS_ICON_NAMES[slskmessages.UserStatus.AWAY], _("Away"), 16, ("colored-icon", "user-status")),
@@ -1630,7 +1633,7 @@ class UserInterfacePage:
                 "browserfont": self.font_browse_button,
 
                 "reverse_file_paths": self.reverse_file_paths_toggle,
-                "exact_file_sizes": self.exact_file_sizes_toggle,
+                "file_size_units": self.file_size_units_combobox,
 
                 "tabmain": self.tab_position_main_combobox,
                 "tabrooms": self.tab_position_chatrooms_combobox,
@@ -1714,7 +1717,7 @@ class UserInterfacePage:
                 "browserfont": self.font_browse_button.get_font(),
 
                 "reverse_file_paths": self.reverse_file_paths_toggle.get_active(),
-                "exact_file_sizes": self.exact_file_sizes_toggle.get_active(),
+                "file_size_units": self.file_size_units_combobox.get_active_id(),
 
                 "tabmain": self.tab_position_main_combobox.get_active_id(),
                 "tabrooms": self.tab_position_chatrooms_combobox.get_active_id(),

--- a/pynicotine/gtkgui/search.py
+++ b/pynicotine/gtkgui/search.py
@@ -705,7 +705,7 @@ class Search:
             directory = "\\".join(fullpath_split)
 
             size = result[2]
-            h_size = humanize(size) if config.sections["ui"]["exact_file_sizes"] else human_size(size)
+            h_size = human_size(size, config.sections["ui"]["file_size_units"])
             h_bitrate, bitrate, h_length, length = slskmessages.FileListMessage.parse_result_bitrate_length(
                 size, result[4])
 

--- a/pynicotine/gtkgui/ui/settings/userinterface.ui
+++ b/pynicotine/gtkgui/ui/settings/userinterface.ui
@@ -872,10 +872,40 @@
               </object>
             </child>
             <child>
-              <object class="GtkCheckButton" id="exact_file_sizes_toggle">
-                <property name="label" translatable="yes">Show exact file sizes (requires a restart)</property>
+              <object class="GtkBox">
                 <property name="visible">True</property>
-                <property name="use-underline">True</property>
+                <property name="spacing">12</property>
+                <property name="orientation">vertical</property>
+                <child>
+                  <object class="GtkBox">
+                    <property name="visible">True</property>
+                    <property name="homogeneous">True</property>
+                    <property name="spacing">12</property>
+                    <child>
+                      <object class="GtkLabel">
+                        <property name="visible">True</property>
+                        <property name="label" translatable="yes">File size units:</property>
+                        <property name="xalign">0</property>
+                        <property name="wrap">True</property>
+                        <property name="wrap-mode">word-char</property>
+                        <property name="mnemonic-widget">file_size_units_combobox</property>
+                      </object>
+                    </child>
+                    <child>
+                      <object class="GtkBox">
+                        <property name="visible">True</property>
+                        <property name="homogeneous">True</property>
+                        <property name="spacing">12</property>
+                        <child>
+                          <object class="GtkComboBoxText" id="file_size_units_combobox">
+                            <property name="visible">True</property>
+                            <property name="valign">center</property>
+                          </object>
+                        </child>
+                      </object>
+                    </child>
+                  </object>
+                </child>
               </object>
             </child>
           </object>

--- a/pynicotine/gtkgui/userbrowse.py
+++ b/pynicotine/gtkgui/userbrowse.py
@@ -590,7 +590,7 @@ class UserBrowse:
 
         for _code, filename, size, _ext, attrs, *_unused in files:
             selected_folder_size += size
-            h_size = humanize(size) if config.sections["ui"]["exact_file_sizes"] else human_size(size)
+            h_size = human_size(size, config.sections["ui"]["file_size_units"])
             h_bitrate, bitrate, h_length, length = slskmessages.FileListMessage.parse_result_bitrate_length(size, attrs)
 
             self.file_list_view.add_row([

--- a/pynicotine/utils.py
+++ b/pynicotine/utils.py
@@ -101,30 +101,33 @@ def human_length(seconds):
     return f"{minutes}:{seconds:02d}"
 
 
-def _human_speed_or_size(unit):
+def _human_speed_or_size(number, unit):
+
+    if unit == "B":  # TODO: == "KiB", MiB", etc
+        return f"{humanize(number)} B"
 
     try:
         for suffix in FILE_SIZE_SUFFIXES:
-            if unit < 1024:
-                if unit > 999:
-                    return f"{unit:.4g} {suffix}"
+            if number < 1024:  # TODO: or suffix == unit:
+                if number > 999:
+                    return f"{number:.4g} {suffix}"
 
-                return f"{unit:.3g} {suffix}"
+                return f"{number:.3g} {suffix}"
 
-            unit /= 1024
+            number /= 1024
 
     except TypeError:
         pass
 
-    return str(unit)
+    return str(number)
 
 
-def human_speed(speed):
-    return _human_speed_or_size(speed) + "/s"
+def human_speed(speed, unit=""):
+    return _human_speed_or_size(speed, unit) + "/s"
 
 
-def human_size(filesize):
-    return _human_speed_or_size(filesize)
+def human_size(filesize, unit=""):
+    return _human_speed_or_size(filesize, unit)
 
 
 def humanize(number):


### PR DESCRIPTION
The proposed config name in https://github.com/nicotine-plus/nicotine-plus/commit/7bb5a123a89b6a522e448165688e244a20fdfd99 #1948 is not future proof.  This PR suggests changing the name and datatype of it to allow for the future implementation of more options other than `True` (Bytes), such as "B", "KiB", "MiB", etc.

+ Changed: `exact_file_sizes` -> `file_size_units` config setting, and change type from bool to str.
+ Changed: Toggle -> ComboBox in Preferences.
+ Added:  temporary migration code `True` -> `"B"` (only needed for 3.3.0 testers).
+ Added: New label and _("Automatic") and _("B (Bytes)") new translatable strings for displaying in UI.

This PR only implements two `""` or `"B"` values in config. Thus, the user functionality is not changed.

![image](https://github.com/nicotine-plus/nicotine-plus/assets/88614182/3ffb0ebc-0e59-467b-9f7b-06b77d7b6754)

If we change this name now then it won't be needed to carry any migration code into stable, because the feature was only recently implemented in 3.3.0.dev. The migration code is temporarily added here for the convenience of testers.

After this PR it would be relatively** simple to implement other file_size_units (and speed units) if and when desired.

** although, suggestions welcome as to how to best do fixed units, see the TODO comment in human_speed_or_size().