### PR TITLE
properly unset chat completion when disabled

### DIFF
--- a/pynicotine/chatrooms.py
+++ b/pynicotine/chatrooms.py
@@ -385,16 +385,19 @@ class ChatRooms:
 
     def update_completions(self):
 
-        self.completion_list = [config.sections["server"]["login"]]
+        if not config.sections["words"]["tab"] and not config.sections["words"]["dropdown"]:
+            self.completion_list = []
+        else:
+            self.completion_list = [config.sections["server"]["login"]]
 
-        if config.sections["words"]["roomnames"]:
-            self.completion_list += self.server_rooms
+            if config.sections["words"]["roomnames"]:
+                self.completion_list += self.server_rooms
 
-        if config.sections["words"]["buddies"]:
-            self.completion_list += list(core.userlist.buddies)
+            if config.sections["words"]["buddies"]:
+                self.completion_list += list(core.userlist.buddies)
 
-        if config.sections["words"]["commands"]:
-            self.completion_list += core.pluginhandler.get_command_list("chatroom")
+            if config.sections["words"]["commands"]:
+                self.completion_list += core.pluginhandler.get_command_list("chatroom")
 
         events.emit("room-completion-list", self.completion_list)
 

--- a/pynicotine/gtkgui/chatrooms.py
+++ b/pynicotine/gtkgui/chatrooms.py
@@ -24,8 +24,6 @@
 
 import os
 
-from locale import strxfrm
-
 from gi.repository import GLib
 from gi.repository import GObject
 from gi.repository import Gtk
@@ -1104,15 +1102,8 @@ class ChatRoom:
 
     def set_completion_list(self, completion_list):
 
-        if not config.sections["words"]["tab"] and not config.sections["words"]["dropdown"]:
-            return
-
-        # We want to include users for this room only
-        if config.sections["words"]["roomusers"]:
+        if completion_list and config.sections["words"]["roomusers"]:
+            # We want to include users for this room only
             completion_list += self.users_list_view.iterators
-
-        # No duplicates
-        completion_list = list(set(completion_list))
-        completion_list.sort(key=strxfrm)
 
         self.chatrooms.completion.set_completion_list(completion_list)

--- a/pynicotine/gtkgui/privatechat.py
+++ b/pynicotine/gtkgui/privatechat.py
@@ -23,8 +23,6 @@
 
 import os
 
-from locale import strxfrm
-
 from gi.repository import GLib
 
 from pynicotine import slskmessages
@@ -498,14 +496,8 @@ class PrivateChat:
 
     def set_completion_list(self, completion_list):
 
-        if not config.sections["words"]["tab"] and not config.sections["words"]["dropdown"]:
-            return
-
-        # Tab-complete the recipient username
-        completion_list.append(self.user)
-
-        # No duplicates
-        completion_list = list(set(completion_list))
-        completion_list.sort(key=strxfrm)
+        if completion_list:
+            # We want to include the recipient username
+            completion_list.append(self.user)
 
         self.chats.completion.set_completion_list(completion_list)

--- a/pynicotine/gtkgui/widgets/textentry.py
+++ b/pynicotine/gtkgui/widgets/textentry.py
@@ -18,6 +18,8 @@
 
 import sys
 
+from locale import strxfrm
+
 from gi.repository import Gtk
 
 from pynicotine import slskmessages
@@ -144,7 +146,7 @@ class ChatCompletion:
 
     def add_completion(self, item):
 
-        if item in self.completions:
+        if self.entry_completion is None or item in self.completions:
             return
 
         if config.sections["words"]["dropdown"]:
@@ -160,7 +162,7 @@ class ChatCompletion:
 
     def remove_completion(self, item):
 
-        iterator = self.completions.pop(item)
+        iterator = self.completions.pop(item, None)
 
         if iterator is not None:
             self.model.remove(iterator)
@@ -178,8 +180,9 @@ class ChatCompletion:
         self.model.clear()
         self.completions.clear()
 
-        if completion_list is None:
-            completion_list = []
+        # No duplicates
+        completion_list = list(set(completion_list))
+        completion_list.sort(key=strxfrm)
 
         for word in completion_list:
             word = str(word)
@@ -191,6 +194,7 @@ class ChatCompletion:
                 iterator = None
 
             else:
+                self.entry_completion = None
                 return
 
             self.completions[word] = iterator

--- a/pynicotine/privatechat.py
+++ b/pynicotine/privatechat.py
@@ -271,15 +271,18 @@ class PrivateChat:
 
     def update_completions(self):
 
-        self.completion_list = [config.sections["server"]["login"]]
+        if not config.sections["words"]["tab"] and not config.sections["words"]["dropdown"]:
+            self.completion_list = []
+        else:
+            self.completion_list = [config.sections["server"]["login"]]
 
-        if config.sections["words"]["roomnames"]:
-            self.completion_list += core.chatrooms.server_rooms
+            if config.sections["words"]["roomnames"]:
+                self.completion_list += core.chatrooms.server_rooms
 
-        if config.sections["words"]["buddies"]:
-            self.completion_list += list(core.userlist.buddies)
+            if config.sections["words"]["buddies"]:
+                self.completion_list += list(core.userlist.buddies)
 
-        if config.sections["words"]["commands"]:
-            self.completion_list += core.pluginhandler.get_command_list("private_chat")
+            if config.sections["words"]["commands"]:
+                self.completion_list += core.pluginhandler.get_command_list("private_chat")
 
         events.emit("private-chat-completion-list", self.completion_list)


### PR DESCRIPTION
+ Fixed: Allow the chat completion to be disabled if both modes are set then unset during the session.
+ Changed: Don't add items to the completions list when user joins room if completions are disabled.
+ Added: Make pop() return None upon removing a non-existent item, because that doesn't happen by default.

If completion was already enabled, then disabling was ineffectual if both modes are toggled off, as in the dropdown still appears and tab completion still happens, because the code in textentry.py to disable it was never reached in this edge case.

This PR allows the clear() code to be reached once after both of the options are unset during the session, or otherwise either need a dedicated clear completions function or to mark the preference label with "(requires a restart)".

Also, there is a performance improvement by not compiling the completion_list if it isn't needed.

----

Marking as draft, too many changes.