### PR TITLE
textentry.py: fix chat remove_completion keyerror

### DIFF
--- a/pynicotine/gtkgui/widgets/textentry.py
+++ b/pynicotine/gtkgui/widgets/textentry.py
@@ -160,7 +160,7 @@ class ChatCompletion:
 
     def remove_completion(self, item):
 
-        iterator = self.completions.pop(item)
+        iterator = self.completions.pop(item, None)
 
         if iterator is not None:
             self.model.remove(iterator)


### PR DESCRIPTION
+ Fixed: Make pop() return None upon removing a non-existent item, because that doesn't happen by default.

_A crash can occur if the network interface goes down and then KeyError is thrown when it comes back up:_
```
Error in sys.excepthook:
Traceback (most recent call last):
  File "/home/user/Git/slook/nicotine-plus/pynicotine/gtkgui/application.py", line 674, in on_process_thread_events
    events.process_thread_events()
  File "/home/user/Git/slook/nicotine-plus/pynicotine/events.py", line 256, in process_thread_events
    self.emit(event_name, *args, **kwargs)
  File "/home/user/Git/slook/nicotine-plus/pynicotine/events.py", line 226, in emit
    function(*args, **kwargs)
  File "/home/user/Git/slook/nicotine-plus/pynicotine/gtkgui/chatrooms.py", line 315, in user_left_room
    page.user_left_room(msg)
  File "/home/user/Git/slook/nicotine-plus/pynicotine/gtkgui/chatrooms.py", line 908, in user_left_room
    self.chatrooms.completion.remove_completion(username)
  File "/home/user/Git/slook/nicotine-plus/pynicotine/gtkgui/widgets/textentry.py", line 163, in remove_completion
    iterator = self.completions.pop(item)
KeyError: 'username-in-chatroom'
```

This PR avoids the crash, but it doesn't prevent the error state from arising in the first place.

I think the problem might happen whenever the network is unreachable for a shorter time than it takes for the proto thread to realize that the connection is dead, such that a (re)connect is attempted without having any chance to do a graceful disconnect.

Crash seemed more likely if the uplink is removed outside of the machine, such as a router dropping out or mobile signal being lost shortly during the time a chat room user went offline.