### PR TITLE
iconnotebook.py: tab highlight is_important fix priority

### DIFF
--- a/pynicotine/gtkgui/widgets/iconnotebook.py
+++ b/pynicotine/gtkgui/widgets/iconnotebook.py
@@ -169,15 +169,14 @@ class TabLabel:
 
     def request_changed(self, is_important=False):
 
-        self.remove_changed()
-
-        # Chat mentions have priority over normal notifications
-        if not self.is_important:
-            self.is_important = is_important
-
-        if self.is_important:
+        if is_important or self.is_important:
+            # Chat mentions have priority until manually cleared
+            self.remove_changed()
+            self.is_important = True
             add_css_class(self.container, "notebook-tab-highlight")
         else:
+            # Normal notification
+            self.remove_changed()
             add_css_class(self.container, "notebook-tab-changed")
 
         add_css_class(self.container, "bold")


### PR DESCRIPTION
+ Fixed: logic error where `self.is_important` set itself back to False without being manually cleared by the user.

Chat room mentions could be overridden by a normal message, because remove_changed() was called too early, such that only the top-level tab retained the proper highlight, thereby after some time making it impossible to see which room the mention was in.

Regression possibly since a5d0e334bf although it was already even more confusing before that... the saga continues.