### PR TITLE
ChatView: new get_line_tag() method

### DIFF
--- a/pynicotine/gtkgui/chatrooms.py
+++ b/pynicotine/gtkgui/chatrooms.py
@@ -809,16 +809,9 @@ class ChatRoom:
         login_username = core.login_username
         text = msg.msg
         room = msg.room
+        tag = self.chat_view.get_line_tag(user, text, login_username)
 
-        if user == login_username:
-            tag = self.chat_view.tag_local
-        elif self.chat_view.find_whole_word(login_username.lower(), text.lower()) > -1:
-            tag = self.chat_view.tag_highlight
-        else:
-            tag = self.chat_view.tag_remote
-
-        if text.startswith("/me "):
-            tag = self.chat_view.tag_action
+        if tag == self.chat_view.tag_action:
             line = f"* {user} {text[4:]}"
             speech = line[2:]
         else:

--- a/pynicotine/gtkgui/privatechat.py
+++ b/pynicotine/gtkgui/privatechat.py
@@ -409,16 +409,15 @@ class PrivateChat:
         newmessage = msg.newmessage
         timestamp = msg.timestamp if not newmessage else None
         usertag = self.chat_view.get_user_tag(self.user)
+        tag = self.chat_view.get_line_tag(self.user, text, core.login_username)
 
         self.show_notification(text)
 
-        if text.startswith("/me "):
+        if tag == self.chat_view.tag_action:
             line = f"* {self.user} {text[4:]}"
-            tag = self.chat_view.tag_action
             speech = line[2:]
         else:
             line = f"[{self.user}] {text}"
-            tag = self.chat_view.tag_remote
             speech = text
 
         timestamp_format = config.sections["logging"]["private_timestamp"]
@@ -466,13 +465,12 @@ class PrivateChat:
     def send_message(self, text):
 
         my_username = core.login_username
+        tag = self.chat_view.get_line_tag(my_username, text)
 
-        if text.startswith("/me "):
+        if tag == self.chat_view.tag_action:
             line = f"* {my_username} {text[4:]}"
-            tag = self.chat_view.tag_action
         else:
             line = f"[{my_username}] {text}"
-            tag = self.chat_view.tag_local
 
         self.chat_view.append_line(line, tag=tag, timestamp_format=config.sections["logging"]["private_timestamp"],
                                    username=my_username, usertag=self.chat_view.get_user_tag(my_username))

--- a/pynicotine/gtkgui/widgets/textview.py
+++ b/pynicotine/gtkgui/widgets/textview.py
@@ -358,7 +358,7 @@ class ChatView(TextView):
         self.tag_users = {}
 
     @staticmethod
-    def find_whole_word(word, text, after=0):
+    def find_whole_word(word, text):
         """ Returns start position of a whole word that is not in a subword """
 
         if word not in text:
@@ -366,7 +366,7 @@ class ChatView(TextView):
 
         word_boundaries = [" "] + PUNCTUATION
         whole = False
-        start = 0
+        start = after = 0
 
         while not whole and start > -1:
             start = text.find(word, after)
@@ -401,14 +401,8 @@ class ChatView(TextView):
                         user = line[start:end]
                         usertag = self.get_user_tag(user)
 
-                        if user == login:
-                            tag = self.tag_local
-
-                        elif self.find_whole_word(login.lower(), line.lower(), after=end) > -1:
-                            tag = self.tag_highlight
-
-                        else:
-                            tag = self.tag_remote
+                        text = line[end + 2:-1]
+                        tag = self.get_line_tag(user, text, login)
 
                 elif "* " in line:
                     tag = self.tag_action
@@ -421,6 +415,19 @@ class ChatView(TextView):
             if lines:
                 self.append_line(_("--- old messages above ---"), tag=self.tag_highlight,
                                  timestamp_format=timestamp_format)
+
+    def get_line_tag(self, user, text, login=None):
+
+        if text.startswith("/me "):
+            return self.tag_action
+
+        if user == login:
+            return self.tag_local
+
+        if login and self.find_whole_word(login.lower(), text.lower()) > -1:
+            return self.tag_highlight
+
+        return self.tag_remote
 
     def get_user_tag(self, username):
 


### PR DESCRIPTION
Since https://github.com/nicotine-plus/nicotine-plus/commit/af9d32cbcceab8b8d3ff499ea9f0a9f61b153e1d the private chat log file readback now has highlighted mentions but incomming new messages don't.

+ Added: private chat mention tag line highlighting for incoming new messages, as well as log file readback.
+ Fixed: Mention of login username in chat failed to highlight during log file readback if mentioned at end of line.
+ Changed: code cleanup, attempt to reduce complexity of chat line tag assignment logic.

The addition of mention highlights in private chats was incidental to the unification of log file readback, however it may be considered useful perhaps to signal priority importance by enabling a caller to set the is_important tab icon urgency hint.