### PR TITLE
config: chatrooms no logging by default

### DIFF
--- a/pynicotine/config.py
+++ b/pynicotine/config.py
@@ -281,7 +281,7 @@ class Config:
                 "private_timestamp": "%Y-%m-%d %H:%M:%S",
                 "log_timestamp": "%Y-%m-%d %H:%M:%S",
                 "privatechat": True,
-                "chatrooms": True,
+                "chatrooms": False,
                 "transfers": False,
                 "debug_file_output": False,
                 "roomlogsdir": os.path.join(log_dir, "rooms"),


### PR DESCRIPTION
The "rooms" setting is sufficient for remembering to log particular chat rooms if desired, otherwise superfluous plain text data (containing massive amounts of spam) is written to disk, perhaps without user knowledge.

+ Changed: `config.defaults["logging"]["chatrooms"] = False`

See discussion #2519 wherein @j-minster raises valid concerns about the nature of plain text data generated by other users who tend to aggressively exercise their right to freedom of speech in the default room, that is persistently written onto local disk by the application.