### PR TITLE
textentry.py: tab completion 1 minimum character required

### DIFF
--- a/pynicotine/gtkgui/widgets/textentry.py
+++ b/pynicotine/gtkgui/widgets/textentry.py
@@ -278,6 +278,9 @@ class ChatCompletion:
         preix = i - last_word_len
 
         if not self.midway_completion:
+            if last_word_len < 1:
+                return False
+
             last_word_lower = last_word.lower()
             self.current_completions = [
                 x for x in self.completions if x.lower().startswith(last_word_lower) and len(x) >= last_word_len


### PR DESCRIPTION
+ Added: Require at least 1 minimum character for tab completion in chat entry

It's never useful to cycle matches with zero characters, and it caused a widget accessibility navigation trap.

Positioning the return condition here still allows the commands (which have a trailing space) to be cycled.