### PR TITLE
iconnotebook.py: prepend_page for global room feed

### DIFF
--- a/pynicotine/gtkgui/chatrooms.py
+++ b/pynicotine/gtkgui/chatrooms.py
@@ -256,8 +256,13 @@ class ChatRooms(IconNotebook):
             return
 
         self.pages[msg.room] = tab = ChatRoom(self, msg.room, msg.users)
+        is_global = (msg.room == core.chatrooms.GLOBAL_ROOM_NAME)
 
-        self.append_page(tab.container, msg.room, focus_callback=tab.on_focus, close_callback=tab.on_leave_room)
+        if is_global:
+            self.prepend_page(tab.container, msg.room, focus_callback=tab.on_focus, close_callback=tab.on_leave_room)
+        else:
+            self.append_page(tab.container, msg.room, focus_callback=tab.on_focus, close_callback=tab.on_leave_room)
+
         tab.set_label(self.get_tab_label_inner(tab.container))
 
         if msg.room in self.autojoin_rooms:
@@ -266,7 +271,7 @@ class ChatRooms(IconNotebook):
             # Did not auto-join room, switch to tab
             core.chatrooms.show_room(msg.room)
 
-        if msg.room == core.chatrooms.GLOBAL_ROOM_NAME:
+        if is_global:
             self.roomlist.toggle_public_feed(True)
             return
 
@@ -367,7 +372,7 @@ class ChatRooms(IconNotebook):
             return
 
         for room in config.sections["server"]["autojoin"]:
-            if isinstance(room, str):
+            if isinstance(room, str) and room not in core.chatrooms.GLOBAL_ROOM_NAME:
                 self.autojoin_rooms.add(room)
 
     def server_disconnect(self, *_args):

--- a/pynicotine/gtkgui/chatrooms.py
+++ b/pynicotine/gtkgui/chatrooms.py
@@ -372,7 +372,7 @@ class ChatRooms(IconNotebook):
             return
 
         for room in config.sections["server"]["autojoin"]:
-            if isinstance(room, str) and room not in core.chatrooms.GLOBAL_ROOM_NAME:
+            if isinstance(room, str) and room != core.chatrooms.GLOBAL_ROOM_NAME:
                 self.autojoin_rooms.add(room)
 
     def server_disconnect(self, *_args):

--- a/pynicotine/gtkgui/widgets/iconnotebook.py
+++ b/pynicotine/gtkgui/widgets/iconnotebook.py
@@ -329,6 +329,10 @@ class IconNotebook:
             tab_label.set_text(tab_label.get_text())
 
     def append_page(self, page, text, focus_callback=None, close_callback=None, full_text=None, user=None):
+        self.insert_page(page, text, focus_callback, close_callback, full_text, user, position=-1)
+
+    def insert_page(self, page, text, focus_callback=None, close_callback=None, full_text=None, user=None,
+                    position=None):
 
         if full_text is None:
             full_text = text
@@ -347,13 +351,20 @@ class IconNotebook:
 
         page.focus_callback = focus_callback
 
-        self.widget.append_page(page, tab_label.container)
+        if position is None:
+            # Open new tab adjacent to current tab
+            position = self.widget.get_current_page() + 1
+
+        self.widget.insert_page(page, tab_label.container, position)
         self.set_tab_reorderable(page, True)
         self.parent.set_visible(True)
 
         if user is not None:
             status = core.user_statuses.get(user, slskmessages.UserStatus.OFFLINE)
             self.set_user_status(page, text, status)
+
+    def prepend_page(self, page, text, focus_callback=None, close_callback=None, full_text=None, user=None):
+        self.insert_page(page, text, focus_callback, close_callback, full_text, user, position=0)
 
     def remove_page(self, page):
 


### PR DESCRIPTION
+ Added: `prepend_page()` It makes sense to open the global room feed chat tab in the first position.
+ Added: `insert_page()` Sometimes it may be useful to open a new tab at a specific position, such as adjacent to current tab.
+ Fixed: Fail to activate new foreground tab if the Public room feed was enabled and is disabled then enabled again.

Since a custom position for the Public chat feed tab cannot be remembered across restarts, this avoids the risk of it getting buried in amongst other open chat tabs. If it is found to be annoying, then the opportunity close it is more easily presented this way, because it will be visible in the same position as it is on startup.

This approach might become more relevant if clickable room name tags as suggested in #2482 are implemented, therin it will be desirable to open a new tab adjacent to the current one.