### PR TITLE
iconnotebook.py: count unread tabs in tooltip text

### DIFF
--- a/pynicotine/gtkgui/widgets/iconnotebook.py
+++ b/pynicotine/gtkgui/widgets/iconnotebook.py
@@ -408,7 +408,7 @@ class IconNotebook:
 
         if self.unread_pages:
             icon_name = "emblem-important-symbolic"
-            tooltip_text = _("Unread Tabs")
+            tooltip_text = f'{len(self.unread_pages)} {_("Unread Tabs")}'
         else:
             icon_name = "pan-down-symbolic"
             tooltip_text = _("All Tabs")


### PR DESCRIPTION
+ Added: Count unread tabs in tooltip text

![image](https://github.com/nicotine-plus/nicotine-plus/assets/88614182/d4a1efc4-d26a-4d9b-9fec-7fd05cbb8f7a)

Ideally the parent top-level tab could acquire the same tooltip text, which would help to determine what the notification is about without the need to activate it.