### PR TITLE
Avoid redundant GetPeerAddress requests to the server

### DIFF
--- a/pynicotine/gtkgui/chatrooms.py
+++ b/pynicotine/gtkgui/chatrooms.py
@@ -610,7 +610,7 @@ class ChatRoom:
 
         username = userdata.username
         status = userdata.status
-        country_code = userdata.country or ""  # country can be None, ensure string is used
+        country_code = core.user_countries.get(username) or userdata.country or ""
         status_icon_name = USER_STATUS_ICON_NAMES.get(status, "")
         flag_icon_name = get_flag_icon_name(country_code)
         h_speed = ""

--- a/pynicotine/gtkgui/dialogs/preferences.py
+++ b/pynicotine/gtkgui/dialogs/preferences.py
@@ -148,7 +148,7 @@ class NetworkPage:
             port_status_text = _("Check Port Status")
 
             self.current_port_label.set_markup(_("<b>%(ip)s</b>, port %(port)s") % {
-                "ip": core.user_ip_address or unknown_label,
+                "ip": core.public_ip_address or unknown_label,
                 "port": core.protothread.listen_port or unknown_label
             })
             self.check_port_status_label.set_markup(f"<a href='{url}' title='{url}'>{port_status_text}</a>")

--- a/pynicotine/gtkgui/userinfo.py
+++ b/pynicotine/gtkgui/userinfo.py
@@ -260,6 +260,11 @@ class UserInfo:
         self.picture_surface = None
         self.indeterminate_progress = True
 
+        country_code = core.user_countries.get(user)
+
+        if country_code:
+            self.user_country(country_code)
+
         # Set up likes list
         self.likes_list_view = TreeView(
             self.window, parent=self.likes_list_container,
@@ -535,7 +540,7 @@ class UserInfo:
         core.privatechat.show_user(self.user)
 
     def on_show_ip_address(self, *_args):
-        core.request_ip_address(self.user)
+        core.request_ip_address(self.user, notify=True)
 
     def on_browse_user(self, *_args):
         core.userbrowse.browse_user(self.user)

--- a/pynicotine/gtkgui/widgets/popupmenu.py
+++ b/pynicotine/gtkgui/widgets/popupmenu.py
@@ -451,7 +451,7 @@ class UserPopupMenu(PopupMenu):
         core.privatechat.show_user(self.user)
 
     def on_show_ip_address(self, *_args):
-        core.request_ip_address(self.user)
+        core.request_ip_address(self.user, notify=True)
 
     def on_user_profile(self, *_args):
         core.userinfo.show_user(self.user)

--- a/pynicotine/networkfilter.py
+++ b/pynicotine/networkfilter.py
@@ -308,7 +308,7 @@ class NetworkFilter:
         if user not in request_list:
             request_list[user] = action
 
-        core.queue.append(slskmessages.GetPeerAddress(user))
+        core.request_ip_address(user)
 
     def _add_user_ip_to_list(self, ip_list, username=None, ip_address=None):
         """ Add the current IP address and username of a user to a list """

--- a/pynicotine/plugins/examplars/port_checker/__init__.py
+++ b/pynicotine/plugins/examplars/port_checker/__init__.py
@@ -20,7 +20,6 @@
 import socket
 import threading
 
-from pynicotine import slskmessages
 from pynicotine.pluginsystem import BasePlugin, ResponseThrottle
 
 
@@ -86,7 +85,7 @@ class Plugin(BasePlugin):
             threading.Thread(target=self.check_port, args=(user, ip_address, port, announce)).start()
         else:
             self.pending_user = user, announce
-            self.core.queue.append(slskmessages.GetPeerAddress(user))
+            self.core.request_ip_address(user)
 
     def check_port(self, user, ip_address, port, announce):
 

--- a/pynicotine/privatechat.py
+++ b/pynicotine/privatechat.py
@@ -234,7 +234,7 @@ class PrivateChat:
             elif not queued_message:
                 # Ask for user's IP address and queue the private message until we receive the address
                 if user not in self.private_message_queue:
-                    core.queue.append(slskmessages.GetPeerAddress(user))
+                    core.request_ip_address(user)
 
                 self.private_message_queue_add(msg)
                 msg.user = None

--- a/pynicotine/userinfo.py
+++ b/pynicotine/userinfo.py
@@ -80,9 +80,6 @@ class UserInfo:
         # Request user interests
         core.queue.append(slskmessages.UserInterests(user))
 
-        # Set user country
-        events.emit("user-country", user, core.get_user_country(user))
-
     def remove_user(self, user):
         self.users.remove(user)
         events.emit("user-info-remove-user", user)

--- a/pynicotine/userlist.py
+++ b/pynicotine/userlist.py
@@ -140,7 +140,9 @@ class UserList:
         if user in self.buddies:
             return
 
-        note = country = ""
+        note = ""
+        country_code = core.user_countries.get(user)
+        country = f"flag_{country_code}" if country_code else ""
         is_trusted = notify_status = is_prioritized = False
         last_seen = "Never seen"
 
@@ -168,8 +170,9 @@ class UserList:
         # Request user status, speed and number of shared files
         core.watch_user(user, force_update=True)
 
-        # Set user country
-        events.emit("user-country", user, core.get_user_country(user))
+        # Request user country
+        if country_code is None:
+            core.request_ip_address(user)
 
     def remove_buddy(self, user):
 


### PR DESCRIPTION
We're now in a position where we can do a better job at avoiding redundant IP address requests to the server, e.g. when joining multiple rooms with overlapping users at once, or a room where several of the members are in our buddy list.

Also fixes an issue where we would keep storing stale IP addresses of room members after leaving a room.