### PR TITLE
preferences.py: fix FontDialogButton AttributeError

### DIFF
--- a/pynicotine/gtkgui/dialogs/preferences.py
+++ b/pynicotine/gtkgui/dialogs/preferences.py
@@ -2784,7 +2784,7 @@ class Preferences(Dialog):
         elif isinstance(widget, Gtk.FontButton):
             widget.set_font("")
 
-        elif isinstance(widget, Gtk.FontDialogButton):
+        elif GTK_API_VERSION >= 4 and GTK_MINOR_VERSION >= 10 and isinstance(widget, Gtk.FontDialogButton):
             widget.set_font_desc(Pango.FontDescription())
 
     @staticmethod
@@ -2846,7 +2846,7 @@ class Preferences(Dialog):
         elif isinstance(widget, FileChooserButton):
             widget.set_path(value)
 
-        elif isinstance(widget, Gtk.FontDialogButton):
+        elif GTK_API_VERSION >= 4 and GTK_MINOR_VERSION >= 10 and isinstance(widget, Gtk.FontDialogButton):
             widget.set_font_desc(Pango.FontDescription.from_string(value))
 
     def set_settings(self):


### PR DESCRIPTION
+ Fixed: AttributeError on Open Preferences (with cog icon button) -> User Interface page -> Close -> Open Preferences...

```
Nicotine+ Version: 3.3.0.dev5
GTK Version: 3.24.24
Python Version: 3.9.2 (linux)

Type: <class 'AttributeError'>
Value: 'gi.repository.Gtk' object has no attribute 'FontDialogButton'
Traceback:   File "/home/user/Git/nicotine-plus/pynicotine/gtkgui/application.py", line 550, in on_configure_chats
    self.on_preferences(page_id="chats")
  File "/home/user/Git/nicotine-plus/pynicotine/gtkgui/application.py", line 372, in on_preferences
    self.preferences.set_settings()
  File "/home/user/Git/nicotine-plus/pynicotine/gtkgui/dialogs/preferences.py", line 2855, in set_settings
    page.set_settings()
  File "/home/user/Git/nicotine-plus/pynicotine/gtkgui/dialogs/preferences.py", line 1810, in set_settings
    self.application.preferences.set_widgets_data(self.options)
  File "/home/user/Git/nicotine-plus/pynicotine/gtkgui/dialogs/preferences.py", line 2762, in set_widgets_data
    self.clear_widget(widget)
  File "/home/user/Git/nicotine-plus/pynicotine/gtkgui/dialogs/preferences.py", line 2787, in clear_widget
    elif isinstance(widget, Gtk.FontDialogButton):
  File "/usr/lib/python3/dist-packages/gi/overrides/__init__.py", line 32, in __getattr__
    return getattr(self._introspection_module, name)
  File "/usr/lib/python3/dist-packages/gi/module.py", line 123, in __getattr__
    raise AttributeError("%r object has no attribute %r" % (
```