### PR TITLE
Modernize message dialogs

### DIFF
--- a/pynicotine/gtkgui/__init__.py
+++ b/pynicotine/gtkgui/__init__.py
@@ -32,11 +32,6 @@ def check_gtk_version(gtk_api_version):
         gtk_api_version = "3"
         pygobject_version = (3, 26, 1)
 
-    if os.getenv("NICOTINE_LIBADWAITA") is None:
-        os.environ["NICOTINE_LIBADWAITA"] = str(int(
-            sys.platform in ("win32", "darwin") or os.environ.get("XDG_SESSION_DESKTOP") == "gnome"
-        ))
-
     try:
         import gi
         gi.check_version(pygobject_version)

--- a/pynicotine/gtkgui/application.py
+++ b/pynicotine/gtkgui/application.py
@@ -36,6 +36,23 @@ from pynicotine.utils import open_uri
 GTK_API_VERSION = Gtk.get_major_version()
 GTK_MINOR_VERSION = Gtk.get_minor_version()
 GTK_GUI_DIR = os.path.normpath(os.path.dirname(os.path.realpath(__file__)))
+LIBADWAITA_API_VERSION = 0
+
+if GTK_API_VERSION >= 4:
+    try:
+        if os.getenv("NICOTINE_LIBADWAITA") is None:
+            os.environ["NICOTINE_LIBADWAITA"] = str(int(
+                sys.platform in ("win32", "darwin") or os.environ.get("XDG_SESSION_DESKTOP") == "gnome"
+            ))
+
+        if os.getenv("NICOTINE_LIBADWAITA") == "1":
+            gi.require_version("Adw", "1")
+
+            from gi.repository import Adw  # pylint: disable=ungrouped-imports
+            LIBADWAITA_API_VERSION = Adw.MAJOR_VERSION
+
+    except (ImportError, ValueError):
+        pass
 
 
 class Application:
@@ -268,13 +285,13 @@ class Application:
 
         remember = dialog.get_option_value()
 
-        if response_id == 2:  # 'Quit'
+        if response_id == "quit":
             if remember:
                 config.sections["ui"]["exitdialog"] = 0
 
             core.quit()
 
-        elif response_id == 3:  # 'Run in Background'
+        elif response_id == "run_background":
             if remember:
                 config.sections["ui"]["exitdialog"] = 2
 
@@ -285,12 +302,19 @@ class Application:
 
         from pynicotine.gtkgui.widgets.dialogs import OptionDialog
 
+        buttons = [
+            ("cancel", _("_No")),
+            ("quit", _("_Quit"))
+        ]
+
+        if self.window.is_visible():
+            buttons.append(("run_background", _("_Run in Background")))
+
         OptionDialog(
             parent=self.window,
             title=_("Quit Nicotine+"),
             message=_("Do you really want to exit?"),
-            second_button=_("_Quit"),
-            third_button=_("_Run in Background") if self.window.is_visible() else None,
+            buttons=buttons,
             option_label=_("Remember choice") if remember else None,
             callback=self.on_confirm_quit_response
         ).show()
@@ -299,12 +323,7 @@ class Application:
         self._instance.quit()
 
     def on_shares_unavailable_response(self, _dialog, response_id, _data):
-
-        if response_id == 2:  # 'Retry'
-            core.shares.rescan_shares()
-
-        elif response_id == 3:  # 'Force Rescan'
-            core.shares.rescan_shares(force=True)
+        core.shares.rescan_shares(force=(response_id == "force_rescan"))
 
     def on_shares_unavailable(self, shares):
 
@@ -320,15 +339,17 @@ class Application:
             title=_("Shares Not Available"),
             message=_("Verify that external disks are mounted and folder permissions are correct."),
             long_message=shares_list_message,
-            first_button=_("_Cancel"),
-            second_button=_("_Retry"),
-            third_button=_("_Force Rescan"),
+            buttons=[
+                ("cancel", _("_Cancel")),
+                ("ok", _("_Retry")),
+                ("force_rescan", _("_Force Rescan"))
+            ],
+            destructive_response_id="force_rescan",
             callback=self.on_shares_unavailable_response
         ).show()
 
-    def on_invalid_password_response(self, _dialog, response_id, _data):
-        if response_id == 2:
-            self.on_preferences(page_id="network")
+    def on_invalid_password_response(self, *_args):
+        self.on_preferences(page_id="network")
 
     def on_invalid_password(self):
 
@@ -342,8 +363,10 @@ class Application:
             parent=self.window,
             title=title,
             message=msg,
-            first_button=_("_Cancel"),
-            second_button=_("Change _Login Details"),
+            buttons=[
+                ("cancel", _("_Cancel")),
+                ("ok", _("Change _Login Details"))
+            ],
             callback=self.on_invalid_password_response
         ).show()
 
@@ -602,7 +625,7 @@ class Application:
 
         loop, error = data
 
-        if response_id == 2:
+        if response_id == "copy_report_bug":
             from pynicotine.gtkgui.widgets import clipboard
 
             clipboard.copy_text(error)
@@ -624,8 +647,10 @@ class Application:
             message=_("Nicotine+ has encountered a critical error and needs to exit. "
                       "Please copy the following message and include it in a bug report:"),
             long_message=error,
-            first_button=_("_Quit Nicotine+"),
-            second_button=_("_Copy & Report Bug"),
+            buttons=[
+                ("quit", _("_Quit Nicotine+")),
+                ("copy_report_bug", _("_Copy & Report Bug"))
+            ],
             callback=self.on_critical_error_response,
             callback_data=(loop, error)
         ).show()

--- a/pynicotine/gtkgui/chatrooms.py
+++ b/pynicotine/gtkgui/chatrooms.py
@@ -138,13 +138,9 @@ class ChatRooms(IconNotebook):
             self.unhighlight_room(room)
             break
 
-    def on_create_room_response(self, dialog, response_id, room):
-
+    def on_create_room_response(self, dialog, _response_id, room):
         private = dialog.get_option_value()
-
-        if response_id == 2:
-            # Create a new room
-            core.chatrooms.show_room(room, private)
+        core.chatrooms.show_room(room, private)
 
     def on_create_room(self, *_args):
 
@@ -1032,12 +1028,11 @@ class ChatRoom:
     def on_view_room_log(self, *_args):
         log.open_log(config.sections["logging"]["roomlogsdir"], self.room)
 
-    def on_delete_room_log_response(self, _dialog, response_id, _data):
+    def on_delete_room_log_response(self, *_args):
 
-        if response_id == 2:
-            log.delete_log(config.sections["logging"]["roomlogsdir"], self.room)
-            self.activity_view.clear()
-            self.chat_view.clear()
+        log.delete_log(config.sections["logging"]["roomlogsdir"], self.room)
+        self.activity_view.clear()
+        self.chat_view.clear()
 
     def on_delete_room_log(self, *_args):
 
@@ -1045,6 +1040,7 @@ class ChatRoom:
             parent=self.window,
             title=_("Delete Logged Messages?"),
             message=_("Do you really want to permanently delete all logged messages for this room?"),
+            destructive_response_id="ok",
             callback=self.on_delete_room_log_response
         ).show()
 

--- a/pynicotine/gtkgui/dialogs/fastconfigure.py
+++ b/pynicotine/gtkgui/dialogs/fastconfigure.py
@@ -207,6 +207,7 @@ class FastConfigure(Dialog):
                 title=_("Edit Shared Folder"),
                 message=_("Enter new virtual name for '%(dir)s':") % {"dir": folder_path},
                 default=virtual_name,
+                action_button_label=_("_Edit"),
                 callback=self.on_edit_shared_folder_response,
                 callback_data=iterator
             ).show()

--- a/pynicotine/gtkgui/dialogs/preferences.py
+++ b/pynicotine/gtkgui/dialogs/preferences.py
@@ -229,6 +229,7 @@ class NetworkPage:
             title=_("Change Password"),
             message=message,
             visibility=False,
+            action_button_label=_("_Change"),
             callback=self.on_change_password_response,
             callback_data=core.user_status
         ).show()
@@ -433,6 +434,7 @@ class DownloadsPage:
             parent=self.application.preferences,
             title=_("Add Download Filter"),
             message=self.filter_syntax_description + "\n\n" + _("Enter a new download filter:"),
+            action_button_label=_("_Add"),
             callback=self.on_add_filter_response,
             option_value=False,
             option_label=_("Enable regular expressions"),
@@ -463,6 +465,7 @@ class DownloadsPage:
                 parent=self.application.preferences,
                 title=_("Edit Download Filter"),
                 message=self.filter_syntax_description + "\n\n" + _("Modify the following download filter:"),
+                action_button_label=_("_Edit"),
                 callback=self.on_edit_filter_response,
                 callback_data=iterator,
                 default=dfilter,
@@ -712,6 +715,7 @@ class SharesPage:
                 default=virtual_name,
                 option_value=is_buddy_only,
                 option_label=_("Share with buddies only"),
+                action_button_label=_("_Edit"),
                 callback=self.on_edit_shared_folder_response,
                 callback_data=iterator
             ).show()
@@ -988,6 +992,7 @@ class IgnoredUsersPage:
             parent=self.application.preferences,
             title=_("Ignore User"),
             message=_("Enter the name of the user you want to ignore:"),
+            action_button_label=_("_Add"),
             callback=self.on_add_ignored_user_response
         ).show()
 
@@ -1017,6 +1022,7 @@ class IgnoredUsersPage:
             parent=self.application.preferences,
             title=_("Ignore IP Address"),
             message=_("Enter an IP address you want to ignore:") + " " + _("* is a wildcard"),
+            action_button_label=_("_Add"),
             callback=self.on_add_ignored_ip_response
         ).show()
 
@@ -1140,6 +1146,7 @@ class BannedUsersPage:
             parent=self.application.preferences,
             title=_("Ban User"),
             message=_("Enter the name of the user you want to ban:"),
+            action_button_label=_("_Add"),
             callback=self.on_add_banned_user_response
         ).show()
 
@@ -1170,6 +1177,7 @@ class BannedUsersPage:
             parent=self.application.preferences,
             title=_("Ban IP Address"),
             message=_("Enter an IP address you want to ban:") + " " + _("* is a wildcard"),
+            action_button_label=_("_Add"),
             callback=self.on_add_banned_ip_response
         ).show()
 
@@ -1396,6 +1404,7 @@ class ChatsPage:
             title=_("Censor Pattern"),
             message=_("Enter a pattern you want to censor. Add spaces around the pattern if you don't "
                       "want to match strings inside words (may fail at the beginning and end of lines)."),
+            action_button_label=_("_Add"),
             callback=self.on_add_censored_response
         ).show()
 
@@ -1422,6 +1431,7 @@ class ChatsPage:
                 title=_("Edit Censored Pattern"),
                 message=_("Enter a pattern you want to censor. Add spaces around the pattern if you don't "
                           "want to match strings inside words (may fail at the beginning and end of lines)."),
+                action_button_label=_("_Edit"),
                 callback=self.on_edit_censored_response,
                 callback_data=iterator,
                 default=pattern
@@ -1453,6 +1463,7 @@ class ChatsPage:
             parent=self.application.preferences,
             title=_("Add Replacement"),
             message=_("Enter a text pattern and what to replace it with:"),
+            action_button_label=_("_Add"),
             callback=self.on_add_replacement_response,
             use_second_entry=True
         ).show()
@@ -1482,6 +1493,7 @@ class ChatsPage:
                 parent=self.application.preferences,
                 title=_("Edit Replacement"),
                 message=_("Enter a text pattern and what to replace it with:"),
+                action_button_label=_("_Edit"),
                 callback=self.on_edit_replacement_response,
                 callback_data=iterator,
                 use_second_entry=True,
@@ -2294,6 +2306,7 @@ class UrlHandlersPage:
             parent=self.application.preferences,
             title=_("Add URL Handler"),
             message=_("Enter the protocol and the command for the URL handler:"),
+            action_button_label=_("_Add"),
             callback=self.on_add_handler_response,
             use_second_entry=True,
             droplist=self.default_protocols,
@@ -2322,6 +2335,7 @@ class UrlHandlersPage:
                 parent=self.application.preferences,
                 title=_("Edit Command"),
                 message=_("Enter a new command for protocol %s:") % protocol,
+                action_button_label=_("_Edit"),
                 callback=self.on_edit_handler_response,
                 callback_data=iterator,
                 droplist=self.default_commands,

--- a/pynicotine/gtkgui/dialogs/statistics.py
+++ b/pynicotine/gtkgui/dialogs/statistics.py
@@ -91,9 +91,8 @@ class Statistics(Dialog):
         if total_value is not None:
             getattr(self, f"{stat_id}_total_label").set_text(total_value)
 
-    def on_reset_statistics_response(self, _dialog, response_id, _data):
-        if response_id == 2:
-            core.statistics.reset_stats()
+    def on_reset_statistics_response(self, *_args):
+        core.statistics.reset_stats()
 
     def on_reset_statistics(self, *_args):
 
@@ -101,6 +100,7 @@ class Statistics(Dialog):
             parent=self,
             title=_("Reset Transfer Statistics?"),
             message=_("Do you really want to reset transfer statistics?"),
+            destructive_response_id="ok",
             callback=self.on_reset_statistics_response
         ).show()
 

--- a/pynicotine/gtkgui/dialogs/wishlist.py
+++ b/pynicotine/gtkgui/dialogs/wishlist.py
@@ -118,6 +118,7 @@ class WishList(Dialog):
                 title=_("Edit Wish"),
                 message=_("Enter new value for wish '%s':") % old_wish,
                 default=old_wish,
+                action_button_label=_("_Edit"),
                 callback=self.on_edit_wish_response,
                 callback_data=old_wish
             ).show()
@@ -132,11 +133,10 @@ class WishList(Dialog):
         self.wish_entry.grab_focus()
         return True
 
-    def clear_wishlist_response(self, _dialog, response_id, _data):
+    def clear_wishlist_response(self, *_args):
 
-        if response_id == 2:
-            for wish in self.list_view.iterators.copy():
-                core.search.remove_wish(wish)
+        for wish in self.list_view.iterators.copy():
+            core.search.remove_wish(wish)
 
         self.wish_entry.grab_focus()
 
@@ -146,6 +146,7 @@ class WishList(Dialog):
             parent=self,
             title=_("Clear Wishlist?"),
             message=_("Do you really want to clear your wishlist?"),
+            destructive_response_id="ok",
             callback=self.clear_wishlist_response
         ).show()
 

--- a/pynicotine/gtkgui/downloads.py
+++ b/pynicotine/gtkgui/downloads.py
@@ -100,9 +100,8 @@ class Downloads(TransferList):
     def clear_selected_transfers(self):
         core.transfers.clear_downloads(downloads=self.selected_transfers)
 
-    def on_clear_queued_response(self, _dialog, response_id, _data):
-        if response_id == 2:
-            core.transfers.clear_downloads(statuses=["Queued"])
+    def on_clear_queued_response(self, *_args):
+        core.transfers.clear_downloads(statuses=["Queued"])
 
     def on_try_clear_queued(self, *_args):
 
@@ -110,12 +109,12 @@ class Downloads(TransferList):
             parent=self.window,
             title=_("Clear Queued Downloads"),
             message=_("Do you really want to clear all queued downloads?"),
+            destructive_response_id="ok",
             callback=self.on_clear_queued_response
         ).show()
 
-    def on_clear_all_response(self, _dialog, response_id, _data):
-        if response_id == 2:
-            core.transfers.clear_downloads()
+    def on_clear_all_response(self, *_args):
+        core.transfers.clear_downloads()
 
     def on_try_clear_all(self, *_args):
 
@@ -123,12 +122,12 @@ class Downloads(TransferList):
             parent=self.window,
             title=_("Clear All Downloads"),
             message=_("Do you really want to clear all downloads?"),
+            destructive_response_id="ok",
             callback=self.on_clear_all_response
         ).show()
 
-    def folder_download_response(self, _dialog, response_id, msg):
-        if response_id == 2:
-            events.emit("folder-contents-response", msg, check_num_files=False)
+    def folder_download_response(self, _dialog, _response_id, msg):
+        events.emit("folder-contents-response", msg, check_num_files=False)
 
     def download_large_folder(self, username, folder, numfiles, msg):
 

--- a/pynicotine/gtkgui/privatechat.py
+++ b/pynicotine/gtkgui/privatechat.py
@@ -367,12 +367,11 @@ class PrivateChat:
     def on_view_chat_log(self, *_args):
         log.open_log(config.sections["logging"]["privatelogsdir"], self.user)
 
-    def on_delete_chat_log_response(self, _dialog, response_id, _data):
+    def on_delete_chat_log_response(self, *_args):
 
-        if response_id == 2:
-            log.delete_log(config.sections["logging"]["privatelogsdir"], self.user)
-            self.chats.history.remove_user(self.user)
-            self.chat_view.clear()
+        log.delete_log(config.sections["logging"]["privatelogsdir"], self.user)
+        self.chats.history.remove_user(self.user)
+        self.chat_view.clear()
 
     def on_delete_chat_log(self, *_args):
 
@@ -380,6 +379,7 @@ class PrivateChat:
             parent=self.window,
             title=_("Delete Logged Messages?"),
             message=_("Do you really want to permanently delete all logged messages for this user?"),
+            destructive_response_id="ok",
             callback=self.on_delete_chat_log_response
         ).show()
 

--- a/pynicotine/gtkgui/uploads.py
+++ b/pynicotine/gtkgui/uploads.py
@@ -99,9 +99,8 @@ class Uploads(TransferList):
     def clear_selected_transfers(self):
         core.transfers.clear_uploads(uploads=self.selected_transfers)
 
-    def on_clear_queued_response(self, _dialog, response_id, _data):
-        if response_id == 2:
-            core.transfers.clear_uploads(statuses=["Queued"])
+    def on_clear_queued_response(self, *_args):
+        core.transfers.clear_uploads(statuses=["Queued"])
 
     def on_try_clear_queued(self, *_args):
 
@@ -109,12 +108,12 @@ class Uploads(TransferList):
             parent=self.window,
             title=_("Clear Queued Uploads"),
             message=_("Do you really want to clear all queued uploads?"),
+            destructive_response_id="ok",
             callback=self.on_clear_queued_response
         ).show()
 
-    def on_clear_all_response(self, _dialog, response_id, _data):
-        if response_id == 2:
-            core.transfers.clear_uploads()
+    def on_clear_all_response(self, *_args):
+        core.transfers.clear_uploads()
 
     def on_try_clear_all(self, *_args):
 
@@ -122,6 +121,7 @@ class Uploads(TransferList):
             parent=self.window,
             title=_("Clear All Uploads"),
             message=_("Do you really want to clear all uploads?"),
+            destructive_response_id="ok",
             callback=self.on_clear_all_response
         ).show()
 

--- a/pynicotine/gtkgui/userbrowse.py
+++ b/pynicotine/gtkgui/userbrowse.py
@@ -776,6 +776,7 @@ class UserBrowse:
             parent=self.window,
             title=str_title,
             message=_("Enter the name of the user you want to upload to:"),
+            action_button_label=_("_Upload"),
             callback=self.on_upload_directory_to_response,
             callback_data=recurse,
             droplist=sorted(core.userlist.buddies, key=strxfrm)
@@ -981,6 +982,7 @@ class UserBrowse:
             parent=self.window,
             title=_("Upload File(s) To User"),
             message=_("Enter the name of the user you want to upload to:"),
+            action_button_label=_("_Upload"),
             callback=self.on_upload_files_response,
             droplist=sorted(core.userlist.buddies, key=strxfrm)
         ).show()

--- a/pynicotine/gtkgui/userlist.py
+++ b/pynicotine/gtkgui/userlist.py
@@ -421,6 +421,7 @@ class UserList:
             parent=self.window,
             title=_("Add User Note"),
             message=_("Add a note about user %s:") % user,
+            action_button_label=_("_Add"),
             callback=self.on_add_note_response,
             callback_data=user,
             default=note

--- a/pynicotine/gtkgui/widgets/iconnotebook.py
+++ b/pynicotine/gtkgui/widgets/iconnotebook.py
@@ -375,13 +375,12 @@ class IconNotebook:
         if self.get_n_pages() == 0:
             self.parent.set_visible(False)
 
-    def remove_all_pages_response(self, dialog, response_id, _data):
+    def remove_all_pages_response(self, dialog, _response_id, _data):
 
-        if response_id == 2:
-            for i in reversed(range(self.get_n_pages())):
-                page = self.get_nth_page(i)
-                tab_label = self.get_tab_label(page)
-                tab_label.close_callback(dialog)
+        for i in reversed(range(self.get_n_pages())):
+            page = self.get_nth_page(i)
+            tab_label = self.get_tab_label(page)
+            tab_label.close_callback(dialog)
 
     def remove_all_pages(self):
 
@@ -389,6 +388,7 @@ class IconNotebook:
             parent=self.window,
             title=_("Close All Tabs?"),
             message=_("Do you really want to close all tabs?"),
+            destructive_response_id="ok",
             callback=self.remove_all_pages_response
         ).show()
 

--- a/pynicotine/gtkgui/widgets/popupmenu.py
+++ b/pynicotine/gtkgui/widgets/popupmenu.py
@@ -571,5 +571,6 @@ class UserPopupMenu(PopupMenu):
             parent=self.application.window,
             title=_("Gift Privileges"),
             message=message,
+            action_button_label=_("_Give Privileges"),
             callback=self.on_give_privileges_response
         ).show()

--- a/pynicotine/gtkgui/widgets/theme.py
+++ b/pynicotine/gtkgui/widgets/theme.py
@@ -29,6 +29,7 @@ from pynicotine import slskmessages
 from pynicotine.config import config
 from pynicotine.gtkgui.application import GTK_API_VERSION
 from pynicotine.gtkgui.application import GTK_GUI_DIR
+from pynicotine.gtkgui.application import LIBADWAITA_API_VERSION
 from pynicotine.logfacility import log
 from pynicotine.shares import FileTypes
 from pynicotine.utils import encode_path
@@ -37,21 +38,9 @@ from pynicotine.utils import encode_path
 """ Global Style """
 
 
-LIBADWAITA = None
-try:
-    if os.getenv("NICOTINE_LIBADWAITA") == "1":
-        import gi
-        gi.require_version("Adw", "1")
-
-        from gi.repository import Adw
-        LIBADWAITA = Adw
-
-except (ImportError, ValueError):
-    pass
-
 CUSTOM_CSS_PROVIDER = Gtk.CssProvider()
 GTK_SETTINGS = Gtk.Settings.get_default()
-USE_COLOR_SCHEME_PORTAL = (sys.platform not in ("win32", "darwin") and not LIBADWAITA)
+USE_COLOR_SCHEME_PORTAL = (sys.platform not in ("win32", "darwin") and not LIBADWAITA_API_VERSION)
 
 if USE_COLOR_SCHEME_PORTAL:
     # GNOME 42+ system-wide dark mode for GTK without libadwaita
@@ -105,9 +94,11 @@ if USE_COLOR_SCHEME_PORTAL:
 
 def set_dark_mode(enabled):
 
-    if LIBADWAITA:
-        color_scheme = LIBADWAITA.ColorScheme.FORCE_DARK if enabled else LIBADWAITA.ColorScheme.DEFAULT
-        LIBADWAITA.StyleManager.get_default().set_color_scheme(color_scheme)
+    if LIBADWAITA_API_VERSION:
+        from gi.repository import Adw  # pylint: disable=no-name-in-module
+
+        color_scheme = Adw.ColorScheme.FORCE_DARK if enabled else Adw.ColorScheme.DEFAULT
+        Adw.StyleManager.get_default().set_color_scheme(color_scheme)
         return
 
     if USE_COLOR_SCHEME_PORTAL and not enabled:

--- a/pynicotine/gtkgui/widgets/trayicon.py
+++ b/pynicotine/gtkgui/widgets/trayicon.py
@@ -219,6 +219,7 @@ class BaseImplementation:
             parent=self.application.window,
             title=_("Start Messaging"),
             message=_("Enter the name of the user whom you want to send a message:"),
+            action_button_label=_("_Message"),
             callback=self.on_open_private_chat_response,
             droplist=sorted(core.userlist.buddies, key=strxfrm)
         ).show()
@@ -239,6 +240,7 @@ class BaseImplementation:
             parent=self.application.window,
             title=_("View User Profile"),
             message=_("Enter the name of the user whose profile you want to see:"),
+            action_button_label=_("_View Profile"),
             callback=self.on_get_a_users_info_response,
             droplist=sorted(core.userlist.buddies, key=strxfrm)
         ).show()
@@ -259,6 +261,7 @@ class BaseImplementation:
             parent=self.application.window,
             title=_("Browse Shares"),
             message=_("Enter the name of the user whose shares you want to see:"),
+            action_button_label=_("_Browse"),
             callback=self.on_get_a_users_shares_response,
             droplist=sorted(core.userlist.buddies, key=strxfrm)
         ).show()


### PR DESCRIPTION
- Use Adw.MessageDialog instead of deprecated Gtk.MessageDialog when libadwaita is enabled
- Use clearer labels for affirmative buttons according to GNOME HIG
- Add support for suggested/destructive buttons
- Make affirmative buttons activate by default according to GNOME HIG
- Stop using deprecated Gtk.ResponseType when possible
- Various API cleanups