### PR TITLE
ChatView: cleanup open read_room_logs

### DIFF
--- a/pynicotine/gtkgui/chatrooms.py
+++ b/pynicotine/gtkgui/chatrooms.py
@@ -651,19 +651,12 @@ class ChatRoom:
     def read_room_logs(self):
 
         numlines = config.sections["logging"]["readroomlines"]
-
-        if not numlines:
-            return
-
         filename = f"{clean_file(self.room)}.log"
         path = os.path.join(config.sections["logging"]["roomlogsdir"], filename)
 
-        try:
-            self.chat_view.append_log_lines(
-                path, numlines, timestamp_format=config.sections["logging"]["rooms_timestamp"]
-            )
-        except OSError:
-            pass
+        self.chat_view.append_log_lines(
+            path, numlines, timestamp_format=config.sections["logging"]["rooms_timestamp"]
+        )
 
     def populate_user_menu(self, user, menu, menu_private_rooms):
 

--- a/pynicotine/gtkgui/privatechat.py
+++ b/pynicotine/gtkgui/privatechat.py
@@ -319,19 +319,12 @@ class PrivateChat:
     def read_private_log(self):
 
         numlines = config.sections["logging"]["readprivatelines"]
-
-        if not numlines:
-            return
-
         filename = f"{clean_file(self.user)}.log"
         path = os.path.join(config.sections["logging"]["privatelogsdir"], filename)
 
-        try:
-            self.chat_view.append_log_lines(
-                path, numlines, timestamp_format=config.sections["logging"]["private_timestamp"]
-            )
-        except OSError:
-            pass
+        self.chat_view.append_log_lines(
+            path, numlines, timestamp_format=config.sections["logging"]["private_timestamp"]
+        )
 
     def server_disconnect(self):
         self.offline_message = False


### PR DESCRIPTION
Code cleanup/optimization (no functional changes)...

+ Refactor with block, only keep file open for as long as needed to deque lines.
+ Don't wrap the getting of user tags, url tags, inserting text and other functions within try/except OSError block.

The only purpose of catching the OSError is in case the log file does not exist, no point including all the other calls within it.