### PR TITLE
Normalize all incoming file paths

### DIFF
--- a/pynicotine/config.py
+++ b/pynicotine/config.py
@@ -91,7 +91,7 @@ class Config:
 
         if sys.platform == "win32":
             try:
-                data_dir = os.path.join(os.environ["APPDATA"], "nicotine")
+                data_dir = os.path.join(os.path.normpath(os.environ["APPDATA"]), "nicotine")
             except KeyError:
                 data_dir, _filename = os.path.split(sys.argv[0])
 
@@ -99,7 +99,6 @@ class Config:
             return config_dir, data_dir
 
         home = os.path.expanduser("~")
-
         legacy_dir = os.path.join(home, ".nicotine")
 
         if os.path.isdir(legacy_dir.encode("utf-8")):
@@ -107,7 +106,6 @@ class Config:
 
         def xdg_path(xdg, default):
             path = os.environ.get(xdg)
-
             path = path.split(":")[0] if path else default
 
             return os.path.join(path, "nicotine")

--- a/pynicotine/gtkgui/dialogs/fastconfigure.py
+++ b/pynicotine/gtkgui/dialogs/fastconfigure.py
@@ -153,8 +153,7 @@ class FastConfigure(Dialog):
             self.rescan_required = True
 
             virtual_name = core.shares.get_normalized_virtual_name(
-                os.path.basename(os.path.normpath(folder_path)),
-                shared_folders=(shared_folders + buddy_shared_folders)
+                os.path.basename(folder_path), shared_folders=(shared_folders + buddy_shared_folders)
             )
             mapping = (virtual_name, folder_path)
 
@@ -307,6 +306,5 @@ class FastConfigure(Dialog):
 
         self.shares_list_view.clear()
 
-        for entry in config.sections["transfers"]["shared"]:
-            virtual_name, path = entry
-            self.shares_list_view.add_row([str(virtual_name), str(path)], select_row=False)
+        for virtual_name, folder_path, *_unused in config.sections["transfers"]["shared"]:
+            self.shares_list_view.add_row([str(virtual_name), os.path.normpath(folder_path)], select_row=False)

--- a/pynicotine/gtkgui/dialogs/preferences.py
+++ b/pynicotine/gtkgui/dialogs/preferences.py
@@ -601,11 +601,13 @@ class SharesPage:
 
         for virtual_name, folder_path, *_unused in self.buddy_shared_folders:
             is_buddy_only = True
-            self.shares_list_view.add_row([str(virtual_name), str(folder_path), is_buddy_only], select_row=False)
+            self.shares_list_view.add_row(
+                [str(virtual_name), os.path.normpath(folder_path), is_buddy_only], select_row=False)
 
         for virtual_name, folder_path, *_unused in self.shared_folders:
             is_buddy_only = False
-            self.shares_list_view.add_row([str(virtual_name), str(folder_path), is_buddy_only], select_row=False)
+            self.shares_list_view.add_row(
+                [str(virtual_name), os.path.normpath(folder_path), is_buddy_only], select_row=False)
 
         self.rescan_required = False
 
@@ -653,8 +655,7 @@ class SharesPage:
             self.rescan_required = True
 
             virtual_name = core.shares.get_normalized_virtual_name(
-                os.path.basename(os.path.normpath(folder_path)),
-                shared_folders=(self.shared_folders + self.buddy_shared_folders)
+                os.path.basename(folder_path), shared_folders=(self.shared_folders + self.buddy_shared_folders)
             )
             mapping = (virtual_name, folder_path)
             is_buddy_only = False

--- a/pynicotine/gtkgui/widgets/filechooser.py
+++ b/pynicotine/gtkgui/widgets/filechooser.py
@@ -39,6 +39,8 @@ class FileChooser:
 
         if not initial_folder:
             initial_folder = os.path.expanduser("~")
+        else:
+            initial_folder = os.path.normpath(initial_folder)
 
         self.parent = parent
         self.callback = callback
@@ -91,9 +93,9 @@ class FileChooser:
             return
 
         if self.select_multiple:
-            selected = [i.get_path() for i in selected_result]
+            selected = [os.path.normpath(i.get_path()) for i in selected_result]
         else:
-            selected = selected_result.get_path()
+            selected = os.path.normpath(selected_result.get_path())
 
         if selected:
             self.callback(selected, self.callback_data)
@@ -107,10 +109,10 @@ class FileChooser:
             return
 
         if self.select_multiple:
-            selected = [i.get_path() for i in self.file_chooser.get_files()]
+            selected = [os.path.normpath(i.get_path()) for i in self.file_chooser.get_files()]
         else:
             selected_file = self.file_chooser.get_file()
-            selected = selected_file.get_path() if selected_file else None
+            selected = os.path.normpath(selected_file.get_path()) if selected_file else None
 
         if selected:
             self.callback(selected, self.callback_data)
@@ -291,7 +293,7 @@ class FileChooserButton:
         if not path:
             return
 
-        self.path = path
+        self.path = path = os.path.normpath(path)
         self.button.set_tooltip_text(path)
         self.label.set_label(os.path.basename(path))
 

--- a/pynicotine/gtkgui/widgets/theme.py
+++ b/pynicotine/gtkgui/widgets/theme.py
@@ -344,6 +344,7 @@ def load_custom_icons(update=False):
     if not user_icon_theme_path:
         return
 
+    user_icon_theme_path = os.path.normpath(user_icon_theme_path)
     log.add_debug("Loading custom icon theme from %s", user_icon_theme_path)
 
     theme_file_path = os.path.join(icon_theme_path, "index.theme")

--- a/pynicotine/logfacility.py
+++ b/pynicotine/logfacility.py
@@ -140,6 +140,7 @@ class Logger:
 
     def write_log_file(self, folder_path, base_name, text, timestamp=None):
 
+        folder_path = os.path.normpath(folder_path)
         log_file = self._get_log_file(folder_path, base_name)
         timestamp_format = config.sections["logging"]["log_timestamp"]
         timestamp = time.strftime(timestamp_format, time.localtime(timestamp))
@@ -151,7 +152,7 @@ class Logger:
 
         except Exception as error:
             # Avoid infinite recursion
-            should_log_file = (folder_path != config.sections["logging"]["debuglogsdir"])
+            should_log_file = (folder_path != os.path.normpath(config.sections["logging"]["debuglogsdir"]))
 
             self.add(_('Couldn\'t write to log file "%(filename)s": %(error)s'), {
                 "filename": os.path.join(folder_path, base_name),

--- a/pynicotine/plugins/core_commands/__init__.py
+++ b/pynicotine/plugins/core_commands/__init__.py
@@ -16,6 +16,8 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+import os
+
 from pynicotine import slskmessages
 from pynicotine.pluginsystem import BasePlugin
 
@@ -529,7 +531,7 @@ class Plugin(BasePlugin):
             self.output("\n" + f"{num_shares} {group_name} shares:")
 
             for virtual_name, folder_path, *_ignored in share_group:
-                self.output(f'• "{virtual_name}" {folder_path}')
+                self.output(f'• "{virtual_name}" {os.path.normpath(folder_path)}')
 
             num_listed += num_shares
 

--- a/pynicotine/userbrowse.py
+++ b/pynicotine/userbrowse.py
@@ -167,7 +167,7 @@ class UserBrowse:
             log.add(_("Loading Shares from disk failed: %(error)s"), {"error": msg})
             return
 
-        username = filename.replace("\\", os.sep).split(os.sep)[-1]
+        username = os.path.basename(filename)
         user_share = self.user_shares.get(username)
 
         if user_share:

--- a/pynicotine/userinfo.py
+++ b/pynicotine/userinfo.py
@@ -126,9 +126,7 @@ class UserInfo:
 
         else:
             try:
-                userpic = config.sections["userinfo"]["pic"]
-
-                with open(encode_path(userpic), "rb") as file_handle:
+                with open(encode_path(config.sections["userinfo"]["pic"]), "rb") as file_handle:
                     pic = file_handle.read()
 
             except Exception:

--- a/pynicotine/utils.py
+++ b/pynicotine/utils.py
@@ -50,13 +50,16 @@ def clean_file(filename):
     return filename
 
 
-def clean_path(path, absolute=False):
+def clean_path(path):
+
+    path = os.path.normpath(path)
 
     # Without hacks it is (up to Vista) not possible to have more
     # than 26 drives mounted, so we can assume a '[a-zA-Z]:\' prefix
     # for drives - we shouldn't escape that
     drive = ""
-    if absolute and path[1:3] == ":\\" and path[0:1] and path[0].isalpha():
+
+    if len(path) >= 3 and path[1] == ":" and path[2] == os.sep:
         drive = path[:3]
         path = path[3:]
 

--- a/test/unit/transfers/test_transfers.py
+++ b/test/unit/transfers/test_transfers.py
@@ -117,20 +117,20 @@ class TransfersTest(TestCase):
     def test_push_upload(self):
         """ Verify that new uploads are prepended to the list """
 
-        core.transfers.push_file("newuser2", "Hello\\Upload\\File.mp3", 2000, "/home/test")
-        core.transfers.push_file("newuser99", "Home\\None.mp3", 100, "/home/more")
+        core.transfers.push_file("newuser2", "Hello\\Upload\\File.mp3", 2000, os.path.join(os.sep, "home", "test"))
+        core.transfers.push_file("newuser99", "Home\\None.mp3", 100, os.path.join(os.sep, "home", "more"))
         transfer = core.transfers.uploads[1]
 
         self.assertEqual(transfer.user, "newuser2")
         self.assertEqual(transfer.filename, "Hello\\Upload\\File.mp3")
-        self.assertEqual(transfer.path, "/home/test")
+        self.assertEqual(transfer.path, os.path.join(os.sep, "home", "test"))
 
     def test_long_basename(self):
         """ Verify that the basename in download paths doesn't exceed 255 bytes.
         The basename can be shorter than 255 bytes when a truncated multi-byte character is discarded. """
 
         user = "abc"
-        finished_folder_path = "/path/to/somewhere/downloads"
+        finished_folder_path = os.path.join(os.sep, "path", "to", "somewhere", "downloads")
 
         # Short file extension
         virtual_path = ("Music\\Test\\片片片片片片片片片片片片片片片片片片片片片片片片片片片片片片片片片片片片片片片片片片片片片片片片片片"


### PR DESCRIPTION
MinGW's Python uses forward slashes as path separators, but paths from e.g. GTK's file chooser use backslashes. Ensure that we don't end up with a mix of different separators on Windows.