### PR TITLE
gtkgui/notifications.py: wishlist urgency hint

### DIFF
--- a/pynicotine/config.py
+++ b/pynicotine/config.py
@@ -399,7 +399,6 @@ class Config:
                 "xposition": -1,
                 "yposition": -1,
                 "maximized": True,
-                "urgencyhint": True,
                 "file_path_tooltips": True,
                 "reverse_file_paths": True,
                 "file_size_unit": ""
@@ -499,6 +498,7 @@ class Config:
                 "roomlistcollapsed",
                 "showaway",
                 "decimalsep",
+                "urgencyhint",
                 "exact_file_sizes"  # TODO: remove in 3.3.0 (was only in 3.3.0.dev)
             ),
             "columns": (

--- a/pynicotine/gtkgui/chatrooms.py
+++ b/pynicotine/gtkgui/chatrooms.py
@@ -222,9 +222,6 @@ class ChatRooms(IconNotebook):
         self.window.application.notifications.update_title()
         self.window.application.tray_icon.update_icon()
 
-        if config.sections["ui"]["urgencyhint"] and not self.window.is_active():
-            self.window.application.notifications.set_urgency_hint(True)
-
     def unhighlight_room(self, room):
 
         if room not in self.highlighted_rooms:

--- a/pynicotine/gtkgui/privatechat.py
+++ b/pynicotine/gtkgui/privatechat.py
@@ -184,9 +184,6 @@ class PrivateChats(IconNotebook):
         self.window.application.notifications.update_title()
         self.window.application.tray_icon.update_icon()
 
-        if config.sections["ui"]["urgencyhint"] and not self.window.is_active():
-            self.window.application.notifications.set_urgency_hint(True)
-
     def unhighlight_user(self, user):
 
         if user not in self.highlighted_users:

--- a/pynicotine/gtkgui/search.py
+++ b/pynicotine/gtkgui/search.py
@@ -139,6 +139,7 @@ class Searches(IconNotebook):
                 continue
 
             tab.update_filter_widgets()
+            self.window.application.notifications.update_title()
             break
 
     def on_search_mode(self, action, state):
@@ -836,6 +837,7 @@ class Search:
                     )
 
             self.searches.request_tab_changed(self.container, is_important=is_wish)
+            self.window.application.notifications.update_title()
 
         # Update number of results, even if they are all filtered
         self.update_result_counter()


### PR DESCRIPTION
Closes #2551

+ Added: Window title notification and taskbar urgency hint for "Wishlist Results Found"
- Removed: Defunct ["ui"]["urgencyhint"] config setting (it was not in Preferences dialog)
+ Changed: Urgency hints now follows the ["notifications"]["notification_window_title"] config setting