### PR TITLE
ChatEntry: remove unused message_class argument

### DIFF
--- a/pynicotine/gtkgui/application.py
+++ b/pynicotine/gtkgui/application.py
@@ -26,11 +26,11 @@ from gi.repository import Gio
 from gi.repository import GLib
 from gi.repository import Gtk
 
-from pynicotine import slskmessages
 from pynicotine.config import config
 from pynicotine.core import core
 from pynicotine.events import events
 from pynicotine.logfacility import log
+from pynicotine.slskmessages import UserStatus
 from pynicotine.utils import open_uri
 
 GTK_API_VERSION = Gtk.get_major_version()
@@ -614,7 +614,7 @@ class Application:
     def on_away(self, *_args):
         """ Away/Online status button """
 
-        core.set_away_mode(core.user_status != slskmessages.UserStatus.AWAY, save_state=True)
+        core.set_away_mode(core.user_status != UserStatus.AWAY, save_state=True)
 
     """ Running """
 

--- a/pynicotine/gtkgui/chatrooms.py
+++ b/pynicotine/gtkgui/chatrooms.py
@@ -29,7 +29,6 @@ from gi.repository import GObject
 from gi.repository import Gtk
 from gi.repository import Pango
 
-from pynicotine import slskmessages
 from pynicotine.chatrooms import Tickers
 from pynicotine.config import config
 from pynicotine.core import core
@@ -52,6 +51,7 @@ from pynicotine.gtkgui.widgets.theme import USER_STATUS_ICON_NAMES
 from pynicotine.gtkgui.widgets.theme import get_flag_icon_name
 from pynicotine.gtkgui.widgets.treeview import TreeView
 from pynicotine.logfacility import log
+from pynicotine.slskmessages import UserStatus
 from pynicotine.utils import clean_file
 from pynicotine.utils import humanize
 from pynicotine.utils import human_speed
@@ -909,10 +909,10 @@ class ChatRoom:
         if status == self.users_list_view.get_row_value(iterator, "status_data"):
             return
 
-        if status == slskmessages.UserStatus.AWAY:
+        if status == UserStatus.AWAY:
             action = _("%s has gone away")
 
-        elif status == slskmessages.UserStatus.ONLINE:
+        elif status == UserStatus.ONLINE:
             action = _("%s has returned")
 
         else:

--- a/pynicotine/gtkgui/chatrooms.py
+++ b/pynicotine/gtkgui/chatrooms.py
@@ -425,8 +425,8 @@ class ChatRoom:
                                              controller_widget=self.chat_container, focus_widget=self.chat_entry)
 
         # Chat Entry
-        ChatEntry(self.window.application, self.chat_entry, chatrooms.completion, room, slskmessages.SayChatroom,
-                  core.chatrooms.send_message, is_chatroom=True)
+        ChatEntry(self.window.application, self.chat_entry, chatrooms.completion, room, core.chatrooms.send_message,
+                  is_chatroom=True)
 
         self.log_toggle.set_active(config.sections["logging"]["chatrooms"])
         if not self.log_toggle.get_active():

--- a/pynicotine/gtkgui/interests.py
+++ b/pynicotine/gtkgui/interests.py
@@ -21,7 +21,6 @@
 from gi.repository import GLib
 from gi.repository import GObject
 
-from pynicotine import slskmessages
 from pynicotine.config import config
 from pynicotine.core import core
 from pynicotine.events import events
@@ -31,6 +30,7 @@ from pynicotine.gtkgui.widgets.popupmenu import PopupMenu
 from pynicotine.gtkgui.widgets.popupmenu import UserPopupMenu
 from pynicotine.gtkgui.widgets.treeview import TreeView
 from pynicotine.gtkgui.widgets.theme import USER_STATUS_ICON_NAMES
+from pynicotine.slskmessages import UserStatus
 from pynicotine.utils import humanize
 from pynicotine.utils import human_speed
 
@@ -225,7 +225,7 @@ class Interests:
     def populate_recommendations(self):
         """ Populates the lists of recommendations and similar users if empty """
 
-        if self.populated_recommends or core.user_status == slskmessages.UserStatus.OFFLINE:
+        if self.populated_recommends or core.user_status == UserStatus.OFFLINE:
             return
 
         self.on_recommendations_clicked()
@@ -397,7 +397,7 @@ class Interests:
         for user, rating in users.items():
             user_stats = core.watched_users.get(user, {})
 
-            status = core.user_statuses.get(user, slskmessages.UserStatus.OFFLINE)
+            status = core.user_statuses.get(user, UserStatus.OFFLINE)
             speed = user_stats.get("upload_speed", 0)
             files = user_stats.get("files", 0)
 

--- a/pynicotine/gtkgui/mainwindow.py
+++ b/pynicotine/gtkgui/mainwindow.py
@@ -28,7 +28,6 @@ from gi.repository import Gio
 from gi.repository import GLib
 from gi.repository import Gtk
 
-from pynicotine import slskmessages
 from pynicotine.config import config
 from pynicotine.core import core
 from pynicotine.events import events
@@ -56,6 +55,7 @@ from pynicotine.gtkgui.widgets.theme import set_global_style
 from pynicotine.gtkgui.widgets.theme import set_use_header_bar
 from pynicotine.gtkgui.widgets.window import Window
 from pynicotine.logfacility import log
+from pynicotine.slskmessages import UserStatus
 from pynicotine.utils import human_speed
 from pynicotine.utils import open_file_path
 
@@ -423,8 +423,8 @@ class MainWindow(Window):
     def update_user_status(self):
 
         status = core.user_status
-        is_online = (status != slskmessages.UserStatus.OFFLINE)
-        is_away = (status == slskmessages.UserStatus.AWAY)
+        is_online = (status != UserStatus.OFFLINE)
+        is_away = (status == UserStatus.AWAY)
 
         # Action status
         self.application.lookup_action("connect").set_enabled(not is_online)
@@ -444,10 +444,10 @@ class MainWindow(Window):
         # Status bar
         username = core.login_username
 
-        if status == slskmessages.UserStatus.AWAY:
+        if status == UserStatus.AWAY:
             status_text = _("Away")
 
-        elif status == slskmessages.UserStatus.ONLINE:
+        elif status == UserStatus.ONLINE:
             status_text = _("Online")
 
         else:
@@ -1200,7 +1200,7 @@ class MainWindow(Window):
             self.auto_away = True
             self.away_timer_id = None
 
-            if core.user_status != slskmessages.UserStatus.AWAY:
+            if core.user_status != UserStatus.AWAY:
                 core.set_away_mode(True)
 
             return
@@ -1208,7 +1208,7 @@ class MainWindow(Window):
         if self.auto_away:
             self.auto_away = False
 
-            if core.user_status == slskmessages.UserStatus.AWAY:
+            if core.user_status == UserStatus.AWAY:
                 core.set_away_mode(False)
 
         # Reset away timer
@@ -1217,7 +1217,7 @@ class MainWindow(Window):
 
     def create_away_timer(self):
 
-        if core.user_status != slskmessages.UserStatus.ONLINE:
+        if core.user_status != UserStatus.ONLINE:
             return
 
         away_interval = config.sections["server"]["autoaway"]

--- a/pynicotine/gtkgui/privatechat.py
+++ b/pynicotine/gtkgui/privatechat.py
@@ -268,8 +268,7 @@ class PrivateChat:
                                         controller_widget=self.container, focus_widget=self.chat_entry)
 
         # Chat Entry
-        ChatEntry(self.window.application, self.chat_entry, chats.completion, user, slskmessages.MessageUser,
-                  core.privatechat.send_message)
+        ChatEntry(self.window.application, self.chat_entry, chats.completion, user, core.privatechat.send_message)
 
         self.log_toggle.set_active(config.sections["logging"]["privatechat"])
 

--- a/pynicotine/gtkgui/privatechat.py
+++ b/pynicotine/gtkgui/privatechat.py
@@ -25,7 +25,6 @@ import os
 
 from gi.repository import GLib
 
-from pynicotine import slskmessages
 from pynicotine.config import config
 from pynicotine.core import core
 from pynicotine.events import events
@@ -41,6 +40,7 @@ from pynicotine.gtkgui.widgets.textentry import ChatEntry
 from pynicotine.gtkgui.widgets.textentry import TextSearchBar
 from pynicotine.gtkgui.widgets.textview import ChatView
 from pynicotine.logfacility import log
+from pynicotine.slskmessages import UserStatus
 from pynicotine.utils import clean_file
 
 
@@ -235,7 +235,7 @@ class PrivateChats(IconNotebook):
 
         for user, page in self.pages.items():
             page.server_disconnect()
-            self.set_user_status(page.container, user, slskmessages.UserStatus.OFFLINE)
+            self.set_user_status(page.container, user, UserStatus.OFFLINE)
 
 
 class PrivateChat:

--- a/pynicotine/gtkgui/search.py
+++ b/pynicotine/gtkgui/search.py
@@ -29,7 +29,6 @@ from collections import defaultdict
 from gi.repository import GObject
 from gi.repository import Gtk
 
-from pynicotine import slskmessages
 from pynicotine.config import config
 from pynicotine.core import core
 from pynicotine.events import events
@@ -58,6 +57,7 @@ from pynicotine.gtkgui.widgets.treeview import show_file_path_tooltip
 from pynicotine.gtkgui.widgets.treeview import show_file_type_tooltip
 from pynicotine.logfacility import log
 from pynicotine.shares import FileTypes
+from pynicotine.slskmessages import FileListMessage
 from pynicotine.utils import factorize
 from pynicotine.utils import humanize
 from pynicotine.utils import human_size
@@ -750,8 +750,7 @@ class Search:
 
             size = result[2]
             h_size = human_size(size, config.sections["ui"]["file_size_unit"])
-            h_bitrate, bitrate, h_length, length = slskmessages.FileListMessage.parse_result_bitrate_length(
-                size, result[4])
+            h_bitrate, bitrate, h_length, length = FileListMessage.parse_result_bitrate_length(size, result[4])
 
             if private:
                 name = _("[PRIVATE]  %s") % name

--- a/pynicotine/gtkgui/userbrowse.py
+++ b/pynicotine/gtkgui/userbrowse.py
@@ -28,7 +28,6 @@ from locale import strxfrm
 from gi.repository import GLib
 from gi.repository import GObject
 
-from pynicotine import slskmessages
 from pynicotine.config import config
 from pynicotine.core import core
 from pynicotine.events import events
@@ -45,6 +44,8 @@ from pynicotine.gtkgui.widgets.popupmenu import UserPopupMenu
 from pynicotine.gtkgui.widgets.textentry import ComboBox
 from pynicotine.gtkgui.widgets.theme import get_file_type_icon_name
 from pynicotine.gtkgui.widgets.treeview import TreeView
+from pynicotine.slskmessages import UserStatus
+from pynicotine.slskmessages import FileListMessage
 from pynicotine.utils import human_size
 from pynicotine.utils import humanize
 from pynicotine.utils import open_file_path
@@ -153,7 +154,7 @@ class UserBrowses(IconNotebook):
 
     def server_disconnect(self, *_args):
         for user, page in self.pages.items():
-            self.set_user_status(page.container, user, slskmessages.UserStatus.OFFLINE)
+            self.set_user_status(page.container, user, UserStatus.OFFLINE)
 
 
 class UserBrowse:
@@ -597,7 +598,7 @@ class UserBrowse:
         for _code, filename, size, _ext, attrs, *_unused in files:
             selected_folder_size += size
             h_size = human_size(size, config.sections["ui"]["file_size_unit"])
-            h_bitrate, bitrate, h_length, length = slskmessages.FileListMessage.parse_result_bitrate_length(size, attrs)
+            h_bitrate, bitrate, h_length, length = FileListMessage.parse_result_bitrate_length(size, attrs)
 
             self.file_list_view.add_row([
                 get_file_type_icon_name(filename),
@@ -1020,8 +1021,8 @@ class UserBrowse:
                 filename = file_data[1]
                 file_size = file_data[2]
                 virtual_path = "\\".join([folder, filename])
-                h_bitrate, _bitrate, h_length, length = slskmessages.FileListMessage.parse_result_bitrate_length(
-                    file_size, file_data[4])
+                h_bitrate, _bitrate, h_length, length = FileListMessage.parse_result_bitrate_length(file_size,
+                                                                                                    file_data[4])
                 selected_size += file_size
                 selected_length += length
 

--- a/pynicotine/gtkgui/userinfo.py
+++ b/pynicotine/gtkgui/userinfo.py
@@ -28,7 +28,6 @@ from gi.repository import Gio
 from gi.repository import GLib
 from gi.repository import Gtk
 
-from pynicotine import slskmessages
 from pynicotine.config import config
 from pynicotine.core import core
 from pynicotine.events import events
@@ -44,6 +43,7 @@ from pynicotine.gtkgui.widgets.textview import TextView
 from pynicotine.gtkgui.widgets.theme import get_flag_icon_name
 from pynicotine.gtkgui.widgets.treeview import TreeView
 from pynicotine.logfacility import log
+from pynicotine.slskmessages import UserStatus
 from pynicotine.utils import humanize
 from pynicotine.utils import human_speed
 
@@ -198,7 +198,7 @@ class UserInfos(IconNotebook):
 
     def server_disconnect(self, *_args):
         for user, page in self.pages.items():
-            self.set_user_status(page.container, user, slskmessages.UserStatus.OFFLINE)
+            self.set_user_status(page.container, user, UserStatus.OFFLINE)
 
 
 class UserInfo:

--- a/pynicotine/gtkgui/userlist.py
+++ b/pynicotine/gtkgui/userlist.py
@@ -25,7 +25,6 @@ import time
 
 from gi.repository import GObject
 
-from pynicotine import slskmessages
 from pynicotine.config import config
 from pynicotine.core import core
 from pynicotine.events import events
@@ -35,6 +34,7 @@ from pynicotine.gtkgui.widgets.popupmenu import UserPopupMenu
 from pynicotine.gtkgui.widgets.theme import USER_STATUS_ICON_NAMES
 from pynicotine.gtkgui.widgets.theme import get_flag_icon_name
 from pynicotine.gtkgui.widgets.treeview import TreeView
+from pynicotine.slskmessages import UserStatus
 from pynicotine.utils import UINT64_LIMIT
 from pynicotine.utils import humanize
 from pynicotine.utils import human_speed
@@ -430,7 +430,7 @@ class UserList:
     def server_disconnect(self, *_args):
 
         for iterator in self.list_view.get_all_rows():
-            self.list_view.set_row_value(iterator, "status", USER_STATUS_ICON_NAMES[slskmessages.UserStatus.OFFLINE])
+            self.list_view.set_row_value(iterator, "status", USER_STATUS_ICON_NAMES[UserStatus.OFFLINE])
             self.list_view.set_row_value(iterator, "speed", "")
             self.list_view.set_row_value(iterator, "files", "")
             self.list_view.set_row_value(iterator, "status_data", 0)

--- a/pynicotine/gtkgui/widgets/textentry.py
+++ b/pynicotine/gtkgui/widgets/textentry.py
@@ -23,12 +23,12 @@ from locale import strxfrm
 from gi.repository import Gtk
 from gi.repository import Pango
 
-from pynicotine import slskmessages
 from pynicotine.config import config
 from pynicotine.core import core
 from pynicotine.gtkgui.application import GTK_API_VERSION
 from pynicotine.gtkgui.widgets.accelerator import Accelerator
 from pynicotine.gtkgui.widgets.theme import add_css_class
+from pynicotine.slskmessages import UserStatus
 
 
 """ Text Entry-related """
@@ -68,7 +68,7 @@ class ChatEntry:
 
     def on_enter(self, *_args):
 
-        if core.user_status == slskmessages.UserStatus.OFFLINE:
+        if core.user_status == UserStatus.OFFLINE:
             return
 
         text = self.widget.get_text()

--- a/pynicotine/gtkgui/widgets/textentry.py
+++ b/pynicotine/gtkgui/widgets/textentry.py
@@ -37,13 +37,12 @@ from pynicotine.gtkgui.widgets.theme import add_css_class
 class ChatEntry:
     """ Custom text entry with support for chat commands and completions """
 
-    def __init__(self, application, widget, completion, entity, message_class, send_message, is_chatroom=False):
+    def __init__(self, application, widget, completion, entity, send_message, is_chatroom=False):
 
         self.application = application
         self.widget = widget
         self.completion = completion
         self.entity = entity
-        self.message_class = message_class
         self.send_message = send_message
         self.is_chatroom = is_chatroom
 

--- a/pynicotine/gtkgui/widgets/textview.py
+++ b/pynicotine/gtkgui/widgets/textview.py
@@ -24,13 +24,13 @@ from collections import deque
 from gi.repository import Gdk
 from gi.repository import Gtk
 
-from pynicotine import slskmessages
 from pynicotine.config import config
 from pynicotine.core import core
 from pynicotine.gtkgui.application import GTK_API_VERSION
 from pynicotine.gtkgui.widgets import clipboard
 from pynicotine.gtkgui.widgets.theme import update_tag_visuals
 from pynicotine.gtkgui.widgets.theme import USER_STATUS_COLORS
+from pynicotine.slskmessages import UserStatus
 from pynicotine.utils import encode_path
 from pynicotine.utils import open_uri
 from pynicotine.utils import PUNCTUATION
@@ -463,7 +463,7 @@ class ChatView(TextView):
         if username not in self.tag_users:
             self.tag_users[username] = self.create_tag(callback=self.username_event, username=username)
 
-        status = core.user_statuses.get(username, slskmessages.UserStatus.OFFLINE)
+        status = core.user_statuses.get(username, UserStatus.OFFLINE)
         color = USER_STATUS_COLORS.get(status)
         self.update_tag(self.tag_users[username], color)
 

--- a/pynicotine/gtkgui/widgets/theme.py
+++ b/pynicotine/gtkgui/widgets/theme.py
@@ -25,13 +25,13 @@ from gi.repository import GLib
 from gi.repository import Gtk
 from gi.repository import Pango
 
-from pynicotine import slskmessages
 from pynicotine.config import config
 from pynicotine.gtkgui.application import GTK_API_VERSION
 from pynicotine.gtkgui.application import GTK_GUI_DIR
 from pynicotine.gtkgui.application import LIBADWAITA_API_VERSION
 from pynicotine.logfacility import log
 from pynicotine.shares import FileTypes
+from pynicotine.slskmessages import UserStatus
 from pynicotine.utils import encode_path
 
 
@@ -308,9 +308,9 @@ FILE_TYPE_ICON_LABELS = {
     "x-office-document-symbolic": _("Document/Text")
 }
 USER_STATUS_ICON_NAMES = {
-    slskmessages.UserStatus.ONLINE: "nplus-status-online",
-    slskmessages.UserStatus.AWAY: "nplus-status-away",
-    slskmessages.UserStatus.OFFLINE: "nplus-status-offline"
+    UserStatus.ONLINE: "nplus-status-online",
+    UserStatus.AWAY: "nplus-status-away",
+    UserStatus.OFFLINE: "nplus-status-offline"
 }
 
 
@@ -375,9 +375,9 @@ def load_custom_icons(update=False):
         return
 
     icon_names = (
-        ("away", USER_STATUS_ICON_NAMES[slskmessages.UserStatus.AWAY]),
-        ("online", USER_STATUS_ICON_NAMES[slskmessages.UserStatus.ONLINE]),
-        ("offline", USER_STATUS_ICON_NAMES[slskmessages.UserStatus.OFFLINE]),
+        ("away", USER_STATUS_ICON_NAMES[UserStatus.AWAY]),
+        ("online", USER_STATUS_ICON_NAMES[UserStatus.ONLINE]),
+        ("offline", USER_STATUS_ICON_NAMES[UserStatus.OFFLINE]),
         ("hilite", "nplus-tab-highlight"),
         ("hilite3", "nplus-tab-changed"),
         ("trayicon_away", "nplus-tray-away"),
@@ -508,9 +508,9 @@ PANGO_WEIGHTS = {
     Pango.Weight.ULTRAHEAVY: 1000
 }
 USER_STATUS_COLORS = {
-    slskmessages.UserStatus.ONLINE: "useronline",
-    slskmessages.UserStatus.AWAY: "useraway",
-    slskmessages.UserStatus.OFFLINE: "useroffline"
+    UserStatus.ONLINE: "useronline",
+    UserStatus.AWAY: "useraway",
+    UserStatus.OFFLINE: "useroffline"
 }
 
 

--- a/pynicotine/plugins/auto_user_browse/__init__.py
+++ b/pynicotine/plugins/auto_user_browse/__init__.py
@@ -16,8 +16,8 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-from pynicotine import slskmessages
 from pynicotine.pluginsystem import BasePlugin
+from pynicotine.slskmessages import UserStatus
 
 
 class Plugin(BasePlugin):
@@ -42,13 +42,13 @@ class Plugin(BasePlugin):
         if user not in self.settings["users"]:
             return
 
-        if status == slskmessages.UserStatus.OFFLINE:
+        if status == UserStatus.OFFLINE:
             self.user_statuses[user] = status
             return
 
-        previous_status = self.user_statuses.get(user, slskmessages.UserStatus.OFFLINE)
+        previous_status = self.user_statuses.get(user, UserStatus.OFFLINE)
 
-        if previous_status == slskmessages.UserStatus.OFFLINE:
+        if previous_status == UserStatus.OFFLINE:
             # User was previously offline
             self.user_statuses[user] = status
             self.core.userbrowse.browse_user(user, switch_page=False)

--- a/pynicotine/plugins/core_commands/__init__.py
+++ b/pynicotine/plugins/core_commands/__init__.py
@@ -18,8 +18,8 @@
 
 import os
 
-from pynicotine import slskmessages
 from pynicotine.pluginsystem import BasePlugin
+from pynicotine.slskmessages import UserStatus
 
 
 class _CommandGroup:
@@ -307,12 +307,12 @@ class Plugin(BasePlugin):
 
     def away_command(self, _args, **_unused):
 
-        if self.core.user_status == slskmessages.UserStatus.OFFLINE:
+        if self.core.user_status == UserStatus.OFFLINE:
             self.output(_("Offline"))
             return
 
-        self.core.set_away_mode(self.core.user_status != slskmessages.UserStatus.AWAY, save_state=True)
-        self.output(_("Online") if self.core.user_status == slskmessages.UserStatus.ONLINE else _("Away"))
+        self.core.set_away_mode(self.core.user_status != UserStatus.AWAY, save_state=True)
+        self.output(_("Online") if self.core.user_status == UserStatus.ONLINE else _("Away"))
 
     def quit_command(self, args, **_unused):
 

--- a/pynicotine/userlist.py
+++ b/pynicotine/userlist.py
@@ -18,11 +18,11 @@
 
 import time
 
-from pynicotine import slskmessages
 from pynicotine.config import config
 from pynicotine.core import core
 from pynicotine.events import events
 from pynicotine.logfacility import log
+from pynicotine.slskmessages import UserStatus
 
 
 class Buddy:
@@ -109,7 +109,7 @@ class UserList:
                 is_trusted=is_trusted,
                 last_seen=last_seen,
                 country=country,
-                status=slskmessages.UserStatus.OFFLINE
+                status=UserStatus.OFFLINE
             )
             events.emit("add-buddy", user, user_data)
 
@@ -130,7 +130,7 @@ class UserList:
     def _server_disconnect(self, _msg):
 
         for user, user_data in self.buddies.items():
-            user_data.status = slskmessages.UserStatus.OFFLINE
+            user_data.status = UserStatus.OFFLINE
             self.set_buddy_last_seen(user, is_online=False)
 
         self.save_buddy_list()
@@ -145,7 +145,7 @@ class UserList:
         country = f"flag_{country_code}" if country_code else ""
         is_trusted = notify_status = is_prioritized = False
         last_seen = "Never seen"
-        status = core.user_statuses.get(user, slskmessages.UserStatus.OFFLINE)
+        status = core.user_statuses.get(user, UserStatus.OFFLINE)
 
         self.buddies[user] = user_data = Buddy(
             username=user,
@@ -165,7 +165,7 @@ class UserList:
         self.save_buddy_list()
         events.emit("add-buddy", user, user_data)
 
-        if core.user_status == slskmessages.UserStatus.OFFLINE:
+        if core.user_status == UserStatus.OFFLINE:
             return
 
         # Request user status, speed and number of shared files
@@ -296,10 +296,10 @@ class UserList:
         if not notify:
             return
 
-        if msg.status == slskmessages.UserStatus.AWAY:
+        if msg.status == UserStatus.AWAY:
             status_text = _("%(user)s is away")
 
-        elif msg.status == slskmessages.UserStatus.ONLINE:
+        elif msg.status == UserStatus.ONLINE:
             status_text = _("%(user)s is online")
 
         else:


### PR DESCRIPTION
Code cleanups:

- Removed: Unused `message_class` argument and variable from textentry.py.
- Removed: Don't import entire `slskmessages` module in 15 cases where only `UserStatus` is required.
- Removed: Don't import entire `slskmessages` module in 2 cases where only `FileListMessage` is required.