### PR TITLE
transfers.py: avoid unnecessary membership check while Transferring

### DIFF
--- a/pynicotine/transfers.py
+++ b/pynicotine/transfers.py
@@ -2158,13 +2158,13 @@ class Transfers:
 
         events.emit("update-upload", transfer, update_parent)
 
+        if status == "Transferring":
+            # Avoid unnecessary user counter updates while transferring
+            return
+
         if status == "Queued" and user in self.user_update_counters:
             # Don't update existing user counter for queued uploads
             # We don't want to push the user back in the queue if they enqueued new files
-            return
-
-        if status == "Transferring":
-            # Avoid unnecessary updates while transferring
             return
 
         self.update_user_counter(user)


### PR DESCRIPTION
Code cleanup/optimization is relevant if there is a very large number of queued users to check if `user` every time there is an update is waste of time in any case, because that data isn't needed for this condition.