### PR TITLE
trayicon.py: add Win32 implementation

### DIFF
--- a/pynicotine/gtkgui/application.py
+++ b/pynicotine/gtkgui/application.py
@@ -717,7 +717,10 @@ class Application:
 
         from pynicotine.gtkgui.mainwindow import MainWindow
         from pynicotine.gtkgui.widgets.notifications import Notifications
+        from pynicotine.gtkgui.widgets.theme import load_icons
         from pynicotine.gtkgui.widgets.trayicon import TrayIcon
+
+        load_icons()
 
         self.set_up_actions()
         self.set_up_action_accels()
@@ -744,8 +747,7 @@ class Application:
         GLib.timeout_add(50, self.on_process_thread_events, priority=GLib.PRIORITY_HIGH_IDLE)
 
     def on_shutdown(self, *_args):
-        # Explicitly hide tray icon, otherwise it will not disappear on Windows
-        self.tray_icon.set_visible(False)
+        self.tray_icon.unload(is_shutdown=True)
 
     def on_confirm_quit_request(self, *_args):
         core.confirm_quit()

--- a/pynicotine/gtkgui/dialogs/preferences.py
+++ b/pynicotine/gtkgui/dialogs/preferences.py
@@ -2953,10 +2953,9 @@ class Preferences(Dialog):
         core.transfers.check_upload_queue()
 
         # Tray icon
-        if not config.sections["ui"]["trayicon"] and self.application.tray_icon.is_visible():
-            self.application.tray_icon.set_visible(False)
-
-        elif config.sections["ui"]["trayicon"] and not self.application.tray_icon.is_visible():
+        if not config.sections["ui"]["trayicon"]:
+            self.application.tray_icon.unload()
+        else:
             self.application.tray_icon.load()
 
         # Main notebook

--- a/pynicotine/gtkgui/mainwindow.py
+++ b/pynicotine/gtkgui/mainwindow.py
@@ -49,7 +49,6 @@ from pynicotine.gtkgui.widgets.textentry import TextSearchBar
 from pynicotine.gtkgui.widgets.textview import TextView
 from pynicotine.gtkgui.widgets.theme import USER_STATUS_ICON_NAMES
 from pynicotine.gtkgui.widgets.theme import add_css_class
-from pynicotine.gtkgui.widgets.theme import load_icons
 from pynicotine.gtkgui.widgets.theme import remove_css_class
 from pynicotine.gtkgui.widgets.theme import set_global_style
 from pynicotine.gtkgui.widgets.theme import set_use_header_bar
@@ -218,10 +217,6 @@ class MainWindow(Window):
 
         self.create_log_context_menu()
         events.connect("log-message", self.log_callback)
-
-        """ Icons """
-
-        load_icons()
 
         """ Notebook Tabs """
 


### PR DESCRIPTION
Restores tray icon and notification support on Windows.

![](https://github.com/nicotine-plus/nicotine-plus/assets/8754153/3e8331dc-adc0-4449-8619-3766a7bc9ed5)
![](https://github.com/nicotine-plus/nicotine-plus/assets/8754153/a87164cc-03ec-4791-a763-811c17f687fa)
