### PR TITLE
ComboBox: select item on dropdown visible

### DIFF
--- a/pynicotine/gtkgui/search.py
+++ b/pynicotine/gtkgui/search.py
@@ -1692,9 +1692,6 @@ class Search:
         if n_chars > 1 and chars == combobox.get_selected_id():
             self.on_refilter()
 
-            # Highlight current list item
-            combobox.set_selected_id(chars)
-
     def on_filter_entry_changed(self, entry):
         if not entry.get_text():
             self.on_refilter()

--- a/pynicotine/gtkgui/widgets/textentry.py
+++ b/pynicotine/gtkgui/widgets/textentry.py
@@ -541,23 +541,19 @@ class ComboBox:
 
     def set_selected_pos(self, position):
 
+        if position is None:
+            return
+
         if GTK_API_VERSION >= 4:
             self.dropdown.set_selected(position)
         else:
             self.dropdown.set_active(position)
 
     def set_selected_id(self, item_id):
-
-        position = self._positions.get(item_id)
-
-        if position is None:
-            position = 0
-
-        self.set_selected_pos(position)
+        self.set_selected_pos(self._positions.get(item_id))
 
     def set_text(self, text):
         self.entry.set_text(text)
-        self.set_selected_id(text)
 
     def remove_pos(self, position):
 
@@ -655,6 +651,8 @@ class ComboBox:
         if not visible:
             self.entry.grab_focus_without_selecting()
             return
+
+        self.set_selected_id(self.get_text())
 
         if GTK_API_VERSION == 3:
             return


### PR DESCRIPTION
+ Fixed: regression since commit 58483c7005806e2b4f589a4001d132f00699f62d in Search Files whereby the filter entries cannot be cleared using the Clear All Filters button. Instead some most recent list items are selected and this screws up `filters_undo`.

- Removed: Selection of list item handling from within the search module, since we want the selection characteristics to be native to our ComboBox widget because it is appropriate for the current item (if present in the list) to be highlighted in all cases.

- Changed: Don't select first item but instead highlight the most recently selected item if the text does not match any list items, this it what should happen anyway... We have to be careful not to overwrite any previous manually entered settings in Preferences.