### PR TITLE
Use pycodestyle instead of flake8

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,4 +1,0 @@
-[flake8]
-builtins = _
-max-line-length = 120
-ignore = W503

--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -77,8 +77,8 @@ jobs:
             mingw-w64-${{ matrix.arch }}-gtk${{ matrix.gtk }}
             mingw-w64-${{ matrix.arch }}-python-chardet
             mingw-w64-${{ matrix.arch }}-python-cx-freeze
-            mingw-w64-${{ matrix.arch }}-python-flake8
             mingw-w64-${{ matrix.arch }}-python-pip
+            mingw-w64-${{ matrix.arch }}-python-pycodestyle
             mingw-w64-${{ matrix.arch }}-python-pylint
             mingw-w64-${{ matrix.arch }}-python-gobject
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -29,10 +29,10 @@ jobs:
           sudo apt install gettext gir1.2-gtk-3.0 libgirepository1.0-dev
           python -m pip install -e ".[test]"
 
-      - name: Flake8 linter
-        run: python -m flake8
+      - name: PEP 8 style checks
+        run: python -m pycodestyle
 
-      - name: Pylint linter
+      - name: Linting
         run: python -m pylint pynicotine test
 
       - name: Integration and unit tests
@@ -83,7 +83,7 @@ jobs:
 
       - name: Install dependencies (Fedora)
         if: matrix.container == 'fedora:rawhide'
-        run: dnf -y install pylint python3-flake8
+        run: dnf -y install pylint python3-pycodestyle
 
       - name: Install dependencies (Rocky Linux)
         if: matrix.container == 'rockylinux:8'
@@ -91,10 +91,10 @@ jobs:
           dnf -y install gcc python3-devel python3-pip
           python3 -m pip install -e ".[test]"
 
-      - name: Flake8 linter
-        run: python3 -m flake8
+      - name: PEP 8 style checks
+        run: python3 -m pycodestyle
 
-      - name: Pylint linter
+      - name: Linting
         run: python3 -m pylint pynicotine test
 
       - name: Integration and unit tests
@@ -128,18 +128,18 @@ jobs:
             mingw-w64-${{ env.ARCH }}-gtk${{ matrix.gtk }}
             mingw-w64-${{ env.ARCH }}-python-chardet
             mingw-w64-${{ env.ARCH }}-python-cx-freeze
-            mingw-w64-${{ env.ARCH }}-python-flake8
             mingw-w64-${{ env.ARCH }}-python-pip
+            mingw-w64-${{ env.ARCH }}-python-pycodestyle
             mingw-w64-${{ env.ARCH }}-python-pylint
             mingw-w64-${{ env.ARCH }}-python-gobject
 
       - name: Install additional dependencies
         run: python3 packaging/windows/dependencies.py
 
-      - name: Flake8 linter
-        run: python3 -m flake8
+      - name: PEP 8 style checks
+        run: python3 -m pycodestyle
 
-      - name: Pylint linter
+      - name: Linting
         run: python3 -m pylint pynicotine test
 
       - name: Integration and unit tests
@@ -172,10 +172,10 @@ jobs:
       - name: Install dependencies
         run: python packaging/macos/dependencies.py
 
-      - name: Flake8 linter
-        run: python -m flake8
+      - name: PEP 8 style checks
+        run: python -m pycodestyle
 
-      - name: Pylint linter
+      - name: Linting
         run: python -m pylint pynicotine test
 
       - name: Integration and unit tests

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,7 +1,6 @@
 # This file is responsible for including all necessary files in the source distribution
 # https://packaging.python.org/en/latest/guides/using-manifest-in/
 
-include .flake8
 include .pylintrc
 include *.md
 recursive-include data *.in

--- a/doc/DEPENDENCIES.md
+++ b/doc/DEPENDENCIES.md
@@ -20,8 +20,8 @@
 
 ## Testing
 
-- [flake8](https://flake8.pycqa.org/) for lint checks;
-- [pylint](https://pylint.pycqa.org/) for lint checks.
+- [pycodestyle](https://pycodestyle.pycqa.org/) for code style checks;
+- [pylint](https://pylint.pycqa.org/) for linting.
 
 
 ## Installing Dependencies
@@ -73,19 +73,19 @@ sudo zypper install gettext-runtime python3-setuptools
 - On Debian/Ubuntu-based distributions:
 
 ```sh
-sudo apt install pylint3 python3-flake8
+sudo apt install pylint3 python3-pycodestyle
 ```
 
 - On Redhat/Fedora-based distributions:
 
 ```sh
-sudo dnf install pylint python3-flake8
+sudo dnf install pylint python3-pycodestyle
 ```
 
 - On SUSE-based distributions:
 
 ```sh
-sudo zypper install python3-pylint python3-flake8
+sudo zypper install python3-pylint python3-pycodestyle
 ```
 
 ### Windows and macOS

--- a/packaging/windows/dependencies.py
+++ b/packaging/windows/dependencies.py
@@ -37,8 +37,8 @@ def install_pacman():
                 f"{prefix}gtk{gtk_version}",
                 f"{prefix}python-chardet",
                 f"{prefix}python-cx-freeze",
-                f"{prefix}python-flake8",
                 f"{prefix}python-pip",
+                f"{prefix}python-pycodestyle",
                 f"{prefix}python-pylint",
                 f"{prefix}python-gobject"]
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[pycodestyle]
+max-line-length = 120

--- a/setup.py
+++ b/setup.py
@@ -104,6 +104,6 @@ functionality while keeping current with the Soulseek protocol.""",
         ],
         python_requires=">=3.6",
         install_requires=["PyGObject>=3.22"],
-        extras_require={"packaging": ["cx_Freeze"], "test": ["flake8", "pylint"]},
+        extras_require={"packaging": ["cx_Freeze"], "test": ["pycodestyle", "pylint"]},
         cmdclass={"build_py": BuildPyCommand}
     )


### PR DESCRIPTION
flake8 bundles pycodestyle, pyflakes and mccabe, but pylint already includes all rules that exist in pyflakes and mccabe.