### PR TITLE
Add option to wait for uploads to finish when quitting

### DIFF
--- a/pynicotine/core.py
+++ b/pynicotine/core.py
@@ -246,24 +246,20 @@ class Core:
     def setup(self):
         events.emit("setup")
 
-    def confirm_quit(self, remember=False):
+    def confirm_quit(self):
+        events.emit("confirm-quit")
 
-        if config.sections["ui"]["exitdialog"] > 0:
-            events.emit("confirm-quit", remember)
-            return
+    def quit(self, signal_type=None, _frame=None, should_finish_uploads=False):
 
-        self.quit()
-
-    def quit(self, signal_type=None, _frame=None):
-
-        log.add(_("Quitting %(program)s %(version)s, %(status)s…"), {
-            "program": config.application_name,
-            "version": config.version,
-            "status": _("terminating") if signal_type == signal.SIGTERM else _("application closing")
-        })
+        if not should_finish_uploads:
+            log.add(_("Quitting %(program)s %(version)s, %(status)s…"), {
+                "program": config.application_name,
+                "version": config.version,
+                "status": _("terminating") if signal_type == signal.SIGTERM else _("application closing")
+            })
 
         # Allow the networking thread to finish up before quitting
-        events.emit("schedule-quit")
+        events.emit("schedule-quit", should_finish_uploads)
 
     def connect(self):
 
@@ -352,7 +348,7 @@ class Core:
     def _thread_callback(self, callback, *args, **kwargs):
         callback(*args, **kwargs)
 
-    def _schedule_quit(self):
+    def _schedule_quit(self, _should_finish_uploads):
         events.emit("quit")
 
     def _quit(self):

--- a/pynicotine/gtkgui/application.py
+++ b/pynicotine/gtkgui/application.py
@@ -223,6 +223,7 @@ class Application:
             ("app.disconnect", ["<Shift><Primary>d"]),
             ("app.away-accel", ["<Primary>h"]),
             ("app.wishlist", ["<Shift><Primary>w"]),
+            ("app.confirm-quit", ["<Primary>q"]),
             ("app.quit", ["<Primary><Alt>q"]),
             ("app.rescan-shares", ["<Shift><Primary>r"]),
             ("app.keyboard-shortcuts", ["<Primary>question", "F1"]),
@@ -274,22 +275,16 @@ class Application:
 
     def on_confirm_quit_response(self, dialog, response_id, _data):
 
-        remember = dialog.get_option_value()
+        should_finish_uploads = dialog.get_option_value()
 
         if response_id == "quit":
-            if remember:
-                config.sections["ui"]["exitdialog"] = 0
-
-            core.quit()
+            core.quit(should_finish_uploads=should_finish_uploads)
 
         elif response_id == "run_background":
-            if remember:
-                config.sections["ui"]["exitdialog"] = 2
-
             if self.window.is_visible():
                 self.window.hide()
 
-    def on_confirm_quit(self, remember=True):
+    def on_confirm_quit(self):
 
         from pynicotine.gtkgui.widgets.dialogs import OptionDialog
 
@@ -306,7 +301,7 @@ class Application:
             title=_("Quit Nicotine+"),
             message=_("Do you really want to exit?"),
             buttons=buttons,
-            option_label=_("Remember choice") if remember else None,
+            option_label=_("Wait for uploads to finish"),
             callback=self.on_confirm_quit_response
         ).show()
 

--- a/pynicotine/gtkgui/ui/dialogs/shortcuts.ui
+++ b/pynicotine/gtkgui/ui/dialogs/shortcuts.ui
@@ -64,7 +64,7 @@
             </child>
             <child>
               <object class="GtkShortcutsShortcut">
-                <property name="action-name">win.close</property>
+                <property name="action-name">app.confirm-quit</property>
                 <property name="title" translatable="yes">Quit / Run in Background</property>
                 <property name="visible">True</property>
               </object>

--- a/pynicotine/gtkgui/ui/mainwindow.ui
+++ b/pynicotine/gtkgui/ui/mainwindow.ui
@@ -1775,8 +1775,8 @@
               </object>
             </child>
             <child>
-              <object class="GtkButton" id="user_status_button">
-                <property name="action-name">app.away</property>
+              <object class="GtkToggleButton" id="user_status_button">
+                <property name="action-name">win.toggle-status</property>
                 <property name="visible">True</property>
                 <child>
                   <object class="GtkBox">

--- a/pynicotine/gtkgui/ui/settings/userinterface.ui
+++ b/pynicotine/gtkgui/ui/settings/userinterface.ui
@@ -84,7 +84,7 @@
                     <property name="visible">True</property>
                     <child>
                       <object class="GtkLabel" id="close_action_label">
-                        <property name="label" translatable="yes">When closing Nicotine+:</property>
+                        <property name="label" translatable="yes">When closing window:</property>
                         <property name="visible">True</property>
                         <property name="wrap">True</property>
                         <property name="wrap-mode">word-char</property>

--- a/pynicotine/slskproto.py
+++ b/pynicotine/slskproto.py
@@ -449,8 +449,8 @@ class NetworkThread(Thread):
         if self._should_process_queue:
             self._queue.append(msg)
 
-    def _schedule_quit(self):
-        self._want_abort = True
+    def _schedule_quit(self, should_finish_uploads):
+        self._want_abort = not should_finish_uploads
 
     # Listening Socket #
 

--- a/test/unit/transfers/test_get_upload_candidate.py
+++ b/test/unit/transfers/test_get_upload_candidate.py
@@ -90,7 +90,7 @@ class GetUploadCandidateTest(TestCase):
             if clear_first and in_progress:
                 self.set_finished(in_progress.pop(0))
 
-            candidate = core.transfers.get_upload_candidate()
+            candidate, _has_active_uploads = core.transfers.get_upload_candidate()
 
             if not clear_first and in_progress:
                 self.set_finished(in_progress.pop(0))


### PR DESCRIPTION
Current behavior in this PR:
- Quitting Nicotine+ from the tray icon or operating system's quit menu item exits immediately, since showing confirmation dialogs here is not common behavior for applications (and users have requested to not show them here before)
- Quitting inside Nicotine+ (Menu -> Quit or Ctrl+Q) always shows a confirmation dialog, with an option to finish uploads before exiting. As before, the Ctrl+Alt+Q shortcut can be used to quit immediately.
- Closing the main window (using the X button or Alt+F4) follows the preference set in Preferences -> User Interface (Quit, show confirmation dialog or run in background)

Closes #885 