### PR TITLE
search.py: add context menu item to view user profiles

### DIFF
--- a/pynicotine/gtkgui/downloads.py
+++ b/pynicotine/gtkgui/downloads.py
@@ -183,18 +183,13 @@ class Downloads(TransferList):
 
     def on_browse_folder(self, *_args):
 
-        requested_users = set()
-        requested_folders = set()
+        transfer = next(iter(self.selected_transfers), None)
 
-        for transfer in self.selected_transfers:
+        if transfer:
             user = transfer.username
             folder_path = transfer.virtual_path.rsplit("\\", 1)[0] + "\\"
 
-            if user not in requested_users and folder_path not in requested_folders:
-                core.userbrowse.browse_user(user, path=folder_path)
-
-                requested_users.add(user)
-                requested_folders.add(folder_path)
+            core.userbrowse.browse_user(user, path=folder_path)
 
     def on_clear_queued(self, *_args):
         core.transfers.clear_downloads(statuses=["Queued"])

--- a/pynicotine/gtkgui/search.py
+++ b/pynicotine/gtkgui/search.py
@@ -566,7 +566,8 @@ class Search:
             ("#" + _("Download _Folder(s)"), self.on_download_folders),
             ("#" + _("Download F_older(s) To…"), self.on_download_folders_to),
             ("", None),
-            ("#" + _("_Browse Folder(s)"), self.on_browse_folder),
+            ("#" + _("View User _Profile"), self.on_user_profile),
+            ("#" + _("_Browse Folder"), self.on_browse_folder),
             ("#" + _("F_ile Properties"), self.on_file_properties),
             ("", None),
             (">" + _("Copy"), self.popup_menu_copy),
@@ -1418,18 +1419,21 @@ class Search:
 
     def on_browse_folder(self, *_args):
 
-        requested_users = set()
-        requested_folders = set()
+        iterator = next(iter(self.selected_results), None)
 
-        for iterator in self.selected_results:
+        if iterator:
             user = self.tree_view.get_row_value(iterator, "user")
             folder_path = self.tree_view.get_row_value(iterator, "file_path_data").rsplit("\\", 1)[0] + "\\"
 
-            if user not in requested_users and folder_path not in requested_folders:
-                core.userbrowse.browse_user(user, path=folder_path)
+            core.userbrowse.browse_user(user, path=folder_path)
 
-                requested_users.add(user)
-                requested_folders.add(folder_path)
+    def on_user_profile(self, *_args):
+
+        iterator = next(iter(self.selected_results), None)
+
+        if iterator:
+            user = self.tree_view.get_row_value(iterator, "user")
+            core.userinfo.show_user(user)
 
     def on_file_properties(self, *_args):
 

--- a/pynicotine/gtkgui/transferlist.py
+++ b/pynicotine/gtkgui/transferlist.py
@@ -227,7 +227,7 @@ class TransferList:
             ("#" + self.abort_label, self.on_abort_transfer),
             ("#" + _("_Clear"), self.on_clear_transfer),
             ("", None),
-            ("#" + _("_Browse Folder(s)"), self.on_browse_folder),
+            ("#" + _("_Browse Folder"), self.on_browse_folder),
             ("#" + _("_Search"), self.on_file_search),
             ("", None),
             (">" + _("Copy"), self.popup_menu_copy),


### PR DESCRIPTION
User profiles are an integral part of the Soulseek network. It's where you learn more about a user's collection, requirements and how to get access to private files.

Currently, the menu item for viewing a user's profile is buried in a submenu, making it awkward to access frequently. Add a primary menu item to make user profiles more obvious and easier to access, similar to SoulseekQt.