### PR TITLE
Changes to confirmation dialog behavior when quitting

### DIFF
--- a/pynicotine/core.py
+++ b/pynicotine/core.py
@@ -251,8 +251,8 @@ class Core:
     def setup(self):
         events.emit("setup")
 
-    def confirm_quit(self):
-        events.emit("confirm-quit")
+    def confirm_quit(self, only_on_active_uploads=False):
+        events.emit("confirm-quit", only_on_active_uploads)
 
     def quit(self, signal_type=None, _frame=None, should_finish_uploads=False):
 

--- a/pynicotine/gtkgui/application.py
+++ b/pynicotine/gtkgui/application.py
@@ -148,7 +148,7 @@ class Application:
             ("message-buddies", self.on_message_buddies, None, False),
             ("wishlist", self.on_wishlist, None, True),
             ("confirm-quit", self.on_confirm_quit_request, None, True),
-            ("force-quit", self.on_force_quit_request, None, True),
+            ("confirm-quit-uploads", self.on_confirm_quit_uploads_request, None, True),
             ("quit", self.on_quit_request, None, True),
 
             # Shares
@@ -221,7 +221,7 @@ class Application:
             ("app.away-accel", ["<Primary>h"]),
             ("app.wishlist", ["<Shift><Primary>w"]),
             ("app.confirm-quit", ["<Primary>q"]),
-            ("app.force-quit", ["<Primary><Alt>q"]),
+            ("app.quit", ["<Primary><Alt>q"]),
             ("app.rescan-shares", ["<Shift><Primary>r"]),
             ("app.keyboard-shortcuts", ["<Primary>question", "F1"]),
             ("app.preferences", ["<Primary>comma", "<Primary>p"]),
@@ -736,8 +736,8 @@ class Application:
     def on_confirm_quit_request(self, *_args):
         core.confirm_quit()
 
-    def on_force_quit_request(self, *_args):
-        core.quit()
+    def on_confirm_quit_uploads_request(self, *_args):
+        core.confirm_quit(only_on_active_uploads=True)
 
     def on_quit_request(self, *_args):
-        core.confirm_quit(only_on_active_uploads=True)
+        core.quit()

--- a/pynicotine/gtkgui/mainwindow.py
+++ b/pynicotine/gtkgui/mainwindow.py
@@ -491,7 +491,7 @@ class MainWindow(Window):
 
         menu.add_items(
             ("", None),
-            ("#" + _("_Quit"), "app.quit")
+            ("#" + _("_Quit"), "app.confirm-quit-uploads")
         )
 
     def create_file_menu(self):

--- a/pynicotine/gtkgui/mainwindow.py
+++ b/pynicotine/gtkgui/mainwindow.py
@@ -491,7 +491,7 @@ class MainWindow(Window):
 
         menu.add_items(
             ("", None),
-            ("#" + _("_Quit…"), "app.confirm-quit")
+            ("#" + _("_Quit"), "app.quit")
         )
 
     def create_file_menu(self):

--- a/pynicotine/gtkgui/ui/dialogs/shortcuts.ui
+++ b/pynicotine/gtkgui/ui/dialogs/shortcuts.ui
@@ -65,13 +65,13 @@
             <child>
               <object class="GtkShortcutsShortcut">
                 <property name="action-name">app.confirm-quit</property>
-                <property name="title" translatable="yes">Quit / Run in Background</property>
+                <property name="title" translatable="yes">Confirm Quit</property>
                 <property name="visible">True</property>
               </object>
             </child>
             <child>
               <object class="GtkShortcutsShortcut">
-                <property name="action-name">app.quit</property>
+                <property name="action-name">app.force-quit</property>
                 <property name="title" translatable="yes">Quit</property>
                 <property name="visible">True</property>
               </object>

--- a/pynicotine/gtkgui/ui/dialogs/shortcuts.ui
+++ b/pynicotine/gtkgui/ui/dialogs/shortcuts.ui
@@ -71,7 +71,7 @@
             </child>
             <child>
               <object class="GtkShortcutsShortcut">
-                <property name="action-name">app.force-quit</property>
+                <property name="action-name">app.quit</property>
                 <property name="title" translatable="yes">Quit</property>
                 <property name="visible">True</property>
               </object>

--- a/pynicotine/gtkgui/widgets/trayicon.py
+++ b/pynicotine/gtkgui/widgets/trayicon.py
@@ -106,7 +106,7 @@ class BaseImplementation:
         self.create_item()
 
         self.create_item(_("Preferences"), self.application.on_preferences)
-        self.create_item(_("Quit"), core.quit)
+        self.create_item(_("Quit"), self.application.on_quit_request)
 
     def update_window_visibility(self):
 

--- a/pynicotine/uploads.py
+++ b/pynicotine/uploads.py
@@ -284,7 +284,7 @@ class Uploads(Transfers):
         statuses = {"Getting status", "Transferring"}
 
         return bool(next(
-            (upload for upload in self.uploads if upload.status in statuses), None
+            (upload for upload in self.transfers if upload.status in statuses), None
         ))
 
     def file_is_upload_queued(self, username, virtual_path):

--- a/pynicotine/uploads.py
+++ b/pynicotine/uploads.py
@@ -279,6 +279,14 @@ class Uploads(Transfers):
         # No limits
         return True
 
+    def has_active_uploads(self):
+
+        statuses = {"Getting status", "Transferring"}
+
+        return bool(next(
+            (upload for upload in self.uploads if upload.status in statuses), None
+        ))
+
     def file_is_upload_queued(self, username, virtual_path):
 
         statuses = {"Queued", "Getting status", "Transferring"}


### PR DESCRIPTION
Behavior is currently as follows:
- Confirmation dialog only shows 'Wait for uploads to finish' checkbox when there are active uploads
- Ctrl+Q always shows confirmation dialog, to prevent accidentally quitting Nicotine+
- Window X button always shows confirmation dialog (can be changed in preferences)
- Ctrl+Alt+Q and OS-level menus (tray icon and main icon right-click menu) force quit Nicotine+
- In all other cases, a confirmation dialog is only shown when 1. there are active uploads, and 2. Nicotine+ is running in the foreground. Showing detached dialogs when attempting to quit an application running in the background usually doesn't work well, and can be disruptive (see e.g. #2487).

Feedback welcome.