### PR TITLE
Remove View menu

### DIFF
--- a/pynicotine/gtkgui/application.py
+++ b/pynicotine/gtkgui/application.py
@@ -197,9 +197,6 @@ class Application:
         enabled_logs = config.sections["logging"]["debugmodes"]
 
         for action_name, callback, state in (
-            # General
-            ("prefer-dark-mode", self.on_prefer_dark_mode, config.sections["ui"]["dark_mode"]),
-
             # Logging
             ("log-downloads", self.on_debug_downloads, ("download" in enabled_logs)),
             ("log-uploads", self.on_debug_uploads, ("upload" in enabled_logs)),
@@ -567,17 +564,6 @@ class Application:
 
     def on_personal_profile(self, *_args):
         core.userinfo.show_user(core.login_username)
-
-    @staticmethod
-    def on_prefer_dark_mode(action, *_args):
-
-        from pynicotine.gtkgui.widgets.theme import set_dark_mode
-
-        state = config.sections["ui"]["dark_mode"]
-        set_dark_mode(not state)
-        action.set_state(GLib.Variant("b", not state))
-
-        config.sections["ui"]["dark_mode"] = not state
 
     def on_away_accelerator(self, action, *_args):
         """Ctrl+H: Away/Online toggle."""

--- a/pynicotine/gtkgui/dialogs/preferences.py
+++ b/pynicotine/gtkgui/dialogs/preferences.py
@@ -2929,12 +2929,10 @@ class Preferences(Dialog):
         # Dark mode
         dark_mode_state = config.sections["ui"]["dark_mode"]
         set_dark_mode(dark_mode_state)
-        self.application.lookup_action("prefer-dark-mode").set_state(GLib.Variant("b", dark_mode_state))
 
         # Header bar
         header_bar_state = config.sections["ui"]["header_bar"]
         self.application.window.set_use_header_bar(header_bar_state)
-        self.application.window.lookup_action("use-header-bar").set_state(GLib.Variant("b", header_bar_state))
 
         # Icons
         load_custom_icons(update=True)

--- a/pynicotine/gtkgui/mainwindow.py
+++ b/pynicotine/gtkgui/mainwindow.py
@@ -406,11 +406,6 @@ class MainWindow(Window):
 
         # View
 
-        state = GLib.Variant("b", config.sections["ui"]["header_bar"])
-        action = Gio.SimpleAction(name="use-header-bar", state=state)
-        action.connect("change-state", self.on_use_header_bar)
-        self.add_action(action)
-
         state = GLib.Variant("b", not config.sections["logging"]["logcollapsed"])
         action = Gio.SimpleAction(name="show-log-history", state=state)
         action.connect("change-state", self.on_show_log_history)
@@ -496,17 +491,6 @@ class MainWindow(Window):
 
         return menu
 
-    def create_view_menu(self):
-
-        menu = PopupMenu(self.application)
-        menu.add_items(
-            ("$" + _("Prefer Dark _Mode"), "app.prefer-dark-mode"),
-            ("$" + _("Use _Header Bar"), "win.use-header-bar"),
-            ("$" + _("Show _Log History Pane"), "win.show-log-history"),
-        )
-
-        return menu
-
     def add_configure_shares_section(self, menu):
 
         menu.add_items(
@@ -552,12 +536,6 @@ class MainWindow(Window):
 
         menu = PopupMenu(self.application)
         self.add_connection_section(menu)
-
-        menu.add_items(
-            (">" + _("_View"), self.create_view_menu()),
-            ("", None)
-        )
-
         self.add_configure_shares_section(menu)
         self.add_browse_shares_section(menu)
 
@@ -574,7 +552,6 @@ class MainWindow(Window):
         menu = PopupMenu(self.application)
         menu.add_items(
             (">" + _("_File"), self.create_file_menu()),
-            (">" + _("_View"), self.create_view_menu()),
             (">" + _("_Shares"), self.create_shares_menu()),
             (">" + _("_Help"), self.create_help_menu())
         )
@@ -728,13 +705,6 @@ class MainWindow(Window):
         # Show active dialogs again after slight delay
         if active_dialogs:
             GLib.idle_add(self._show_dialogs, active_dialogs)
-
-    def on_use_header_bar(self, action, state):
-
-        action.set_state(state)
-        enabled = state.get_boolean()
-
-        self.set_use_header_bar(enabled)
 
     def on_change_focus_view(self, *_args):
         """F6 - move focus between header bar/toolbar and main content."""


### PR DESCRIPTION
All options in this menu have either been moved to Preferences -> User Interface, or can be toggled by other means. Nicotine+ also respects the system dark mode preference on Windows and macOS now, so a quick-access dark mode menu item shouldn't be necessary in most cases.