### PR TITLE
shares.py: implement custom database format for shares

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -10,7 +10,6 @@ Build-Depends: debhelper-compat (= 10),
                gir1.2-gtk-4.0 (>= 4.6.9) | gir1.2-gtk-3.0 (>= 3.22.30),
                lintian,
                python3-all,
-               python3-gdbm,
                python3-gi,
                python3-pytest,
                python3-pytest-xvfb,
@@ -26,7 +25,6 @@ Architecture: all
 Depends: ${python3:Depends},
          ${misc:Depends},
          gir1.2-gtk-4.0 (>= 4.6.9) | gir1.2-gtk-3.0 (>= 3.22.30),
-         python3-gdbm,
          python3-gi
 Recommends: gir1.2-gspell-1
 Description: graphical client for Soulseek peer-to-peer network

--- a/doc/DEPENDENCIES.md
+++ b/doc/DEPENDENCIES.md
@@ -5,7 +5,6 @@
 ### Required
 
 - [python3](https://www.python.org/) >= 3.6;
-- [python3-gdbm](https://docs.python.org/3/library/dbm.html#module-dbm.gnu) for scanning shared files.
 - [gtk4](https://gtk.org/) >= 4.6.9 or [gtk3](https://gtk.org/) >= 3.22.30 for graphical interface;
 - [pygobject](https://pygobject.readthedocs.io/) for Python bindings for GTK;
 
@@ -35,7 +34,7 @@
 - On Debian/Ubuntu-based distributions:
 
 ```sh
-sudo apt install gir1.2-gspell-1 gir1.2-gtk-4.0 gir1.2-adw-1 python3-gi python3-gdbm
+sudo apt install gir1.2-gspell-1 gir1.2-gtk-4.0 gir1.2-adw-1 python3-gi
 ```
 
 - On Redhat/Fedora-based distributions:
@@ -47,7 +46,7 @@ sudo dnf install gspell gtk4 libaadwaita python3-gobject
 - On SUSE-based distributions:
 
 ```sh
-sudo zypper install typelib-1_0-Gspell-1 typelib-1_0-Gtk-4_0 typelib-1_0-Adw-1 python3-gobject python3-dbm
+sudo zypper install typelib-1_0-Gspell-1 typelib-1_0-Gtk-4_0 typelib-1_0-Adw-1 python3-gobject
 ```
 
 #### Installing Build Dependencies

--- a/packaging/macos/dependencies.py
+++ b/packaging/macos/dependencies.py
@@ -45,7 +45,7 @@ def install_pypi():
     """Install dependencies from PyPi."""
 
     subprocess.check_call([sys.executable, "-m", "pip", "install", "--no-binary", "cx_Freeze",
-                           "-e", ".[packaging,test]", "semidbm"])
+                           "-e", ".[packaging,test]"])
 
 
 if __name__ == "__main__":

--- a/packaging/windows/dependencies.py
+++ b/packaging/windows/dependencies.py
@@ -19,7 +19,6 @@
 
 import os
 import subprocess
-import sys
 
 """ Script used to install dependencies in MinGW """
 
@@ -48,13 +47,5 @@ def install_pacman():
     subprocess.check_call(["pacman", "--noconfirm", "-S", "--needed"] + packages)
 
 
-def install_pypi():
-    """Install dependencies from PyPi."""
-
-    packages = ["semidbm"]
-    subprocess.check_call([sys.executable, "-m", "pip", "install"] + packages)
-
-
 if __name__ == "__main__":
     install_pacman()
-    install_pypi()

--- a/pynicotine/search.py
+++ b/pynicotine/search.py
@@ -431,8 +431,9 @@ class Search:
 
                     partial_results = set()
 
-                    for complete_word, indices in wordindex.items():
+                    for complete_word in wordindex:
                         if complete_word.endswith(word):
+                            indices = wordindex[complete_word]
                             partial_results.update(indices)
 
                     if partial_results:
@@ -534,7 +535,7 @@ class Search:
         numresults = min(len(resultlist), maxresults)
 
         for index in islice(resultlist, numresults):
-            fileinfo = fileindex.get(repr(index))
+            fileinfo = fileindex.get(index)
 
             if fileinfo is not None:
                 fileinfos.append(fileinfo)

--- a/pynicotine/transfers.py
+++ b/pynicotine/transfers.py
@@ -290,7 +290,7 @@ class Transfers:
             return None
 
         with open(transfers_file, "rb") as handle:
-            from pynicotine.utils import RestrictedUnpickler
+            from pynicotine.shares import RestrictedUnpickler
             return RestrictedUnpickler(handle, encoding="utf-8").load()
 
     def load_transfers(self, transfer_type):

--- a/pynicotine/userbrowse.py
+++ b/pynicotine/userbrowse.py
@@ -28,7 +28,6 @@ from pynicotine.events import events
 from pynicotine.logfacility import log
 from pynicotine.utils import clean_file
 from pynicotine.utils import encode_path
-from pynicotine.utils import RestrictedUnpickler
 
 
 class UserBrowse:
@@ -152,6 +151,7 @@ class UserBrowse:
                 import bz2
 
                 with bz2.BZ2File(file_path_encoded) as file_handle:
+                    from pynicotine.shares import RestrictedUnpickler
                     shares_list = RestrictedUnpickler(file_handle, encoding="utf-8").load()
 
             except Exception:

--- a/pynicotine/utils.py
+++ b/pynicotine/utils.py
@@ -22,7 +22,6 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import os
-import pickle
 import sys
 
 UINT32_LIMIT = 4294967295
@@ -508,14 +507,6 @@ def write_file_and_backup(path, callback, protect=False):
 
     if protect:
         os.umask(oldumask)
-
-
-class RestrictedUnpickler(pickle.Unpickler):
-    """Don't allow code execution from pickles."""
-
-    def find_class(self, module, name):
-        # Forbid all globals
-        raise pickle.UnpicklingError(f"global '{module}.{name}' is forbidden")
 
 
 # Debugging #

--- a/test/unit/shares/test_shares.py
+++ b/test/unit/shares/test_shares.py
@@ -37,6 +37,7 @@ class SharesTest(TestCase):
 
         config.sections["transfers"]["shared"] = [("Shares", SHARES_FOLDER_PATH)]
         core.shares.rescan_shares(use_thread=False)
+        core.shares.load_shares(core.shares.share_dbs, core.shares.scanner_share_db_paths)
 
     def tearDown(self):
         core.quit()
@@ -71,7 +72,7 @@ class SharesTest(TestCase):
 
         # File ID associated with word "ogg" should return our nicotinetestdata.ogg file
         self.assertIn(ogg_indexes[0], nicotinetestdata_indexes)
-        self.assertEqual(core.shares.share_dbs["fileindex"][str(ogg_indexes[0])][0], "Shares\\nicotinetestdata.ogg")
+        self.assertEqual(core.shares.share_dbs["fileindex"][ogg_indexes[0]][0], "Shares\\nicotinetestdata.ogg")
 
     def test_hidden_file_folder_scan(self):
         """Test that hidden files and folders are excluded."""


### PR DESCRIPTION
gdbm is a hassle to install on some systems, and semidbm has been unmaintained for several years. Implement a custom, straightforward key-value database format that's optimized for Nicotine+ shares.

Should be merged at the same time as https://github.com/nicotine-plus/nicotine-plus/pull/2557