### PR TITLE
Stop using 'Remote file error' transfer status

### DIFF
--- a/doc/SLSKPROTOCOL.md
+++ b/doc/SLSKPROTOCOL.md
@@ -92,9 +92,9 @@ If you find any inconsistencies, errors or omissions in the documentation, pleas
 | Complete              |                                             |
 | Disallowed extension  | Sent by Soulseek NS for filtered extensions |
 | File not shared.      | Note: Ends with a dot                       |
+| File read error.      | Note: Ends with a dot                       |
 | Pending shutdown.     | Note: Ends with a dot                       |
 | Queued                |                                             |
-| Remote file error     |                                             |
 | Too many files        |                                             |
 | Too many megabytes    |                                             |
 
@@ -104,6 +104,7 @@ If you find any inconsistencies, errors or omissions in the documentation, pleas
 | ---------------------------------- | ----------------------------------------------------------- |
 | Blocked country                    | Exclusive to Nicotine+, no longer used in Nicotine+ >=3.2.0 |
 | File not shared                    | Exclusive to Nicotine+, no longer used in Nicotine+ >=3.1.1 |
+| Remote file error                  | Sent by Soulseek NS in response to legacy download requests |
 | User limit of x megabytes exceeded | Exclusive to Nicotine+, no longer used in Nicotine+ >=3.1.1 |
 | User limit of x files exceeded     | Exclusive to Nicotine+, no longer used in Nicotine+ >=3.1.1 |
 

--- a/pynicotine/downloads.py
+++ b/pynicotine/downloads.py
@@ -189,7 +189,7 @@ class Downloads(Transfers):
         username = msg.user
         user_offline = (msg.status == slskmessages.UserStatus.OFFLINE)
         download_statuses = {"Queued", "Getting status", "Too many files", "Too many megabytes", "Pending shutdown.",
-                             "User logged off", "Connection timeout", "Remote file error", "Cancelled"}
+                             "User logged off", "Connection closed", "Connection timeout", "Cancelled"}
 
         for download in reversed(self.transfers.copy()):
             if (download.username == username
@@ -526,7 +526,7 @@ class Downloads(Transfers):
                 # SoulseekQt also sends this message for finished downloads when unsharing files, ignore
                 continue
 
-            if reason in {"File not shared.", "File not shared", "Remote file error"} and not download.legacy_attempt:
+            if reason == "File not shared." and not download.legacy_attempt:
                 # The peer is possibly using an old client that doesn't support Unicode
                 # (Soulseek NS). Attempt to request file name encoded as latin-1 once.
 
@@ -581,7 +581,7 @@ class Downloads(Transfers):
                 break
 
             # Already failed once previously, give up
-            self.abort_download(download, abort_reason="Remote file error")
+            self.abort_download(download, abort_reason="Connection closed")
 
             log.add_transfer("Upload attempt by user %(user)s for file %(filename)s failed. Reason: %(reason)s", {
                 "filename": virtual_path,
@@ -1009,7 +1009,7 @@ class Downloads(Transfers):
 
     def check_download_queue(self):
 
-        failed_statuses = {"Connection timeout", "Local file error", "Remote file error"}
+        failed_statuses = {"Connection closed", "Connection timeout", "File read error.", "Local file error"}
 
         for download in reversed(self.transfers):
             if download.status in failed_statuses:

--- a/pynicotine/gtkgui/transfers.py
+++ b/pynicotine/gtkgui/transfers.py
@@ -88,6 +88,7 @@ class Transfers:
             "Queued (privileged)": _("Queued (privileged)"),
             "Getting status": _("Getting status"),
             "Transferring": _("Transferring"),
+            "Connection closed": _("Connection closed"),
             "Connection timeout": _("Connection timeout"),
             "Pending shutdown.": _("Pending shutdown"),
             "User logged off": _("User logged off"),
@@ -103,7 +104,7 @@ class Transfers:
             "File not shared.": _("File not shared"),
             "Download folder error": _("Download folder error"),
             "Local file error": _("Local file error"),
-            "Remote file error": _("Remote file error")
+            "File read error.": _("File read error")
         }
 
         self.tree_view = TreeView(

--- a/pynicotine/uploads.py
+++ b/pynicotine/uploads.py
@@ -1071,9 +1071,11 @@ class Uploads(Transfers):
                 return False, reason
 
         # Do we actually share that file with the world?
-        if (not core.shares.file_is_shared(username, virtual_path, real_path)
-                or not self.file_is_readable(virtual_path, real_path)):
+        if not core.shares.file_is_shared(username, virtual_path, real_path):
             return False, "File not shared."
+
+        if not self.file_is_readable(virtual_path, real_path):
+            return False, "File read error."
 
         return True, None
 


### PR DESCRIPTION
Soulseek NS only sends this status message in response to legacy download requests, which we no longer use.

Modern Soulseek clients send a UploadFailed message when a file connection closed unexpectedly, but Soulseek NS also sends it at the beginning of an upload attempt when it can't read a file. Instead of marking these files with a "Remote file error" status, which will be incorrect in most cases, add a new local "Connection closed" status.

Additionally, start sending a "File read error." rejection message when we can't read a file when uploading, instead of a "File not shared." message. This is what SoulseekQt does (although SoulseekQt sends an incorrect path, making the message not appear in the UI).