### PR TITLE
Fix minor warning whilst testing the albanian po file

### DIFF
--- a/po/sq.po
+++ b/po/sq.po
@@ -5,7 +5,7 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: PACKAGE VERSION\n"
+"Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2023-09-20 16:24+0300\n"
 "PO-Revision-Date: 2023-09-07 19:08+0000\n"


### PR DESCRIPTION
nicotine@bran ~/src/nicotine-plus % for i in po/*.po; msgfmt -c -o /dev/null $i po/sq.po:7: warning: header field 'Project-Id-Version' still has the initial default value

Perhaps this can also be added to the tests?