### PR TITLE
Show chat room tabs before connecting to server

### DIFF
--- a/pynicotine/gtkgui/popovers/roomlist.py
+++ b/pynicotine/gtkgui/popovers/roomlist.py
@@ -112,6 +112,7 @@ class RoomList(Popover):
             ("remove-room", self.remove_room),
             ("room-list", self.room_list),
             ("server-disconnect", self.clear),
+            ("show-room", self.show_room),
             ("user-joined-room", self.user_joined_room),
             ("user-left-room", self.user_left_room)
         ):
@@ -158,7 +159,12 @@ class RoomList(Popover):
             return
 
         user_count = self.list_view.get_row_value(iterator, "users_data")
-        user_count = (user_count - 1 if decrement else user_count + 1)
+
+        if decrement:
+            if user_count > 0:
+                user_count -= 1
+        else:
+            user_count += 1
 
         if self.list_view.get_row_value(iterator, "is_private_data"):
             h_user_count = humanize(user_count - self.PRIVATE_USERS_OFFSET)
@@ -175,11 +181,11 @@ class RoomList(Popover):
         self.add_room(msg.room, is_private=True)
 
     def join_room(self, msg):
-
-        if msg.room == core.chatrooms.GLOBAL_ROOM_NAME:
-            self.toggle_public_feed(True)
-
         self.update_room_user_count(msg.room)
+
+    def show_room(self, room, *_args):
+        if room == core.chatrooms.GLOBAL_ROOM_NAME:
+            self.toggle_public_feed(True)
 
     def remove_room(self, room):
 
@@ -242,7 +248,7 @@ class RoomList(Popover):
             return
 
         if self.public_feed_toggle.get_active():
-            core.chatrooms.show_global_room()
+            core.chatrooms.show_room(core.chatrooms.GLOBAL_ROOM_NAME)
             self.close(use_transition=False)
             return
 

--- a/pynicotine/gtkgui/ui/chatrooms.ui
+++ b/pynicotine/gtkgui/ui/chatrooms.ui
@@ -94,6 +94,7 @@
                       <object class="GtkEntry" id="chat_entry">
                         <property name="hexpand">True</property>
                         <property name="placeholder-text" translatable="yes">Send message…</property>
+                        <property name="sensitive">False</property>
                         <property name="show-emoji-icon">True</property>
                         <property name="visible">True</property>
                         <property name="width-chars">8</property>

--- a/pynicotine/slskmessages.py
+++ b/pynicotine/slskmessages.py
@@ -541,10 +541,10 @@ class SayChatroom(ServerMessage):
 
     __slots__ = ("room", "msg", "user")
 
-    def __init__(self, room=None, msg=None):
+    def __init__(self, room=None, msg=None, user=None):
         self.room = room
         self.msg = msg
-        self.user = None
+        self.user = user
 
     def make_network_message(self):
         msg = bytearray()


### PR DESCRIPTION
Instead of waiting for a response from the server before showing a chat room tab, show it immediately.

Benefits:
- All tabs in Nicotine+ now behave the same
- Can read chat room history before connecting to the server
- Makes Nicotine+ feel faster, since slow connections no longer determine when tabs will be added
- If you're no longer able to join a private room that you've joined in the past, the tab still appears, allowing you to remove the room without manually editing the config. Redirect private messages from the server about room join failures to the appropriate chat room tab.