### PR TITLE
CLI: prompt for username and password when necessary

### DIFF
--- a/pynicotine/core.py
+++ b/pynicotine/core.py
@@ -271,6 +271,9 @@ class Core:
 
     def connect(self):
 
+        if self.user_status != slskmessages.UserStatus.OFFLINE:
+            return
+
         if config.need_config():
             log.add(_("You need to specify a username and password before connecting…"))
             self.setup()
@@ -288,7 +291,8 @@ class Core:
         ))
 
     def disconnect(self):
-        self.send_message_to_network_thread(slskmessages.ServerDisconnect())
+        if self.user_status != slskmessages.UserStatus.OFFLINE:
+            self.send_message_to_network_thread(slskmessages.ServerDisconnect())
 
     def send_message_to_network_thread(self, message):
         """Sends message to the networking thread to inform about something."""

--- a/pynicotine/plugins/core_commands/__init__.py
+++ b/pynicotine/plugins/core_commands/__init__.py
@@ -45,6 +45,14 @@ class Plugin(BasePlugin):
                 "description": _("List available commands"),
                 "parameters": ["[query]"]
             },
+            "connect": {
+                "callback": self.connect_command,
+                "description": _("Connect to the server"),
+            },
+            "disconnect": {
+                "callback": self.disconnect_command,
+                "description": _("Disconnect from the server"),
+            },
             "away": {
                 "aliases": ["a"],
                 "callback": self.away_command,
@@ -307,6 +315,12 @@ class Plugin(BasePlugin):
             output_text += "\n" + _("Type %(command)s to list available commands") % {"command": "/help"}
 
         self.output(output_text)
+
+    def connect_command(self, _args, **_unused):
+        self.core.connect()
+
+    def disconnect_command(self, _args, **_unused):
+        self.core.disconnect()
 
     def away_command(self, _args, **_unused):
 


### PR DESCRIPTION
These changes are enough to get you up and running in headless mode, but avoids adding commands for logging in as another user or changing your password.

We should add these eventually, but it will require more discussion and work to get them right. For now, I'm simply adding the bare minimum to get Nicotine+ 3.3.0 out the door.