### PR TITLE
test_startup.py: remove dependency on Xvfb

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt update
-          sudo apt install gettext gir1.2-gtk-3.0 libgirepository1.0-dev
+          sudo apt install gettext gir1.2-gtk-3.0 libgirepository1.0-dev libgtk-3-bin
           python -m pip install build .[tests]
 
       - name: PEP 8 style checks
@@ -36,7 +36,7 @@ jobs:
         run: python -m pylint --recursive=y .
 
       - name: Integration and unit tests
-        run: xvfb-run python -m unittest -v
+        run: python -m unittest -v
 
       - name: Build
         run: python -m build
@@ -82,7 +82,7 @@ jobs:
           fetch-depth: 0
 
       - name: Install dependencies
-        run: dnf -y install gettext gtk${{ matrix.gtk }} python3 python3-gobject util-linux xorg-x11-server-Xvfb
+        run: dnf -y install gettext gtk${{ matrix.gtk }} python3 python3-gobject util-linux
 
       - name: Install dependencies (Fedora)
         if: matrix.container == 'fedora:rawhide'
@@ -102,7 +102,7 @@ jobs:
         run: python3 -m pylint --recursive=y .
 
       - name: Integration and unit tests
-        run: xvfb-run python3 -m unittest -v
+        run: python3 -m unittest -v
 
       - name: Build
         run: python3 -m build

--- a/debian/control
+++ b/debian/control
@@ -8,10 +8,10 @@ Build-Depends: debhelper-compat (= 10),
                dh-python,
                gettext,
                gir1.2-gtk-4.0 (>= 4.6.9) | gir1.2-gtk-3.0 (>= 3.22.30),
+               libgtk-4-bin | libgtk-3-bin,
                lintian,
                python3-all,
                python3-gi,
-               python3-pytest,
                python3-pytest-xvfb,
                python3-setuptools
 Vcs-Git: https://github.com/nicotine-plus/nicotine-plus.git


### PR DESCRIPTION
Note that Ubuntu 22.04 doesn't ship gtk4-broadwayd, so we still need to use Xvfb there.