### PR TITLE
Statistics: remove started transfers from GUI

### DIFF
--- a/pynicotine/gtkgui/dialogs/statistics.py
+++ b/pynicotine/gtkgui/dialogs/statistics.py
@@ -42,10 +42,6 @@ class Statistics(Dialog):
             self.downloaded_size_total_label,
             self.reset_button,
             self.since_timestamp_total_label,
-            self.started_downloads_session_label,
-            self.started_downloads_total_label,
-            self.started_uploads_session_label,
-            self.started_uploads_total_label,
             self.uploaded_size_session_label,
             self.uploaded_size_total_label
         ) = ui.load(scope=self, path="dialogs/statistics.ui")
@@ -55,7 +51,7 @@ class Statistics(Dialog):
             content_box=self.container,
             show_callback=self.on_show,
             title=_("Transfer Statistics"),
-            width=450,
+            width=425,
             resizable=False,
             close_destroy=False
         )
@@ -81,10 +77,16 @@ class Statistics(Dialog):
             total_value = humanize(total_value)
 
         if session_value is not None:
-            getattr(self, f"{stat_id}_session_label").set_text(session_value)
+            session_label = getattr(self, f"{stat_id}_session_label", None)
+
+            if session_label is not None:
+                session_label.set_text(session_value)
 
         if total_value is not None:
-            getattr(self, f"{stat_id}_total_label").set_text(total_value)
+            total_label = getattr(self, f"{stat_id}_total_label", None)
+
+            if total_label is not None:
+                total_label.set_text(total_value)
 
     def on_reset_statistics_response(self, *_args):
         core.statistics.reset_stats()

--- a/pynicotine/gtkgui/dialogs/statistics.py
+++ b/pynicotine/gtkgui/dialogs/statistics.py
@@ -46,6 +46,28 @@ class Statistics(Dialog):
             self.uploaded_size_total_label
         ) = ui.load(scope=self, path="dialogs/statistics.ui")
 
+        self.stat_id_labels = {
+            "completed_downloads": {
+                "session": self.completed_downloads_session_label,
+                "total": self.completed_downloads_total_label
+            },
+            "completed_uploads": {
+                "session": self.completed_uploads_session_label,
+                "total": self.completed_uploads_total_label
+            },
+            "downloaded_size": {
+                "session": self.downloaded_size_session_label,
+                "total": self.downloaded_size_total_label
+            },
+            "uploaded_size": {
+                "session": self.uploaded_size_session_label,
+                "total": self.uploaded_size_total_label
+            },
+            "since_timestamp": {
+                "total": self.since_timestamp_total_label
+            }
+        }
+
         super().__init__(
             parent=application.window,
             content_box=self.container,
@@ -59,6 +81,11 @@ class Statistics(Dialog):
         events.connect("update-stat", self.update_stat)
 
     def update_stat(self, stat_id, session_value, total_value):
+
+        current_stat_id_labels = self.stat_id_labels.get(stat_id)
+
+        if not current_stat_id_labels:
+            return
 
         if not self.widget.get_visible():
             return
@@ -77,15 +104,15 @@ class Statistics(Dialog):
             total_value = humanize(total_value)
 
         if session_value is not None:
-            session_label = getattr(self, f"{stat_id}_session_label", None)
+            session_label = current_stat_id_labels["session"]
 
-            if session_label is not None:
+            if session_label.get_text() != session_value:
                 session_label.set_text(session_value)
 
         if total_value is not None:
-            total_label = getattr(self, f"{stat_id}_total_label", None)
+            total_label = current_stat_id_labels["total"]
 
-            if total_label is not None:
+            if total_label.get_text() != total_value:
                 total_label.set_text(total_value)
 
     def on_reset_statistics_response(self, *_args):

--- a/pynicotine/gtkgui/ui/dialogs/statistics.ui
+++ b/pynicotine/gtkgui/ui/dialogs/statistics.ui
@@ -29,58 +29,7 @@
         <child>
           <object class="GtkBox">
             <property name="homogeneous">True</property>
-            <property name="spacing">12</property>
-            <property name="visible">True</property>
-            <child>
-              <object class="GtkLabel">
-                <property name="label" translatable="yes">Started Downloads</property>
-                <property name="mnemonic-widget">started_downloads_session_label</property>
-                <property name="visible">True</property>
-                <property name="xalign">1</property>
-                <style>
-                  <class name="dim-label"/>
-                </style>
-              </object>
-            </child>
-            <child>
-              <object class="GtkLabel" id="started_downloads_session_label">
-                <property name="ellipsize">end</property>
-                <property name="selectable">True</property>
-                <property name="visible">True</property>
-                <property name="xalign">0</property>
-              </object>
-            </child>
-          </object>
-        </child>
-        <child>
-          <object class="GtkBox">
-            <property name="homogeneous">True</property>
-            <property name="spacing">12</property>
-            <property name="visible">True</property>
-            <child>
-              <object class="GtkLabel">
-                <property name="label" translatable="yes">Completed Downloads</property>
-                <property name="mnemonic-widget">completed_downloads_session_label</property>
-                <property name="visible">True</property>
-                <property name="xalign">1</property>
-                <style>
-                  <class name="dim-label"/>
-                </style>
-              </object>
-            </child>
-            <child>
-              <object class="GtkLabel" id="completed_downloads_session_label">
-                <property name="ellipsize">end</property>
-                <property name="selectable">True</property>
-                <property name="visible">True</property>
-                <property name="xalign">0</property>
-              </object>
-            </child>
-          </object>
-        </child>
-        <child>
-          <object class="GtkBox">
-            <property name="homogeneous">True</property>
+            <property name="margin-top">6</property>
             <property name="spacing">12</property>
             <property name="visible">True</property>
             <child>
@@ -105,19 +54,14 @@
           </object>
         </child>
         <child>
-          <object class="GtkLabel">
-            <property name="visible">True</property>
-          </object>
-        </child>
-        <child>
           <object class="GtkBox">
             <property name="homogeneous">True</property>
             <property name="spacing">12</property>
             <property name="visible">True</property>
             <child>
               <object class="GtkLabel">
-                <property name="label" translatable="yes">Started Uploads</property>
-                <property name="mnemonic-widget">started_uploads_session_label</property>
+                <property name="label" translatable="yes">Uploaded Size</property>
+                <property name="mnemonic-widget">uploaded_size_session_label</property>
                 <property name="visible">True</property>
                 <property name="xalign">1</property>
                 <style>
@@ -126,7 +70,34 @@
               </object>
             </child>
             <child>
-              <object class="GtkLabel" id="started_uploads_session_label">
+              <object class="GtkLabel" id="uploaded_size_session_label">
+                <property name="ellipsize">end</property>
+                <property name="selectable">True</property>
+                <property name="visible">True</property>
+                <property name="xalign">0</property>
+              </object>
+            </child>
+          </object>
+        </child>
+        <child>
+          <object class="GtkBox">
+            <property name="homogeneous">True</property>
+            <property name="margin-top">12</property>
+            <property name="spacing">12</property>
+            <property name="visible">True</property>
+            <child>
+              <object class="GtkLabel">
+                <property name="label" translatable="yes">Completed Downloads</property>
+                <property name="mnemonic-widget">completed_downloads_session_label</property>
+                <property name="visible">True</property>
+                <property name="xalign">1</property>
+                <style>
+                  <class name="dim-label"/>
+                </style>
+              </object>
+            </child>
+            <child>
+              <object class="GtkLabel" id="completed_downloads_session_label">
                 <property name="ellipsize">end</property>
                 <property name="selectable">True</property>
                 <property name="visible">True</property>
@@ -162,39 +133,10 @@
           </object>
         </child>
         <child>
-          <object class="GtkBox">
-            <property name="homogeneous">True</property>
-            <property name="spacing">12</property>
+          <object class="GtkLabel">
             <property name="visible">True</property>
-            <child>
-              <object class="GtkLabel">
-                <property name="label" translatable="yes">Uploaded Size</property>
-                <property name="mnemonic-widget">uploaded_size_session_label</property>
-                <property name="visible">True</property>
-                <property name="xalign">1</property>
-                <style>
-                  <class name="dim-label"/>
-                </style>
-              </object>
-            </child>
-            <child>
-              <object class="GtkLabel" id="uploaded_size_session_label">
-                <property name="ellipsize">end</property>
-                <property name="selectable">True</property>
-                <property name="visible">True</property>
-                <property name="xalign">0</property>
-              </object>
-            </child>
           </object>
         </child>
-      </object>
-    </child>
-    <child>
-      <object class="GtkBox">
-        <property name="hexpand">True</property>
-        <property name="orientation">vertical</property>
-        <property name="spacing">12</property>
-        <property name="visible">True</property>
         <child>
           <object class="GtkLabel" id="since_timestamp_total_label">
             <property name="label" translatable="yes">Total</property>
@@ -209,12 +151,13 @@
         <child>
           <object class="GtkBox">
             <property name="homogeneous">True</property>
+            <property name="margin-top">6</property>
             <property name="spacing">12</property>
             <property name="visible">True</property>
             <child>
               <object class="GtkLabel">
-                <property name="label" translatable="yes">Started Downloads</property>
-                <property name="mnemonic-widget">started_downloads_total_label</property>
+                <property name="label" translatable="yes">Downloaded Size</property>
+                <property name="mnemonic-widget">downloaded_size_total_label</property>
                 <property name="visible">True</property>
                 <property name="xalign">1</property>
                 <style>
@@ -223,7 +166,7 @@
               </object>
             </child>
             <child>
-              <object class="GtkLabel" id="started_downloads_total_label">
+              <object class="GtkLabel" id="downloaded_size_total_label">
                 <property name="ellipsize">end</property>
                 <property name="selectable">True</property>
                 <property name="visible">True</property>
@@ -235,6 +178,33 @@
         <child>
           <object class="GtkBox">
             <property name="homogeneous">True</property>
+            <property name="spacing">12</property>
+            <property name="visible">True</property>
+            <child>
+              <object class="GtkLabel">
+                <property name="label" translatable="yes">Uploaded Size</property>
+                <property name="mnemonic-widget">uploaded_size_total_label</property>
+                <property name="visible">True</property>
+                <property name="xalign">1</property>
+                <style>
+                  <class name="dim-label"/>
+                </style>
+              </object>
+            </child>
+            <child>
+              <object class="GtkLabel" id="uploaded_size_total_label">
+                <property name="ellipsize">end</property>
+                <property name="selectable">True</property>
+                <property name="visible">True</property>
+                <property name="xalign">0</property>
+              </object>
+            </child>
+          </object>
+        </child>
+        <child>
+          <object class="GtkBox">
+            <property name="homogeneous">True</property>
+            <property name="margin-top">12</property>
             <property name="spacing">12</property>
             <property name="visible">True</property>
             <child>
@@ -265,63 +235,6 @@
             <property name="visible">True</property>
             <child>
               <object class="GtkLabel">
-                <property name="label" translatable="yes">Downloaded Size</property>
-                <property name="mnemonic-widget">downloaded_size_total_label</property>
-                <property name="visible">True</property>
-                <property name="xalign">1</property>
-                <style>
-                  <class name="dim-label"/>
-                </style>
-              </object>
-            </child>
-            <child>
-              <object class="GtkLabel" id="downloaded_size_total_label">
-                <property name="ellipsize">end</property>
-                <property name="selectable">True</property>
-                <property name="visible">True</property>
-                <property name="xalign">0</property>
-              </object>
-            </child>
-          </object>
-        </child>
-        <child>
-          <object class="GtkLabel">
-            <property name="visible">True</property>
-          </object>
-        </child>
-        <child>
-          <object class="GtkBox">
-            <property name="homogeneous">True</property>
-            <property name="spacing">12</property>
-            <property name="visible">True</property>
-            <child>
-              <object class="GtkLabel">
-                <property name="label" translatable="yes">Started Uploads</property>
-                <property name="mnemonic-widget">started_uploads_total_label</property>
-                <property name="visible">True</property>
-                <property name="xalign">1</property>
-                <style>
-                  <class name="dim-label"/>
-                </style>
-              </object>
-            </child>
-            <child>
-              <object class="GtkLabel" id="started_uploads_total_label">
-                <property name="ellipsize">end</property>
-                <property name="selectable">True</property>
-                <property name="visible">True</property>
-                <property name="xalign">0</property>
-              </object>
-            </child>
-          </object>
-        </child>
-        <child>
-          <object class="GtkBox">
-            <property name="homogeneous">True</property>
-            <property name="spacing">12</property>
-            <property name="visible">True</property>
-            <child>
-              <object class="GtkLabel">
                 <property name="label" translatable="yes">Completed Uploads</property>
                 <property name="mnemonic-widget">completed_uploads_total_label</property>
                 <property name="visible">True</property>
@@ -333,32 +246,6 @@
             </child>
             <child>
               <object class="GtkLabel" id="completed_uploads_total_label">
-                <property name="ellipsize">end</property>
-                <property name="selectable">True</property>
-                <property name="visible">True</property>
-                <property name="xalign">0</property>
-              </object>
-            </child>
-          </object>
-        </child>
-        <child>
-          <object class="GtkBox">
-            <property name="homogeneous">True</property>
-            <property name="spacing">12</property>
-            <property name="visible">True</property>
-            <child>
-              <object class="GtkLabel">
-                <property name="label" translatable="yes">Uploaded Size</property>
-                <property name="mnemonic-widget">uploaded_size_total_label</property>
-                <property name="visible">True</property>
-                <property name="xalign">1</property>
-                <style>
-                  <class name="dim-label"/>
-                </style>
-              </object>
-            </child>
-            <child>
-              <object class="GtkLabel" id="uploaded_size_total_label">
                 <property name="ellipsize">end</property>
                 <property name="selectable">True</property>
                 <property name="visible">True</property>


### PR DESCRIPTION
Stats for both started and finished transfers were originally added when Nicotine+ had several bugs in its transfers module, and we wanted to know what percentage of transfers failed.

The statistics for started transfers have a flaw though: pausing and resuming a transfer counts as a new one. I don't think they are worth keeping, since the number of completed transfers seems more useful. It would also give us more space to potentially add more statistics to the GUI.

I don't want to remove any stored statistics yet, but I'd like to remove started transfers from the GUI, and see if we get any feedback/complaints about it. If not, we can remove them completely in a future release.