### PR TITLE
Statistics: update ui values only if dialog is visible

### DIFF
--- a/pynicotine/gtkgui/dialogs/statistics.py
+++ b/pynicotine/gtkgui/dialogs/statistics.py
@@ -18,7 +18,6 @@
 
 import time
 
-from pynicotine.config import config
 from pynicotine.core import core
 from pynicotine.events import events
 from pynicotine.gtkgui.widgets import ui
@@ -58,6 +57,7 @@ class Statistics(Dialog):
             buttons_start=(self.close_button,),
             buttons_end=(self.reset_button,),
             default_button=self.close_button,
+            show_callback=self.on_show,
             title=_("Transfer Statistics"),
             width=450,
             resizable=False,
@@ -67,10 +67,10 @@ class Statistics(Dialog):
 
         events.connect("update-stat-value", self.update_stat_value)
 
-        for stat_id in config.defaults["statistics"]:
-            core.statistics.update_ui(stat_id)
-
     def update_stat_value(self, stat_id, session_value, total_value):
+
+        if not self.widget.get_visible():
+            return
 
         if stat_id in {"downloaded_size", "uploaded_size"}:
             session_value = human_size(session_value)
@@ -106,3 +106,6 @@ class Statistics(Dialog):
 
     def on_close(self, *_args):
         self.close()
+
+    def on_show(self, *_args):
+        core.statistics.update_stats()

--- a/pynicotine/transfers.py
+++ b/pynicotine/transfers.py
@@ -506,9 +506,6 @@ class Statistics:
         for stat_id in config.defaults["statistics"]:
             self.session_stats[stat_id] = 0 if stat_id != "since_timestamp" else int(time.time())
 
-        for stat_id in config.defaults["statistics"]:
-            self.update_ui(stat_id)
-
     def _quit(self):
         self.session_stats.clear()
 
@@ -516,14 +513,19 @@ class Statistics:
 
         self.session_stats[stat_id] += stat_value
         config.sections["statistics"][stat_id] += stat_value
-        self.update_ui(stat_id)
 
-    def update_ui(self, stat_id):
+        self._update_stat(stat_id)
+
+    def _update_stat(self, stat_id):
 
         session_stat_value = self.session_stats[stat_id]
         total_stat_value = config.sections["statistics"][stat_id]
 
         events.emit("update-stat-value", stat_id, session_stat_value, total_stat_value)
+
+    def update_stats(self):
+        for stat_id in self.session_stats:
+            self._update_stat(stat_id)
 
     def reset_stats(self):
 
@@ -531,4 +533,4 @@ class Statistics:
             stat_value = 0 if stat_id != "since_timestamp" else int(time.time())
             self.session_stats[stat_id] = config.sections["statistics"][stat_id] = stat_value
 
-            self.update_ui(stat_id)
+        self.update_stats()


### PR DESCRIPTION
Minor performance optimization

+ Fixed: After the Statistics dialog is shown once or more then closed then it's unnecessary to make the strings thereafter