### PR TITLE
fix UPnP

### DIFF
--- a/pynicotine/portmapper.py
+++ b/pynicotine/portmapper.py
@@ -228,10 +228,10 @@ class UPnP(BaseImplementation):
                 "MX": str(UPnP.MX_RESPONSE_DELAY)
             }
 
-        def send(self, sock):
+        def sendto(self, sock, addr):
 
             msg = bytes(self)
-            sock.send(msg)
+            sock.sendto(msg, addr)
 
             log.add_debug("UPnP: SSDP request: %s", msg)
 
@@ -328,30 +328,29 @@ class UPnP(BaseImplementation):
                 sock.setsockopt(socket.SOL_SOCKET, socket.SO_BROADCAST, 1)
                 sock.settimeout(UPnP.MX_RESPONSE_DELAY + 0.1)  # Larger timeout in case data arrives at the last moment
                 sock.bind((private_ip, 0))
-                sock.connect((UPnP.MULTICAST_HOST, UPnP.MULTICAST_PORT))
 
                 # Protocol 1
                 wan_ip1 = UPnP.SSDPRequest("urn:schemas-upnp-org:service:WANIPConnection:1")
                 wan_ppp1 = UPnP.SSDPRequest("urn:schemas-upnp-org:service:WANPPPConnection:1")
                 wan_igd1 = UPnP.SSDPRequest("urn:schemas-upnp-org:device:InternetGatewayDevice:1")
 
-                wan_ip1.send(sock)
+                wan_ip1.sendto(sock, (UPnP.MULTICAST_HOST, UPnP.MULTICAST_PORT))
                 log.add_debug("UPnP: Sent M-SEARCH IP request 1")
 
-                wan_ppp1.send(sock)
+                wan_ppp1.sendto(sock, (UPnP.MULTICAST_HOST, UPnP.MULTICAST_PORT))
                 log.add_debug("UPnP: Sent M-SEARCH PPP request 1")
 
-                wan_igd1.send(sock)
+                wan_igd1.sendto(sock, (UPnP.MULTICAST_HOST, UPnP.MULTICAST_PORT))
                 log.add_debug("UPnP: Sent M-SEARCH IGD request 1")
 
                 # Protocol 2
                 wan_ip2 = UPnP.SSDPRequest("urn:schemas-upnp-org:service:WANIPConnection:2")
                 wan_igd2 = UPnP.SSDPRequest("urn:schemas-upnp-org:device:InternetGatewayDevice:2")
 
-                wan_ip2.send(sock)
+                wan_ip2.sendto(sock, (UPnP.MULTICAST_HOST, UPnP.MULTICAST_PORT))
                 log.add_debug("UPnP: Sent M-SEARCH IP request 2")
 
-                wan_igd2.send(sock)
+                wan_igd2.sendto(sock, (UPnP.MULTICAST_HOST, UPnP.MULTICAST_PORT))
                 log.add_debug("UPnP: Sent M-SEARCH IGD request 2")
 
                 locations = set()


### PR DESCRIPTION
Turns out you cannot `connect()` to a multicast address, so there was a good reason why Nicotine+-3.2.9 used `sendto()` instead of `send()`.

Further info: https://www.cs.unc.edu/~jeffay/dirt/FAQ/comp249-001-F99/mcast-socket.html

Fixes: https://github.com/nicotine-plus/nicotine-plus/issues/2673