### PR TITLE
userbrowse.py: don't select folders with similar name when recursing

### DIFF
--- a/pynicotine/tests/unit/transfers/test_downloads.py
+++ b/pynicotine/tests/unit/transfers/test_downloads.py
@@ -245,6 +245,10 @@ class DownloadsTest(TestCase):
             ]),
             ("share\\Soulseek\\folder2\\sub2", [
                 (1, "file6.mp3", 8000000, "", {})
+            ]),
+            ("share\\SoulseekSecond", [
+                (1, "file7.mp3", 9000000, "", {}),
+                (1, "file8.mp3", 10000000, "", {})
             ])
         ])
 
@@ -255,8 +259,10 @@ class DownloadsTest(TestCase):
         core.userbrowse.download_folder(username, target_folder_path, download_folder_path="test", recurse=True)
 
         transfers = list(core.downloads.transfers.values())
-        self.assertEqual(len(transfers), 9)
+        self.assertEqual(len(transfers), 11)
 
+        self.assertEqual(transfers[10].folder_path, os.path.join("test", "share", "SoulseekSecond"))
+        self.assertEqual(transfers[9].folder_path, os.path.join("test", "share", "SoulseekSecond"))
         self.assertEqual(transfers[8].folder_path, os.path.join("test", "share", "Soulseek", "folder2", "sub2"))
         self.assertEqual(transfers[7].folder_path, os.path.join("test", "share", "Soulseek", "folder2"))
         self.assertEqual(transfers[6].folder_path, os.path.join("test", "share", "Soulseek", "folder1", "sub1"))

--- a/pynicotine/userbrowse.py
+++ b/pynicotine/userbrowse.py
@@ -245,11 +245,8 @@ class UserBrowse:
             return
 
         for folder_path, files in self.user_shares[username].items():
-            if not recurse and requested_folder_path != folder_path:
-                continue
-
-            if requested_folder_path not in folder_path:
-                # Not a subfolder of the requested folder, skip
+            if (requested_folder_path != folder_path
+                    and not (recurse and folder_path.startswith(f"{requested_folder_path}\\"))):
                 continue
 
             # Get final download destination
@@ -282,11 +279,8 @@ class UserBrowse:
             return
 
         for folder_path, files in local_shares.items():
-            if not recurse and requested_folder_path != folder_path:
-                continue
-
-            if requested_folder_path not in folder_path:
-                # Not a subfolder of the requested folder, skip
+            if (requested_folder_path != folder_path
+                    and not (recurse and folder_path.startswith(f"{requested_folder_path}\\"))):
                 continue
 
             for _code, basename, file_size, *_unused in files:


### PR DESCRIPTION
Fixes #2782