### PR TITLE
treeview.py: remember column sort order

### DIFF
--- a/pynicotine/gtkgui/buddies.py
+++ b/pynicotine/gtkgui/buddies.py
@@ -61,7 +61,7 @@ class Buddies:
         # Columns
         self.list_view = TreeView(
             window, parent=self.list_container, name="buddy_list",
-            activate_row_callback=self.on_row_activated,
+            persistent_sort=True, activate_row_callback=self.on_row_activated,
             delete_accelerator_callback=self.on_remove_buddy,
             columns={
                 # Visible columns

--- a/pynicotine/gtkgui/chatrooms.py
+++ b/pynicotine/gtkgui/chatrooms.py
@@ -467,7 +467,7 @@ class ChatRoom:
 
         self.users_list_view = TreeView(
             self.window, parent=self.users_list_container, name="chat_room", secondary_name=room,
-            activate_row_callback=self.on_row_activated,
+            persistent_sort=True, activate_row_callback=self.on_row_activated,
             columns={
                 # Visible columns
                 "status": {

--- a/pynicotine/gtkgui/search.py
+++ b/pynicotine/gtkgui/search.py
@@ -516,7 +516,8 @@ class Search:
                     "title": _("Speed"),
                     "width": 120,
                     "sort_column": "speed_data",
-                    "sensitive_column": "free_slot_data"
+                    "sensitive_column": "free_slot_data",
+                    "default_sort_type": "descending"
                 },
                 "in_queue": {
                     "column_type": "number",
@@ -581,7 +582,6 @@ class Search:
                 "file_attributes_data": {"data_type": GObject.TYPE_PYOBJECT},
                 "id_data": {
                     "data_type": GObject.TYPE_UINT64,
-                    "default_sort_type": "ascending",
                     "iterator_key": True
                 }
             }

--- a/pynicotine/gtkgui/transfers.py
+++ b/pynicotine/gtkgui/transfers.py
@@ -112,7 +112,7 @@ class Transfers:
 
         self.tree_view = TreeView(
             window, parent=self.tree_container, name=transfer_type,
-            multi_select=True, activate_row_callback=self.on_row_activated,
+            multi_select=True, persistent_sort=True, activate_row_callback=self.on_row_activated,
             delete_accelerator_callback=self.on_clear_transfers_accelerator,
             columns={
                 # Visible columns


### PR DESCRIPTION
For now, this is only done for downloads, uploads, buddies and chat room users. Remembering the sort order of searches and user shares is too intrusive, always sort search results by speed instead.

Closes #373 
Closes #2170 
Closes #2758 