### PR TITLE
GUI: remove transfer tab highlights

### DIFF
--- a/pynicotine/downloads.py
+++ b/pynicotine/downloads.py
@@ -465,8 +465,6 @@ class Downloads(Transfers):
         self._file_downloaded_actions(username, download_file_path)
         self._folder_downloaded_actions(username, transfer.folder_path)
 
-        finished = True
-        events.emit("download-notification", finished)
         core.pluginhandler.download_finished_notification(username, virtual_path, download_file_path)
 
         log.add_download(
@@ -1195,8 +1193,6 @@ class Downloads(Transfers):
             else:
                 self._finish_transfer(download)
                 need_update = False
-
-        events.emit("download-notification")
 
         if need_update:
             self._update_transfer(download)

--- a/pynicotine/events.py
+++ b/pynicotine/events.py
@@ -161,7 +161,6 @@ EVENT_NAMES = {
     "download-connection-closed",
     "download-file-error",
     "download-large-folder",
-    "download-notification",
     "file-connection-closed",
     "file-download-progress",
     "file-transfer-init",
@@ -181,7 +180,6 @@ EVENT_NAMES = {
     "upload-denied",
     "upload-failed",
     "upload-file-error",
-    "upload-notification",
 
     # User info
     "user-info-progress",

--- a/pynicotine/gtkgui/downloads.py
+++ b/pynicotine/gtkgui/downloads.py
@@ -86,7 +86,6 @@ class Downloads(Transfers):
             ("clear-download", self.clear_transfer),
             ("clear-downloads", self.clear_transfers),
             ("download-large-folder", self.download_large_folder),
-            ("download-notification", self.new_transfer_notification),
             ("start", self.start),
             ("update-download", self.update_model)
         ):

--- a/pynicotine/gtkgui/transfers.py
+++ b/pynicotine/gtkgui/transfers.py
@@ -261,7 +261,6 @@ class Transfers:
     def on_focus(self, *_args):
 
         self.update_model(select_parent=(self.pending_parent_rows_timer_id is not None))
-        self.window.notebook.remove_tab_changed(self.transfer_page)
 
         if self.container.get_visible():
             self.tree_view.grab_focus()
@@ -314,10 +313,6 @@ class Transfers:
             self.selected_users[transfer.username] = None
 
         self.select_child_transfers(transfer)
-
-    def new_transfer_notification(self, finished=False):
-        if self.window.current_page_id != self.transfer_page.id:
-            self.window.notebook.request_tab_changed(self.transfer_page, is_important=finished)
 
     def on_file_search(self, *_args):
 

--- a/pynicotine/gtkgui/uploads.py
+++ b/pynicotine/gtkgui/uploads.py
@@ -87,8 +87,7 @@ class Uploads(Transfers):
             ("clear-upload", self.clear_transfer),
             ("clear-uploads", self.clear_transfers),
             ("start", self.start),
-            ("update-upload", self.update_model),
-            ("upload-notification", self.new_transfer_notification)
+            ("update-upload", self.update_model)
         ):
             events.connect(event_name, callback)
 

--- a/pynicotine/uploads.py
+++ b/pynicotine/uploads.py
@@ -1054,8 +1054,6 @@ class Uploads(Transfers):
                 self._finish_transfer(upload)
                 need_update = False
 
-        events.emit("upload-notification")
-
         if need_update:
             self._update_transfer(upload)
 


### PR DESCRIPTION
In their current state, these are mostly visual noise rather than being helpful. If you have a lot of transfers, the tabs are almost always highlighted. Auto-cleared transfers are not taken into account either.

If we bring back highlights in the future, we should be a lot more restrictive about when to activate them.