### PR TITLE
Version 3.3.0

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -5,7 +5,7 @@ The current stable version of Nicotine+ is 3.2.9, see [DOWNLOADS.md](doc/DOWNLOA
 You can run the latest unstable build of Nicotine+ to test recent changes and bug fixes, see [TESTING.md](doc/TESTING.md).
 
 
-## Version 3.3.0rc3 (Release Candidate 3)
+## Version 3.3.0 (February 1, 2024)
 
 ### Changes
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Check out the [screenshots](data/screenshots/SCREENSHOTS.md) and [source code](h
 
 ## Download
 
-The current stable version of Nicotine+ is 3.2.9, released on March 5, 2023. See the [release notes](NEWS.md).
+The current stable version of Nicotine+ is 3.3.0, released on February 1, 2024. See the [release notes](NEWS.md).
 
 Downloads are available for:
 

--- a/data/org.nicotine_plus.Nicotine.appdata.xml.in
+++ b/data/org.nicotine_plus.Nicotine.appdata.xml.in
@@ -78,7 +78,7 @@
     <content_attribute id="social-info">mild</content_attribute>
   </content_rating>
   <releases>
-    <release version="3.3.0rc3" type="development" date="2024-01-22"/>
+    <release version="3.3.0" date="2024-02-01"/>
     <release version="3.2.9" date="2023-03-05"/>
     <release version="3.2.8" date="2023-01-06"/>
     <release version="3.2.7" date="2022-12-01"/>

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,8 +1,8 @@
-nicotine (3.3.0-rc3) mantic; urgency=medium
+nicotine (3.3.0-1) mantic; urgency=medium
 
-  * Release candidate 3.
+  * Latest upstream.
 
- -- Mat <mail@mathias.is>  Mon, 22 Jan 2024 21:45:42 +0200
+ -- Mat <mail@mathias.is>  Thu, 01 Feb 2024 22:19:53 +0200
 
 nicotine (3.2.9-1) kinetic; urgency=medium
 

--- a/doc/DOWNLOADS.md
+++ b/doc/DOWNLOADS.md
@@ -74,18 +74,17 @@ pip3 install --upgrade nicotine-plus
 
 ### Official Release
 
-Stable installers for Windows 7 and later are available for download. Installing Nicotine+ requires administrator privileges.
+Stable installers are available for download. Installing Nicotine+ requires administrator privileges.
 
 *NOTE: The installer format has changed since Nicotine+ 3.2.0. If you are upgrading from Nicotine+ 3.1.1 or earlier, please uninstall Nicotine+ first (this will not remove your existing settings).*
 
-- [Download Nicotine+ 64-bit Windows Installer](https://github.com/nicotine-plus/nicotine-plus/releases/latest/download/windows-x86_64-installer.zip)  [[SHA256](https://github.com/nicotine-plus/nicotine-plus/releases/latest/download/windows-x86_64-installer.zip.sha256)]
-- [Download Nicotine+ 32-bit Windows Installer](https://github.com/nicotine-plus/nicotine-plus/releases/latest/download/windows-i686-installer.zip)  [[SHA256](https://github.com/nicotine-plus/nicotine-plus/releases/latest/download/windows-i686-installer.zip.sha256)]
+- [Download Windows Installer](https://github.com/nicotine-plus/nicotine-plus/releases/latest/download/windows-x86_64-installer.zip)  [[SHA256](https://github.com/nicotine-plus/nicotine-plus/releases/latest/download/windows-x86_64-installer.zip.sha256)]  
+  for Windows 10 or later
 
 Standalone executables are also available. They can be run from any folder and do not require installation or administrator privileges. Configuration files are stored in `C:\Users\USERNAME\AppData\Roaming\nicotine`.
 
-- [Download Nicotine+ 64-bit Windows Standalone Package](https://github.com/nicotine-plus/nicotine-plus/releases/latest/download/windows-x86_64-package.zip)  [[SHA256](https://github.com/nicotine-plus/nicotine-plus/releases/latest/download/windows-x86_64-package.zip.sha256)]
-- [Download Nicotine+ 32-bit Windows Standalone Package](https://github.com/nicotine-plus/nicotine-plus/releases/latest/download/windows-i686-package.zip)  [[SHA256](https://github.com/nicotine-plus/nicotine-plus/releases/latest/download/windows-i686-package.zip.sha256)]
-
+- [Download Windows Standalone Package](https://github.com/nicotine-plus/nicotine-plus/releases/latest/download/windows-x86_64-package.zip)  [[SHA256](https://github.com/nicotine-plus/nicotine-plus/releases/latest/download/windows-x86_64-package.zip.sha256)]  
+  for Windows 10 or later
 
 ### Package Managers
 
@@ -101,8 +100,10 @@ If you are using any of the package managers listed, you can install Nicotine+ u
 
 ### Official Release
 
-A stable installer is available on macOS Catalina 10.15 and later.
-
 *NOTE: You have to follow [these instructions](https://support.apple.com/guide/mac-help/open-a-mac-app-from-an-unidentified-developer-mh40616/mac) the first time you open Nicotine+ on macOS.*
 
-- [Download Nicotine+ macOS Installer](https://github.com/nicotine-plus/nicotine-plus/releases/latest/download/macos-installer.zip)  [[SHA256](https://github.com/nicotine-plus/nicotine-plus/releases/latest/download/macos-installer.zip.sha256)]
+- [Download macOS Intel Installer](https://github.com/nicotine-plus/nicotine-plus/releases/latest/download/macos-x86_64-installer.zip)  [[SHA256](https://github.com/nicotine-plus/nicotine-plus/releases/latest/download/macos-x86_64-installer.zip.sha256)]  
+  for macOS 12 Monterey or later
+
+- [Download macOS Apple Silicon Installer](https://github.com/nicotine-plus/nicotine-plus/releases/latest/download/macos-arm64-installer.zip)  [[SHA256](https://github.com/nicotine-plus/nicotine-plus/releases/latest/download/macos-arm64-installer.zip.sha256)]  
+  for macOS 14 Sonoma or later

--- a/pynicotine/__init__.py
+++ b/pynicotine/__init__.py
@@ -18,7 +18,7 @@
 
 __application_name__ = "Nicotine+"
 __application_id__ = "org.nicotine_plus.Nicotine"
-__version__ = "3.3.0rc3"
+__version__ = "3.3.0"
 __author__ = "Nicotine+ Team"
 __copyright__ = """© 2004–2024 Nicotine+ Contributors
 © 2003–2004 Nicotine Contributors


### PR DESCRIPTION
PR is mainly for testing CI in preparation for release. We could try to target February 1 as the release date if no serious bugs emerge, but we can revisit the situation in a week.