### PR TITLE
Add HIDDEN_FOLDER_NAMES class to shares.py for easier management to exclude multiple folders from shares

### DIFF
--- a/pynicotine/shares.py
+++ b/pynicotine/shares.py
@@ -478,11 +478,9 @@ class Scanner:
 
         # If the last folder in the path starts with a dot, or is a Synology extended
         # attribute, snapshot or recycle bin folder, we exclude it
-        HIDDEN_FOLDER_NAMES = {"@eaDir", "#recycle", "#snapshot"}
-
         if filename is None:
             last_folder = os.path.basename(folder)
-
+            HIDDEN_FOLDER_NAMES = {"@eaDir", "#recycle", "#snapshot"}
             if last_folder.startswith(".") or last_folder in self.HIDDEN_FOLDER_NAMES:
                 return True
 

--- a/pynicotine/shares.py
+++ b/pynicotine/shares.py
@@ -478,13 +478,15 @@ class Scanner:
 
         # If the last folder in the path starts with a dot, or is a Synology extended
         # attribute, snapshot or recycle bin folder, we exclude it
+        HIDDEN_FOLDER_NAMES = {"@eaDir", "#recycle", "#snapshot"}
+        
         if filename is None:
             last_folder = os.path.basename(folder)
-
-            if last_folder.startswith(".") or last_folder in ["@eaDir", "#recycle", "#snapshot"]:
+            
+            if last_folder.startswith(".") or last_folder in self.HIDDEN_FOLDER_NAMES:
                 return True
 
-        # If we're asked to check a file we exclude it if it start with a dot
+        # If we're asked to check a file, we exclude it if it starts with a dot
         if filename is not None and filename.startswith("."):
             return True
 

--- a/pynicotine/shares.py
+++ b/pynicotine/shares.py
@@ -230,9 +230,10 @@ class Scanner:
     It handles scanning of folders and files, as well as building
     databases and writing them to disk.
     """
-    
+
+    # Add foldernames that need to be excluded from shares
     HIDDEN_FOLDER_NAMES = {"@eaDir", "#recycle", "#snapshot"}
-    
+
     def __init__(self, config_obj, queue, share_groups, share_db_paths, init=False, rescan=True,
                  rebuild=False, reveal_buddy_shares=False, reveal_trusted_shares=False):
 

--- a/pynicotine/shares.py
+++ b/pynicotine/shares.py
@@ -480,7 +480,9 @@ class Scanner:
         # attribute, snapshot or recycle bin folder, we exclude it
         if filename is None:
             last_folder = os.path.basename(folder)
+            
             HIDDEN_FOLDER_NAMES = {"@eaDir", "#recycle", "#snapshot"}
+            
             if last_folder.startswith(".") or last_folder in self.HIDDEN_FOLDER_NAMES:
                 return True
 

--- a/pynicotine/shares.py
+++ b/pynicotine/shares.py
@@ -230,7 +230,9 @@ class Scanner:
     It handles scanning of folders and files, as well as building
     databases and writing them to disk.
     """
-
+    
+    HIDDEN_FOLDER_NAMES = {"@eaDir", "#recycle", "#snapshot"}
+    
     def __init__(self, config_obj, queue, share_groups, share_db_paths, init=False, rescan=True,
                  rebuild=False, reveal_buddy_shares=False, reveal_trusted_shares=False):
 
@@ -472,17 +474,16 @@ class Scanner:
         gc.collect()
         return num_folders
 
-    @staticmethod
-    def is_hidden(folder, filename=None, entry=None):
+    @classmethod
+    def is_hidden(cls, folder, filename=None, entry=None):
         """Stop sharing any dot/hidden folders/files."""
 
-        # If the last folder in the path starts with a dot, or is a Synology extended
-        # attribute, snapshot or recycle bin folder, we exclude it
+        # If the last folder in the path starts with a dot, or uses
+        # the same name as well-known hidden folders, we exclude it
         if filename is None:
             last_folder = os.path.basename(folder)
 
-            HIDDEN_FOLDER_NAMES = {"@eaDir", "#recycle", "#snapshot"}
-            if last_folder.startswith(".") or last_folder in self.HIDDEN_FOLDER_NAMES:
+            if last_folder.startswith(".") or last_folder in cls.HIDDEN_FOLDER_NAMES:
                 return True
 
         # If we're asked to check a file, we exclude it if it starts with a dot

--- a/pynicotine/shares.py
+++ b/pynicotine/shares.py
@@ -480,9 +480,8 @@ class Scanner:
         # attribute, snapshot or recycle bin folder, we exclude it
         if filename is None:
             last_folder = os.path.basename(folder)
-            
+
             HIDDEN_FOLDER_NAMES = {"@eaDir", "#recycle", "#snapshot"}
-            
             if last_folder.startswith(".") or last_folder in self.HIDDEN_FOLDER_NAMES:
                 return True
 

--- a/pynicotine/shares.py
+++ b/pynicotine/shares.py
@@ -479,10 +479,10 @@ class Scanner:
         # If the last folder in the path starts with a dot, or is a Synology extended
         # attribute, snapshot or recycle bin folder, we exclude it
         HIDDEN_FOLDER_NAMES = {"@eaDir", "#recycle", "#snapshot"}
-        
+
         if filename is None:
             last_folder = os.path.basename(folder)
-            
+
             if last_folder.startswith(".") or last_folder in self.HIDDEN_FOLDER_NAMES:
                 return True
 

--- a/pynicotine/shares.py
+++ b/pynicotine/shares.py
@@ -481,7 +481,7 @@ class Scanner:
         if filename is None:
             last_folder = os.path.basename(folder)
 
-            if last_folder.startswith(".") or last_folder == ["@eaDir", "#recycle", "#snapshot"]:
+            if last_folder.startswith(".") or last_folder in ["@eaDir", "#recycle", "#snapshot"]:
                 return True
 
         # If we're asked to check a file we exclude it if it start with a dot

--- a/pynicotine/shares.py
+++ b/pynicotine/shares.py
@@ -477,11 +477,11 @@ class Scanner:
         """Stop sharing any dot/hidden folders/files."""
 
         # If the last folder in the path starts with a dot, or is a Synology extended
-        # attribute folder, we exclude it
+        # attribute, snapshot or recycle bin folder, we exclude it
         if filename is None:
             last_folder = os.path.basename(folder)
 
-            if last_folder.startswith(".") or last_folder == "@eaDir":
+            if last_folder.startswith(".") or last_folder == ["@eaDir", "#recycle", "#snapshot"]:
                 return True
 
         # If we're asked to check a file we exclude it if it start with a dot

--- a/pynicotine/shares.py
+++ b/pynicotine/shares.py
@@ -231,7 +231,6 @@ class Scanner:
     databases and writing them to disk.
     """
 
-    # Add foldernames that need to be excluded from shares
     HIDDEN_FOLDER_NAMES = {"@eaDir", "#recycle", "#snapshot"}
 
     def __init__(self, config_obj, queue, share_groups, share_db_paths, init=False, rescan=True,
@@ -479,8 +478,6 @@ class Scanner:
     def is_hidden(cls, folder, filename=None, entry=None):
         """Stop sharing any dot/hidden folders/files."""
 
-        # If the last folder in the path starts with a dot, or uses
-        # the same name as well-known hidden folders, we exclude it
         if filename is None:
             last_folder = os.path.basename(folder)
 


### PR DESCRIPTION
Added the Synology #snapshot and #recycle folders to be excluded from Share as these folders contain data that have been already deleted which may be a security issues and may flood the SLSK network with unnecessary files.