### PR TITLE
PortMapper: suppress debug stack trace if "No UPnP devices found"

### DIFF
--- a/pynicotine/portmapper.py
+++ b/pynicotine/portmapper.py
@@ -569,16 +569,15 @@ class PortMapper:
                 self._upnp.add_port_mapping(self.LEASE_DURATION)
 
             except Exception as upnp_error:
-                log.add_debug("UPnP not available, port forwarding failed: %s", upnp_error)
-
                 log.add(_("%(protocol)s: Failed to forward external port %(external_port)s: %(error)s"), {
                     "protocol": self._active_implementation.NAME,
                     "external_port": self._active_implementation.port,
                     "error": upnp_error
                 })
 
-                from traceback import format_exc
-                log.add_debug(format_exc())
+                if str(upnp_error) != _("No UPnP devices found"):
+                    from traceback import format_exc
+                    log.add_debug(format_exc())
 
                 self._active_implementation = None
                 self._is_mapping_port = False


### PR DESCRIPTION
The non-existance of UPnP is already logged and this condition cannot be debugged using the produced stack trace, it's just noise that happens during the startup sequence and at renewal intervals...

_Before:_
```
[2024-02-16 22:55:35] [Misc] UPnP: 0 service(s) detected
[2024-02-16 22:55:35] [Misc] UPnP not available, port forwarding failed: No UPnP devices found
[2024-02-16 22:55:35] UPnP: Failed to forward external port 12345: No UPnP devices found
[2024-02-16 22:55:35] [Misc] Traceback (most recent call last):
  File "/home/user/Git/nicotine-plus/master/pynicotine/portmapper.py", line 562, in _add_port_mapping
    self._natpmp.add_port_mapping(self.LEASE_DURATION)
  File "/home/user/Git/nicotine-plus/master/pynicotine/portmapper.py", line 175, in add_port_mapping
    raise PortmapError(f"NAT-PMP error code {result}")
pynicotine.portmapper.PortmapError: NAT-PMP error code None

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/user/Git/nicotine-plus/master/pynicotine/portmapper.py", line 569, in _add_port_mapping
    self._upnp.add_port_mapping(self.LEASE_DURATION)
  File "/home/user/Git/nicotine-plus/master/pynicotine/portmapper.py", line 463, in add_port_mapping
    raise PortmapError(_("No UPnP devices found"))
pynicotine.portmapper.PortmapError: No UPnP devices found
```

_After:_
```
[2024-02-16 23:01:01] [Misc] UPnP: 0 service(s) detected
[2024-02-16 23:01:01] UPnP: Failed to forward external port 12345: No UPnP devices found
```

... A stack trace would still be produced if there was really an actual error, but I cannot test whether the placement of the Exception handler would yield anything useful or not, because my network environment doesn't have NAT-PMP nor UPnP.