### PR TITLE
GUI: rework window parenting

### DIFF
--- a/pynicotine/gtkgui/application.py
+++ b/pynicotine/gtkgui/application.py
@@ -123,6 +123,15 @@ class Application:
     def add_window(self, window):
         self._instance.add_window(window)
 
+    def remove_window(self, window):
+        self._instance.remove_window(window)
+
+    def get_active_window(self):
+        return self._instance.get_active_window()
+
+    def get_windows(self):
+        return self._instance.get_windows()
+
     def _set_up_actions(self):
 
         # Regular actions
@@ -535,7 +544,7 @@ class Application:
             buttons.append(("run_background", _("_Run in Background")))
 
         OptionDialog(
-            parent=self.window,
+            application=self,
             title=_("Quit Nicotine+"),
             message=message,
             buttons=buttons,
@@ -556,7 +565,7 @@ class Application:
             shares_list_message += f'• "{virtual_name}" {folder_path}\n'
 
         OptionDialog(
-            parent=self.window,
+            application=self,
             title=_("Shares Not Available"),
             message=_("Verify that external disks are mounted and folder permissions are correct."),
             long_message=shares_list_message,
@@ -581,7 +590,7 @@ class Application:
                 "if this is your first time logging in.") % config.sections["server"]["login"]
 
         OptionDialog(
-            parent=self.window,
+            application=self,
             title=title,
             message=msg,
             buttons=[
@@ -752,7 +761,7 @@ class Application:
         from pynicotine.gtkgui.widgets.dialogs import EntryDialog
 
         EntryDialog(
-            parent=self.window,
+            application=self,
             title=_("Message Downloading Users"),
             message=_("Send private message to all users who are downloading from you:"),
             action_button_label=_("_Send Message"),
@@ -766,7 +775,7 @@ class Application:
         from pynicotine.gtkgui.widgets.dialogs import EntryDialog
 
         EntryDialog(
-            parent=self.window,
+            application=self,
             title=_("Message Buddies"),
             message=_("Send private message to all online buddies:"),
             action_button_label=_("_Send Message"),
@@ -796,7 +805,7 @@ class Application:
         from pynicotine.gtkgui.widgets.filechooser import FileChooser
 
         FileChooser(
-            parent=self.window,
+            application=self,
             title=_("Select a Saved Shares List File"),
             callback=self.on_load_shares_from_disk_selected,
             initial_folder=core.userbrowse.create_user_shares_folder(),
@@ -893,7 +902,7 @@ class Application:
         from pynicotine.gtkgui.widgets.dialogs import OptionDialog
 
         OptionDialog(
-            parent=self.window,
+            application=self,
             title=_("Critical Error"),
             message=_("Nicotine+ has encountered a critical error and needs to exit. "
                       "Please copy the following message and include it in a bug report:"),

--- a/pynicotine/gtkgui/buddies.py
+++ b/pynicotine/gtkgui/buddies.py
@@ -61,7 +61,7 @@ class Buddies:
 
         # Columns
         self.list_view = TreeView(
-            window, parent=self.list_container, name="buddy_list",
+            window.application, parent=self.list_container, name="buddy_list",
             persistent_sort=True, activate_row_callback=self.on_row_activated,
             delete_accelerator_callback=self.on_remove_buddy,
             columns={
@@ -496,7 +496,7 @@ class Buddies:
         note = self.list_view.get_row_value(iterator, "comments") or ""
 
         EntryDialog(
-            parent=self.window,
+            application=self.window.application,
             title=_("Add User Note"),
             message=_("Add a note about user %s:") % user,
             action_button_label=_("_Add"),

--- a/pynicotine/gtkgui/chatrooms.py
+++ b/pynicotine/gtkgui/chatrooms.py
@@ -76,7 +76,10 @@ class ChatRooms(IconNotebook):
         self.highlighted_rooms = {}
         self.completion = ChatCompletion()
         self.spell_checker = SpellChecker()
-        self.room_list = RoomList(window)
+        self.room_list = RoomList(
+            application=window.application, menu_button=window.room_list_button,
+            text_entry=window.chatrooms_entry
+        )
         self.command_help = None
         self.room_wall = None
 
@@ -164,10 +167,10 @@ class ChatRooms(IconNotebook):
             tab.update_room_user_completions()
 
             if self.command_help is None:
-                self.command_help = ChatCommandHelp(window=self.window, interface="chatroom")
+                self.command_help = ChatCommandHelp(application=self.window.application, interface="chatroom")
 
             if self.room_wall is None:
-                self.room_wall = RoomWall(window=self.window)
+                self.room_wall = RoomWall(application=self.window.application)
 
             self.command_help.set_menu_button(tab.help_button)
             self.room_wall.set_menu_button(tab.room_wall_button)
@@ -193,7 +196,7 @@ class ChatRooms(IconNotebook):
 
         if room not in core.chatrooms.server_rooms and room not in core.chatrooms.private_rooms:
             OptionDialog(
-                parent=self.window,
+                application=self.window.application,
                 title=_("Create New Room?"),
                 message=_('Do you really want to create a new room "%s"?') % room,
                 option_label=_("Make room private"),
@@ -457,7 +460,7 @@ class ChatRoom:
         self.toggle_chat_buttons()
 
         self.users_list_view = TreeView(
-            self.window, parent=self.users_list_container, name="chat_room", secondary_name=room,
+            self.window.application, parent=self.users_list_container, name="chat_room", secondary_name=room,
             persistent_sort=True, activate_row_callback=self.on_row_activated,
             columns={
                 # Visible columns
@@ -980,7 +983,7 @@ class ChatRoom:
     def on_delete_room_log(self, *_args):
 
         OptionDialog(
-            parent=self.window,
+            application=self.window.application,
             title=_("Delete Logged Messages?"),
             message=_("Do you really want to permanently delete all logged messages for this room?"),
             destructive_response_id="ok",

--- a/pynicotine/gtkgui/dialogs/about.py
+++ b/pynicotine/gtkgui/dialogs/about.py
@@ -377,7 +377,7 @@ Copyright (c) 2017 IP2Location.com
         ) = ui.load(scope=self, path="dialogs/about.ui")
 
         super().__init__(
-            parent=application.window,
+            application=application,
             content_box=self.container,
             show_callback=self.on_show,
             close_callback=self.on_close,

--- a/pynicotine/gtkgui/dialogs/fastconfigure.py
+++ b/pynicotine/gtkgui/dialogs/fastconfigure.py
@@ -61,7 +61,7 @@ class FastConfigure(Dialog):
         self.pages = [self.welcome_page, self.account_page, self.port_page, self.share_page, self.summary_page]
 
         super().__init__(
-            parent=application.window,
+            application=application,
             content_box=self.stack,
             buttons_start=(self.previous_button,),
             buttons_end=(self.next_button,),
@@ -82,12 +82,12 @@ class FastConfigure(Dialog):
 
         # Page specific, share_page
         self.download_folder_button = FileChooserButton(
-            self.download_folder_container, window=self, chooser_type="folder",
+            self.download_folder_container, application=self.application, chooser_type="folder",
             selected_function=self.on_download_folder_selected
         )
 
         self.shares_list_view = TreeView(
-            application.window, parent=self.shares_list_container, multi_select=True,
+            application, parent=self.shares_list_container, multi_select=True,
             activate_row_callback=self.on_edit_shared_folder,
             delete_accelerator_callback=self.on_remove_shared_folder,
             columns={
@@ -196,7 +196,7 @@ class FastConfigure(Dialog):
             folder_path = self.shares_list_view.get_row_value(iterator, "folder")
 
             EntryDialog(
-                parent=self,
+                application=self.application,
                 title=_("Edit Shared Folder"),
                 message=_("Enter new virtual name for '%(dir)s':") % {"dir": folder_path},
                 default=virtual_name,

--- a/pynicotine/gtkgui/dialogs/fileproperties.py
+++ b/pynicotine/gtkgui/dialogs/fileproperties.py
@@ -57,7 +57,7 @@ class FileProperties(Dialog):
         ) = ui.load(scope=self, path="dialogs/fileproperties.ui")
 
         super().__init__(
-            parent=application.window,
+            application=application,
             content_box=self.container,
             buttons_start=(self.previous_button, self.next_button),
             default_button=self.next_button,

--- a/pynicotine/gtkgui/dialogs/pluginsettings.py
+++ b/pynicotine/gtkgui/dialogs/pluginsettings.py
@@ -55,7 +55,7 @@ class PluginSettings(Dialog):
         )
 
         super().__init__(
-            parent=application.preferences,
+            application=application,
             content_box=self.scrolled_window,
             buttons_start=(cancel_button,),
             buttons_end=(ok_button,),
@@ -192,7 +192,7 @@ class PluginSettings(Dialog):
 
         from pynicotine.gtkgui.widgets.treeview import TreeView
         self.option_widgets[option_name] = treeview = TreeView(
-            self.application.window, parent=scrolled_window, activate_row_callback=self.on_row_activated,
+            self.application, parent=scrolled_window, activate_row_callback=self.on_row_activated,
             delete_accelerator_callback=self.on_delete_accelerator,
             columns={
                 "description": {
@@ -248,7 +248,7 @@ class PluginSettings(Dialog):
         label = self._generate_widget_container(description, container, homogeneous=True)
 
         self.option_widgets[option_name] = FileChooserButton(
-            container, window=self.widget, label=label, chooser_type=file_chooser_type
+            container, application=self.application, label=label, chooser_type=file_chooser_type
         )
         self.application.preferences.set_widget(self.option_widgets[option_name], option_value)
 
@@ -363,7 +363,7 @@ class PluginSettings(Dialog):
     def on_add(self, _button, treeview):
 
         EntryDialog(
-            parent=self,
+            application=self.application,
             title=_("Add Item"),
             message=treeview.description,
             callback=self.on_add_response,
@@ -388,7 +388,7 @@ class PluginSettings(Dialog):
             value = treeview.get_row_value(iterator, "description")
 
             EntryDialog(
-                parent=self,
+                application=self.application,
                 title=_("Edit Item"),
                 message=treeview.description,
                 callback=self.on_edit_response,

--- a/pynicotine/gtkgui/dialogs/preferences.py
+++ b/pynicotine/gtkgui/dialogs/preferences.py
@@ -194,7 +194,7 @@ class NetworkPage:
 
         if user_status != core.users.login_status:
             MessageDialog(
-                parent=self.application.preferences,
+                application=self.application,
                 title=_("Password Change Rejected"),
                 message=("Since your login status changed, your password has not been changed. Please try again.")
             ).present()
@@ -222,7 +222,7 @@ class NetworkPage:
                        + _("Enter password to use when logging in:"))
 
         EntryDialog(
-            parent=self.application.preferences,
+            application=self.application,
             title=_("Change Password"),
             message=message,
             visibility=False,
@@ -295,15 +295,15 @@ class DownloadsPage:
         )
 
         self.download_folder_button = FileChooserButton(
-            self.download_folder_label.get_parent(), window=application.preferences,
+            self.download_folder_label.get_parent(), application=application,
             label=self.download_folder_label, end_button=self.download_folder_default_button, chooser_type="folder"
         )
         self.incomplete_folder_button = FileChooserButton(
-            self.incomplete_folder_label.get_parent(), window=application.preferences,
+            self.incomplete_folder_label.get_parent(), application=application,
             label=self.incomplete_folder_label, end_button=self.incomplete_folder_default_button, chooser_type="folder"
         )
         self.received_folder_button = FileChooserButton(
-            self.received_folder_label.get_parent(), window=application.preferences,
+            self.received_folder_label.get_parent(), application=application,
             label=self.received_folder_label, end_button=self.received_folder_default_button, chooser_type="folder"
         )
 
@@ -311,7 +311,7 @@ class DownloadsPage:
                                            "can be used, otherwise only wildcard * matches "
                                            "are supported.").replace("<b>", "").replace("</b>", "")
         self.filter_list_view = TreeView(
-            application.window, parent=self.filter_list_container, multi_select=True,
+            application, parent=self.filter_list_container, multi_select=True,
             activate_row_callback=self.on_edit_filter,
             delete_accelerator_callback=self.on_remove_filter,
             columns={
@@ -454,7 +454,7 @@ class DownloadsPage:
     def on_add_filter(self, *_args):
 
         EntryDialog(
-            parent=self.application.preferences,
+            application=self.application,
             title=_("Add Download Filter"),
             message=self.filter_syntax_description + "\n\n" + _("Enter a new download filter:"),
             action_button_label=_("_Add"),
@@ -485,7 +485,7 @@ class DownloadsPage:
             enable_regex = self.filter_list_view.get_row_value(iterator, "regex")
 
             EntryDialog(
-                parent=self.application.preferences,
+                application=self.application,
                 title=_("Edit Download Filter"),
                 message=self.filter_syntax_description + "\n\n" + _("Modify the following download filter:"),
                 action_button_label=_("_Edit"),
@@ -590,7 +590,7 @@ class SharesPage:
         self.trusted_shared_folders = []
 
         self.shares_list_view = TreeView(
-            application.window, parent=self.shares_list_container, multi_select=True,
+            application, parent=self.shares_list_container, multi_select=True,
             activate_row_callback=self.on_edit_shared_folder,
             delete_accelerator_callback=self.on_remove_shared_folder,
             columns={
@@ -683,7 +683,7 @@ class SharesPage:
     def on_add_shared_folder(self, *_args):
 
         FolderChooser(
-            parent=self.application.preferences,
+            application=self.application,
             callback=self.on_add_shared_folder_selected,
             title=_("Add a Shared Folder"),
             select_multiple=True
@@ -726,7 +726,7 @@ class SharesPage:
             default_item = self.shares_list_view.get_row_value(iterator, "accessible_to")
 
             EntryDialog(
-                parent=self.application.preferences,
+                application=self.application,
                 title=_("Edit Shared Folder"),
                 message=_("Enter new virtual name for '%(dir)s':") % {"dir": folder_path},
                 default=virtual_name,
@@ -892,7 +892,7 @@ class UserProfilePage:
 
         self.description_view = TextView(self.description_view_container, parse_urls=False)
         self.select_picture_button = FileChooserButton(
-            self.select_picture_label.get_parent(), window=application.preferences, label=self.select_picture_label,
+            self.select_picture_label.get_parent(), application=application, label=self.select_picture_label,
             end_button=self.reset_picture_button, chooser_type="image", is_flat=True
         )
 
@@ -951,7 +951,7 @@ class IgnoredUsersPage:
 
         self.ignored_users = []
         self.ignored_users_list_view = TreeView(
-            application.window, parent=self.ignored_users_container, multi_select=True,
+            application, parent=self.ignored_users_container, multi_select=True,
             delete_accelerator_callback=self.on_remove_ignored_user,
             columns={
                 "username": {
@@ -964,7 +964,7 @@ class IgnoredUsersPage:
 
         self.ignored_ips = {}
         self.ignored_ips_list_view = TreeView(
-            application.window, parent=self.ignored_ips_container, multi_select=True,
+            application, parent=self.ignored_ips_container, multi_select=True,
             delete_accelerator_callback=self.on_remove_ignored_ip,
             columns={
                 "ip_address": {
@@ -1027,7 +1027,7 @@ class IgnoredUsersPage:
     def on_add_ignored_user(self, *_args):
 
         EntryDialog(
-            parent=self.application.preferences,
+            application=self.application,
             title=_("Ignore User"),
             message=_("Enter the name of the user you want to ignore:"),
             action_button_label=_("_Add"),
@@ -1057,7 +1057,7 @@ class IgnoredUsersPage:
     def on_add_ignored_ip(self, *_args):
 
         EntryDialog(
-            parent=self.application.preferences,
+            application=self.application,
             title=_("Ignore IP Address"),
             message=_("Enter an IP address you want to ignore:") + " " + _("* is a wildcard"),
             action_button_label=_("_Add"),
@@ -1094,7 +1094,7 @@ class BannedUsersPage:
 
         self.banned_users = []
         self.banned_users_list_view = TreeView(
-            application.window, parent=self.banned_users_container, multi_select=True,
+            application, parent=self.banned_users_container, multi_select=True,
             delete_accelerator_callback=self.on_remove_banned_user,
             columns={
                 "username": {
@@ -1107,7 +1107,7 @@ class BannedUsersPage:
 
         self.banned_ips = {}
         self.banned_ips_list_view = TreeView(
-            application.window, parent=self.banned_ips_container, multi_select=True,
+            application, parent=self.banned_ips_container, multi_select=True,
             delete_accelerator_callback=self.on_remove_banned_ip,
             columns={
                 "ip_address": {
@@ -1190,7 +1190,7 @@ class BannedUsersPage:
     def on_add_banned_user(self, *_args):
 
         EntryDialog(
-            parent=self.application.preferences,
+            application=self.application,
             title=_("Ban User"),
             message=_("Enter the name of the user you want to ban:"),
             action_button_label=_("_Add"),
@@ -1221,7 +1221,7 @@ class BannedUsersPage:
     def on_add_banned_ip(self, *_args):
 
         EntryDialog(
-            parent=self.application.preferences,
+            application=self.application,
             title=_("Ban IP Address"),
             message=_("Enter an IP address you want to ban:") + " " + _("* is a wildcard"),
             action_button_label=_("_Add"),
@@ -1287,7 +1287,7 @@ class ChatsPage:
 
         self.censored_patterns = []
         self.censor_list_view = TreeView(
-            application.window, parent=self.censor_list_container, multi_select=True,
+            application, parent=self.censor_list_container, multi_select=True,
             activate_row_callback=self.on_edit_censored,
             delete_accelerator_callback=self.on_remove_censored,
             columns={
@@ -1301,7 +1301,7 @@ class ChatsPage:
 
         self.replacements = {}
         self.replacement_list_view = TreeView(
-            application.window, parent=self.replacement_list_container, multi_select=True,
+            application, parent=self.replacement_list_container, multi_select=True,
             activate_row_callback=self.on_edit_replacement,
             delete_accelerator_callback=self.on_remove_replacement,
             columns={
@@ -1443,7 +1443,7 @@ class ChatsPage:
     def on_add_censored(self, *_args):
 
         EntryDialog(
-            parent=self.application.preferences,
+            application=self.application,
             title=_("Censor Pattern"),
             message=_("Enter a pattern you want to censor. Add spaces around the pattern if you don't "
                       "want to match strings inside words (may fail at the beginning and end of lines)."),
@@ -1470,7 +1470,7 @@ class ChatsPage:
             pattern = self.censor_list_view.get_row_value(iterator, "pattern")
 
             EntryDialog(
-                parent=self.application.preferences,
+                application=self.application,
                 title=_("Edit Censored Pattern"),
                 message=_("Enter a pattern you want to censor. Add spaces around the pattern if you don't "
                           "want to match strings inside words (may fail at the beginning and end of lines)."),
@@ -1503,7 +1503,7 @@ class ChatsPage:
     def on_add_replacement(self, *_args):
 
         EntryDialog(
-            parent=self.application.preferences,
+            application=self.application,
             title=_("Add Replacement"),
             message=_("Enter a text pattern and what to replace it with:"),
             action_button_label=_("_Add"),
@@ -1533,7 +1533,7 @@ class ChatsPage:
             replacement = self.replacement_list_view.get_row_value(iterator, "replacement")
 
             EntryDialog(
-                parent=self.application.preferences,
+                application=self.application,
                 title=_("Edit Replacement"),
                 message=_("Enter a text pattern and what to replace it with:"),
                 action_button_label=_("_Edit"),
@@ -1863,7 +1863,7 @@ class UserInterfacePage:
             self.icon_view.insert(box, -1)
 
         self.icon_theme_button = FileChooserButton(
-            self.icon_theme_label.get_parent(), window=application.preferences,
+            self.icon_theme_label.get_parent(), application=application,
             label=self.icon_theme_label, end_button=self.icon_theme_clear_button, chooser_type="folder"
         )
 
@@ -2127,22 +2127,22 @@ class LoggingPage:
             f"<a href='{format_codes_url}' title='{format_codes_url}'>{format_codes_label}</a>")
 
         self.private_chat_log_folder_button = FileChooserButton(
-            self.private_chat_log_folder_label.get_parent(), window=application.preferences,
+            self.private_chat_log_folder_label.get_parent(), application=application,
             label=self.private_chat_log_folder_label, end_button=self.private_chat_log_folder_default_button,
             chooser_type="folder"
         )
         self.chatroom_log_folder_button = FileChooserButton(
-            self.chatroom_log_folder_label.get_parent(), window=application.preferences,
+            self.chatroom_log_folder_label.get_parent(), application=application,
             label=self.chatroom_log_folder_label, end_button=self.chatroom_log_folder_default_button,
             chooser_type="folder"
         )
         self.transfer_log_folder_button = FileChooserButton(
-            self.transfer_log_folder_label.get_parent(), window=application.preferences,
+            self.transfer_log_folder_label.get_parent(), application=application,
             label=self.transfer_log_folder_label, end_button=self.transfer_log_folder_default_button,
             chooser_type="folder"
         )
         self.debug_log_folder_button = FileChooserButton(
-            self.debug_log_folder_label.get_parent(), window=application.preferences,
+            self.debug_log_folder_label.get_parent(), application=application,
             label=self.debug_log_folder_label, end_button=self.debug_log_folder_default_button,
             chooser_type="folder"
         )
@@ -2237,8 +2237,7 @@ class SearchesPage:
         self.application = application
         self.search_required = False
 
-        self.filter_help = SearchFilterHelp(application.preferences)
-        self.filter_help.set_menu_button(self.filter_help_button)
+        self.filter_help = SearchFilterHelp(application=application, menu_button=self.filter_help_button)
 
         if GTK_API_VERSION >= 4:
             inner_button = next(iter(self.filter_help_button))
@@ -2406,7 +2405,7 @@ class UrlHandlersPage:
 
         self.protocols = {}
         self.protocol_list_view = TreeView(
-            application.window, parent=self.protocol_list_container, multi_select=True,
+            application, parent=self.protocol_list_container, multi_select=True,
             activate_row_callback=self.on_edit_handler,
             delete_accelerator_callback=self.on_remove_handler,
             columns={
@@ -2483,7 +2482,7 @@ class UrlHandlersPage:
     def on_add_handler(self, *_args):
 
         EntryDialog(
-            parent=self.application.preferences,
+            application=self.application,
             title=_("Add URL Handler"),
             message=_("Enter the protocol and the command for the URL handler:"),
             action_button_label=_("_Add"),
@@ -2512,7 +2511,7 @@ class UrlHandlersPage:
             command = self.protocol_list_view.get_row_value(iterator, "command")
 
             EntryDialog(
-                parent=self.application.preferences,
+                application=self.application,
                 title=_("Edit Command"),
                 message=_("Enter a new command for protocol %s:") % protocol,
                 action_button_label=_("_Edit"),
@@ -2766,7 +2765,7 @@ class PluginsPage:
         self.plugin_description_view = TextView(self.plugin_description_view_container, editable=False,
                                                 pixels_below_lines=2)
         self.plugin_list_view = TreeView(
-            application.window, parent=self.plugin_list_container, always_select=True,
+            application, parent=self.plugin_list_container, always_select=True,
             select_row_callback=self.on_select_plugin,
             columns={
                 # Visible columns
@@ -2929,7 +2928,7 @@ class Preferences(Dialog):
         ) = ui.load(scope=self, path="dialogs/preferences.ui")
 
         super().__init__(
-            parent=application.window,
+            application=application,
             content_box=self.container,
             buttons_start=(self.cancel_button, self.export_button),
             buttons_end=(self.apply_button, self.ok_button),

--- a/pynicotine/gtkgui/dialogs/shortcuts.py
+++ b/pynicotine/gtkgui/dialogs/shortcuts.py
@@ -27,8 +27,8 @@ class Shortcuts(Dialog):
         self.dialog, self.emoji_shortcut = ui.load(scope=self, path="dialogs/shortcuts.ui")
 
         super().__init__(
-            widget=self.dialog,
-            parent=application.window
+            application=application,
+            widget=self.dialog
         )
         application.window.set_help_overlay(self.dialog)
 

--- a/pynicotine/gtkgui/dialogs/statistics.py
+++ b/pynicotine/gtkgui/dialogs/statistics.py
@@ -69,7 +69,7 @@ class Statistics(Dialog):
         }
 
         super().__init__(
-            parent=application.window,
+            application=application,
             content_box=self.container,
             show_callback=self.on_show,
             title=_("Transfer Statistics"),
@@ -120,7 +120,7 @@ class Statistics(Dialog):
     def on_reset_statistics(self, *_args):
 
         OptionDialog(
-            parent=self,
+            application=self.application,
             title=_("Reset Transfer Statistics?"),
             message=_("Do you really want to reset transfer statistics?"),
             destructive_response_id="ok",

--- a/pynicotine/gtkgui/dialogs/wishlist.py
+++ b/pynicotine/gtkgui/dialogs/wishlist.py
@@ -40,7 +40,7 @@ class WishList(Dialog):
         ) = ui.load(scope=self, path="dialogs/wishlist.ui")
 
         super().__init__(
-            parent=application.window,
+            application=application,
             modal=False,
             content_box=self.container,
             show_callback=self.on_show,
@@ -48,11 +48,10 @@ class WishList(Dialog):
             width=600,
             height=600
         )
-        application.add_window(self.widget)
 
         self.application = application
         self.list_view = TreeView(
-            application.window, parent=self.list_container, multi_select=True, activate_row_callback=self.on_edit_wish,
+            application, parent=self.list_container, multi_select=True, activate_row_callback=self.on_edit_wish,
             delete_accelerator_callback=self.on_remove_wish,
             columns={
                 "wish": {
@@ -129,7 +128,7 @@ class WishList(Dialog):
             old_wish = self.list_view.get_row_value(iterator, "wish")
 
             EntryDialog(
-                parent=self,
+                application=self.application,
                 title=_("Edit Wish"),
                 message=_("Enter new value for wish '%s':") % old_wish,
                 default=old_wish,
@@ -169,7 +168,7 @@ class WishList(Dialog):
     def on_clear_wishlist(self, *_args):
 
         OptionDialog(
-            parent=self,
+            application=self.application,
             title=_("Clear Wishlist?"),
             message=_("Do you really want to clear your wishlist?"),
             destructive_response_id="ok",

--- a/pynicotine/gtkgui/downloads.py
+++ b/pynicotine/gtkgui/downloads.py
@@ -92,7 +92,7 @@ class Downloads(Transfers):
         ):
             events.connect(event_name, callback)
 
-        self.download_speeds = DownloadSpeeds(window)
+        self.download_speeds = DownloadSpeeds(application=window.application, menu_button=window.download_status_button)
 
     def start(self):
         self.init_transfers(core.downloads.transfers.values())
@@ -116,7 +116,7 @@ class Downloads(Transfers):
     def on_try_clear_queued(self, *_args):
 
         OptionDialog(
-            parent=self.window,
+            application=self.window.application,
             title=_("Clear Queued Downloads"),
             message=_("Do you really want to clear all queued downloads?"),
             destructive_response_id="ok",
@@ -129,7 +129,7 @@ class Downloads(Transfers):
     def on_try_clear_all(self, *_args):
 
         OptionDialog(
-            parent=self.window,
+            application=self.window.application,
             title=_("Clear All Downloads"),
             message=_("Do you really want to clear all downloads?"),
             destructive_response_id="ok",
@@ -147,7 +147,7 @@ class Downloads(Transfers):
     def download_large_folder(self, username, folder, numfiles, download_callback, callback_args):
 
         OptionDialog(
-            parent=self.window,
+            application=self.window.application,
             title=_("Download %(num)i files?") % {"num": numfiles},
             message=_("Do you really want to download %(num)i files from %(user)s's folder %(folder)s?") % {
                 "num": numfiles, "user": username, "folder": folder},

--- a/pynicotine/gtkgui/interests.py
+++ b/pynicotine/gtkgui/interests.py
@@ -70,7 +70,7 @@ class Interests:
 
         # Columns
         self.likes_list_view = TreeView(
-            window, parent=self.likes_list_container,
+            window.application, parent=self.likes_list_container,
             delete_accelerator_callback=self.on_remove_thing_i_like,
             columns={
                 "likes": {
@@ -82,7 +82,7 @@ class Interests:
         )
 
         self.dislikes_list_view = TreeView(
-            window, parent=self.dislikes_list_container,
+            window.application, parent=self.dislikes_list_container,
             delete_accelerator_callback=self.on_remove_thing_i_dislike,
             columns={
                 "dislikes": {
@@ -94,7 +94,7 @@ class Interests:
         )
 
         self.recommendations_list_view = TreeView(
-            window, parent=self.recommendations_list_container,
+            window.application, parent=self.recommendations_list_container,
             activate_row_callback=self.on_r_row_activated,
             columns={
                 # Visible columns
@@ -117,7 +117,7 @@ class Interests:
         )
 
         self.similar_users_list_view = TreeView(
-            window, parent=self.similar_users_list_container,
+            window.application, parent=self.similar_users_list_container,
             activate_row_callback=self.on_ru_row_activated,
             columns={
                 # Visible columns

--- a/pynicotine/gtkgui/popovers/chatcommandhelp.py
+++ b/pynicotine/gtkgui/popovers/chatcommandhelp.py
@@ -26,14 +26,14 @@ from pynicotine.gtkgui.widgets.theme import add_css_class
 
 class ChatCommandHelp(Popover):
 
-    def __init__(self, window, interface):
+    def __init__(self, application, interface):
 
         self.interface = interface
         self.scrollable = Gtk.ScrolledWindow(visible=True)
         self.container = None
 
         super().__init__(
-            window=window,
+            application=application,
             content_box=self.scrollable,
             show_callback=self._on_show,
             close_callback=self._on_close,

--- a/pynicotine/gtkgui/popovers/chathistory.py
+++ b/pynicotine/gtkgui/popovers/chathistory.py
@@ -42,7 +42,7 @@ from pynicotine.utils import encode_path
 
 class ChatHistory(Popover):
 
-    def __init__(self, window):
+    def __init__(self, application, menu_button, text_entry):
 
         (
             self.container,
@@ -51,14 +51,15 @@ class ChatHistory(Popover):
         ) = ui.load(scope=self, path="popovers/chathistory.ui")
 
         super().__init__(
-            window=window,
+            application=application,
             content_box=self.container,
+            menu_button=menu_button,
             width=1000,
             height=700
         )
 
         self.list_view = TreeView(
-            window, parent=self.list_container, activate_row_callback=self.on_show_user,
+            application, parent=self.list_container, activate_row_callback=self.on_show_user,
             search_entry=self.search_entry,
             columns={
                 "status": {
@@ -87,13 +88,8 @@ class ChatHistory(Popover):
         )
 
         Accelerator("<Primary>f", self.widget, self.on_search_accelerator)
-        self.completion_entry = CompletionEntry(window.private_entry, self.list_view.model, column=0)
+        self.completion_entry = CompletionEntry(text_entry, self.list_view.model, column=0)
 
-        if GTK_API_VERSION >= 4:
-            inner_button = next(iter(window.private_history_button))
-            add_css_class(widget=inner_button, css_class="arrow-button")
-
-        self.set_menu_button(window.private_history_button)
         self.load_users()
 
         for event_name, callback in (
@@ -109,6 +105,14 @@ class ChatHistory(Popover):
         self.completion_entry.destroy()
 
         super().destroy()
+
+    def set_menu_button(self, menu_button):
+
+        super().set_menu_button(menu_button)
+
+        if menu_button is not None and GTK_API_VERSION >= 4:
+            inner_button = next(iter(menu_button))
+            add_css_class(widget=inner_button, css_class="arrow-button")
 
     def server_login(self, msg):
 

--- a/pynicotine/gtkgui/popovers/downloadspeeds.py
+++ b/pynicotine/gtkgui/popovers/downloadspeeds.py
@@ -22,9 +22,8 @@ from pynicotine.gtkgui.popovers.transferspeeds import TransferSpeeds
 
 class DownloadSpeeds(TransferSpeeds):
 
-    def __init__(self, window):
-        super().__init__(window=window, transfer_type="download")
-        self.set_menu_button(window.download_status_button)
+    def __init__(self, application, menu_button):
+        super().__init__(application=application, menu_button=menu_button, transfer_type="download")
 
     @staticmethod
     def update_transfer_limits():

--- a/pynicotine/gtkgui/popovers/roomlist.py
+++ b/pynicotine/gtkgui/popovers/roomlist.py
@@ -38,7 +38,7 @@ class RoomList(Popover):
 
     PRIVATE_USERS_OFFSET = 10000000
 
-    def __init__(self, window):
+    def __init__(self, application, menu_button, text_entry):
 
         (
             self.container,
@@ -50,8 +50,9 @@ class RoomList(Popover):
         ) = ui.load(scope=self, path="popovers/roomlist.ui")
 
         super().__init__(
-            window=window,
+            application=application,
             content_box=self.container,
+            menu_button=menu_button,
             width=350,
             height=500
         )
@@ -59,7 +60,7 @@ class RoomList(Popover):
         self.initializing_feed = False
 
         self.list_view = TreeView(
-            window, parent=self.list_container,
+            application, parent=self.list_container,
             activate_row_callback=self.on_row_activated, search_entry=self.search_entry,
             columns={
                 # Visible columns
@@ -87,7 +88,7 @@ class RoomList(Popover):
         )
 
         self.popup_room = None
-        self.popup_menu = PopupMenu(window.application, self.list_view.widget, self.on_popup_menu)
+        self.popup_menu = PopupMenu(application, self.list_view.widget, self.on_popup_menu)
         self.popup_menu.add_items(
             ("#" + _("Join Room"), self.on_popup_join),
             ("#" + _("Leave Room"), self.on_popup_leave),
@@ -112,13 +113,7 @@ class RoomList(Popover):
         self.private_room_toggle.connect("notify::active", self.on_toggle_accept_private_room)
 
         Accelerator("<Primary>f", self.widget, self.on_search_accelerator)
-        self.completion_entry = CompletionEntry(window.chatrooms_entry, self.list_view.model, column=0)
-
-        if GTK_API_VERSION >= 4:
-            inner_button = next(iter(window.room_list_button))
-            add_css_class(widget=inner_button, css_class="arrow-button")
-
-        self.set_menu_button(window.room_list_button)
+        self.completion_entry = CompletionEntry(text_entry, self.list_view.model, column=0)
 
         for event_name, callback in (
             ("join-room", self.join_room),
@@ -139,6 +134,14 @@ class RoomList(Popover):
         self.completion_entry.destroy()
 
         super().destroy()
+
+    def set_menu_button(self, menu_button):
+
+        super().set_menu_button(menu_button)
+
+        if menu_button is not None and GTK_API_VERSION >= 4:
+            inner_button = next(iter(menu_button))
+            add_css_class(widget=inner_button, css_class="arrow-button")
 
     def get_selected_room(self):
 

--- a/pynicotine/gtkgui/popovers/roomwall.py
+++ b/pynicotine/gtkgui/popovers/roomwall.py
@@ -26,7 +26,7 @@ from pynicotine.gtkgui.widgets.textview import TextView
 
 class RoomWall(Popover):
 
-    def __init__(self, window):
+    def __init__(self, application):
 
         (
             self.container,
@@ -35,7 +35,7 @@ class RoomWall(Popover):
         ) = ui.load(scope=self, path="popovers/roomwall.ui")
 
         super().__init__(
-            window=window,
+            application=application,
             content_box=self.container,
             show_callback=self._on_show,
             width=600,

--- a/pynicotine/gtkgui/popovers/searchfilterhelp.py
+++ b/pynicotine/gtkgui/popovers/searchfilterhelp.py
@@ -22,13 +22,14 @@ from pynicotine.gtkgui.widgets.popover import Popover
 
 class SearchFilterHelp(Popover):
 
-    def __init__(self, window):
+    def __init__(self, application, menu_button):
 
         (self.container,) = ui.load(scope=self, path="popovers/searchfilterhelp.ui")
 
         super().__init__(
-            window=window,
+            application=application,
             content_box=self.container,
+            menu_button=menu_button,
             width=600,
             height=500
         )

--- a/pynicotine/gtkgui/popovers/transferspeeds.py
+++ b/pynicotine/gtkgui/popovers/transferspeeds.py
@@ -25,7 +25,7 @@ from pynicotine.gtkgui.widgets.theme import add_css_class
 
 class TransferSpeeds(Popover):
 
-    def __init__(self, window, transfer_type):
+    def __init__(self, application, menu_button, transfer_type):
 
         self.transfer_type = transfer_type
 
@@ -39,8 +39,9 @@ class TransferSpeeds(Popover):
         ) = ui.load(scope=self, path=f"popovers/{transfer_type}speeds.ui")
 
         super().__init__(
-            window=window,
+            application=application,
             content_box=self.container,
+            menu_button=menu_button,
             show_callback=self.on_show
         )
 

--- a/pynicotine/gtkgui/popovers/uploadspeeds.py
+++ b/pynicotine/gtkgui/popovers/uploadspeeds.py
@@ -22,9 +22,8 @@ from pynicotine.gtkgui.popovers.transferspeeds import TransferSpeeds
 
 class UploadSpeeds(TransferSpeeds):
 
-    def __init__(self, window):
-        super().__init__(window=window, transfer_type="upload")
-        self.set_menu_button(window.upload_status_button)
+    def __init__(self, application, menu_button):
+        super().__init__(application=application, menu_button=menu_button, transfer_type="upload")
 
     @staticmethod
     def update_transfer_limits():

--- a/pynicotine/gtkgui/privatechat.py
+++ b/pynicotine/gtkgui/privatechat.py
@@ -64,7 +64,10 @@ class PrivateChats(IconNotebook):
         self.highlighted_users = []
         self.completion = ChatCompletion()
         self.spell_checker = SpellChecker()
-        self.history = ChatHistory(window)
+        self.history = ChatHistory(
+            application=window.application, menu_button=window.private_history_button,
+            text_entry=window.private_entry
+        )
         self.command_help = None
 
         for event_name, callback in (
@@ -136,7 +139,7 @@ class PrivateChats(IconNotebook):
             tab.update_room_user_completions()
 
             if self.command_help is None:
-                self.command_help = ChatCommandHelp(window=self.window, interface="private_chat")
+                self.command_help = ChatCommandHelp(application=self.window.application, interface="private_chat")
 
             self.command_help.set_menu_button(tab.help_button)
 
@@ -459,7 +462,7 @@ class PrivateChat:
     def on_delete_chat_log(self, *_args):
 
         OptionDialog(
-            parent=self.window,
+            application=self.window.application,
             title=_("Delete Logged Messages?"),
             message=_("Do you really want to permanently delete all logged messages for this user?"),
             destructive_response_id="ok",

--- a/pynicotine/gtkgui/search.py
+++ b/pynicotine/gtkgui/search.py
@@ -491,7 +491,7 @@ class Search:
             entry=self.filter_country_entry, item_selected_callback=self.on_refilter)
 
         self.tree_view = TreeView(
-            self.window, parent=self.tree_container, name="file_search", persistent_sort=True,
+            self.window.application, parent=self.tree_container, name="file_search", persistent_sort=True,
             multi_select=True, activate_row_callback=self.on_row_activated, focus_in_callback=self.on_refilter,
             columns={
                 # Visible columns

--- a/pynicotine/gtkgui/transfers.py
+++ b/pynicotine/gtkgui/transfers.py
@@ -114,7 +114,7 @@ class Transfers:
         self.selected_transfers = {}
 
         self.tree_view = TreeView(
-            window, parent=self.tree_container, name=transfer_type,
+            window.application, parent=self.tree_container, name=transfer_type,
             multi_select=True, persistent_sort=True, activate_row_callback=self.on_row_activated,
             delete_accelerator_callback=self.on_clear_transfers_accelerator,
             columns={

--- a/pynicotine/gtkgui/uploads.py
+++ b/pynicotine/gtkgui/uploads.py
@@ -91,7 +91,7 @@ class Uploads(Transfers):
         ):
             events.connect(event_name, callback)
 
-        self.upload_speeds = UploadSpeeds(window)
+        self.upload_speeds = UploadSpeeds(application=window.application, menu_button=window.upload_status_button)
 
     def start(self):
         self.init_transfers(core.uploads.transfers.values())
@@ -122,7 +122,7 @@ class Uploads(Transfers):
     def on_try_clear_queued(self, *_args):
 
         OptionDialog(
-            parent=self.window,
+            application=self.window.application,
             title=_("Clear Queued Uploads"),
             message=_("Do you really want to clear all queued uploads?"),
             destructive_response_id="ok",
@@ -135,7 +135,7 @@ class Uploads(Transfers):
     def on_try_clear_all(self, *_args):
 
         OptionDialog(
-            parent=self.window,
+            application=self.window.application,
             title=_("Clear All Uploads"),
             message=_("Do you really want to clear all uploads?"),
             destructive_response_id="ok",

--- a/pynicotine/gtkgui/userbrowse.py
+++ b/pynicotine/gtkgui/userbrowse.py
@@ -248,7 +248,7 @@ class UserBrowse:
 
         # Setup folder_tree_view
         self.folder_tree_view = TreeView(
-            self.window, parent=self.folder_tree_container, has_tree=True,
+            self.window.application, parent=self.folder_tree_container, has_tree=True,
             multi_select=True, activate_row_callback=self.on_folder_row_activated,
             select_row_callback=self.on_select_folder,
             columns={
@@ -306,7 +306,7 @@ class UserBrowse:
 
         # Setup file_list_view
         self.file_list_view = TreeView(
-            self.window, parent=self.file_list_container, name="user_browse",
+            self.window.application, parent=self.file_list_container, name="user_browse",
             multi_select=True, activate_row_callback=self.on_file_row_activated,
             columns={
                 # Visible columns
@@ -944,6 +944,7 @@ class UserBrowse:
             str_title = _("Upload Folder To User")
 
         EntryDialog(
+            application=self.window.application,
             parent=self.window,
             title=str_title,
             message=_("Enter the name of the user you want to upload to:"),

--- a/pynicotine/gtkgui/userinfo.py
+++ b/pynicotine/gtkgui/userinfo.py
@@ -308,7 +308,7 @@ class UserInfo:
 
         # Set up likes list
         self.likes_list_view = TreeView(
-            self.window, parent=self.likes_list_container,
+            self.window.application, parent=self.likes_list_container,
             columns={
                 "likes": {
                     "column_type": "text",
@@ -320,7 +320,7 @@ class UserInfo:
 
         # Set up dislikes list
         self.dislikes_list_view = TreeView(
-            self.window, parent=self.dislikes_list_container,
+            self.window.application, parent=self.dislikes_list_container,
             columns={
                 "dislikes": {
                     "column_type": "text",
@@ -712,7 +712,7 @@ class UserInfo:
             message += "\n\n" + error
 
         EntryDialog(
-            parent=self.window,
+            application=self.window.application,
             title=_("Gift Privileges"),
             message=message,
             action_button_label=_("_Give Privileges"),

--- a/pynicotine/gtkgui/widgets/iconnotebook.py
+++ b/pynicotine/gtkgui/widgets/iconnotebook.py
@@ -424,6 +424,7 @@ class IconNotebook:
     def remove_all_pages(self, *_args):
 
         OptionDialog(
+            application=self.window.application,
             parent=self.window,
             title=_("Close All Tabs?"),
             message=_("Do you really want to close all tabs?"),

--- a/pynicotine/gtkgui/widgets/popover.py
+++ b/pynicotine/gtkgui/widgets/popover.py
@@ -18,14 +18,16 @@
 
 from gi.repository import Gtk
 
+from pynicotine.gtkgui.application import GTK_API_VERSION
 from pynicotine.gtkgui.widgets.theme import add_css_class
 
 
 class Popover:
 
-    def __init__(self, window, content_box=None, show_callback=None, close_callback=None, width=0, height=0):
+    def __init__(self, application, content_box=None, menu_button=None, show_callback=None,
+                 close_callback=None, width=0, height=0):
 
-        self.window = window
+        self.application = application
         self.show_callback = show_callback
         self.close_callback = close_callback
 
@@ -34,6 +36,8 @@ class Popover:
 
         self.widget = Gtk.Popover(child=content_box)
         self.menu_button = None
+        self.set_menu_button(menu_button)
+
         self.widget.connect("notify::visible", self._on_visible_changed)
         self.widget.connect("closed", self._on_close)
 
@@ -61,8 +65,13 @@ class Popover:
         if not popover_width and not popover_height:
             return
 
-        main_window_width = self.window.get_width()
-        main_window_height = self.window.get_height()
+        active_window = self.application.get_active_window()
+
+        if GTK_API_VERSION >= 4:
+            main_window_width = active_window.get_width()
+            main_window_height = active_window.get_height()
+        else:
+            main_window_width, main_window_height = active_window.get_size()
 
         if main_window_width and popover_width > main_window_width:
             popover_width = main_window_width - 60

--- a/pynicotine/gtkgui/widgets/treeview.py
+++ b/pynicotine/gtkgui/widgets/treeview.py
@@ -46,12 +46,12 @@ from pynicotine.gtkgui.widgets.theme import add_css_class
 
 class TreeView:
 
-    def __init__(self, window, parent, columns, has_tree=False, multi_select=False, always_select=False,
+    def __init__(self, application, parent, columns, has_tree=False, multi_select=False, always_select=False,
                  persistent_sort=False, name=None, secondary_name=None, activate_row_callback=None,
                  focus_in_callback=None, select_row_callback=None, delete_accelerator_callback=None,
                  search_entry=None):
 
-        self.window = window
+        self.application = application
         self.widget = Gtk.TreeView(fixed_height_mode=True, has_tooltip=True, visible=True)
         self.model = None
         self.multi_select = multi_select
@@ -92,7 +92,7 @@ class TreeView:
 
         Accelerator("<Primary>c", self.widget, self.on_copy_cell_data_accelerator)
         self._column_menu = self.widget.column_menu = PopupMenu(
-            self.window.application, self.widget, callback=self.on_column_header_menu, connect_events=False)
+            self.application, self.widget, callback=self.on_column_header_menu, connect_events=False)
 
         if multi_select:
             self.widget.set_rubber_banding(True)

--- a/pynicotine/gtkgui/widgets/window.py
+++ b/pynicotine/gtkgui/widgets/window.py
@@ -21,10 +21,8 @@ from pynicotine.gtkgui.application import GTK_API_VERSION
 
 class Window:
 
-    active_dialogs = []  # Class variable keeping dialog objects alive
-    activation_token = None
-
-    def __init__(self, widget):
+    def __init__(self, application, widget):
+        self.application = application
         self.widget = widget
 
     def get_surface(self):
@@ -71,9 +69,12 @@ class Window:
 
     def present(self):
 
-        if self.activation_token is not None:
-            # Set XDG activation token if provided by tray icon
-            self.widget.set_startup_id(self.activation_token)
+        if self.application.tray_icon is not None:
+            activation_token = self.application.tray_icon.get_activation_token()
+
+            if activation_token is not None:
+                # Set XDG activation token if provided by tray icon
+                self.widget.set_startup_id(activation_token)
 
         self.widget.present()
 


### PR DESCRIPTION
Instead of explicitly specifying a parent window, let the application provide an appropriate one instead.