### PR TITLE
gtkgui/userbrowse.py: "Copy Folder U_RL" menu item label

### DIFF
--- a/pynicotine/gtkgui/userbrowse.py
+++ b/pynicotine/gtkgui/userbrowse.py
@@ -287,7 +287,7 @@ class UserBrowse:
                 ("#" + _("F_ile Properties"), self.on_file_properties, True),
                 ("", None),
                 ("#" + _("Copy _Folder Path"), self.on_copy_folder_path),
-                ("#" + _("Copy _URL"), self.on_copy_folder_url),
+                ("#" + _("Copy Folder U_RL"), self.on_copy_folder_url),
                 ("", None),
                 (">" + _("User"), self.user_popup_menu)
             )
@@ -299,7 +299,7 @@ class UserBrowse:
                 ("#" + _("F_ile Properties"), self.on_file_properties, True),
                 ("", None),
                 ("#" + _("Copy _Folder Path"), self.on_copy_folder_path),
-                ("#" + _("Copy _URL"), self.on_copy_folder_url),
+                ("#" + _("Copy Folder U_RL"), self.on_copy_folder_url),
                 ("", None),
                 (">" + _("User"), self.user_popup_menu)
             )


### PR DESCRIPTION
+ Changed: label used in folder popup menus, this frees up the "U" key that could be better used for an "Upload" item.

Same string as used elsewhere.