### PR TITLE
Core Commands: /away command shows login username on output

### DIFF
--- a/pynicotine/plugins/core_commands/__init__.py
+++ b/pynicotine/plugins/core_commands/__init__.py
@@ -326,11 +326,15 @@ class Plugin(BasePlugin):
     def away_command(self, _args, **_unused):
 
         if self.core.users.login_status == UserStatus.OFFLINE:
-            self.output(_("Offline"))
+            self.output(_("%(user)s is offline") % {"user": self.config.sections["server"]["login"]})
             return
 
         self.core.users.set_away_mode(self.core.users.login_status != UserStatus.AWAY, save_state=True)
-        self.output(_("Online") if self.core.users.login_status == UserStatus.ONLINE else _("Away"))
+
+        if self.core.users.login_status == UserStatus.ONLINE:
+            self.output(_("%(user)s is online") % {"user": self.core.users.login_username})
+        else:
+            self.output(_("%(user)s is away") % {"user": self.core.users.login_username})
 
     def quit_command(self, args, **_unused):
 


### PR DESCRIPTION
Otherwise it's nearly impossible to determine our own username when running in headless mode, except for using the /ip command for localhost address 127.0.0.1

Suggestion for different code would be welcomed if there is a neater structure of the if condition block?