### PR TITLE
slskproto.py: broadcast with connect_ex() in local_ip_address()

### DIFF
--- a/pynicotine/slskproto.py
+++ b/pynicotine/slskproto.py
@@ -585,7 +585,7 @@ class NetworkThread(Thread):
 
             # Send a broadcast packet on a local address (doesn't need to be reachable,
             # but MacOS requires port to be non-zero)
-            local_socket.connect(("10.255.255.255", 1))
+            local_socket.connect_ex(("10.255.255.255", 1))
 
             # This returns the "primary" IP on the local box, even if that IP is a NAT/private/internal IP
             ip_address = local_socket.getsockname()[0]


### PR DESCRIPTION
+ Changed: to avoid exception 'OSError: [Errno 101] Network is unreachable' # (doesn't need to be reachable)

Edge-case platform-sepcific regression since add35dc0, exception is handled in `_bind_listen_port()` which throws to log:

```
Your branch is up to date with 'origin/master'.
~/git/slook/nicotine-plus $ python3 ./nicotine
[2024-03-04 10:54:53] Loading Python 3.11.8
[2024-03-04 10:54:53] Loading Nicotine+ 3.3.3.dev1
[2024-03-04 10:54:53] Translation files (.mo) are unavailable, using default English strings
[2024-03-04 10:54:53] Loading GTK 4.12.4
[2024-03-04 10:54:54] Loading plugin system
[2024-03-04 10:54:54] Loaded plugin Nicotine+ Commands
[2024-03-04 10:54:54] Reconnecting to server in 12 seconds
[2024-03-04 10:54:54] Cannot listen on port 2234. Ensure no other application uses it, or choose a different port. Error: [Errno 101] Network is unreachable
[2024-03-04 10:54:55] Rescanning shares…
[2024-03-04 10:54:55] Rescan complete: 0 folders found
[2024-03-04 10:55:06] Cannot listen on port 2234. Ensure no other application uses it, or choose a different port. Error: [Errno 101] Network is unreachable
[2024-03-04 10:55:08] Quitting Nicotine+ 3.3.3.dev1, application closing…
[2024-03-04 10:55:08] Quit Nicotine+ 3.3.3.dev1!
```

Connection cannot be established on Android Oreo 8.1.0 AOSP (non-GMS) in Termux native Linux shell or Debian GNU/Linux 6.2.1-PRoot-Distro aarch64, because for some reason this environment won't broadcast to any local broadcast address other than `0.0.0.0`. Connectivity in other apps, using wlan0 interface (served by WiFi mobile hotspot), is fine.

It's possible (but not tested) that other similar platforms might also be prevented from connecting due to this error. The exception is not intended this case, because we don't actually need to use the local broadcast address for anything else afterwards, see link:

> [socket.`connect_ex`(_address_)](https://docs.python.org/3.8/library/socket.html#socket.socket.connect_ex)
> _"Like connect(address), but return an error indicator instead of raising an exception for errors returned by the C-level connect() call (other problems, such as “host not found,” can still raise exceptions)."_

Alternatively, `sys.platform != "darwin"` could be used to set the broadcast ip address to `0.0.0.0` as it was before add35dc0, but using `connect_ex()` seems like the more proper solution, see log output:

```
~/git/slook/nicotine-plus $ git switch headless-termux-connect
Switched to branch 'headless-termux-connect'
~/git/slook/nicotine-plus $ python3 ./nicotine
[2024-03-04 10:55:20] Loading Python 3.11.8
[2024-03-04 10:55:20] Loading Nicotine+ 3.3.3.dev1
[2024-03-04 10:55:20] Translation files (.mo) are unavailable, using default English strings
[2024-03-04 10:55:21] Loading GTK 4.12.4
[2024-03-04 10:55:22] Loading plugin system
[2024-03-04 10:55:22] Loaded plugin Nicotine+ Commands
[2024-03-04 10:55:22] Listening on port: 2234
[2024-03-04 10:55:22] Connecting to server.slsknet.org:2242
[2024-03-04 10:55:22] Connected to server server.slsknet.org:2242, logging in…
[2024-03-04 10:55:22] UPnP: Failed to forward external port 2234: [Errno 101] Network is unreachable
[2024-03-04 10:55:22] Rescanning shares…
[2024-03-04 10:55:22] Rescan complete: 0 folders found
[2024-03-04 10:55:22] 1988 privileged users
[2024-03-04 10:55:22] You have no Soulseek privileges. While privileges are active, your downloads will be queued ahead of those of non-privileged users.
```

Now, the application can be run in either headless mode or with GTK 4 using X11/Xfce on this platform, see screenshot...

![image](https://github.com/nicotine-plus/nicotine-plus/assets/88614182/a2bdd590-736f-4da2-91d9-5b6edafb2125)

... showing "Online" after the fix in this PR.
