### PR TITLE
search.py: remove unused show_search() method

### DIFF
--- a/pynicotine/search.py
+++ b/pynicotine/search.py
@@ -147,9 +147,6 @@ class Search:
         for token in self.searches.copy():
             self.remove_search(token)
 
-    def show_search(self, token):
-        events.emit("show-search", token)
-
     def sanitize_search_term(self, search_term):
 
         included_words = []


### PR DESCRIPTION
+ Removed: this show_search() method isn't called from anywhere. Not to be confused with any of the other methods with the same name that exist elsewhere in the program.

It's difficult to imagine a use case for a plugin to call this method, because such a plugin would have to know the token which it is unlikely to spawn nor keep track of.

Edit: Closing, it is called from application.py