### PR TITLE
gtkgui: select selected file on_browse_folder()

### DIFF
--- a/pynicotine/gtkgui/downloads.py
+++ b/pynicotine/gtkgui/downloads.py
@@ -199,11 +199,13 @@ class Downloads(Transfers):
 
         transfer = next(iter(self.selected_transfers), None)
 
-        if transfer:
-            user = transfer.username
-            folder_path, separator, _basename = transfer.virtual_path.rpartition("\\")
+        if not transfer:
+            return
 
-            core.userbrowse.browse_user(user, path=(folder_path + separator))
+        user = transfer.username
+        path = transfer.virtual_path
+
+        core.userbrowse.browse_user(user, path=path)
 
     def on_clear_queued(self, *_args):
         core.downloads.clear_downloads(statuses={TransferStatus.QUEUED})

--- a/pynicotine/gtkgui/search.py
+++ b/pynicotine/gtkgui/search.py
@@ -1499,9 +1499,9 @@ class Search:
             return
 
         user = self.tree_view.get_row_value(iterator, "user")
-        folder_path, separator, _basename = self.tree_view.get_row_value(iterator, "file_path_data").rpartition("\\")
+        path = self.tree_view.get_row_value(iterator, "file_path_data")
 
-        core.userbrowse.browse_user(user, path=(folder_path + separator))
+        core.userbrowse.browse_user(user, path=path)
 
     def on_user_profile(self, *_args):
 

--- a/pynicotine/gtkgui/uploads.py
+++ b/pynicotine/gtkgui/uploads.py
@@ -184,9 +184,9 @@ class Uploads(Transfers):
             return
 
         user = config.sections["server"]["login"]
-        folder_path, separator, _basename = transfer.virtual_path.rpartition("\\")
+        path = transfer.virtual_path
 
-        core.userbrowse.browse_user(user, path=(folder_path + separator))
+        core.userbrowse.browse_user(user, path=path)
 
     def on_abort_users(self, *_args):
 


### PR DESCRIPTION
+ Added: Select the selected file when browsing to the folder from a "_Browse Folder" context menu action

The `_basename` data already exist but they were discarded, yet there is no good reason to truncate the `path` because in most cases where this function is called (usually from a file selection) it seems expected to select a file in the shares, if it still exists there.