### PR TITLE
added white icon theme set

### DIFF
--- a/data/icons/themes/white/README.md
+++ b/data/icons/themes/white/README.md
@@ -1,0 +1,4 @@
+# White Icon Theme
+
+This is a White Icon Theme set built in Inkscape from the example set that can be enabled in the Nicotine+ preferences.
+

--- a/data/icons/themes/white/away.svg
+++ b/data/icons/themes/white/away.svg
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   viewBox="0 0 16 16"
+   version="1.1"
+   id="svg1"
+   sodipodi:docname="away.svg"
+   inkscape:version="1.3.2 (091e20ef0f, 2023-11-25)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs1" />
+  <sodipodi:namedview
+     id="namedview1"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:zoom="49.9375"
+     inkscape:cx="8"
+     inkscape:cy="8"
+     inkscape:window-width="1920"
+     inkscape:window-height="1008"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg1" />
+  <path
+     fill="#c9ae13"
+     d="M8 3a5 5 0 0 0-5 5 5 5 0 0 0 5 5 5 5 0 0 0 5-5 5 5 0 0 0-.006-.223A3.75 3.75 0 0 1 11.75 8 3.75 3.75 0 0 1 8 4.25a3.75 3.75 0 0 1 .223-1.244A5 5 0 0 0 8 3z"
+     id="path1"
+     style="fill:#ffffff" />
+</svg>

--- a/data/icons/themes/white/hilite.svg
+++ b/data/icons/themes/white/hilite.svg
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   viewBox="0 0 16 16"
+   version="1.1"
+   id="svg1"
+   sodipodi:docname="hilite.svg"
+   inkscape:version="1.3.2 (091e20ef0f, 2023-11-25)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs1" />
+  <sodipodi:namedview
+     id="namedview1"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:zoom="49.9375"
+     inkscape:cx="8"
+     inkscape:cy="8"
+     inkscape:window-width="1920"
+     inkscape:window-height="1008"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg1" />
+  <circle
+     r="4"
+     cy="8"
+     cx="8"
+     fill="#497ec2"
+     id="circle1"
+     style="fill:#ffffff" />
+</svg>

--- a/data/icons/themes/white/hilite3.svg
+++ b/data/icons/themes/white/hilite3.svg
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   viewBox="0 0 16 16"
+   version="1.1"
+   id="svg1"
+   sodipodi:docname="hilite3.svg"
+   inkscape:version="1.3.2 (091e20ef0f, 2023-11-25)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs1" />
+  <sodipodi:namedview
+     id="namedview1"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:zoom="49.9375"
+     inkscape:cx="8"
+     inkscape:cy="8"
+     inkscape:window-width="1920"
+     inkscape:window-height="1008"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg1" />
+  <path
+     fill="#497ec2"
+     d="M8 3.775A4.24 4.24 0 0 0 3.775 8 4.24 4.24 0 0 0 8 12.225 4.24 4.24 0 0 0 12.225 8 4.24 4.24 0 0 0 8 3.775Zm0 2A2.21 2.21 0 0 1 10.225 8 2.21 2.21 0 0 1 8 10.225 2.21 2.21 0 0 1 5.775 8 2.21 2.21 0 0 1 8 5.775Z"
+     id="path1"
+     style="fill:#ffffff" />
+</svg>

--- a/data/icons/themes/white/n.svg
+++ b/data/icons/themes/white/n.svg
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   width="128"
+   height="128"
+   version="1.1"
+   id="svg2"
+   sodipodi:docname="n.svg"
+   inkscape:version="1.3.2 (091e20ef0f, 2023-11-25)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs2" />
+  <sodipodi:namedview
+     id="namedview2"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:zoom="6.2421875"
+     inkscape:cx="64"
+     inkscape:cy="64"
+     inkscape:window-width="1920"
+     inkscape:window-height="1008"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg2" />
+  <path
+     fill="#d38c2d"
+     d="M12 16v96a4 4 0 0 0 4 4h12a4 4 0 0 0 4-4V36h4c2.21 0 5.82-.081 7.972.398 4.16.926 6.704 3.47 7.63 7.63C52.082 46.18 52 49.79 52 52v60a4 4 0 0 0 4 4h12a4 4 0 0 0 4-4v-12h16v12a4 4 0 0 0 4 4h12a4 4 0 0 0 4-4v-12h12a4 4 0 0 0 4-4V84l-4-4h-12V64l-4-4H92l-4 4v16H72V52L40 12H16l-4 4z"
+     id="path1"
+     style="fill:#808080" />
+  <path
+     fill="#f9aa40"
+     d="M12 16v92a4 4 45 0 0 4 4h12a4 4 135 0 0 4-4V32h4c2.21 0 5.82-.081 7.972.398 4.16.926 6.704 3.47 7.63 7.63C52.082 42.18 52 45.79 52 48v60a4 4 45 0 0 4 4h12a4 4 135 0 0 4-4V96h16v12a4 4 45 0 0 4 4h12a4 4 135 0 0 4-4V96h12a4 4 135 0 0 4-4v-8a4 4 45 0 0-4-4h-12V64a4 4 45 0 0-4-4H92a4 4 135 0 0-4 4v16H72V48c0-2.21.023-5.799-.245-7.99-1.617-13.217-11.077-25.512-23.774-27.674C45.806 11.966 42.21 12 40 12H16a4 4 135 0 0-4 4z"
+     id="path2"
+     style="fill:#ffffff" />
+</svg>

--- a/data/icons/themes/white/offline.svg
+++ b/data/icons/themes/white/offline.svg
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   viewBox="0 0 16 16"
+   version="1.1"
+   id="svg1"
+   sodipodi:docname="offline.svg"
+   inkscape:version="1.3.2 (091e20ef0f, 2023-11-25)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs1" />
+  <sodipodi:namedview
+     id="namedview1"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:zoom="49.9375"
+     inkscape:cx="8"
+     inkscape:cy="8"
+     inkscape:window-width="1920"
+     inkscape:window-height="1008"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg1" />
+  <path
+     fill="#e04f5e"
+     d="M8 3a5 5 0 0 0-5 5 5 5 0 0 0 5 5 5 5 0 0 0 5-5 5 5 0 0 0-5-5zm0 2a3 3 0 0 1 3 3 3 3 0 0 1-3 3 3 3 0 0 1-3-3 3 3 0 0 1 3-3z"
+     id="path1"
+     style="fill:#ffffff" />
+</svg>

--- a/data/icons/themes/white/online.svg
+++ b/data/icons/themes/white/online.svg
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   viewBox="0 0 16 16"
+   version="1.1"
+   id="svg1"
+   sodipodi:docname="online.svg"
+   inkscape:version="1.3.2 (091e20ef0f, 2023-11-25)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs1" />
+  <sodipodi:namedview
+     id="namedview1"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:zoom="49.9375"
+     inkscape:cx="8"
+     inkscape:cy="8"
+     inkscape:window-width="1920"
+     inkscape:window-height="1008"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg1" />
+  <circle
+     cx="8"
+     cy="8"
+     r="5"
+     fill="#16bb5c"
+     id="circle1"
+     style="fill:#ffffff" />
+</svg>

--- a/data/icons/themes/white/trayicon_away.svg
+++ b/data/icons/themes/white/trayicon_away.svg
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   width="48"
+   height="48"
+   version="1.1"
+   id="svg4"
+   sodipodi:docname="trayicon_away.svg"
+   inkscape:version="1.3.2 (091e20ef0f, 2023-11-25)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs4" />
+  <sodipodi:namedview
+     id="namedview4"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:zoom="16.645833"
+     inkscape:cx="24"
+     inkscape:cy="24"
+     inkscape:window-width="1920"
+     inkscape:window-height="1008"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg4" />
+  <path
+     fill="#d38c2d"
+     d="M0 5v41a2 2 0 0 0 2 2h5a2 2 0 0 0 2-2V15h1c1.105 0 2.93-.014 3.946.403 1.6.658 2.993 2.05 3.651 3.65C18.014 20.07 18 21.896 18 23v23a2 2 0 0 0 2 2h5a2 2 0 0 0 2-2v-4h6v4a2 2 0 0 0 2 2h5a2 2 0 0 0 2-2v-4h4a2 2 0 0 0 2-2v-5l-2-2h-4v-7l-2-2h-5l-2 2v7h-6V23L10 3H2Z"
+     id="path1"
+     style="fill:#808080" />
+  <path
+     fill="#f9aa40"
+     d="M0 5v38a2 2 45 0 0 2 2h5a2 2 135 0 0 2-2V12h1c1.105 0 2.93-.014 3.946.403 1.6.658 2.993 2.05 3.651 3.65C18.014 17.07 18 18.896 18 20v23a2 2 45 0 0 2 2h5a2 2 135 0 0 2-2v-4h6v4a2 2 45 0 0 2 2h5a2 2 135 0 0 2-2v-4h4a2 2 135 0 0 2-2v-2a2 2 45 0 0-2-2h-4v-7a2 2 45 0 0-2-2h-5a2 2 135 0 0-2 2v7h-6V20c0-1.105-.021-2.902-.242-3.982-.85-4.164-4.134-11.864-12.763-12.901C12.9 2.985 11.105 3 10 3H2a2 2 135 0 0-2 2Z"
+     id="path2"
+     style="fill:#ffffff" />
+  <path
+     fill="#927f0d"
+     d="M47.943 10.002 30.073 10A9 9 0 0 0 30 11a9 9 0 0 0 9 9 9 9 0 0 0 9-9 9 9 0 0 0-.057-.998z"
+     id="path3"
+     style="fill:#808080" />
+  <path
+     fill="#e0c314"
+     d="M38.258.053A9 9 0 0 0 30 9a9 9 0 0 0 9 9 9 9 0 0 0 8.947-8.258A8 8 0 0 1 46 10a8 8 0 0 1-8-8 8 8 0 0 1 .258-1.947z"
+     id="path4"
+     style="fill:#ffffff" />
+</svg>

--- a/data/icons/themes/white/trayicon_connect.svg
+++ b/data/icons/themes/white/trayicon_connect.svg
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   width="48"
+   height="48"
+   version="1.1"
+   id="svg3"
+   sodipodi:docname="trayicon_connect.svg"
+   inkscape:version="1.3.2 (091e20ef0f, 2023-11-25)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs3" />
+  <sodipodi:namedview
+     id="namedview3"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:zoom="16.645833"
+     inkscape:cx="24"
+     inkscape:cy="24"
+     inkscape:window-width="1920"
+     inkscape:window-height="1008"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg3" />
+  <path
+     fill="#d38c2d"
+     d="M0 5v41a2 2 0 0 0 2 2h5a2 2 0 0 0 2-2V15h1c1.105 0 2.93-.014 3.946.403 1.6.658 2.993 2.05 3.651 3.65C18.014 20.07 18 21.896 18 23v23a2 2 0 0 0 2 2h5a2 2 0 0 0 2-2v-4h6v4a2 2 0 0 0 2 2h5a2 2 0 0 0 2-2v-4h4a2 2 0 0 0 2-2v-5l-2-2h-4v-7l-2-2h-5l-2 2v7h-6V23L10 3H2Z"
+     id="path1"
+     style="fill:#808080" />
+  <path
+     fill="#f9aa40"
+     d="M0 5v38a2 2 45 0 0 2 2h5a2 2 135 0 0 2-2V12h1c1.105 0 2.93-.014 3.946.403 1.6.658 2.993 2.05 3.651 3.65C18.014 17.07 18 18.896 18 20v23a2 2 45 0 0 2 2h5a2 2 135 0 0 2-2v-4h6v4a2 2 45 0 0 2 2h5a2 2 135 0 0 2-2v-4h4a2 2 135 0 0 2-2v-2a2 2 45 0 0-2-2h-4v-7a2 2 45 0 0-2-2h-5a2 2 135 0 0-2 2v7h-6V20c0-1.105-.021-2.902-.242-3.982-.85-4.164-4.134-11.864-12.763-12.901C12.9 2.985 11.105 3 10 3H2a2 2 135 0 0-2 2Z"
+     id="path2"
+     style="fill:#ffffff" />
+  <circle
+     cx="39"
+     cy="11"
+     r="9"
+     fill="#007a2c"
+     id="circle2"
+     style="fill:#808080" />
+  <circle
+     cx="39"
+     cy="9"
+     r="9"
+     fill="#1bc563"
+     id="circle3"
+     style="fill:#ffffff" />
+</svg>

--- a/data/icons/themes/white/trayicon_disconnect.svg
+++ b/data/icons/themes/white/trayicon_disconnect.svg
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   width="48"
+   height="48"
+   version="1.1"
+   id="svg4"
+   sodipodi:docname="trayicon_disconnect.svg"
+   inkscape:version="1.3.2 (091e20ef0f, 2023-11-25)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs4" />
+  <sodipodi:namedview
+     id="namedview4"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:zoom="16.645833"
+     inkscape:cx="24"
+     inkscape:cy="24"
+     inkscape:window-width="1920"
+     inkscape:window-height="1008"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg4" />
+  <path
+     fill="#d38c2d"
+     d="M0 5v41a2 2 0 0 0 2 2h5a2 2 0 0 0 2-2V15h1c1.105 0 2.93-.014 3.946.403 1.6.658 2.993 2.05 3.651 3.65C18.014 20.07 18 21.896 18 23v23a2 2 0 0 0 2 2h5a2 2 0 0 0 2-2v-4h6v4a2 2 0 0 0 2 2h5a2 2 0 0 0 2-2v-4h4a2 2 0 0 0 2-2v-5l-2-2h-4v-7l-2-2h-5l-2 2v7h-6V23L10 3H2Z"
+     id="path1"
+     style="fill:#808080" />
+  <path
+     fill="#f9aa40"
+     d="M0 5v38a2 2 45 0 0 2 2h5a2 2 135 0 0 2-2V12h1c1.105 0 2.93-.014 3.946.403 1.6.658 2.993 2.05 3.651 3.65C18.014 17.07 18 18.896 18 20v23a2 2 45 0 0 2 2h5a2 2 135 0 0 2-2v-4h6v4a2 2 45 0 0 2 2h5a2 2 135 0 0 2-2v-4h4a2 2 135 0 0 2-2v-2a2 2 45 0 0-2-2h-4v-7a2 2 45 0 0-2-2h-5a2 2 135 0 0-2 2v7h-6V20c0-1.105-.021-2.902-.242-3.982-.85-4.164-4.134-11.864-12.763-12.901C12.9 2.985 11.105 3 10 3H2a2 2 135 0 0-2 2Z"
+     id="path2"
+     style="fill:#ffffff" />
+  <path
+     fill="#af1f2d"
+     d="M39 2a9 9 0 0 0-9 9 9 9 0 0 0 9 9 9 9 0 0 0 9-9 9 9 0 0 0-9-9zm0 5a4 4 0 0 1 4 4 4 4 0 0 1-4 4 4 4 0 0 1-4-4 4 4 0 0 1 4-4z"
+     id="path3"
+     style="fill:#808080" />
+  <path
+     fill="#e15b68"
+     d="M39 0a9 9 0 0 0-9 9 9 9 0 0 0 9 9 9 9 0 0 0 9-9 9 9 0 0 0-9-9zm0 5a4 4 0 0 1 4 4 4 4 0 0 1-4 4 4 4 0 0 1-4-4 4 4 0 0 1 4-4z"
+     id="path4"
+     style="fill:#ffffff" />
+</svg>

--- a/data/icons/themes/white/trayicon_msg.svg
+++ b/data/icons/themes/white/trayicon_msg.svg
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   width="48"
+   height="48"
+   version="1.1"
+   id="svg3"
+   sodipodi:docname="trayicon_msg.svg"
+   inkscape:version="1.3.2 (091e20ef0f, 2023-11-25)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs3" />
+  <sodipodi:namedview
+     id="namedview3"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:zoom="16.645833"
+     inkscape:cx="24"
+     inkscape:cy="24"
+     inkscape:window-width="1920"
+     inkscape:window-height="1008"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg3" />
+  <path
+     fill="#d38c2d"
+     d="M0 5v41a2 2 0 0 0 2 2h5a2 2 0 0 0 2-2V15h1c1.105 0 2.93-.014 3.946.403 1.6.658 2.993 2.05 3.651 3.65C18.014 20.07 18 21.896 18 23v23a2 2 0 0 0 2 2h5a2 2 0 0 0 2-2v-4h6v4a2 2 0 0 0 2 2h5a2 2 0 0 0 2-2v-4h4a2 2 0 0 0 2-2v-5l-2-2h-4v-7l-2-2h-5l-2 2v7h-6V23L10 3H2Z"
+     id="path1"
+     style="fill:#808080" />
+  <path
+     fill="#f9aa40"
+     d="M0 5v38a2 2 45 0 0 2 2h5a2 2 135 0 0 2-2V12h1c1.105 0 2.93-.014 3.946.403 1.6.658 2.993 2.05 3.651 3.65C18.014 17.07 18 18.896 18 20v23a2 2 45 0 0 2 2h5a2 2 135 0 0 2-2v-4h6v4a2 2 45 0 0 2 2h5a2 2 135 0 0 2-2v-4h4a2 2 135 0 0 2-2v-2a2 2 45 0 0-2-2h-4v-7a2 2 45 0 0-2-2h-5a2 2 135 0 0-2 2v7h-6V20c0-1.105-.021-2.902-.242-3.982-.85-4.164-4.134-11.864-12.763-12.901C12.9 2.985 11.105 3 10 3H2a2 2 135 0 0-2 2Z"
+     id="path2"
+     style="fill:#ffffff" />
+  <rect
+     width="14"
+     height="14"
+     x="29.062"
+     y="-24.819"
+     rx="1"
+     ry="1"
+     fill="#3065a7"
+     transform="rotate(45)"
+     id="rect2"
+     style="fill:#808080" />
+  <rect
+     width="14"
+     height="14"
+     x="26.94"
+     y="-26.94"
+     rx="1"
+     ry="1"
+     fill="#6193d2"
+     transform="rotate(45)"
+     id="rect3"
+     style="fill:#ffffff" />
+</svg>


### PR DESCRIPTION
This PR adds a White Icon Theme set generated in Inkscape from the example set. This fits in better with newer iterations of Gnome which use all white icon themes by default.