### PR TITLE
Fix last.fm now playing

### DIFF
--- a/pynicotine/gtkgui/dialogs/preferences.py
+++ b/pynicotine/gtkgui/dialogs/preferences.py
@@ -2669,7 +2669,7 @@ class NowPlayingPage:
 
         if self.lastfm_radio.get_active():
             self.player_replacers = ["$n", "$t", "$a", "$b"]
-            self.command_label.set_text(_("Username;APIKEY:"))
+            self.command_label.set_text(_("Username;APIKEY"))
 
         elif self.mpris_radio.get_active():
             self.player_replacers = ["$n", "$p", "$a", "$b", "$t", "$y", "$c", "$r", "$k", "$l", "$f"]


### PR DESCRIPTION
It wouldn't work because of a 403 HTTP status, but this was because
the program showed that you had to put a colon after username;apikey
I removed this from the UI and now it works.
