### PR TITLE
slskproto.py: handle MemoryError

### DIFF
--- a/pynicotine/slskproto.py
+++ b/pynicotine/slskproto.py
@@ -2440,7 +2440,7 @@ class NetworkThread(Thread):
                     self._close_connection(self._conns, sock)
                     return
 
-            except OSError as error:
+            except (OSError, MemoryError) as error:
                 log.add_conn(("Cannot read data from connection %(addr)s, closing connection. "
                               "Error: %(error)s"), {
                     "addr": conn_obj_established.addr,


### PR DESCRIPTION
Fixes #3022

An exception handler already exists if `_read_data()` throws `OSError`, so it is inexpensive to handle the case of `MemoryError` here also. 

Closing the connection is probably the best action to take in such circumstances. The program should be able to recover itself enough to continue running, albeit in a limited capacity, refusing connections until either...

- demand for resources reduces (such as peers giving up), or;
- more system resources become available (such as another application terminating).

... As such normal operation would hopefully be resumed eventually, in theory, but this needs further testing in the wild to determine if further actions are required or not (for example, setting `MAX_SOCKETS` in accordance with available memory, or cleaning up old connection data that might be still hanging around in memory for no good reason).