### PR TITLE
mainwindow.ui: show normal mouse cursor over empty area of status bar

### DIFF
--- a/pynicotine/gtkgui/ui/mainwindow.ui
+++ b/pynicotine/gtkgui/ui/mainwindow.ui
@@ -1682,14 +1682,19 @@
         <property name="spacing">18</property>
         <property name="visible">True</property>
         <child>
-          <object class="GtkLabel" id="status_label">
-            <property name="ellipsize">end</property>
+          <object class="GtkBox">
             <property name="hexpand">True</property>
-            <property name="margin-start">12</property>
-            <property name="selectable">True</property>
-            <property name="single-line-mode">True</property>
             <property name="visible">True</property>
-            <property name="xalign">0</property>
+            <child>
+              <object class="GtkLabel" id="status_label">
+                <property name="ellipsize">end</property>
+                <property name="margin-start">12</property>
+                <property name="selectable">True</property>
+                <property name="single-line-mode">True</property>
+                <property name="visible">True</property>
+                <property name="xalign">0</property>
+              </object>
+            </child>
           </object>
         </child>
         <child>


### PR DESCRIPTION
* Fixed: Show normal mouse cursor over empty area of status bar, instead of incorrectly showing text selection beam cursor...

_Before:_
![image](https://github.com/nicotine-plus/nicotine-plus/assets/88614182/ce6c8f75-d98e-40d4-90f8-adef2e044e03)

_After:_
![image](https://github.com/nicotine-plus/nicotine-plus/assets/88614182/de4e8b05-0e44-4781-9a23-a3b04520d1a2)

... It is done by using using a GtkBox as a filler widget for doing the hexpand, for want of a better way?