### PR TITLE
gtkgui/transfers.py: don't display current_byte_offset when finished

### DIFF
--- a/pynicotine/gtkgui/transfers.py
+++ b/pynicotine/gtkgui/transfers.py
@@ -473,7 +473,7 @@ class Transfers:
     @staticmethod
     def get_hsize(current_byte_offset, size):
 
-        if current_byte_offset == size:
+        if current_byte_offset >= size:
             return human_size(size)
 
         return f"{human_size(current_byte_offset)} / {human_size(size)}"

--- a/pynicotine/gtkgui/transfers.py
+++ b/pynicotine/gtkgui/transfers.py
@@ -472,6 +472,10 @@ class Transfers:
 
     @staticmethod
     def get_hsize(current_byte_offset, size):
+
+        if current_byte_offset == size:
+            return human_size(size)
+
         return f"{human_size(current_byte_offset)} / {human_size(size)}"
 
     @staticmethod


### PR DESCRIPTION
+ Changed: Avoid one `human_size()` call for each Finished transfer, it's also faster to read and more logical to view.

![image](https://github.com/nicotine-plus/nicotine-plus/assets/88614182/818eb40c-f889-42c2-904c-7e6bc18a4e01)
