### PR TITLE
Unwatch users when updates are no longer needed

### DIFF
--- a/pynicotine/buddies.py
+++ b/pynicotine/buddies.py
@@ -124,7 +124,7 @@ class Buddies:
             return
 
         for username in self.users:
-            core.users.watch_user(username)
+            core.users.watch_user(username, context="buddies")
 
     def _server_disconnect(self, _msg):
 
@@ -165,7 +165,7 @@ class Buddies:
         events.emit("add-buddy", username, user_data)
 
         # Request user status, speed and number of shared files
-        core.users.watch_user(username)
+        core.users.watch_user(username, context="buddies")
 
     def remove_buddy(self, username):
 
@@ -176,6 +176,7 @@ class Buddies:
             core.chatrooms.update_completions()
             core.privatechat.update_completions()
 
+        core.users.unwatch_user(username, context="buddies")
         self.save_buddy_list()
         events.emit("remove-buddy", username)
 

--- a/pynicotine/downloads.py
+++ b/pynicotine/downloads.py
@@ -71,7 +71,7 @@ class Downloads(Transfers):
 
     def __init__(self):
 
-        super().__init__(transfers_file_path=os.path.join(config.data_folder_path, "downloads.json"))
+        super().__init__(name="downloads")
 
         self._requested_folders = defaultdict(dict)
         self._requested_folder_token = 0
@@ -493,14 +493,6 @@ class Downloads(Transfers):
 
         if status:
             events.emit("abort-download", transfer, status, update_parent)
-
-    def _auto_clear_transfer(self, transfer):
-
-        if config.sections["transfers"]["autoclear_downloads"]:
-            self._clear_transfer(transfer)
-            return True
-
-        return False
 
     def _clear_transfer(self, transfer, denied_message=None, update_parent=True):
 
@@ -1332,7 +1324,11 @@ class Downloads(Transfers):
         if not download.retry_attempt:
             # Attempt to request file name encoded as latin-1 once
 
-            self._abort_transfer(download)
+            # We mark download as failed when aborting it, to avoid a redundant request
+            # to unwatch the user. Need to call _unfail_transfer() to undo this.
+            self._abort_transfer(download, status=TransferStatus.CONNECTION_CLOSED)
+            self._unfail_transfer(download)
+
             download.legacy_attempt = download.retry_attempt = True
 
             if self._enqueue_transfer(download):

--- a/pynicotine/gtkgui/popovers/chathistory.py
+++ b/pynicotine/gtkgui/popovers/chathistory.py
@@ -116,7 +116,7 @@ class ChatHistory(Popover):
 
         for iterator in self.list_view.iterators.values():
             username = self.list_view.get_row_value(iterator, "user")
-            core.users.watch_user(username)
+            core.users.watch_user(username, context="chathistory")
 
     def server_disconnect(self, *_args):
         for iterator in self.list_view.iterators.values():
@@ -217,7 +217,7 @@ class ChatHistory(Popover):
     def update_user(self, username, message, timestamp=None):
 
         self.remove_user(username)
-        core.users.watch_user(username)
+        core.users.watch_user(username, context="chathistory")
 
         if not timestamp:
             timestamp_format = config.sections["logging"]["log_timestamp"]

--- a/pynicotine/privatechat.py
+++ b/pynicotine/privatechat.py
@@ -71,7 +71,7 @@ class PrivateChat:
             return
 
         for username in self.users:
-            core.users.watch_user(username)  # Get notified of user status
+            core.users.watch_user(username, context="privatechat")  # Get notified of user status
 
     def _server_disconnect(self, _msg):
 
@@ -95,6 +95,7 @@ class PrivateChat:
             config.sections["privatechat"]["users"].remove(username)
 
         self.users.remove(username)
+        core.users.unwatch_user(username, context="privatechat")
         events.emit("private-chat-remove-user", username)
 
     def remove_all_users(self, is_permanent=True):
@@ -105,7 +106,7 @@ class PrivateChat:
 
         self.add_user(username)
         events.emit("private-chat-show-user", username, switch_page, remembered)
-        core.users.watch_user(username)
+        core.users.watch_user(username, context="privatechat")
 
     def clear_private_messages(self, username):
         events.emit("clear-private-messages", username)

--- a/pynicotine/slskproto.py
+++ b/pynicotine/slskproto.py
@@ -78,6 +78,7 @@ from pynicotine.slskmessages import SetDownloadLimit
 from pynicotine.slskmessages import SetUploadLimit
 from pynicotine.slskmessages import SetWaitPort
 from pynicotine.slskmessages import SharedFileListResponse
+from pynicotine.slskmessages import UnwatchUser
 from pynicotine.slskmessages import UploadFile
 from pynicotine.slskmessages import UserInfoResponse
 from pynicotine.slskmessages import UserStatus
@@ -1462,6 +1463,9 @@ class NetworkThread(Thread):
             # Only cache IP address of watched users, otherwise we won't know if
             # a user reconnects and changes their IP address.
             self._user_addresses[msg_obj.user] = None
+
+        elif msg_class is UnwatchUser and msg_obj.user != self._server_username:
+            self._user_addresses.pop(msg_obj.user, None)
 
         conn_obj = self._conns[self._server_socket]
         conn_obj.obuf.extend(msg_obj.pack_uint32(len(msg) + 4))

--- a/pynicotine/uploads.py
+++ b/pynicotine/uploads.py
@@ -45,7 +45,7 @@ class Uploads(Transfers):
 
     def __init__(self):
 
-        super().__init__(transfers_file_path=os.path.join(config.data_folder_path, "uploads.json"))
+        super().__init__(name="uploads")
 
         self.pending_shutdown = False
         self.upload_speed = 0
@@ -379,14 +379,6 @@ class Uploads(Transfers):
         if status:
             events.emit("abort-upload", transfer, status, update_parent)
 
-    def _auto_clear_transfer(self, transfer):
-
-        if config.sections["transfers"]["autoclear_uploads"]:
-            self._clear_transfer(transfer)
-            return True
-
-        return False
-
     def _clear_transfer(self, transfer, denied_message=None, update_parent=True):
 
         log.add_transfer("Clearing upload %(path)s to user %(user)s", {
@@ -566,8 +558,8 @@ class Uploads(Transfers):
 
             if not self.is_file_readable(virtual_path, real_path):
                 self._abort_transfer(
-                    upload_candidate, denied_message=TransferRejectReason.FILE_READ_ERROR,
-                    status=TransferStatus.LOCAL_FILE_ERROR
+                    upload_candidate, status=TransferStatus.LOCAL_FILE_ERROR,
+                    denied_message=TransferRejectReason.FILE_READ_ERROR
                 )
                 continue
 
@@ -686,7 +678,7 @@ class Uploads(Transfers):
         for upload in uploads:
             if upload.status not in ignored_statuses:
                 self._abort_transfer(
-                    upload, denied_message=denied_message, status=status, update_parent=False)
+                    upload, status=status, denied_message=denied_message, update_parent=False)
 
         events.emit("abort-uploads", uploads, status)
 
@@ -836,7 +828,7 @@ class Uploads(Transfers):
         folder_path = os.path.dirname(real_path)
 
         if transfer is not None:
-            self._abort_transfer(transfer)
+            self._unfail_transfer(transfer)
 
             transfer.folder_path = folder_path
             transfer.size = size
@@ -910,7 +902,7 @@ class Uploads(Transfers):
         folder_path = os.path.dirname(real_path)
 
         if transfer is not None:
-            self._abort_transfer(transfer)
+            self._unfail_transfer(transfer)
 
             transfer.folder_path = folder_path
             transfer.size = size

--- a/pynicotine/userbrowse.py
+++ b/pynicotine/userbrowse.py
@@ -69,7 +69,7 @@ class UserBrowse:
             return
 
         for username in self.users:
-            core.users.watch_user(username)  # Get notified of user status
+            core.users.watch_user(username, context="userbrowse")  # Get notified of user status
 
     def send_upload_attempt_notification(self, username):
         """Send notification to user when attempting to initiate upload from
@@ -85,7 +85,9 @@ class UserBrowse:
         events.emit("user-browse-show-user", user=username, path=path, switch_page=switch_page)
 
     def remove_user(self, username):
+
         del self.users[username]
+        core.users.unwatch_user(username, context="userbrowse")
         events.emit("user-browse-remove-user", username)
 
     def remove_all_users(self):
@@ -149,7 +151,7 @@ class UserBrowse:
             events.emit("peer-connection-error", username, is_offline=True)
             return
 
-        core.users.watch_user(username)
+        core.users.watch_user(username, context="userbrowse")
 
         if browsed_user is None or new_request:
             self.request_user_shares(username)

--- a/pynicotine/userinfo.py
+++ b/pynicotine/userinfo.py
@@ -54,7 +54,7 @@ class UserInfo:
             return
 
         for username in self.users:
-            core.users.watch_user(username)  # Get notified of user status
+            core.users.watch_user(username, context="userinfo")  # Get notified of user status
 
     def _server_disconnect(self, _msg):
         self.requested_info_times.clear()
@@ -133,7 +133,7 @@ class UserInfo:
 
         else:
             # Request user status, speed and number of shared files
-            core.users.watch_user(username)
+            core.users.watch_user(username, context="userinfo")
 
             # Request user description, picture and queue information
             core.send_message_to_peer(username, slskmessages.UserInfoRequest())
@@ -142,7 +142,9 @@ class UserInfo:
         core.send_message_to_server(slskmessages.UserInterests(username))
 
     def remove_user(self, username):
+
         self.users.remove(username)
+        core.users.unwatch_user(username, context="userinfo")
         events.emit("user-info-remove-user", username)
 
     def remove_all_users(self):


### PR DESCRIPTION
Currently, the list of watched users grows indefinitely until we disconnect/quit. Unwatch users when we no longer need to track them.