### PR TITLE
utils.py: don't catch TypeError in _human_speed_or_size()

### DIFF
--- a/pynicotine/utils.py
+++ b/pynicotine/utils.py
@@ -223,18 +223,14 @@ def _human_speed_or_size(number, unit=None):
     if unit == "B":
         return humanize(number)
 
-    try:
-        for suffix in FILE_SIZE_SUFFIXES:
-            if number < 1024:
-                if number > 999:
-                    return f"{number:.4g} {suffix}"
+    for suffix in FILE_SIZE_SUFFIXES:
+        if number < 1024:
+            if number > 999:
+                return f"{number:.4g} {suffix}"
 
-                return f"{number:.3g} {suffix}"
+            return f"{number:.3g} {suffix}"
 
-            number /= 1024
-
-    except TypeError:
-        pass
+        number /= 1024
 
     return str(number)
 


### PR DESCRIPTION
Minor cleanup.

- Removed: try/except block because there aren't any calls that could lead to a TypeError being encountered anymore (if there ever was, then it doesn't seem to the case now).