### PR TITLE
config: remove unused "readroomlogs" setting

### DIFF
--- a/pynicotine/config.py
+++ b/pynicotine/config.py
@@ -271,7 +271,6 @@ class Config:
                 "debug_file_output": False,
                 "roomlogsdir": os.path.join(log_folder_path, "rooms"),
                 "privatelogsdir": os.path.join(log_folder_path, "private"),
-                "readroomlogs": True,
                 "readroomlines": 200,
                 "readprivatelines": 200,
                 "private_chats": [],
@@ -529,7 +528,8 @@ class Config:
             ),
             "logging": (
                 "logsdir",
-                "timestamps"
+                "timestamps",
+                "readroomlogs"
             ),
             "ticker": (
                 "default",


### PR DESCRIPTION
- Removed: There is no reference to the "readroomlogs" setting anywhere, it would be redundant anyway because the number of lines can be set to zero for the same intended effect as turning this off.