### PR TITLE
ChatView: don't timestamp old messages separator in append_log_lines()

### DIFF
--- a/pynicotine/gtkgui/chatrooms.py
+++ b/pynicotine/gtkgui/chatrooms.py
@@ -660,12 +660,13 @@ class ChatRoom:
 
     def prepend_old_messages(self):
 
-        log_lines = self._read_old_messages()
+        log_lines = log.read_log(
+            folder_path=log.room_folder_path,
+            basename=self.room,
+            num_lines=config.sections["logging"]["readroomlines"]
+        )
 
         self.chat_view.append_log_lines(log_lines, login_username=config.sections["server"]["login"])
-
-    def _read_old_messages(self):
-        return log.read_log(log.room_folder_path, self.room, config.sections["logging"]["readroomlines"])
 
     def populate_room_users(self, users):
 

--- a/pynicotine/gtkgui/chatrooms.py
+++ b/pynicotine/gtkgui/chatrooms.py
@@ -569,7 +569,7 @@ class ChatRoom:
         )
 
         self.setup_public_feed()
-        self.read_room_logs()
+        self.prepend_old_messages()
 
     def load(self):
         GLib.idle_add(self.read_room_logs_finished)
@@ -658,14 +658,14 @@ class ChatRoom:
 
         self.activity_view.auto_scroll = self.chat_view.auto_scroll = True
 
-    def read_room_logs(self):
+    def prepend_old_messages(self):
 
-        self.chat_view.append_log_lines(
-            folder_path=log.room_folder_path,
-            basename=self.room,
-            num_lines=config.sections["logging"]["readroomlines"],
-            timestamp_format=config.sections["logging"]["rooms_timestamp"]
-        )
+        log_lines = self._read_old_messages()
+
+        self.chat_view.append_log_lines(log_lines, login_username=config.sections["server"]["login"])
+
+    def _read_old_messages(self):
+        return log.read_log(log.room_folder_path, self.room, config.sections["logging"]["readroomlines"])
 
     def populate_room_users(self, users):
 

--- a/pynicotine/gtkgui/privatechat.py
+++ b/pynicotine/gtkgui/privatechat.py
@@ -396,12 +396,13 @@ class PrivateChat:
 
     def prepend_old_messages(self):
 
-        log_lines = self._read_old_messages()
+        log_lines = log.read_log(
+            folder_path=log.private_chat_folder_path,
+            basename=self.user,
+            num_lines=config.sections["logging"]["readprivatelines"]
+        )
 
         self.chat_view.append_log_lines(log_lines, login_username=config.sections["server"]["login"])
-
-    def _read_old_messages(self):
-        return log.read_log(log.private_chat_folder_path, self.user, config.sections["logging"]["readprivatelines"])
 
     def server_login(self):
         self.chat_entry.set_sensitive(True)

--- a/pynicotine/gtkgui/privatechat.py
+++ b/pynicotine/gtkgui/privatechat.py
@@ -379,7 +379,7 @@ class PrivateChat:
 
         self.popup_menus = (self.popup_menu, self.popup_menu_user_chat, self.popup_menu_user_tab)
 
-        self.read_private_log()
+        self.prepend_old_messages()
 
     def load(self):
         GLib.idle_add(self.read_private_log_finished)
@@ -394,14 +394,14 @@ class PrivateChat:
         self.chat_view.scroll_bottom()
         self.chat_view.auto_scroll = True
 
-    def read_private_log(self):
+    def prepend_old_messages(self):
 
-        self.chat_view.append_log_lines(
-            folder_path=log.private_chat_folder_path,
-            basename=self.user,
-            num_lines=config.sections["logging"]["readprivatelines"],
-            timestamp_format=config.sections["logging"]["private_timestamp"]
-        )
+        log_lines = self._read_old_messages()
+
+        self.chat_view.append_log_lines(log_lines, login_username=config.sections["server"]["login"])
+
+    def _read_old_messages(self):
+        return log.read_log(log.private_chat_folder_path, self.user, config.sections["logging"]["readprivatelines"])
 
     def server_login(self):
         self.chat_entry.set_sensitive(True)

--- a/pynicotine/gtkgui/widgets/textview.py
+++ b/pynicotine/gtkgui/widgets/textview.py
@@ -405,7 +405,7 @@ class ChatView(TextView):
         if not log_lines:
             return
 
-        login_lower = login_username.lower() if login_username else None
+        login_username_lower = login_username.lower() if login_username else None
 
         for log_line in log_lines:
             try:
@@ -429,7 +429,7 @@ class ChatView(TextView):
                     if user == login_username:
                         message_type = "local"
 
-                    elif login_lower and find_whole_word(login_lower, text.lower()) > -1:
+                    elif login_username_lower and find_whole_word(login_username_lower, text.lower()) > -1:
                         message_type = "hilite"
 
                     else:

--- a/pynicotine/gtkgui/widgets/textview.py
+++ b/pynicotine/gtkgui/widgets/textview.py
@@ -22,14 +22,12 @@ import time
 from gi.repository import Gdk
 from gi.repository import Gtk
 
-from pynicotine.config import config
 from pynicotine.core import core
 from pynicotine.gtkgui.application import GTK_API_VERSION
 from pynicotine.gtkgui.widgets import clipboard
 from pynicotine.gtkgui.widgets.accelerator import Accelerator
 from pynicotine.gtkgui.widgets.theme import update_tag_visuals
 from pynicotine.gtkgui.widgets.theme import USER_STATUS_COLORS
-from pynicotine.logfacility import log
 from pynicotine.slskmessages import UserStatus
 from pynicotine.utils import find_whole_word
 from pynicotine.utils import open_uri
@@ -49,7 +47,6 @@ class TextView:
 
     except TypeError:
         # Broken cursor theme, but what can we do...
-        log.add_debug("Cannot load cursors from theme, falling back to default cursor")
         DEFAULT_CURSOR = POINTER_CURSOR = TEXT_CURSOR = None
 
     MAX_NUM_LINES = 50000
@@ -199,8 +196,6 @@ class TextView:
 
         self._insert_text(line, tag)
         self._remove_old_lines(num_lines)
-
-        return num_lines
 
     def get_has_selection(self):
         return self.textbuffer.get_has_selection()
@@ -404,24 +399,19 @@ class ChatView(TextView):
         Accelerator("Down", self.widget, self.on_page_down_accelerator)
         Accelerator("Page_Down", self.widget, self.on_page_down_accelerator)
 
-    def append_log_lines(self, folder_path, basename, num_lines, timestamp_format):
+    def append_log_lines(self, log_lines, login_username=None):
 
-        if not num_lines:
+        if not log_lines:
             return
 
-        lines = log.read_log(folder_path, basename, num_lines)
+        login_lower = login_username.lower() if login_username else None
 
-        if not lines:
-            return
-
-        login = config.sections["server"]["login"]
-
-        for line in lines:
+        for log_line in log_lines:
             try:
-                line = line.decode("utf-8")
+                line = log_line.decode("utf-8")
 
             except UnicodeDecodeError:
-                line = line.decode("latin-1")
+                line = log_line.decode("latin-1")
 
             user = message_type = usertag = None
 
@@ -435,10 +425,10 @@ class ChatView(TextView):
 
                     text = line[end + 2:-1]
 
-                    if user == login:
+                    if user == login_username:
                         message_type = "local"
 
-                    elif login and find_whole_word(login.lower(), text.lower()) > -1:
+                    elif login_lower and find_whole_word(login_lower, text.lower()) > -1:
                         message_type = "hilite"
 
                     else:
@@ -449,8 +439,7 @@ class ChatView(TextView):
 
             self.append_line(line, message_type=message_type, username=user, usertag=usertag)
 
-        self.append_line(_("--- old messages above ---"), message_type="hilite",
-                         timestamp_format=timestamp_format)
+        self.append_line(_("--- old messages above ---"), message_type="hilite")
 
     def clear(self):
         super().clear()


### PR DESCRIPTION
Minor UI change:

+ Changed: Don't timestamp the `--- old messages above ---` separator line, because the complexity required in the code it is not really worthwhile for this purpose, actually it is visually easier to spot it with no timestamp.

Minor code cleanups:

+ Changed: the lowercase `login_username` string is required for each line in lines, so it needs doing only once beforehand
+ Changed: Call the `read_log()` method directly from gui module instead of parsing config values into the widget
+ Removed: no caller gets the value that was returned by append_line()

This structure of methods is part of what will be required for future enhancements that are planned in draft PR #2792 (please try running that branch and let me know what you think of the overall idea), but this PR is ready to be merged, if desired.