### PR TITLE
uploads: refactor code related to pending shutdown

### DIFF
--- a/pynicotine/core.py
+++ b/pynicotine/core.py
@@ -224,23 +224,22 @@ class Core:
     def setup(self):
         events.emit("setup")
 
-    def confirm_quit(self, only_on_active_uploads=False):
-        events.emit("confirm-quit", only_on_active_uploads)
+    def confirm_quit(self):
+        events.emit("confirm-quit")
 
-    def quit(self, signal_type=None, _frame=None, should_finish_uploads=False):
+    def quit(self, signal_type=None, _frame=None):
 
-        if not should_finish_uploads:
-            import signal
-            log.add(_("Quitting %(program)s %(version)s, %(status)s…"), {
-                "program": pynicotine.__application_name__,
-                "version": pynicotine.__version__,
-                "status": _("terminating") if signal_type == signal.SIGTERM else _("application closing")
-            })
+        import signal
+        log.add(_("Quitting %(program)s %(version)s, %(status)s…"), {
+            "program": pynicotine.__application_name__,
+            "version": pynicotine.__version__,
+            "status": _("terminating") if signal_type == signal.SIGTERM else _("application closing")
+        })
 
         # Allow the networking thread to finish up before quitting
-        events.emit("schedule-quit", should_finish_uploads)
+        events.emit("schedule-quit")
 
-    def _schedule_quit(self, _should_finish_uploads):
+    def _schedule_quit(self):
         events.emit("quit")
 
     def _quit(self):

--- a/pynicotine/events.py
+++ b/pynicotine/events.py
@@ -182,6 +182,8 @@ EVENT_NAMES = {
     "upload-denied",
     "upload-failed",
     "upload-file-error",
+    "uploads-shutdown-request",
+    "uploads-shutdown-cancel",
 
     # User info
     "user-info-progress",

--- a/pynicotine/gtkgui/transfers.py
+++ b/pynicotine/gtkgui/transfers.py
@@ -102,7 +102,7 @@ class Transfers:
     UNKNOWN_STATUS_PRIORITY = 1000
 
     path_separator = path_label = retry_label = abort_label = None
-    transfer_page = user_counter = file_counter = expand_button = expand_icon = grouping_button = None
+    transfer_page = user_counter = file_counter = expand_button = expand_icon = grouping_button = status_label = None
 
     def __init__(self, window, transfer_type):
 
@@ -365,6 +365,16 @@ class Transfers:
             return translated_status
 
         return status
+
+    def update_limits(self):
+        """Underline status bar bandwidth labels when alternative speed limits
+        are active."""
+
+        if config.sections["transfers"][f"use_{self.type}_speed_limit"] == "alternative":
+            add_css_class(self.status_label, "underline")
+            return
+
+        remove_css_class(self.status_label, "underline")
 
     def update_num_users_files(self):
         self.user_counter.set_text(humanize(len(self.users)))

--- a/pynicotine/gtkgui/uploads.py
+++ b/pynicotine/gtkgui/uploads.py
@@ -24,6 +24,8 @@
 
 import os
 
+from gi.repository import Gtk
+
 from pynicotine.config import config
 from pynicotine.core import core
 from pynicotine.events import events
@@ -33,6 +35,7 @@ from pynicotine.gtkgui.transfers import Transfers
 from pynicotine.gtkgui.widgets import clipboard
 from pynicotine.gtkgui.widgets.dialogs import OptionDialog
 from pynicotine.transfers import TransferStatus
+from pynicotine.utils import human_speed
 from pynicotine.utils import open_file_path
 from pynicotine.utils import open_folder_path
 
@@ -58,6 +61,7 @@ class Uploads(Transfers):
         self.expand_button = window.uploads_expand_button
         self.expand_icon = window.uploads_expand_icon
         self.grouping_button = window.uploads_grouping_button
+        self.status_label = window.upload_status_label
 
         super().__init__(window, transfer_type="upload")
 
@@ -85,8 +89,12 @@ class Uploads(Transfers):
             ("abort-uploads", self.abort_transfers),
             ("clear-upload", self.clear_transfer),
             ("clear-uploads", self.clear_transfers),
+            ("set-connection-stats", self.set_connection_stats),
             ("start", self.start),
-            ("update-upload", self.update_model)
+            ("update-upload", self.update_model),
+            ("update-upload-limits", self.update_limits),
+            ("uploads-shutdown-request", self.shutdown_request),
+            ("uploads-shutdown-cancel", self.shutdown_cancel)
         ):
             events.connect(event_name, callback)
 
@@ -117,6 +125,34 @@ class Uploads(Transfers):
 
     def remove_selected_transfers(self):
         core.uploads.clear_uploads(uploads=self.selected_transfers)
+
+    def set_connection_stats(self, upload_bandwidth=0, **_kwargs):
+
+        upload_bandwidth = human_speed(upload_bandwidth)
+        upload_bandwidth_text = f"{upload_bandwidth} ( {len(core.uploads.active_users)} )"
+
+        if self.window.upload_status_label.get_text() == upload_bandwidth_text:
+            return
+
+        self.window.upload_status_label.set_text(upload_bandwidth_text)
+        self.window.application.tray_icon.set_upload_status(
+            _("Uploads: %(speed)s") % {"speed": upload_bandwidth})
+
+    def shutdown_request(self):
+
+        icon_name = "system-shutdown-symbolic"
+        icon_args = (Gtk.IconSize.BUTTON,) if GTK_API_VERSION == 3 else ()  # pylint: disable=no-member
+        toggle_status_action = self.window.lookup_action("toggle-status")
+
+        toggle_status_action.handler_block_by_func(self.window.on_toggle_status)
+        self.window.user_status_button.set_active(True)
+        toggle_status_action.handler_unblock_by_func(self.window.on_toggle_status)
+
+        self.window.user_status_icon.set_from_icon_name(icon_name, *icon_args)
+        self.window.user_status_label.set_text(_("Quitting..."))
+
+    def shutdown_cancel(self):
+        self.window.update_user_status()
 
     def on_try_clear_queued(self, *_args):
 

--- a/pynicotine/headless/application.py
+++ b/pynicotine/headless/application.py
@@ -69,7 +69,7 @@ class Application:
         if user_input.lower().startswith("y"):
             core.quit()
 
-    def on_confirm_quit(self, _only_on_active_uploads):
+    def on_confirm_quit(self):
         responses = "[y/N] "
         cli.prompt(_("Do you really want to exit? %s") % responses, callback=self.on_confirm_quit_response)
 

--- a/pynicotine/slskproto.py
+++ b/pynicotine/slskproto.py
@@ -443,8 +443,8 @@ class NetworkThread(Thread):
         if self._should_process_queue:
             self._message_queue.append(msg)
 
-    def _schedule_quit(self, should_finish_uploads):
-        self._want_abort = not should_finish_uploads
+    def _schedule_quit(self):
+        self._want_abort = True
 
     # Listening Socket #
 


### PR DESCRIPTION
The previous code was bad/sloppy for many reasons:
- Core should not be aware of uploads, only the uploads module should
- No events for starting/stopping a pending shutdown for uploads
- Implemented in the wrong module
- Gave me a headache when reading it

Based on previous feedback from users, also change the behavior to always show a confirmation dialog on quit if uploads are active (unless the window is hidden/running in the background).