### PR TITLE
config.py: remove 'maxresults' option

### DIFF
--- a/pynicotine/config.py
+++ b/pynicotine/config.py
@@ -291,7 +291,6 @@ class Config:
             "searches": {
                 "expand_searches": True,
                 "group_searches": "folder_grouping",
-                "maxresults": 150,
                 "enable_history": True,
                 "history": [],
                 "enablefilters": False,
@@ -518,7 +517,8 @@ class Config:
                 "reopen_tabs",
                 "max_stored_results",
                 "re_filter",
-                "remove_special_chars"
+                "remove_special_chars",
+                "maxresults"
             ),
             "userinfo": (
                 "descrutf8",

--- a/pynicotine/gtkgui/dialogs/preferences.py
+++ b/pynicotine/gtkgui/dialogs/preferences.py
@@ -2254,7 +2254,6 @@ class SearchesPage:
             self.filter_include_entry,
             self.filter_length_entry,
             self.max_displayed_results_spinner,
-            self.max_sent_results_spinner,
             self.min_search_term_length_spinner,
             self.repond_search_requests_toggle,
             self.show_private_results_toggle
@@ -2272,7 +2271,6 @@ class SearchesPage:
 
         self.options = {
             "searches": {
-                "maxresults": self.max_sent_results_spinner,
                 "enablefilters": self.enable_default_filters_toggle,
                 "defilter": None,
                 "search_results": self.repond_search_requests_toggle,
@@ -2327,7 +2325,6 @@ class SearchesPage:
 
         return {
             "searches": {
-                "maxresults": self.max_sent_results_spinner.get_value_as_int(),
                 "enablefilters": self.enable_default_filters_toggle.get_active(),
                 "defilter": [
                     self.filter_include_entry.get_text(),

--- a/pynicotine/gtkgui/ui/settings/search.ui
+++ b/pynicotine/gtkgui/ui/settings/search.ui
@@ -12,12 +12,6 @@
     <property name="step-increment">1</property>
     <property name="upper">1000</property>
   </object>
-  <object class="GtkAdjustment" id="_max_sent_results_adjustment">
-    <property name="lower">50</property>
-    <property name="page-increment">50</property>
-    <property name="step-increment">25</property>
-    <property name="upper">100000</property>
-  </object>
   <object class="GtkBox" id="container">
     <property name="orientation">vertical</property>
     <property name="spacing">30</property>
@@ -471,31 +465,6 @@
                         <child>
                           <object class="GtkSpinButton" id="min_search_term_length_spinner">
                             <property name="adjustment">_min_search_term_length_adjustment</property>
-                            <property name="numeric">True</property>
-                            <property name="valign">center</property>
-                            <property name="visible">True</property>
-                          </object>
-                        </child>
-                      </object>
-                    </child>
-                    <child>
-                      <object class="GtkBox">
-                        <property name="spacing">12</property>
-                        <property name="visible">True</property>
-                        <child>
-                          <object class="GtkLabel">
-                            <property name="hexpand">True</property>
-                            <property name="label" translatable="yes">Maximum search results to send per search request:</property>
-                            <property name="mnemonic-widget">max_sent_results_spinner</property>
-                            <property name="visible">True</property>
-                            <property name="wrap">True</property>
-                            <property name="wrap-mode">word-char</property>
-                            <property name="xalign">0</property>
-                          </object>
-                        </child>
-                        <child>
-                          <object class="GtkSpinButton" id="max_sent_results_spinner">
-                            <property name="adjustment">_max_sent_results_adjustment</property>
                             <property name="numeric">True</property>
                             <property name="valign">center</property>
                             <property name="visible">True</property>

--- a/pynicotine/tests/unit/search/test_search.py
+++ b/pynicotine/tests/unit/search/test_search.py
@@ -120,7 +120,6 @@ class SearchTest(TestCase):
     def test_create_search_result_list(self):
         """Test creating search result lists from the word index."""
 
-        max_results = 1500
         word_index = {
             "iso": [34, 35, 36, 37, 38],
             "lts": [63, 68, 73],
@@ -133,7 +132,7 @@ class SearchTest(TestCase):
         partial_words = {"stem"}
 
         results = core.search._create_search_result_list(
-            included_words, excluded_words, partial_words, max_results, word_index)
+            included_words, excluded_words, partial_words, word_index)
         self.assertEqual(results, {37, 38})
 
         included_words = {"lts", "iso"}
@@ -141,7 +140,7 @@ class SearchTest(TestCase):
         partial_words = set()
 
         results = core.search._create_search_result_list(
-            included_words, excluded_words, partial_words, max_results, word_index)
+            included_words, excluded_words, partial_words, word_index)
         self.assertIsNone(results)
 
         included_words = {"iso"}
@@ -149,7 +148,7 @@ class SearchTest(TestCase):
         partial_words = {"ibberish"}
 
         results = core.search._create_search_result_list(
-            included_words, excluded_words, partial_words, max_results, word_index)
+            included_words, excluded_words, partial_words, word_index)
         self.assertIsNone(results)
 
     def test_exclude_server_phrases(self):
@@ -172,7 +171,7 @@ class SearchTest(TestCase):
             share_db.close = lambda: None
 
         num_results, fileinfos, private_fileinfos = core.search._create_file_info_list(
-            results, max_results=100, permission_level=PermissionLevel.PUBLIC
+            results, permission_level=PermissionLevel.PUBLIC
         )
         self.assertEqual(num_results, 3)
         self.assertEqual(fileinfos, [


### PR DESCRIPTION
Someone asked what the purpose of this option is, and I didn't have a good answer. It's another one of those options that have been around forever, and nobody bothered looking into.

Hard code the maximum number of returned results to 500 instead. This should leave room for useful results in almost every case, but also avoid wasting bandwidth by returning thousands of results for popular search terms.