### PR TITLE
settings/search.ui: add revealer for default filters

### DIFF
--- a/pynicotine/gtkgui/ui/settings/search.ui
+++ b/pynicotine/gtkgui/ui/settings/search.ui
@@ -130,16 +130,50 @@
         <property name="spacing">12</property>
         <property name="visible">True</property>
         <child>
-          <object class="GtkLabel">
-            <property name="halign">start</property>
-            <property name="label" translatable="yes">Search Result Filters</property>
-            <property name="selectable">True</property>
+          <object class="GtkBox">
+            <property name="homogeneous">True</property>
+            <property name="spacing">12</property>
             <property name="visible">True</property>
-            <property name="wrap">True</property>
-            <property name="xalign">0</property>
-            <style>
-              <class name="heading"/>
-            </style>
+            <child>
+              <object class="GtkLabel">
+                <property name="halign">start</property>
+                <property name="label" translatable="yes">Search Result Filters</property>
+                <property name="selectable">True</property>
+                <property name="visible">True</property>
+                <property name="wrap">True</property>
+                <property name="xalign">0</property>
+                <style>
+                  <class name="heading"/>
+                </style>
+              </object>
+            </child>
+            <child>
+              <object class="GtkMenuButton" id="filter_help_button">
+                <property name="halign">end</property>
+                <property name="visible">True</property>
+                <child>
+                  <object class="GtkBox">
+                    <property name="spacing">6</property>
+                    <property name="visible">True</property>
+                    <child>
+                      <object class="GtkImage">
+                        <property name="icon-name">dialog-question-symbolic</property>
+                        <property name="visible">True</property>
+                      </object>
+                    </child>
+                    <child>
+                      <object class="GtkLabel" id="filter_help_label">
+                        <property name="ellipsize">end</property>
+                        <property name="label" translatable="yes">Result Filter Help</property>
+                        <property name="mnemonic-widget">filter_help_button</property>
+                        <property name="visible">True</property>
+                        <property name="xalign">0</property>
+                      </object>
+                    </child>
+                  </object>
+                </child>
+              </object>
+            </child>
           </object>
         </child>
         <child>
@@ -167,226 +201,222 @@
           </object>
         </child>
         <child>
-          <object class="GtkBox">
-            <property name="homogeneous">True</property>
-            <property name="margin-top">6</property>
-            <property name="spacing">12</property>
+          <object class="GtkRevealer">
+            <property name="reveal-child" bind-source="enable_default_filters_toggle" bind-property="active" bind-flags="bidirectional|sync-create"/>
+            <property name="transition-type">slide-down</property>
             <property name="visible">True</property>
             <child>
-              <object class="GtkLabel">
-                <property name="label" translatable="yes">Include:</property>
-                <property name="mnemonic-widget">filter_include_entry</property>
-                <property name="visible">True</property>
-                <property name="wrap">True</property>
-                <property name="wrap-mode">word-char</property>
-                <property name="xalign">0</property>
-              </object>
-            </child>
-            <child>
-              <object class="GtkEntry" id="filter_include_entry">
-                <property name="tooltip-text" translatable="yes">Filter in results whose file paths contain the specified text. Multiple phrases and words can be specified, e.g. exact phrase|music|term|exact phrase two</property>
-                <property name="valign">center</property>
-                <property name="visible">True</property>
-                <property name="width-chars">8</property>
-              </object>
-            </child>
-          </object>
-        </child>
-        <child>
-          <object class="GtkBox">
-            <property name="homogeneous">True</property>
-            <property name="spacing">12</property>
-            <property name="visible">True</property>
-            <child>
-              <object class="GtkLabel">
-                <property name="label" translatable="yes">Exclude:</property>
-                <property name="mnemonic-widget">filter_exclude_entry</property>
-                <property name="visible">True</property>
-                <property name="wrap">True</property>
-                <property name="wrap-mode">word-char</property>
-                <property name="xalign">0</property>
-              </object>
-            </child>
-            <child>
-              <object class="GtkEntry" id="filter_exclude_entry">
-                <property name="tooltip-text" translatable="yes">Filter out results whose file paths contain the specified text. Multiple phrases and words can be specified, e.g. exact phrase|music|term|exact phrase two</property>
-                <property name="valign">center</property>
-                <property name="visible">True</property>
-                <property name="width-chars">8</property>
-              </object>
-            </child>
-          </object>
-        </child>
-        <child>
-          <object class="GtkBox">
-            <property name="homogeneous">True</property>
-            <property name="spacing">12</property>
-            <property name="visible">True</property>
-            <child>
-              <object class="GtkLabel">
-                <property name="label" translatable="yes">File Type:</property>
-                <property name="mnemonic-widget">filter_file_type_entry</property>
-                <property name="visible">True</property>
-                <property name="wrap">True</property>
-                <property name="wrap-mode">word-char</property>
-                <property name="xalign">0</property>
-              </object>
-            </child>
-            <child>
-              <object class="GtkEntry" id="filter_file_type_entry">
-                <property name="halign">end</property>
-                <property name="max-width-chars">26</property>
-                <property name="tooltip-text" translatable="yes">File type, e.g. flac wav or !mp3 !m4a</property>
-                <property name="valign">center</property>
-                <property name="visible">True</property>
-                <property name="width-chars">8</property>
-              </object>
-            </child>
-          </object>
-        </child>
-        <child>
-          <object class="GtkBox">
-            <property name="homogeneous">True</property>
-            <property name="spacing">12</property>
-            <property name="visible">True</property>
-            <child>
-              <object class="GtkLabel">
-                <property name="label" translatable="yes">Size:</property>
-                <property name="mnemonic-widget">filter_file_size_entry</property>
-                <property name="visible">True</property>
-                <property name="wrap">True</property>
-                <property name="wrap-mode">word-char</property>
-                <property name="xalign">0</property>
-              </object>
-            </child>
-            <child>
-              <object class="GtkEntry" id="filter_file_size_entry">
-                <property name="halign">end</property>
-                <property name="max-width-chars">26</property>
-                <property name="tooltip-text" translatable="yes">File size, e.g. &gt;10.5m &lt;1g</property>
-                <property name="valign">center</property>
-                <property name="visible">True</property>
-                <property name="width-chars">8</property>
-              </object>
-            </child>
-          </object>
-        </child>
-        <child>
-          <object class="GtkBox">
-            <property name="homogeneous">True</property>
-            <property name="spacing">12</property>
-            <property name="visible">True</property>
-            <child>
-              <object class="GtkLabel">
-                <property name="label" translatable="yes">Bitrate:</property>
-                <property name="mnemonic-widget">filter_bitrate_entry</property>
-                <property name="visible">True</property>
-                <property name="wrap">True</property>
-                <property name="wrap-mode">word-char</property>
-                <property name="xalign">0</property>
-              </object>
-            </child>
-            <child>
-              <object class="GtkEntry" id="filter_bitrate_entry">
-                <property name="halign">end</property>
-                <property name="max-width-chars">26</property>
-                <property name="tooltip-text" translatable="yes">Bitrate, e.g. 256 &lt;1412</property>
-                <property name="valign">center</property>
-                <property name="visible">True</property>
-                <property name="width-chars">8</property>
-              </object>
-            </child>
-          </object>
-        </child>
-        <child>
-          <object class="GtkBox">
-            <property name="homogeneous">True</property>
-            <property name="spacing">12</property>
-            <property name="visible">True</property>
-            <child>
-              <object class="GtkLabel">
-                <property name="label" translatable="yes">Duration:</property>
-                <property name="mnemonic-widget">filter_length_entry</property>
-                <property name="visible">True</property>
-                <property name="wrap">True</property>
-                <property name="wrap-mode">word-char</property>
-                <property name="xalign">0</property>
-              </object>
-            </child>
-            <child>
-              <object class="GtkEntry" id="filter_length_entry">
-                <property name="halign">end</property>
-                <property name="max-width-chars">26</property>
-                <property name="tooltip-text" translatable="yes">Duration, e.g. &gt;6:00 &lt;12:00 !6:54</property>
-                <property name="valign">center</property>
-                <property name="visible">True</property>
-                <property name="width-chars">8</property>
-              </object>
-            </child>
-          </object>
-        </child>
-        <child>
-          <object class="GtkBox">
-            <property name="homogeneous">True</property>
-            <property name="spacing">12</property>
-            <property name="visible">True</property>
-            <child>
-              <object class="GtkLabel">
-                <property name="label" translatable="yes">Country Code:</property>
-                <property name="mnemonic-widget">filter_country_entry</property>
-                <property name="visible">True</property>
-                <property name="wrap">True</property>
-                <property name="wrap-mode">word-char</property>
-                <property name="xalign">0</property>
-              </object>
-            </child>
-            <child>
-              <object class="GtkEntry" id="filter_country_entry">
-                <property name="halign">end</property>
-                <property name="max-width-chars">26</property>
-                <property name="tooltip-text" translatable="yes">Country code, e.g. US ES or !DE !GB</property>
-                <property name="valign">center</property>
-                <property name="visible">True</property>
-                <property name="width-chars">8</property>
-              </object>
-            </child>
-          </object>
-        </child>
-        <child>
-          <object class="GtkBox">
-            <property name="margin-top">6</property>
-            <property name="spacing">6</property>
-            <property name="visible">True</property>
-            <child>
-              <object class="GtkCheckButton" id="filter_free_slot_toggle">
-                <property name="hexpand">True</property>
-                <property name="label" translatable="yes">Free Slot</property>
-                <property name="tooltip-text" translatable="yes">Only show results from users with an available upload slot.</property>
-                <property name="use-underline">True</property>
-                <property name="valign">start</property>
-                <property name="visible">True</property>
-              </object>
-            </child>
-            <child>
-              <object class="GtkMenuButton" id="filter_help_button">
+              <object class="GtkBox">
+                <property name="orientation">vertical</property>
+                <property name="spacing">12</property>
                 <property name="visible">True</property>
                 <child>
                   <object class="GtkBox">
-                    <property name="spacing">6</property>
+                    <property name="homogeneous">True</property>
+                    <property name="margin-top">6</property>
+                    <property name="spacing">12</property>
                     <property name="visible">True</property>
                     <child>
-                      <object class="GtkImage">
-                        <property name="icon-name">dialog-question-symbolic</property>
+                      <object class="GtkLabel">
+                        <property name="label" translatable="yes">Include:</property>
+                        <property name="mnemonic-widget">filter_include_entry</property>
                         <property name="visible">True</property>
+                        <property name="wrap">True</property>
+                        <property name="wrap-mode">word-char</property>
+                        <property name="xalign">0</property>
                       </object>
                     </child>
                     <child>
-                      <object class="GtkLabel" id="filter_help_label">
-                        <property name="ellipsize">end</property>
-                        <property name="label" translatable="yes">Result Filter Help</property>
-                        <property name="mnemonic-widget">filter_help_button</property>
+                      <object class="GtkEntry" id="filter_include_entry">
+                        <property name="tooltip-text" translatable="yes">Filter in results whose file paths contain the specified text. Multiple phrases and words can be specified, e.g. exact phrase|music|term|exact phrase two</property>
+                        <property name="valign">center</property>
                         <property name="visible">True</property>
+                        <property name="width-chars">8</property>
+                      </object>
+                    </child>
+                  </object>
+                </child>
+                <child>
+                  <object class="GtkBox">
+                    <property name="homogeneous">True</property>
+                    <property name="spacing">12</property>
+                    <property name="visible">True</property>
+                    <child>
+                      <object class="GtkLabel">
+                        <property name="label" translatable="yes">Exclude:</property>
+                        <property name="mnemonic-widget">filter_exclude_entry</property>
+                        <property name="visible">True</property>
+                        <property name="wrap">True</property>
+                        <property name="wrap-mode">word-char</property>
                         <property name="xalign">0</property>
+                      </object>
+                    </child>
+                    <child>
+                      <object class="GtkEntry" id="filter_exclude_entry">
+                        <property name="tooltip-text" translatable="yes">Filter out results whose file paths contain the specified text. Multiple phrases and words can be specified, e.g. exact phrase|music|term|exact phrase two</property>
+                        <property name="valign">center</property>
+                        <property name="visible">True</property>
+                        <property name="width-chars">8</property>
+                      </object>
+                    </child>
+                  </object>
+                </child>
+                <child>
+                  <object class="GtkBox">
+                    <property name="homogeneous">True</property>
+                    <property name="spacing">12</property>
+                    <property name="visible">True</property>
+                    <child>
+                      <object class="GtkLabel">
+                        <property name="label" translatable="yes">File Type:</property>
+                        <property name="mnemonic-widget">filter_file_type_entry</property>
+                        <property name="visible">True</property>
+                        <property name="wrap">True</property>
+                        <property name="wrap-mode">word-char</property>
+                        <property name="xalign">0</property>
+                      </object>
+                    </child>
+                    <child>
+                      <object class="GtkEntry" id="filter_file_type_entry">
+                        <property name="halign">end</property>
+                        <property name="max-width-chars">26</property>
+                        <property name="tooltip-text" translatable="yes">File type, e.g. flac wav or !mp3 !m4a</property>
+                        <property name="valign">center</property>
+                        <property name="visible">True</property>
+                        <property name="width-chars">8</property>
+                      </object>
+                    </child>
+                  </object>
+                </child>
+                <child>
+                  <object class="GtkBox">
+                    <property name="homogeneous">True</property>
+                    <property name="spacing">12</property>
+                    <property name="visible">True</property>
+                    <child>
+                      <object class="GtkLabel">
+                        <property name="label" translatable="yes">Size:</property>
+                        <property name="mnemonic-widget">filter_file_size_entry</property>
+                        <property name="visible">True</property>
+                        <property name="wrap">True</property>
+                        <property name="wrap-mode">word-char</property>
+                        <property name="xalign">0</property>
+                      </object>
+                    </child>
+                    <child>
+                      <object class="GtkEntry" id="filter_file_size_entry">
+                        <property name="halign">end</property>
+                        <property name="max-width-chars">26</property>
+                        <property name="tooltip-text" translatable="yes">File size, e.g. &gt;10.5m &lt;1g</property>
+                        <property name="valign">center</property>
+                        <property name="visible">True</property>
+                        <property name="width-chars">8</property>
+                      </object>
+                    </child>
+                  </object>
+                </child>
+                <child>
+                  <object class="GtkBox">
+                    <property name="homogeneous">True</property>
+                    <property name="spacing">12</property>
+                    <property name="visible">True</property>
+                    <child>
+                      <object class="GtkLabel">
+                        <property name="label" translatable="yes">Bitrate:</property>
+                        <property name="mnemonic-widget">filter_bitrate_entry</property>
+                        <property name="visible">True</property>
+                        <property name="wrap">True</property>
+                        <property name="wrap-mode">word-char</property>
+                        <property name="xalign">0</property>
+                      </object>
+                    </child>
+                    <child>
+                      <object class="GtkEntry" id="filter_bitrate_entry">
+                        <property name="halign">end</property>
+                        <property name="max-width-chars">26</property>
+                        <property name="tooltip-text" translatable="yes">Bitrate, e.g. 256 &lt;1412</property>
+                        <property name="valign">center</property>
+                        <property name="visible">True</property>
+                        <property name="width-chars">8</property>
+                      </object>
+                    </child>
+                  </object>
+                </child>
+                <child>
+                  <object class="GtkBox">
+                    <property name="homogeneous">True</property>
+                    <property name="spacing">12</property>
+                    <property name="visible">True</property>
+                    <child>
+                      <object class="GtkLabel">
+                        <property name="label" translatable="yes">Duration:</property>
+                        <property name="mnemonic-widget">filter_length_entry</property>
+                        <property name="visible">True</property>
+                        <property name="wrap">True</property>
+                        <property name="wrap-mode">word-char</property>
+                        <property name="xalign">0</property>
+                      </object>
+                    </child>
+                    <child>
+                      <object class="GtkEntry" id="filter_length_entry">
+                        <property name="halign">end</property>
+                        <property name="max-width-chars">26</property>
+                        <property name="tooltip-text" translatable="yes">Duration, e.g. &gt;6:00 &lt;12:00 !6:54</property>
+                        <property name="valign">center</property>
+                        <property name="visible">True</property>
+                        <property name="width-chars">8</property>
+                      </object>
+                    </child>
+                  </object>
+                </child>
+                <child>
+                  <object class="GtkBox">
+                    <property name="homogeneous">True</property>
+                    <property name="spacing">12</property>
+                    <property name="visible">True</property>
+                    <child>
+                      <object class="GtkLabel">
+                        <property name="label" translatable="yes">Country Code:</property>
+                        <property name="mnemonic-widget">filter_country_entry</property>
+                        <property name="visible">True</property>
+                        <property name="wrap">True</property>
+                        <property name="wrap-mode">word-char</property>
+                        <property name="xalign">0</property>
+                      </object>
+                    </child>
+                    <child>
+                      <object class="GtkEntry" id="filter_country_entry">
+                        <property name="halign">end</property>
+                        <property name="max-width-chars">26</property>
+                        <property name="tooltip-text" translatable="yes">Country code, e.g. US ES or !DE !GB</property>
+                        <property name="valign">center</property>
+                        <property name="visible">True</property>
+                        <property name="width-chars">8</property>
+                      </object>
+                    </child>
+                  </object>
+                </child>
+                <child>
+                  <object class="GtkBox">
+                    <property name="spacing">12</property>
+                    <property name="visible">True</property>
+                    <child>
+                      <object class="GtkLabel">
+                        <property name="height-request">24</property>
+                        <property name="hexpand">True</property>
+                        <property name="label" translatable="yes">Free Slot:</property>
+                        <property name="mnemonic-widget">filter_free_slot_toggle</property>
+                        <property name="visible">True</property>
+                        <property name="wrap">True</property>
+                        <property name="wrap-mode">word-char</property>
+                        <property name="xalign">0</property>
+                      </object>
+                    </child>
+                    <child>
+                      <object class="GtkSwitch" id="filter_free_slot_toggle">
+                        <property name="tooltip-text" translatable="yes">Only show results from users with an available upload slot.</property>
+                        <property name="valign">center</property>
+                        <property name="visible">True</property>
                       </object>
                     </child>
                   </object>


### PR DESCRIPTION
+ Added: Revealer for default filter entries, this saves vertical space and better guides how the function is activated.
+ Changed: "Free Slot" checkbox to "Free Slot:" switch (involves a string change).

_Collapsed:_
![image](https://github.com/user-attachments/assets/45712027-ee38-43a9-96f3-568358d9064c)

_Revealed:_
![image](https://github.com/user-attachments/assets/c6e7bc0d-33ee-4b16-9dd3-493a6d063e14)