### PR TITLE
config.py: increase default max_displayed_results to 2000

### DIFF
--- a/pynicotine/config.py
+++ b/pynicotine/config.py
@@ -310,7 +310,7 @@ class Config:
                 "filtertype": [],
                 "filterlength": [],
                 "search_results": True,
-                "max_displayed_results": 1500,
+                "max_displayed_results": 2000,
                 "min_search_chars": 3,
                 "private_search_results": False
             },


### PR DESCRIPTION
- Changed: increase default `max_displayed_results` to `2000` because the application has become much more performant since this default was last increased two years ago, and there are generally more results readily available on the network as well.