### PR TITLE
ChatEntry: Scroll to bottom on entering empty message

### DIFF
--- a/pynicotine/gtkgui/widgets/textentry.py
+++ b/pynicotine/gtkgui/widgets/textentry.py
@@ -213,6 +213,7 @@ class ChatEntry:
         text = self.widget.get_text().strip()
 
         if not text:
+            self.chat_view.scroll_bottom()
             return
 
         is_double_slash_cmd = text.startswith("//")


### PR DESCRIPTION
+ Added: Goto end of chat log by pressing Return key or click send message icon while entry is empty, instead of a noop.

Scrolling to the bottom is probably what is desired when sending a non-empty message as well, but that is not implemented in this PR because `scroll_bottom()` is usually called anyway if there is text present in the entry and the view is already at the bottom.

There doesn't seem to be any possibility that `chat_view` will be `None` because `send_message()` isn't available before the parent is set, but there might be a better method of implementing the desired behaviour without causing duplicated scrolling events?