### PR TITLE
TextSearchBar: get selection content in text entry on Find

### DIFF
--- a/pynicotine/gtkgui/widgets/textentry.py
+++ b/pynicotine/gtkgui/widgets/textentry.py
@@ -630,12 +630,24 @@ class TextSearchBar:
 
     def set_visible(self, visible):
 
+        self.search_bar.set_search_mode(False)
+
         if visible:
+            text_buffer = self.textview.get_buffer()
+            text_buffer_selection_bounds = text_buffer.get_selection_bounds()
+
+            if not self.entry.get_text() and text_buffer_selection_bounds:
+                selection_start, selection_end = text_buffer_selection_bounds
+
+                selection_content = text_buffer.get_text(
+                    selection_start, selection_end, include_hidden_chars=True).strip(" \n")
+
+                if "\n" not in selection_content:
+                    self.entry.set_text(selection_content)
+
             self.search_bar.set_search_mode(True)
             self.entry.grab_focus()
             return
-
-        self.search_bar.set_search_mode(False)
 
         if self.focus_widget is not None and self.focus_widget.get_sensitive():
             self.focus_widget.grab_focus()

--- a/pynicotine/gtkgui/widgets/textentry.py
+++ b/pynicotine/gtkgui/widgets/textentry.py
@@ -630,23 +630,22 @@ class TextSearchBar:
 
     def set_visible(self, visible):
 
-        self.search_bar.set_search_mode(False)
+        self.search_bar.set_search_mode(visible)
 
         if visible:
             text_buffer = self.textview.get_buffer()
-            text_buffer_selection_bounds = text_buffer.get_selection_bounds()
+            selection_bounds = text_buffer.get_selection_bounds()
 
-            if not self.entry.get_text() and text_buffer_selection_bounds:
-                selection_start, selection_end = text_buffer_selection_bounds
-
+            if selection_bounds:
+                selection_start, selection_end = selection_bounds
                 selection_content = text_buffer.get_text(
-                    selection_start, selection_end, include_hidden_chars=True).strip(" \n")
+                    selection_start, selection_end, include_hidden_chars=True)
 
-                if "\n" not in selection_content:
+                if self.entry.get_text().lower() != selection_content.lower():
                     self.entry.set_text(selection_content)
 
-            self.search_bar.set_search_mode(True)
             self.entry.grab_focus()
+            self.entry.set_position(-1)
             return
 
         if self.focus_widget is not None and self.focus_widget.get_sensitive():


### PR DESCRIPTION
+ Added: Populate the Find text entry with selected text on initializing new text search in chat, private chat or log window

Not tested in GTK 4 which has `get_selection_content()` but `get_selection_bounds()` should work in both GTK 3 and GTK 4.

~If multiple lines are selected then just show the Find bar with a blank entry as before.~

It would be nicer to have a `get_selection_content()` helper function in `textview.py` but the Class isn't available from `textedit.py` only the widget can be referenced from there with the way it is at the moment.