### PR TITLE
Only set window urgency hint for private chats and mentions

### DIFF
--- a/pynicotine/gtkgui/application.py
+++ b/pynicotine/gtkgui/application.py
@@ -500,21 +500,36 @@ class Application:
             log.add(_("Unable to show notification: %s"), error)
 
     def _show_chatroom_notification(self, room, message, title=None, high_priority=False):
+
         self._show_notification(
             message, title, action="app.chatroom-notification-activated", action_target=room,
-            high_priority=high_priority)
+            high_priority=high_priority
+        )
+
+        if high_priority:
+            self.window.set_urgency_hint(True)
 
     def _show_download_notification(self, message, title=None, high_priority=False):
+
         self._show_notification(
-            message, title, action="app.download-notification-activated", high_priority=high_priority)
+            message, title, action="app.download-notification-activated",
+            high_priority=high_priority
+        )
 
     def _show_private_chat_notification(self, user, message, title=None):
+
         self._show_notification(
-            message, title, action="app.private-chat-notification-activated", action_target=user, high_priority=True)
+            message, title, action="app.private-chat-notification-activated", action_target=user,
+            high_priority=True
+        )
+        self.window.set_urgency_hint(True)
 
     def _show_search_notification(self, search_token, message, title=None):
+
         self._show_notification(
-            message, title, action="app.search-notification-activated", action_target=search_token, high_priority=True)
+            message, title, action="app.search-notification-activated", action_target=search_token,
+            high_priority=True
+        )
 
     # Core Events #
 

--- a/pynicotine/gtkgui/mainwindow.py
+++ b/pynicotine/gtkgui/mainwindow.py
@@ -389,16 +389,16 @@ class MainWindow(Window):
             # Private Chats have a higher priority
             user = self.privatechat.highlighted_users[-1]
             notification_text = _("Private Message from %(user)s") % {"user": user}
+            self.set_urgency_hint(True)
 
         elif self.chatrooms.highlighted_rooms:
             # Allow for the possibility the username is not available
             room, user = list(self.chatrooms.highlighted_rooms.items())[-1]
             notification_text = _("Mentioned by %(user)s in Room %(room)s") % {"user": user, "room": room}
+            self.set_urgency_hint(True)
 
         elif any(is_important for is_important in self.search.unread_pages.values()):
             notification_text = _("Wishlist Results Found")
-
-        self.set_urgency_hint(bool(notification_text))
 
         if not notification_text:
             self.set_title(pynicotine.__application_name__)


### PR DESCRIPTION
Per definition, urgency hints should only be used when a timely response is required (typically instant messaging).

Fixes #3123
