### PR TITLE
website.yml: prevent forks from attempting to deploy pages

### DIFF
--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -3,6 +3,7 @@ name: Website
 on:
   push:
     branches: ["master"]
+    paths: ["*.md"]
   workflow_dispatch:
 
 # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
@@ -19,6 +20,7 @@ concurrency:
 
 jobs:
   build:
+    if: github.repository == 'nicotine-plus/nicotine-plus'
     runs-on: ubuntu-latest
     timeout-minutes: 15
     env:


### PR DESCRIPTION
The CI always fails on forked repo's because the website can't be deployed anywhere other than in the official repo, it is annoying to have the [failure notifications](https://github.com/slook/nicotine-plus/actions/workflows/website.yml) appear whenever synchronizing latest changes for testing.

+ Added: Avoid unnecessarily deploying the site unless .md file(s) are being pushed
+ Added: Condition to restrict building (and thereby also blocking deploy) only when running on the official repo

If there is a case for deploying the site other than when a markdown file is altered, then the workflow can be manually dispatched.