### PR TITLE
website.yml: prevent forks from attempting to deploy pages

### DIFF
--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -19,6 +19,7 @@ concurrency:
 
 jobs:
   build:
+    if: github.repository == 'nicotine-plus/nicotine-plus'
     runs-on: ubuntu-latest
     timeout-minutes: 15
     env:


### PR DESCRIPTION
+ Added: Condition to restrict building (and thereby also blocking deploy) only when running on the official repo

The CI always fails on forked repo's because the website can't be deployed anywhere other than in the official repo, it is annoying to have the [failure notifications](https://github.com/slook/nicotine-plus/actions/workflows/website.yml) appear whenever synchronizing latest changes for testing.