### PR TITLE
website.yml: deploy pages only when pushing markdown files

### DIFF
--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -3,6 +3,7 @@ name: Website
 on:
   push:
     branches: ["master"]
+    paths: ["*.md"]
   workflow_dispatch:
 
 # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages


### PR DESCRIPTION
+ Added: Avoid unnecessarily deploying the site unless .md file(s) are being pushed

If there is a case for deploying pages to the the site other than when a markdown file is altered, then the workflow can be manually dispatched.