### PR TITLE
debian/copyright: correct path to data/ip_country_data.csv

### DIFF
--- a/debian/copyright
+++ b/debian/copyright
@@ -32,8 +32,7 @@ Copyright: 2003-2024 Nicotine+ Translators
 License: GPL-3+
 Comment: see TRANSLATORS.md for more information.
 
-Files: pynicotine/external/country_codes.py
-       pynicotine/external/ip_ranges.py
+Files: pynicotine/external/data/ip_country_data.csv
 Copyright: 2001-2024 Hexasoft Development Sdn. Bhd.
 License: CC-BY-SA-4.0
 


### PR DESCRIPTION
In previous PR #3131 I failed to notice that the path had also changed.
