### PR TITLE
docs: links to old version of Nicotine+ 3.2.9 for legacy users

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,13 +14,15 @@ Check out the [screenshots](data/screenshots/SCREENSHOTS.md) and [source code](h
 
 ## Download
 
-The current stable version of Nicotine+ is 3.2.9, released on March 5, 2023. See the [release notes](NEWS.md).
+This is an old version of Nicotine+ 3.2.9, released on March 5, 2023. See the [release notes](NEWS.md).
 
-Downloads are available for:
+Legacy Downloads are available for:
 
  * [GNU/Linux, *BSD and Solaris](doc/DOWNLOADS.md#gnulinux-bsd-solaris)
  * [Windows](doc/DOWNLOADS.md#windows)
  * [macOS](doc/DOWNLOADS.md#macos)
+
+If you want the latest version of Nicotine+, see the [Nicotine+ Website](https://nicotine-plus.org/).
 
 
 ## Get Involved

--- a/doc/DOWNLOADS.md
+++ b/doc/DOWNLOADS.md
@@ -1,126 +1,61 @@
-# Downloads
+# Download Nicotine+ 3.2.9
 
-Download the current stable version of Nicotine+ for your operating system. For the release notes, see [NEWS.md](../NEWS.md).
+This is the last version that runs with Python 3.5 on Debian 9 Stretch, Windows 7 and macOS Catalina, which are no longer supported.
 
-If you want to download the latest unstable build and help test Nicotine+, see [TESTING.md](TESTING.md).
+Download an old version of Nicotine+ 3.2.9 for your unsupported legacy operating system. For the release notes, see [NEWS.md](../NEWS.md).
+
+If you want to install the latest version of Nicotine+ for modern systems, see the [Nicotine+ Website](https://nicotine-plus.org/).
+
 
 ## GNU/Linux, *BSD, Solaris
 
-### Ubuntu/Debian
+### Ubuntu 18.04 LTS "Bionic Beaver"/Debian 9 LTS "Stretch" and newer
 
-To use [stable packages](https://launchpad.net/~nicotine-team/+archive/ubuntu/stable) on Ubuntu and Debian, add the *nicotine-team/stable* PPA repository by running the following:
+[Download a .deb package](https://github.com/nicotine-plus/nicotine-plus/releases/download/3.2.9/debian-package.zip) for Debian-based systems.
 
-```sh
-sudo apt install software-properties-common
-sudo add-apt-repository ppa:nicotine-team/stable
-sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 6CEB6050A30E5769
-sudo apt update
-sudo apt install nicotine
-```
-
-If you prefer to install a .deb package directly, you can [download one here](https://github.com/nicotine-plus/nicotine-plus/releases/latest/download/debian-package.zip).
-
-Unlike the repository installation method, you need to download and install Nicotine+ from the link above every time you want to update to the latest version.
-
-### Fedora
-
-To install Nicotine+ on Fedora, run the following:
-
-```sh
-sudo dnf install nicotine+
-```
-
-### Arch Linux/Manjaro/Parabola
-
-Nicotine+ is available in the community repository of Arch Linux, Manjaro and Parabola. To install, run the following:
-
-```sh
-sudo pacman -S nicotine+
-```
-
-### Void Linux
-
-To install Nicotine+ on Void Linux, run the following:
-
-```sh
-sudo xbps-install -S nicotine+
-```
+Unlike the repository installation method, you need to download and install Nicotine+ every time you want to update to the latest version.
 
 ### Other Distributions
 
-#### Flatpak
+You could try to find an old package or build one from the [archived source code artifact](https://github.com/nicotine-plus/nicotine-plus/releases/tag/3.2.9),
+see [Packaging](PACKAGING.md).
 
-If your Linux distribution supports [Flatpak](https://www.flatpak.org/setup/), you can install the current stable version of Nicotine+ from Flathub.
+### Git
 
-- [Download Nicotine+ from Flathub](https://flathub.org/apps/details/org.nicotine_plus.Nicotine)
-
-#### pip
-
-If Nicotine+ is not packaged for your system, the current stable version can be installed using [pip](https://pip.pypa.io/).
-
-Ensure the [runtime dependencies](DEPENDENCIES.md) are installed, and run the following:
+To run Nicotine+ 3.2.9 directly from a local [Git](https://git-scm.com/) folder,
+ensure the [runtime dependencies](DEPENDENCIES.md) are installed, and run the
+following:
 
 ```sh
-pip3 install nicotine-plus
+git clone -b 3.2.x https://github.com/nicotine-plus/nicotine-plus.git
+cd nicotine-plus
+./nicotine
 ```
 
-Keep in mind that Nicotine+ will not update automatically. When a new release is available, run the following:
-
-```sh
-pip3 install --upgrade nicotine-plus
-```
 
 ## Windows
 
-### Official Release
+### Official Release (Windows 7 SP1 and newer)
 
-Stable Windows installers for Nicotine+ are available for download. Installing Nicotine+ requires administrator privileges.
+Stable Windows installers for the old version of Nicotine+ 3.2.9 are available on Windows 7 SP1 and newer. Installing Nicotine+ requires administrator privileges.
 
 *NOTE: The installer format has changed since Nicotine+ 3.2.0. If you are upgrading from Nicotine+ 3.1.1 or earlier, please uninstall Nicotine+ first (this will not remove your existing settings).*
 
-- [Download Nicotine+ 64-bit Windows Installer](https://github.com/nicotine-plus/nicotine-plus/releases/latest/download/windows-x86_64-installer.zip)  [[SHA256](https://github.com/nicotine-plus/nicotine-plus/releases/latest/download/windows-x86_64-installer.zip.sha256)]
-- [Download Nicotine+ 32-bit Windows Installer](https://github.com/nicotine-plus/nicotine-plus/releases/latest/download/windows-i686-installer.zip)  [[SHA256](https://github.com/nicotine-plus/nicotine-plus/releases/latest/download/windows-i686-installer.zip.sha256)]
+- [Download Nicotine+ 3.2.9 64-bit Legacy Windows Installer](https://github.com/nicotine-plus/nicotine-plus/releases/download/3.2.9/windows-x86_64-installer.zip)  [[SHA256](https://github.com/nicotine-plus/nicotine-plus/releases/download/3.2.9/windows-x86_64-installer.zip.sha256)]
+- [Download Nicotine+ 3.2.9 32-bit Legacy Windows Installer](https://github.com/nicotine-plus/nicotine-plus/releases/download/3.2.9/windows-i686-installer.zip)  [[SHA256](https://github.com/nicotine-plus/nicotine-plus/releases/download/3.2.9/windows-i686-installer.zip.sha256)]
 
-Portable packages are also available. They can be run from any folder and do not require installation or administrator privileges.
+Standalone executables are also available. They can be run from any folder and do not require installation.
 
-- [Download Nicotine+ 64-bit Windows Portable Package](https://github.com/nicotine-plus/nicotine-plus/releases/latest/download/windows-x86_64-package.zip)  [[SHA256](https://github.com/nicotine-plus/nicotine-plus/releases/latest/download/windows-x86_64-package.zip.sha256)]
-- [Download Nicotine+ 32-bit Windows Portable Package](https://github.com/nicotine-plus/nicotine-plus/releases/latest/download/windows-i686-package.zip)  [[SHA256](https://github.com/nicotine-plus/nicotine-plus/releases/latest/download/windows-i686-package.zip.sha256)]
+- [Download Nicotine+ 3.2.9 64-bit Legacy Windows Standalone Package](https://github.com/nicotine-plus/nicotine-plus/releases/download/3.2.9/windows-x86_64-package.zip)  [[SHA256](https://github.com/nicotine-plus/nicotine-plus/releases/download/3.2.9/windows-x86_64-package.zip.sha256)]
+- [Download Nicotine+ 3.2.9 32-bit Legacy Windows Standalone Package](https://github.com/nicotine-plus/nicotine-plus/releases/download/3.2.9/windows-i686-package.zip)  [[SHA256](https://github.com/nicotine-plus/nicotine-plus/releases/download/3.2.9/windows-i686-package.zip.sha256)]
 
-### Scoop
-
-Nicotine+ can be installed using [Scoop](https://scoop.sh/). Run the following:
-
-```sh
-scoop bucket add extras
-scoop install extras/nicotine-plus
-```
-
-In order to upgrade Nicotine+ to a newer release, run the following:
-
-```sh
-scoop update nicotine-plus
-```
-
-### Chocolatey
-
-Nicotine+ can be installed using [Chocolatey](https://chocolatey.org/install). Run the following:
-
-```sh
-choco install nicotine-plus
-```
-
-In order to upgrade Nicotine+ to a newer release, run the following:
-
-```sh
-choco upgrade nicotine-plus
-```
 
 ## macOS
 
 ### Official Release (Catalina/10.15 and newer)
 
-A stable macOS installer for Nicotine+ is available on macOS Catalina 10.15 and newer.
+A stable macOS installer for the old version of Nicotine+ 3.2.9 is available on macOS Catalina 10.15 and newer.
 
 *NOTE: You have to follow [these instructions](https://support.apple.com/guide/mac-help/open-a-mac-app-from-an-unidentified-developer-mh40616/mac) the first time you open Nicotine+ on macOS.*
 
-- [Download Nicotine+ macOS Installer](https://github.com/nicotine-plus/nicotine-plus/releases/latest/download/macos-installer.zip)  [[SHA256](https://github.com/nicotine-plus/nicotine-plus/releases/latest/download/macos-installer.zip.sha256)]
+- [Download Nicotine+ 3.2.9 Legacy macOS Installer](https://github.com/nicotine-plus/nicotine-plus/releases/download/3.2.9/macos-installer.zip)  [[SHA256](https://github.com/nicotine-plus/nicotine-plus/releases/download/3.2.9/macos-installer.zip.sha256)]

--- a/doc/TESTING.md
+++ b/doc/TESTING.md
@@ -1,60 +1,117 @@
 # Testing
 
-For those who like living on the bleeding edge, you can run the latest unstable build of Nicotine+ to test recent changes and bug fixes.
+For those who like living on the bleeding edge, you can run the latest unstable
+build of Nicotine+ to test recent changes and bug fixes.
 
-For information about Nicotine+ development procedures for maintainers, developers and code contributors, see [DEVELOPING.md](DEVELOPING.md).
+For information about Nicotine+ development procedures for maintainers,
+developers and code contributors, see [DEVELOPING.md](DEVELOPING.md).
 
-If you want to download the current stable version of Nicotine+, see [DOWNLOADS.md](DOWNLOADS.md).
+If you want to download a stable version of Nicotine+, see
+[DOWNLOADS.md](DOWNLOADS.md).
 
 
 ## GNU/Linux
 
-### Ubuntu/Debian
+### PPA (Ubuntu/Debian)
 
-[Download a .deb package](https://nightly.link/nicotine-plus/nicotine-plus/workflows/packaging/3.2.x/debian-package.zip) for Debian-based systems.
+To use [unstable packages](https://launchpad.net/~nicotine-team/+archive/ubuntu/unstable)
+on Ubuntu and Debian, add the *nicotine-team/unstable* PPA repository.
 
-You need to download and install Nicotine+ from the link above every time you want to update to the latest unstable build.
+On Ubuntu and distributions based on it (e.g. Linux Mint, elementary OS,
+Pop!_OS, various Ubuntu flavors), run the following:
+
+```sh
+sudo add-apt-repository ppa:nicotine-team/unstable
+sudo apt update; sudo apt install nicotine
+```
+
+On Debian and distributions based on it (e.g. Devuan, Peppermint OS), run the
+following:
+
+```sh
+sudo apt update; sudo apt install python3-launchpadlib software-properties-common
+sudo add-apt-repository 'deb https://ppa.launchpadcontent.net/nicotine-team/unstable/ubuntu jammy main'
+sudo apt update; sudo apt install nicotine
+```
+
+If you prefer to install a .deb package directly, you can [download one here](https://nightly.link/nicotine-plus/nicotine-plus/workflows/packaging/master/debian-package.zip).
+Unlike the repository installation method, you need to download and install
+Nicotine+ from the link above every time you want to update to the latest
+unstable build.
 
 ### Flatpak
 
-Unstable [Flatpak](https://www.flatpak.org/setup/) packages are built after every commit to the 3.2.x branch.
+Unstable [Flatpak](https://www.flatpak.org/setup/) packages are built after
+every commit to the master branch.
 
-- [Download Unstable Flatpak Package](https://nightly.link/nicotine-plus/nicotine-plus/workflows/packaging/3.2.x/flatpak-package-x86_64.zip)
+ - [Download Unstable Flatpak Package](https://nightly.link/nicotine-plus/nicotine-plus/workflows/packaging/master/flatpak-package-x86_64.zip)
+    — [`INFO`](https://nightly.link/nicotine-plus/nicotine-plus/workflows/packaging/master/flatpak-package-x86_64)  
+
+### Snap
+
+Unstable [Snap](https://snapcraft.io/docs/installing-snapd) packages are
+published in the Snap Store, and can be installed by running the following:
+
+```sh
+sudo snap install nicotine-plus --edge
+```
 
 ### Other
 
-See [All Platforms](#all-platforms) for installing the unstable version of Nicotine+ on other distributions.
+See [All Platforms](#all-platforms) for installing the unstable version of
+Nicotine+ on other distributions.
 
 
 ## Windows
 
-Unstable Windows packages are built after every commit to the 3.2.x branch.
+Unstable packages are built after every commit to the master branch.
 
-- [Download Unstable 64-bit Windows Installer](https://nightly.link/nicotine-plus/nicotine-plus/workflows/packaging/3.2.x/windows-x86_64-installer.zip)
-- [Download Unstable 32-bit Windows Installer](https://nightly.link/nicotine-plus/nicotine-plus/workflows/packaging/3.2.x/windows-i686-installer.zip)
+ - [Download Unstable Windows Installer](https://nightly.link/nicotine-plus/nicotine-plus/workflows/packaging/master/windows-x86_64-installer.zip)
+    — [`INFO`](https://nightly.link/nicotine-plus/nicotine-plus/workflows/packaging/master/windows-x86_64-installer)  
+   for Windows 10 or later
 
-Portable packages are also available. They can be run from any folder and do not require installation or administrator privileges.
+Standalone executables are also available. They can be run from any folder and
+do not require installation.
 
-- [Download Unstable 64-bit Windows Portable Package](https://nightly.link/nicotine-plus/nicotine-plus/workflows/packaging/3.2.x/windows-x86_64-package.zip)
-- [Download Unstable 32-bit Windows Portable Package](https://nightly.link/nicotine-plus/nicotine-plus/workflows/packaging/3.2.x/windows-i686-package.zip)
+ - [Download Unstable Windows Standalone Package](https://nightly.link/nicotine-plus/nicotine-plus/workflows/packaging/master/windows-x86_64-package.zip)
+    — [`INFO`](https://nightly.link/nicotine-plus/nicotine-plus/workflows/packaging/master/windows-x86_64-package)  
+   for Windows 10 or later
+
+> **NOTE**: Configuration files are always stored in  
+> *C:\Users\\<USERNAME\>\AppData\Roaming\nicotine*
 
 ## macOS
 
-Unstable installers for macOS Catalina 10.15 and newer are built after every commit to the 3.2.x branch.
+Unstable installers are built after every commit to the master branch.
 
-- [Download Unstable macOS Installer](https://nightly.link/nicotine-plus/nicotine-plus/workflows/packaging/3.2.x/macos-installer.zip)
+> **IMPORTANT**: You must follow [these instructions](https://support.apple.com/guide/mac-help/open-a-mac-app-from-an-unidentified-developer-mh40616/mac)
+> the first time you start Nicotine+.
+
+ - [Download Unstable macOS Intel Installer](https://nightly.link/nicotine-plus/nicotine-plus/workflows/packaging/master/macos-x86_64-installer.zip)
+    — [`INFO`](https://nightly.link/nicotine-plus/nicotine-plus/workflows/packaging/master/macos-x86_64-installer)  
+   for macOS 12 Monterey or later
+
+ - [Download Unstable macOS Apple Silicon Installer](https://nightly.link/nicotine-plus/nicotine-plus/workflows/packaging/master/macos-arm64-installer.zip)
+    — [`INFO`](https://nightly.link/nicotine-plus/nicotine-plus/workflows/packaging/master/macos-arm64-installer)  
+   for macOS 14 Sonoma or later
 
 
 ## All Platforms
 
-The following installation methods work out of the box on GNU/Linux, *BSD and Solaris. On Windows, a [MinGW development environment](PACKAGING.md#windows) is required. On macOS, [Homebrew](PACKAGING.md#macos) is required. Consider using the Windows and macOS packages above if you do not need to modify the source code.
+The following installation methods work out of the box on GNU/Linux, *BSD and
+Solaris. On Windows, a [MinGW development environment](PACKAGING.md#windows) is
+required. On macOS, [Homebrew](PACKAGING.md#macos) is required. Consider using
+the Windows and macOS packages above if you do not need to modify the source
+code.
 
 ### pip
 
-The latest unstable build of Nicotine+ can be installed using [pip](https://pip.pypa.io/). Ensure the [runtime dependencies](DEPENDENCIES.md) are installed, and run the following:
+The latest unstable build of Nicotine+ can be installed using
+[pip](https://pip.pypa.io/). Ensure the [runtime dependencies](DEPENDENCIES.md)
+are installed, and run the following:
 
 ```sh
-pip3 install git+https://github.com/nicotine-plus/nicotine-plus.git@3.2.x
+pip3 install git+https://github.com/nicotine-plus/nicotine-plus.git
 ```
 
 To start Nicotine+:
@@ -66,7 +123,7 @@ nicotine
 To update to the latest unstable build of Nicotine+, run the following:
 
 ```sh
-pip3 install --upgrade git+https://github.com/nicotine-plus/nicotine-plus.git@3.2.x
+pip3 install --upgrade git+https://github.com/nicotine-plus/nicotine-plus.git
 ```
 
 To uninstall Nicotine+, run:
@@ -77,10 +134,12 @@ pip3 uninstall nicotine-plus
 
 ### Git
 
-To run Nicotine+ directly from a local [Git](https://git-scm.com/) folder, ensure the [runtime dependencies](DEPENDENCIES.md) are installed, and run the following:
+To run Nicotine+ directly from a local [Git](https://git-scm.com/) folder,
+ensure the [runtime dependencies](DEPENDENCIES.md) are installed, and run the
+following:
 
 ```sh
-git clone -b 3.2.x https://github.com/nicotine-plus/nicotine-plus.git
+git clone https://github.com/nicotine-plus/nicotine-plus.git
 cd nicotine-plus
 ./nicotine
 ```


### PR DESCRIPTION
All the nightly links to artifacts from old action runs expired long ago and so are now broken, so these deep links need updating to support legacy users who may need to look on GitHub for old versions to install.

+ Fixed: Broken links to old binary packages in the `3.2.x` branch
+ Changed: Instances of phrases like "current version" -> "legacy version" or "old version" to avoid confusion
+ Changed: Synchronize TESTING.md with the `master` branch to replace all the Nightly links which are broken now
+ Changed: "Portable" -> "Standalone" to match the same terminology used in the master branch

Preview it on my fork links:
https://github.com/slook/nicotine-plus/blob/docs-legacy-3.2.9/README.md
https://github.com/slook/nicotine-plus/blob/docs-legacy-3.2.9/doc/DOWNLOADS.md