### PR TITLE
CI: test building without isolation

### DIFF
--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -105,9 +105,11 @@ jobs:
             ${{ matrix.prefix }}-libadwaita
             ${{ matrix.prefix }}-python-build
             ${{ matrix.prefix }}-python-cx-freeze
+            ${{ matrix.prefix }}-python-gobject
             ${{ matrix.prefix }}-python-pycodestyle
             ${{ matrix.prefix }}-python-pylint
-            ${{ matrix.prefix }}-python-gobject
+            ${{ matrix.prefix }}-python-setuptools
+            ${{ matrix.prefix }}-python-wheel
             ${{ matrix.prefix }}-webp-pixbuf-loader
 
       - name: Install additional dependencies

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,7 +27,7 @@ jobs:
         run: |
           sudo apt update
           sudo apt install gettext gir1.2-gtk-3.0 libgirepository1.0-dev libgtk-3-bin
-          python -m pip install build .[tests]
+          python -m pip install build setuptools wheel .[tests]
 
       - name: PEP 8 style checks
         run: python -m pycodestyle
@@ -40,6 +40,9 @@ jobs:
 
       - name: Build
         run: python -m build
+
+      - name: Build without isolation
+        run: python3 -m build --no-isolation
 
   ubuntu-debian:
     runs-on: ubuntu-latest
@@ -82,7 +85,7 @@ jobs:
       - name: Install dependencies
         run: |
           dnf -y install gettext gtk${{ matrix.gtk }} pylint python3 python3-build \
-            python3-gobject python3-pycodestyle
+            python3-gobject python3-pycodestyle python3-setuptools python3-wheel
 
       - name: PEP 8 style checks
         run: python3 -m pycodestyle
@@ -95,6 +98,9 @@ jobs:
 
       - name: Build
         run: python3 -m build
+
+      - name: Build without isolation
+        run: python3 -m build --no-isolation
 
   opensuse:
     runs-on: ubuntu-latest
@@ -112,7 +118,8 @@ jobs:
         run: |
           zypper refresh
           zypper -n install dejavu-fonts gettext-tools python312-build python312-gobject \
-            python312-gobject-Gdk python312-pycodestyle python312-pylint typelib-1_0-Gtk-4_0
+            python312-gobject-Gdk python312-pycodestyle python312-pylint \
+            python312-setuptools python312-wheel typelib-1_0-Gtk-4_0
 
       - name: PEP 8 style checks
         run: python3.12 -m pycodestyle
@@ -125,6 +132,9 @@ jobs:
 
       - name: Build
         run: python3.12 -m build
+
+      - name: Build without isolation
+        run: python3.12 -m build --no-isolation
 
   alpine:
     runs-on: ubuntu-latest
@@ -141,7 +151,8 @@ jobs:
       - name: Install dependencies
         run: |
           apk update
-          apk add font-dejavu gettext gtk4.0 py3-build py3-gobject3 py3-pycodestyle py3-pylint
+          apk add font-dejavu gettext gtk4.0 py3-build py3-gobject3 py3-pycodestyle \
+            py3-pylint py3-setuptools py3-wheel
 
       - name: PEP 8 style checks
         run: python3 -m pycodestyle
@@ -154,6 +165,9 @@ jobs:
 
       - name: Build
         run: python3 -m build
+
+      - name: Build without isolation
+        run: python3 -m build --no-isolation
 
   windows:
     runs-on: windows-latest
@@ -184,9 +198,11 @@ jobs:
             ${{ matrix.prefix }}-libadwaita
             ${{ matrix.prefix }}-python-build
             ${{ matrix.prefix }}-python-cx-freeze
+            ${{ matrix.prefix }}-python-gobject
             ${{ matrix.prefix }}-python-pycodestyle
             ${{ matrix.prefix }}-python-pylint
-            ${{ matrix.prefix }}-python-gobject
+            ${{ matrix.prefix }}-python-setuptools
+            ${{ matrix.prefix }}-python-wheel
             ${{ matrix.prefix }}-webp-pixbuf-loader
 
       - name: Install additional dependencies
@@ -203,6 +219,9 @@ jobs:
 
       - name: Build
         run: python3 -m build
+
+      - name: Build without isolation
+        run: python3 -m build --no-isolation
 
   macos:
     strategy:
@@ -242,3 +261,6 @@ jobs:
 
       - name: Build
         run: venv/bin/python3 -m build
+
+      - name: Build without isolation
+        run: venv/bin/python3 -m build --no-isolation

--- a/doc/DEPENDENCIES.md
+++ b/doc/DEPENDENCIES.md
@@ -9,23 +9,25 @@
  - [gtk4](https://gtk.org/) >= 4.6.9 or [gtk3](https://gtk.org/) >= 3.22.30
       for graphical interface;
  - [pygobject](https://pygobject.gnome.org/)
-      for Python bindings for GTK;
+      for Python bindings for GTK.
 
 ### Recommended
 
  - [libadwaita](https://gitlab.gnome.org/GNOME/libadwaita)
-      for Adwaita theme on GNOME (GTK 4).
+      for Adwaita theme on GNOME (GTK 4);
  - [gspell](https://gitlab.gnome.org/GNOME/gspell)
       for spell checking in chat (GTK 3).
 
 ## Building
 
+ - [python3-setuptools](https://setuptools.pypa.io/)
+      for build backend;
  - [python3-build](https://build.pypa.io/)
       for building;
+ - [python3-wheel](https://wheel.readthedocs.io/)
+      for packaging;
  - [gettext](https://www.gnu.org/software/gettext/)
-      for generating translations;
- - [python3-setuptools](https://setuptools.pypa.io/)
-      for packaging.
+      for generating translations.
 
 ## Testing
 
@@ -70,25 +72,25 @@
  - On Debian/Ubuntu-based distributions:
 
    ```sh
-   sudo apt install gettext python3-build python3-setuptools
+   sudo apt install gettext python3-build python3-setuptools python3-wheel
    ```
 
  - On Redhat/Fedora-based distributions:
 
    ```sh
-   sudo dnf install gettext python3-build python3-setuptools
+   sudo dnf install gettext python3-build python3-setuptools python3-wheel
    ```
 
  - On SUSE-based distributions:
 
    ```sh
-   sudo zypper install gettext-tools python312-build python312-setuptools
+   sudo zypper install gettext-tools python312-build python312-setuptools python312-wheel
    ```
 
  - On Alpine-based distributions:
 
    ```sh
-   sudo apk add gettext py3-build py3-setuptools
+   sudo apk add gettext py3-build py3-setuptools py3-wheel
    ```
 
 #### Installing Test Dependencies

--- a/packaging/macos/dependencies.py
+++ b/packaging/macos/dependencies.py
@@ -38,7 +38,7 @@ def install_pypi():
     """Install dependencies from PyPi."""
 
     subprocess.check_call([sys.executable, "-m", "pip", "install", "--no-binary", ":all:",
-                           "-e", ".[packaging,tests]", "build"])
+                           "-e", ".[packaging,tests]", "build", "setuptools", "wheel"])
 
 
 if __name__ == "__main__":

--- a/packaging/windows/dependencies.py
+++ b/packaging/windows/dependencies.py
@@ -40,9 +40,11 @@ def install_pacman():
                 f"{prefix}-libadwaita",
                 f"{prefix}-python-build",
                 f"{prefix}-python-cx-freeze",
+                f"{prefix}-python-gobject",
                 f"{prefix}-python-pycodestyle",
                 f"{prefix}-python-pylint",
-                f"{prefix}-python-gobject",
+                f"{prefix}-python-setuptools",
+                f"{prefix}-python-wheel",
                 f"{prefix}-webp-pixbuf-loader"]
 
     subprocess.check_call(["pacman", "--noconfirm", "-S", "--needed"] + packages)


### PR DESCRIPTION
By default, python3-build builds packages in a virtual environment, which contains dependencies like setuptools and wheel. Add a step that attempts building without the virtual environment.