### PR TITLE
transfers.py: reset last_byte_offset when aborting transfer

### DIFF
--- a/pynicotine/transfers.py
+++ b/pynicotine/transfers.py
@@ -402,6 +402,10 @@ class Transfers:
         transfer.legacy_attempt = False
         transfer.size_changed = False
 
+        # Reset last byte offset to avoid incorrect offset subtractions between
+        # previous and new transfer sessions when updating statistics
+        transfer.last_byte_offset = None
+
         if transfer.sock is not None:
             core.send_message_to_network_thread(CloseConnection(transfer.sock))
 
@@ -466,6 +470,7 @@ class Transfers:
 
         transfer.status = TransferStatus.FINISHED
         transfer.current_byte_offset = transfer.size
+        transfer.last_byte_offset = None
 
     def _auto_clear_transfer(self, transfer):
 

--- a/pynicotine/uploads.py
+++ b/pynicotine/uploads.py
@@ -863,7 +863,7 @@ class Uploads(Transfers):
             transfer.size = size
 
             if transfer.status == TransferStatus.FINISHED:
-                transfer.current_byte_offset = transfer.last_byte_offset = None
+                transfer.current_byte_offset = None
                 transfer.speed = transfer.avg_speed = transfer.time_elapsed = transfer.time_left = 0
         else:
             transfer = Transfer(username, virtual_path, folder_path, size)
@@ -932,7 +932,7 @@ class Uploads(Transfers):
             transfer.size = size
 
             if transfer.status == TransferStatus.FINISHED:
-                transfer.current_byte_offset = transfer.last_byte_offset = None
+                transfer.current_byte_offset = None
                 transfer.speed = transfer.avg_speed = transfer.time_elapsed = transfer.time_left = 0
         else:
             transfer = Transfer(username, virtual_path, folder_path, size)


### PR DESCRIPTION
Fixes #3162
