### PR TITLE
Reconnect when changing listening port or network interface

### DIFF
--- a/pynicotine/core.py
+++ b/pynicotine/core.py
@@ -92,7 +92,7 @@ class Core:
 
         for event_name, callback in (
             ("quit", self._quit),
-            ("server-reconnect", self.connect)
+            ("server-reconnect", self._server_reconnect)
         ):
             events.connect(event_name, callback)
 
@@ -305,6 +305,13 @@ class Core:
     def disconnect(self):
         from pynicotine.slskmessages import ServerDisconnect
         self.send_message_to_network_thread(ServerDisconnect())
+
+    def reconnect(self):
+        from pynicotine.slskmessages import ServerReconnect
+        self.send_message_to_network_thread(ServerReconnect())
+
+    def _server_reconnect(self, _msg):
+        self.connect()
 
     def send_message_to_network_thread(self, message):
         """Sends message to the networking thread to inform about something."""

--- a/pynicotine/gtkgui/dialogs/preferences.py
+++ b/pynicotine/gtkgui/dialogs/preferences.py
@@ -920,7 +920,6 @@ class UserProfilePage:
         ) = self.widgets = ui.load(scope=self, path="settings/userinfo.ui")
 
         self.application = application
-        self.user_profile_required = False
 
         self.description_view = TextView(self.description_view_container, parse_urls=False)
         self.select_picture_button = FileChooserButton(
@@ -943,25 +942,15 @@ class UserProfilePage:
         self.__dict__.clear()
 
     def set_settings(self):
-
         self.description_view.clear()
         self.application.preferences.set_widgets_data(self.options)
 
-        self.user_profile_required = False
-
     def get_settings(self):
-
-        description = repr(self.description_view.get_text())
-        picture_path = self.select_picture_button.get_path()
-
-        if (description != config.sections["userinfo"]["descr"]
-                or picture_path != config.sections["userinfo"]["pic"]):
-            self.user_profile_required = True
 
         return {
             "userinfo": {
-                "descr": description,
-                "pic": picture_path
+                "descr": repr(self.description_view.get_text()),
+                "pic": self.select_picture_button.get_path()
             }
         }
 
@@ -1369,7 +1358,6 @@ class ChatsPage:
 
         self.application = application
         self.completion_required = False
-        self.private_room_required = False
 
         format_codes_url = "https://docs.python.org/3/library/datetime.html#format-codes"
         format_codes_label = _("Format codes")
@@ -1481,7 +1469,6 @@ class ChatsPage:
         self.replacements = config.sections["words"]["autoreplaced"].copy()
 
         self.completion_required = False
-        self.private_room_required = False
 
     def get_settings(self):
 
@@ -1524,9 +1511,6 @@ class ChatsPage:
     def on_activate_link(self, _label, url):
         open_uri(url)
         return True
-
-    def on_private_room_changed(self, *_args):
-        self.private_room_required = True
 
     def on_completion_changed(self, *_args):
         self.completion_required = True
@@ -2351,7 +2335,6 @@ class SearchesPage:
         ) = self.widgets = ui.load(scope=self, path="settings/search.ui")
 
         self.application = application
-        self.search_required = False
 
         self.filter_help = SearchFilterHelp(application.preferences)
         self.filter_help.set_menu_button(self.filter_help_button)
@@ -2377,7 +2360,6 @@ class SearchesPage:
 
         searches = config.sections["searches"]
         self.application.preferences.set_widgets_data(self.options)
-        self.search_required = False
 
         if searches["defilter"] is not None:
             num_filters = len(searches["defilter"])
@@ -2432,9 +2414,6 @@ class SearchesPage:
                 "private_search_results": self.show_private_results_toggle.get_active()
             }
         }
-
-    def on_toggle_search_history(self, *_args):
-        self.search_required = True
 
     def on_clear_search_history(self, *_args):
 
@@ -3240,39 +3219,25 @@ class Preferences(Dialog):
             recompress_shares_required = False
 
         try:
-            user_profile_required = self.pages["user-profile"].user_profile_required
-
-        except KeyError:
-            user_profile_required = False
-
-        try:
-            private_room_required = self.pages["chats"].private_room_required
-
-        except KeyError:
-            private_room_required = False
-
-        try:
             completion_required = self.pages["chats"].completion_required
 
         except KeyError:
             completion_required = False
 
-        try:
-            search_required = self.pages["searches"].search_required
-
-        except KeyError:
-            search_required = False
-
         return (
             portmap_required,
             rescan_required,
             recompress_shares_required,
-            user_profile_required,
-            private_room_required,
             completion_required,
-            search_required,
             options
         )
+
+    def has_option_changed(self, options, section, key):
+
+        if key not in options[section]:
+            return False
+
+        return options[section][key] != config.sections[section][key]
 
     def update_settings(self, settings_closed=False):
 
@@ -3280,12 +3245,34 @@ class Preferences(Dialog):
             portmap_required,
             rescan_required,
             recompress_shares_required,
-            user_profile_required,
-            private_room_required,
             completion_required,
-            search_required,
             options
         ) = self.get_settings()
+
+        for section, key in (
+            ("server", "login"),
+            ("server", "portrange"),
+            ("server", "interface"),
+            ("server", "server")
+        ):
+            if self.has_option_changed(options, section, key):
+                core.reconnect()
+                break
+
+        for section, key in (
+            ("userinfo", "descr"),
+            ("userinfo", "pic")
+        ):
+            if self.has_option_changed(options, section, key):
+                core.userinfo.show_user(refresh=True, switch_page=False)
+                break
+
+        if self.has_option_changed(options, "server", "private_chatrooms"):
+            active = options["server"]["private_chatrooms"]
+            self.application.window.chatrooms.room_list.toggle_accept_private_room(active)
+
+        if self.has_option_changed(options, "searches", "enable_history"):
+            self.application.window.search.populate_search_history()
 
         for key, data in options.items():
             config.sections[key].update(data)
@@ -3329,19 +3316,9 @@ class Preferences(Dialog):
         elif portmap_required == "remove":
             core.portmapper.remove_port_mapping()
 
-        if user_profile_required:
-            core.userinfo.show_user(refresh=True, switch_page=False)
-
-        if private_room_required:
-            active = config.sections["server"]["private_chatrooms"]
-            self.application.window.chatrooms.room_list.toggle_accept_private_room(active)
-
         if completion_required:
             core.chatrooms.update_completions()
             core.privatechat.update_completions()
-
-        if search_required:
-            self.application.window.search.populate_search_history()
 
         if recompress_shares_required and not rescan_required:
             core.shares.rescan_shares(init=True, rescan=False)

--- a/pynicotine/gtkgui/ui/settings/chats.ui
+++ b/pynicotine/gtkgui/ui/settings/chats.ui
@@ -60,7 +60,6 @@
               <object class="GtkSwitch" id="private_room_toggle">
                 <property name="valign">center</property>
                 <property name="visible">True</property>
-                <signal name="notify::active" handler="on_private_room_changed"/>
               </object>
             </child>
           </object>

--- a/pynicotine/gtkgui/ui/settings/network.ui
+++ b/pynicotine/gtkgui/ui/settings/network.ui
@@ -156,7 +156,7 @@
             <child>
               <object class="GtkLabel">
                 <property name="hexpand">True</property>
-                <property name="label" translatable="yes">Listening port (requires a restart):</property>
+                <property name="label" translatable="yes">Listening port:</property>
                 <property name="mnemonic-widget">listen_port_spinner</property>
                 <property name="visible">True</property>
                 <property name="wrap">True</property>
@@ -349,7 +349,7 @@
             <property name="visible">True</property>
             <child>
               <object class="GtkLabel" id="network_interface_label">
-                <property name="label" translatable="yes">Network interface (requires a restart):</property>
+                <property name="label" translatable="yes">Network interface:</property>
                 <property name="visible">True</property>
                 <property name="wrap">True</property>
                 <property name="wrap-mode">word-char</property>

--- a/pynicotine/gtkgui/ui/settings/search.ui
+++ b/pynicotine/gtkgui/ui/settings/search.ui
@@ -60,7 +60,6 @@
               <object class="GtkSwitch" id="enable_search_history_toggle">
                 <property name="valign">center</property>
                 <property name="visible">True</property>
-                <signal name="notify::active" handler="on_toggle_search_history"/>
               </object>
             </child>
           </object>

--- a/pynicotine/slskmessages.py
+++ b/pynicotine/slskmessages.py
@@ -174,6 +174,13 @@ class ServerDisconnect(InternalMessage):
         self.manual_disconnect = manual_disconnect
 
 
+class ServerReconnect(InternalMessage):
+    __slots__ = ("manual_reconnect",)
+
+    def __init__(self, manual_reconnect=False):
+        self.manual_reconnect = manual_reconnect
+
+
 class EmitNetworkMessageEvents(InternalMessage):
     """Sent to the networking thread to tell it to emit events for list of
     network messages.

--- a/pynicotine/users.py
+++ b/pynicotine/users.py
@@ -216,12 +216,12 @@ class Users:
 
         del self.watched[username]
 
-    def _server_disconnect(self, manual_disconnect=False):
+    def _server_disconnect(self, msg):
 
         self.login_status = UserStatus.OFFLINE
 
         if core.pluginhandler:
-            core.pluginhandler.server_disconnect_notification(manual_disconnect)
+            core.pluginhandler.server_disconnect_notification(msg.manual_disconnect)
 
         # Clean up connections
         self.addresses.clear()


### PR DESCRIPTION
Closes #2704 

Two translatable strings are modified, but since the only change is removing the `(requires a restart)` part from them, we could modify the translated strings manually and include this PR in Nicotine+ 3.3.7.