### PR TITLE
Show folder count while rescanning shares

### DIFF
--- a/pynicotine/gtkgui/mainwindow.py
+++ b/pynicotine/gtkgui/mainwindow.py
@@ -59,6 +59,7 @@ from pynicotine.gtkgui.widgets.theme import set_use_header_bar
 from pynicotine.gtkgui.widgets.window import Window
 from pynicotine.logfacility import log
 from pynicotine.slskmessages import UserStatus
+from pynicotine.utils import humanize
 from pynicotine.utils import open_folder_path
 
 
@@ -132,6 +133,7 @@ class MainWindow(Window):
             self.room_list_label,
             self.room_search_entry,
             self.scan_progress_container,
+            self.scan_progress_label,
             self.scan_progress_spinner,
             self.search_content,
             self.search_end,
@@ -220,6 +222,9 @@ class MainWindow(Window):
             self.vertical_paned.child_set_property(self.content, "shrink", False)
             self.vertical_paned.child_set_property(self.log_container, "resize", False)
             self.vertical_paned.child_set_property(self.log_container, "shrink", False)
+
+        # Avoid unnecessary 'notify' signals when updating number of currently scanned folders
+        self.scan_progress_label.freeze_notify()
 
         # Logging
         self.log_view = TextView(
@@ -1149,17 +1154,29 @@ class MainWindow(Window):
 
     def shares_preparing(self):
 
+        label = _("Preparing Shares")
+
         # Hide widget to keep tooltips for other widgets visible
         self.scan_progress_container.set_visible(False)
-        self.scan_progress_container.set_tooltip_text(_("Preparing Shares"))
+        self.scan_progress_container.set_tooltip_text(label)
+        self.scan_progress_label.set_label(label)
         self.scan_progress_container.set_visible(True)
         self.scan_progress_spinner.start()
 
-    def shares_scanning(self):
+    def shares_scanning(self, folder_count=None):
+
+        label = _("Scanning Shares")
+
+        if folder_count is not None:
+            # TODO: turn this into a proper translated string in 3.4.0
+            self.scan_progress_label.set_label(
+                f"{_('Shared Folders')}: {humanize(folder_count)}")
+            return
 
         # Hide widget to keep tooltips for other widgets visible
         self.scan_progress_container.set_visible(False)
-        self.scan_progress_container.set_tooltip_text(_("Scanning Shares"))
+        self.scan_progress_container.set_tooltip_text(label)
+        self.scan_progress_label.set_label(label)
         self.scan_progress_container.set_visible(True)
         self.scan_progress_spinner.start()
 

--- a/pynicotine/gtkgui/ui/mainwindow.ui
+++ b/pynicotine/gtkgui/ui/mainwindow.ui
@@ -1692,14 +1692,16 @@
         </child>
         <child>
           <object class="GtkBox" id="scan_progress_container">
-            <property name="spacing">6</property>
+            <property name="spacing">8</property>
             <property name="visible">False</property>
             <child>
-              <object class="GtkLabel">
+              <object class="GtkLabel" id="scan_progress_label">
                 <property name="ellipsize">end</property>
-                <property name="label" bind-source="scan_progress_container" bind-property="tooltip-text" bind-flags="bidirectional|sync-create"/>"
                 <property name="selectable">True</property>
                 <property name="visible">True</property>
+                <attributes>
+                  <attribute name="font-features" value="tnum=1"/>
+                </attributes>
                 <style>
                   <class name="caption"/>
                   <class name="dim-label"/>


### PR DESCRIPTION
We should give users a sign that the scanner is actually doing something.

The strings are a bit of a mess currently, since we can't add new translatable strings in 3.3.x, but we can improve the situation in 3.4.x.