### PR TITLE
DOWNLOADS.md: Add guix to list of OS supported packages

### DIFF
--- a/doc/DOWNLOADS.md
+++ b/doc/DOWNLOADS.md
@@ -23,6 +23,7 @@ using the package manager.
 | [Fedora](https://packages.fedoraproject.org/pkgs/nicotine+/nicotine+/)                   | `nicotine+`                |
 | [FreeBSD Ports](https://www.freshports.org/net-p2p/py-nicotine-plus)                     | `net-p2p/py-nicotine-plus` |
 | [Gentoo](https://packages.gentoo.org/packages/net-p2p/nicotine+)                         | `net-p2p/nicotine+`        |
+| [Guix](https://packages.guix.gnu.org/packages/nicotine+/)                                | `nicotine+`                |
 | [Mageia](https://madb.mageialinux-online.org/show?distribution=cauldron&rpm=nicotine%2B) | `nicotine+`                |
 | [Manjaro](https://manjaristas.org/branch_compare?q=nicotine%2B)                          | `nicotine+`                |
 | [NixOS](https://search.nixos.org/packages?show=nicotine-plus)                            | `nicotine-plus`            |


### PR DESCRIPTION
I noticed that Guix was missing from the list of OS supported packages at [doc/DOWNLOADS.md](https://github.com/nicotine-plus/nicotine-plus/blob/e7ee74c6c499df147ffb3d0edb8cd0c24666cb6c/doc/DOWNLOADS.md)
