### PR TITLE
tests.yml: test Fedora Rawhide on arm64

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -69,13 +69,14 @@ jobs:
         run: autopkgtest . -- null
 
   fedora:
-    runs-on: ubuntu-latest
     timeout-minutes: 15
     strategy:
       fail-fast: false
       matrix:
         container: ['fedora:rawhide']
         gtk: [3, 4]
+        os: ['ubuntu-latest', 'ubuntu-24.04-arm']
+    runs-on: ${{ matrix.os }}
     container: ${{ matrix.container }}
     steps:
       - name: Checkout code


### PR DESCRIPTION
https://github.blog/changelog/2025-01-16-linux-arm64-hosted-runners-now-available-for-free-in-public-repositories-public-preview/

This job uses development versions of GTK and other libraries, so it could be useful to catch any arm64 regressions.
