### PR TITLE
logfacility.py: Optimize reading of log lines

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -12,6 +12,7 @@ You can run the latest unstable build of Nicotine+ to test recent changes and bu
  * Added isolated mode (`nicotine --isolated`) for standalone environments (e.g. Docker containers)
  * Added Czech translation (thank you @slrslr)
  * Added Tamil translation (thank you @TamilNeram)
+ * Optimized reading of large chat logs
  * Show number of scanned folders while rescanning shares
  * Skip unit tests requiring network connection by default
 


### PR DESCRIPTION
Turns out using deque for reading lines from a large file is really slow, even when you only want to show a fraction of the contents in the GUI. Use a more efficient implementation for reading lines instead.

Some profiling results (150 MB log file):

Master:
![master](https://github.com/user-attachments/assets/b64f22b1-1d15-4521-8893-a467f3178af6)

#2792:
![pr-2792](https://github.com/user-attachments/assets/4922a3fb-96ee-43bb-91b4-8172447beeef)

This PR:
![pr](https://github.com/user-attachments/assets/a6327ac2-68f7-4cf1-af4d-c2a5b2795b3e)

@slook This change is relevant for #2792.
