### PR TITLE
logfacility.py: READ_BLOCK_SIZE -> io.DEFAULT_BUFFER_SIZE

### DIFF
--- a/pynicotine/logfacility.py
+++ b/pynicotine/logfacility.py
@@ -16,6 +16,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+import io
 import os
 import sys
 import time
@@ -76,8 +77,6 @@ class Logger:
         EmbeddedMessage,
         UnknownPeerMessage
     }
-
-    READ_BLOCK_SIZE = 4096
 
     def __init__(self):
 
@@ -232,8 +231,8 @@ class Logger:
         lines_left = num_lines + 1
 
         while lines_left > 0:
-            read_offset -= self.READ_BLOCK_SIZE
-            read_size = self.READ_BLOCK_SIZE
+            read_size = io.DEFAULT_BUFFER_SIZE
+            read_offset -= read_size
 
             if read_offset < 0:
                 # Reached beginning of file, read remaining data


### PR DESCRIPTION
+ Changed: Use built-in constant instead of READ_BLOCK_SIZE use [io.DEFAULT_BUFFER_SIZE](https://docs.python.org/3/library/io.html#io.DEFAULT_BUFFER_SIZE):

> _An int containing the default buffer size used by the module’s buffered I/O classes. [open()](https://docs.python.org/3/library/functions.html#open) uses the file’s [blksize](https://docs.python.org/3/library/os.html#os.stat_result.st_blksize) (as obtained by os.stat()) if possible._

On my system this is `8192` instead of `4096`.

Imported the entire `io` module since other functions from it are likely to be required in future.