### PR TITLE
uploads.py: temporarily cache queue positions

### DIFF
--- a/pynicotine/downloads.py
+++ b/pynicotine/downloads.py
@@ -351,10 +351,13 @@ class Downloads(Transfers):
 
     def _dequeue_transfer(self, transfer):
 
-        super()._dequeue_transfer(transfer)
+        if not super()._dequeue_transfer(transfer):
+            return False
 
         if transfer in self._pending_queue_messages:
             del self._pending_queue_messages[transfer]
+
+        return True
 
     def _file_downloaded_actions(self, username, file_path):
 

--- a/pynicotine/transfers.py
+++ b/pynicotine/transfers.py
@@ -494,6 +494,8 @@ class Transfers:
         self.queued_transfers[transfer] = None
         self._user_queue_sizes[transfer.username] += transfer.size
 
+        return True
+
     def _enqueue_limited_transfers(self, username):
         # Optional method
         pass
@@ -504,7 +506,7 @@ class Transfers:
         virtual_path = transfer.virtual_path
 
         if virtual_path not in self.queued_users.get(username, {}):
-            return
+            return False
 
         self._user_queue_sizes[username] -= transfer.size
         del self.queued_transfers[transfer]
@@ -520,6 +522,7 @@ class Transfers:
             self._enqueue_limited_transfers(username)
 
         transfer.queue_position = 0
+        return True
 
     def _activate_transfer(self, transfer, token):
 
@@ -548,7 +551,7 @@ class Transfers:
         token = transfer.token
 
         if token is None or token not in self.active_users.get(username, {}):
-            return
+            return False
 
         del self.active_users[username][token]
 
@@ -566,6 +569,8 @@ class Transfers:
         transfer.sock = None
         transfer.token = None
 
+        return True
+
     def _fail_transfer(self, transfer):
         self.failed_users[transfer.username][transfer.virtual_path] = transfer
 
@@ -575,12 +580,14 @@ class Transfers:
         virtual_path = transfer.virtual_path
 
         if virtual_path not in self.failed_users.get(username, {}):
-            return
+            return False
 
         del self.failed_users[username][virtual_path]
 
         if not self.failed_users[username]:
             del self.failed_users[username]
+
+        return True
 
     # Saving #
 

--- a/pynicotine/uploads.py
+++ b/pynicotine/uploads.py
@@ -27,6 +27,8 @@
 import os
 import time
 
+from collections import defaultdict
+
 from pynicotine.config import config
 from pynicotine.core import core
 from pynicotine.events import events
@@ -55,7 +57,8 @@ from pynicotine.utils import encode_path
 
 
 class Uploads(Transfers):
-    __slots__ = ("pending_shutdown", "upload_speed", "token", "_pending_network_msgs",
+    __slots__ = ("pending_shutdown", "upload_speed", "token", "_queue_positions",
+                 "_queue_position_users", "_privileged_position_requested", "_pending_network_msgs",
                  "_user_update_counter", "_user_update_counters", "_upload_queue_timer_id",
                  "_retry_failed_uploads_timer_id")
 
@@ -67,6 +70,9 @@ class Uploads(Transfers):
         self.upload_speed = 0
         self.token = initial_token()
 
+        self._queue_positions = {}
+        self._queue_position_users = defaultdict(dict)
+        self._privileged_position_requested = False
         self._pending_network_msgs = []
         self._user_update_counter = 0
         self._user_update_counters = {}
@@ -122,6 +128,8 @@ class Uploads(Transfers):
         for timer_id in (self._upload_queue_timer_id, self._retry_failed_uploads_timer_id):
             events.cancel_scheduled(timer_id)
 
+        self._queue_positions.clear()
+        self._queue_position_users.clear()
         self._pending_network_msgs.clear()
         self._user_update_counters.clear()
         self._user_update_counter = 0
@@ -314,16 +322,29 @@ class Uploads(Transfers):
         if self.is_privileged(username):
             transfer.modifier = "privileged" if username in core.users.privileged else "prioritized"
 
+        # Clear queue position cache until next position request
+        self._queue_positions.clear()
+        self._queue_position_users.pop(username, None)
+
+        return True
+
     def _dequeue_transfer(self, transfer):
 
         username = transfer.username
 
-        super()._dequeue_transfer(transfer)
+        if not super()._dequeue_transfer(transfer):
+            return False
 
         if username not in self.queued_users:
             self._user_update_counters.pop(username, None)
 
         transfer.modifier = None
+
+        # Clear queue position cache until next position request
+        self._queue_positions.clear()
+        self._queue_position_users.pop(username, None)
+
+        return True
 
     def _activate_transfer(self, transfer, token):
         super()._activate_transfer(transfer, token)
@@ -1175,32 +1196,49 @@ class Uploads(Transfers):
 
         is_fifo_queue = config.sections["transfers"]["fifoqueue"]
         is_privileged_queue = self.is_privileged(username)
-        privileged_queued_users = {k: v for k, v in self.queued_users.items() if self.is_privileged(k)}
+        privileged_queued_users = {k: len(v) for k, v in self.queued_users.items() if self.is_privileged(k)}
         queue_position = 0
 
         if is_fifo_queue:
-            num_non_privileged = 0
+            if is_privileged_queue != self._privileged_position_requested or upload not in self._queue_positions:
+                self._queue_position_users.clear()
 
-            for position, i_upload in enumerate(self.queued_transfers, start=1):
-                if is_privileged_queue and i_upload.username not in privileged_queued_users:
-                    num_non_privileged += 1
+                if is_privileged_queue:
+                    self._queue_positions.clear()
+                    position = 1
 
-                if i_upload == upload:
-                    queue_position += position - num_non_privileged
-                    break
+                    for i_upload in self.queued_transfers:
+                        if i_upload.username in privileged_queued_users:
+                            self._queue_positions[i_upload] = position
+                            position += 1
+                else:
+                    self._queue_positions = {
+                        i_upload: position
+                        for position, i_upload in enumerate(self.queued_transfers, start=1)
+                    }
+
+            queue_position = self._queue_positions[upload]
         else:
-            for position, i_upload in enumerate(self.queued_users.get(username, {}).values(), start=1):
-                if i_upload == upload:
-                    if is_privileged_queue:
-                        num_queued_users = len(privileged_queued_users)
-                    else:
-                        # Cycling through privileged users first
-                        queue_position += sum(
-                            len(queued_uploads) for queued_uploads in privileged_queued_users.values())
-                        num_queued_users = len(self.queued_users)
+            user_queue_positions = self._queue_position_users[username]
 
-                    queue_position += position + num_queued_users
-                    break
+            if upload not in user_queue_positions:
+                self._queue_positions.clear()
+                user_queue_positions.update({
+                    i_upload: position
+                    for position, i_upload in enumerate(self.queued_users[username].values(), start=1)
+                })
+
+            if is_privileged_queue:
+                num_queued_users = len(privileged_queued_users)
+            else:
+                # Cycling through privileged users first
+                queue_position += sum(
+                    num_queued_uploads for num_queued_uploads in privileged_queued_users.values())
+                num_queued_users = len(self.queued_users)
+
+            queue_position += num_queued_users + user_queue_positions[upload]
+
+        self._privileged_position_requested = is_privileged_queue
 
         if queue_position > 0:
             core.send_message_to_peer(


### PR DESCRIPTION
Queue position requests are sent in batches, and calculating the position for each request is slow. Cache the positions until the queue changes.

Fixes #3199 