### PR TITLE
settings/network.ui: "Auto-connect" -> "Connect"

### DIFF
--- a/pynicotine/gtkgui/ui/settings/network.ui
+++ b/pynicotine/gtkgui/ui/settings/network.ui
@@ -296,7 +296,7 @@
               <object class="GtkLabel">
                 <property name="height-request">24</property>
                 <property name="hexpand">True</property>
-                <property name="label" translatable="yes">Auto-connect to server on startup</property>
+                <property name="label" translatable="yes">Connect to server on startup</property>
                 <property name="mnemonic-widget">auto_connect_startup_toggle</property>
                 <property name="visible">True</property>
                 <property name="wrap">True</property>


### PR DESCRIPTION
+ Changed: string containing a hyphenated word that isn't in any [well-known English dictionary](https://dictionary.cambridge.org/spellcheck/english/?q=Auto-connect)

This prefixed "[auto-](https://dictionary.cambridge.org/dictionary/english/auto?q=auto-)connect" word is unlike "[auto-reply](https://dictionary.cambridge.org/dictionary/english/auto-reply)" (which is an actual word that is explicitly in the dictionary). 

In this case our made up prefixerizationage might ambiguously infer something to do with streaming music from the internet whenever you start your car...

![image](https://github.com/user-attachments/assets/49178909-62c9-4f1d-86be-093a18d16455)

"Automatically connect" could also be considered but that's probably unnecessary detail here, since the string does already specify when this action will occur, which is "on startup".