### PR TITLE
DEVELOPING.md: don't mention oldest Python version number

### DIFF
--- a/doc/DEVELOPING.md
+++ b/doc/DEVELOPING.md
@@ -29,8 +29,8 @@ Developing in a single language is also easier for everyone involved in the
 project.
 
 We aim to support the oldest [Python version](https://devguide.python.org/versions/)
-still receiving security updates, up to the latest.
-
+still receiving security updates, up to the latest. In any case, there's no rush to
+bump the minimum version requirement unless it brings a new feature that we need.
 
 ### GTK
 
@@ -249,13 +249,15 @@ within 24 hours. In order to preserve author information for commits, use the
 
 Nicotine+ uses the following versioning scheme: `A.B.C`, e.g. `3.3.8`
 
-  - A is incremented when major changes are made to the user interface that
+  - `A` is incremented when major changes are made to the user interface that
     significantly change the workflow of the application. In practice, this is
     unlikely to happen.
-  - B is incremented when significant features or new dependencies are added,
+  - `B` is incremented when significant features or new dependencies are added,
     version requirements are increased, or in the case of major changes to
-    existing code that are deemed too intrusive for a smaller release.
-  - C is incremented when bug fixes, performance improvements or smaller
+    existing code that are deemed too intrusive for a smaller release. The
+    previous feature branch (e.g. `3.3.x`) is created in case any critical bugs
+    are discovered while the next planned release is still in development.
+  - `C` is incremented when bug fixes, performance improvements or smaller
     tweaks to existing functionality are made. Low-risk functionality that does
     not affect translatable strings can also be added.
 
@@ -271,6 +273,9 @@ volunteers in their spare time. However, keep the following points in mind:
    releases before they can be delivered to users.
  - Releasing large updates can make it more difficult to pinpoint eventual
    issues that were introduced since the previous release.
+ - The final bug fix release (`C`) of each feature branch (`B`) has to be very
+   stable before any dependency requirements are bumped, because legacy users
+   might end up needing to use an old version for a long time.
 
 ### Creating a Nicotine+ Release
 

--- a/doc/DEVELOPING.md
+++ b/doc/DEVELOPING.md
@@ -29,8 +29,9 @@ Developing in a single language is also easier for everyone involved in the
 project.
 
 We aim to support the oldest [Python version](https://devguide.python.org/versions/)
-still receiving security updates, up to the latest. In any case, there's no rush to
-bump the minimum version requirement unless it brings a new feature that we need.
+still receiving security updates, up to the latest. There is no rush to bump the
+minimum version requirement, since LTS distributions may use older Python
+versions, but a smaller range of versions is easier to test.
 
 ### GTK
 

--- a/doc/DEVELOPING.md
+++ b/doc/DEVELOPING.md
@@ -28,9 +28,9 @@ allows for running Nicotine+ on almost any system without compiling anything.
 Developing in a single language is also easier for everyone involved in the
 project.
 
-We aim to support the oldest minor Python 3 version still used by supported
-releases of distributions and operating systems. The minimum version Nicotine+
-currently supports is 3.6.
+We aim to support the oldest [Python version](https://devguide.python.org/versions/)
+still receiving security updates, up to the latest.
+
 
 ### GTK
 


### PR DESCRIPTION
- Removed: Inaccurate mention of Python `3.6`
+ Added: Link to [Status of Python versions chart](https://devguide.python.org/versions/#python-release-cycle) on the Python website
+ Added: When incrementing `B` mention the creation of old feature branches to enable critical bug fix maintenance
+ Added: Fourth point to keep in mind about old branch maintenance