### PR TITLE
DEVELOPING.md: simplify Continuous Integration Testing section

### DIFF
--- a/doc/DEVELOPING.md
+++ b/doc/DEVELOPING.md
@@ -145,60 +145,43 @@ by the Nicotine+ team.
 
 ## Continuous Integration Testing
 
-It is important that all patches pass unit testing. Unfortunately developers
-make all kinds of changes to their local development environment that can have
-unintended consequences. This means sometimes tests on the developer's computer
-pass when they should not, and other times failing when they should not have.
-
-To properly validate that things are working, continuous integration (CI) is
-required. This means compiling, performing local in-tree unit tests,
-installing through the system package manager, and finally testing the actually
-installed build artifacts to ensure they do what the user expects them to do.
-
-The key thing to remember is that in order to do this properly, this all needs
-to be done within a realistic end user system that has not been unintentionally
-modified by a developer. This might mean a chroot container with the help of
-QEMU and KVM to verify that everything is working as expected. The hermetically
-sealed test environment validates that the developer's expected steps for, as
-an example in the case of a library, compilation, linking, unit testing, and
-post installation testing are actually replicable.
-
-There are [different ways](https://wiki.debian.org/qa.debian.org#Other_distributions)
-of performing CI on different distros. The most common one is via the
-international [DEP-8](https://dep-team.pages.debian.net/deps/dep8/) standard as
-used by hundreds of different operating systems.
-
-### Autopkgtest
-
-On Debian based distributions, `autopkgtest` implements the DEP-8 standard.
-To create and use a build image environment for Ubuntu, follow these steps.
-First install the `autopkgtest(1)` tools:
-
-```sh
-sudo apt install autopkgtest
-```
-
-Next create the test image, substituting `hirsute` or `amd64` for other
-releases or architectures:
-
-```sh
-autopkgtest-buildvm-ubuntu-cloud -r hirsute -a amd64
-```
-
-Test your changes on the host architecture in QEMU with KVM support and 8GB of
-RAM and four CPUs:
-
-```sh
-autopkgtest --shell-fail --apt-upgrade . -- \
-      qemu --ram-size=8192 --cpus=4 --show-boot path_to_build_image.img \
-      --qemu-options='-enable-kvm'
-```
+It is important that all changes pass unit and integration testing. To properly
+validate that things are working, continuous integration (CI) is implemented
+using GitHub Actions workflows, which run tests on various platforms for each
+commit.
 
 ### Creating Tests
 
 Tests are defined in the [pynicotine/tests/](https://github.com/nicotine-plus/nicotine-plus/tree/HEAD/pynicotine/tests/)
 folder, and should be expanded to cover larger parts of the client when
 possible.
+
+### Running Tests
+
+Although GitHub Actions runs tests automatically when pushing changes to the
+repository, it is also possible to run them locally. This can be helpful to
+quickly test smaller changes, but local testing should not be relied upon for
+changes that affect packaging or are likely to break on other platforms.
+
+To run unit and integration tests using Python's unittest module:
+```sh
+python3 -m unittest
+```
+
+To check the code style using pycodestyle:
+```sh
+python3 -m pycodestyle
+```
+
+To perform code linting using Pylint:
+```sh
+python3 -m pylint --recursive=y .
+```
+
+To test building the application:
+```sh
+python3 -m build
+```
 
 
 ## Translations


### PR DESCRIPTION
- Removed: Outdated and irrelevant detail about running the test suite locally, since GitHub Actions make this task superfluous.