### PR TITLE
preferences.py: remove 'Everyone' permission for sending files

### DIFF
--- a/pynicotine/gtkgui/dialogs/preferences.py
+++ b/pynicotine/gtkgui/dialogs/preferences.py
@@ -272,7 +272,6 @@ class DownloadsPage:
             container=self.sent_files_permission_container,
             items=(
                 (_("No one"), 0),
-                (_("Everyone"), 1),
                 (_("Buddies"), 2),
                 (_("Trusted buddies"), 3)
             )


### PR DESCRIPTION
Let's just get rid of this footgun already.

Related to #3353 