### PR TITLE
Substitute non-separator backslashes in file paths

### DIFF
--- a/pynicotine/transfers.py
+++ b/pynicotine/transfers.py
@@ -67,8 +67,8 @@ class Transfer:
                  "current_byte_offset", "last_byte_offset", "transferred_bytes_total",
                  "speed", "avg_speed", "time_elapsed", "time_left", "modifier",
                  "queue_position", "file_attributes", "iterator", "status",
-                 "legacy_attempt", "retry_attempt", "size_changed", "is_lowercase_path",
-                 "request_timer_id")
+                 "legacy_attempt", "retry_attempt", "size_changed", "is_backslash_path",
+                 "is_lowercase_path", "request_timer_id")
 
     def __init__(self, username, virtual_path=None, folder_path=None, size=0, file_attributes=None,
                  status=None, current_byte_offset=None):
@@ -97,6 +97,7 @@ class Transfer:
         self.legacy_attempt = False
         self.retry_attempt = False
         self.size_changed = False
+        self.is_backslash_path = False
         self.is_lowercase_path = False
 
         if file_attributes is None:


### PR DESCRIPTION
Fixes #1380 

Builds on #3280 