### PR TITLE
preferences.py: remove "Enable colored usernames" option toggle

### DIFF
--- a/pynicotine/config.py
+++ b/pynicotine/config.py
@@ -338,7 +338,7 @@ class Config:
                 "useronline": "#16BB5C",
                 "useraway": "#C9AE13",
                 "useroffline": "#E04F5E",
-                "usernamehotspots": True,
+                "usernamehotspots": True,                                            # TODO: remove in 3.4.0
                 "usernamestyle": "bold",
                 "textbg": "",
                 "search": "",

--- a/pynicotine/gtkgui/dialogs/preferences.py
+++ b/pynicotine/gtkgui/dialogs/preferences.py
@@ -1622,7 +1622,6 @@ class UserInterfacePage:
 
         (
             self.buddy_list_position_label,
-            self.chat_colored_usernames_toggle,
             self.chat_username_appearance_label,
             self.close_action_label,
             self.color_chat_action_button,
@@ -1966,7 +1965,6 @@ class UserInterfacePage:
                 "tab_hilite": self.color_tab_highlighted_entry,
                 "tab_changed": self.color_tab_changed_entry,
                 "usernamestyle": self.chat_username_appearance_combobox,
-                "usernamehotspots": self.chat_colored_usernames_toggle,
                 "buddylistinchatrooms": self.buddy_list_position_combobox,
                 "header_bar": self.header_bar_toggle
             }
@@ -2064,7 +2062,6 @@ class UserInterfacePage:
                 "tab_default": self.color_tab_entry.get_text().strip(),
                 "tab_changed": self.color_tab_changed_entry.get_text().strip(),
                 "usernamestyle": self.chat_username_appearance_combobox.get_selected_id(),
-                "usernamehotspots": self.chat_colored_usernames_toggle.get_active(),
                 "buddylistinchatrooms": self.buddy_list_position_combobox.get_selected_id(),
                 "header_bar": self.header_bar_toggle.get_active()
             }

--- a/pynicotine/gtkgui/ui/settings/userinterface.ui
+++ b/pynicotine/gtkgui/ui/settings/userinterface.ui
@@ -1054,30 +1054,6 @@
         </child>
         <child>
           <object class="GtkBox">
-            <property name="spacing">12</property>
-            <property name="visible">True</property>
-            <child>
-              <object class="GtkLabel">
-                <property name="height-request">24</property>
-                <property name="hexpand">True</property>
-                <property name="label" translatable="yes">Enable colored usernames</property>
-                <property name="mnemonic-widget">chat_colored_usernames_toggle</property>
-                <property name="visible">True</property>
-                <property name="wrap">True</property>
-                <property name="wrap-mode">word-char</property>
-                <property name="xalign">0</property>
-              </object>
-            </child>
-            <child>
-              <object class="GtkSwitch" id="chat_colored_usernames_toggle">
-                <property name="valign">center</property>
-                <property name="visible">True</property>
-              </object>
-            </child>
-          </object>
-        </child>
-        <child>
-          <object class="GtkBox">
             <property name="homogeneous">True</property>
             <property name="margin-top">6</property>
             <property name="spacing">12</property>

--- a/pynicotine/gtkgui/widgets/theme.py
+++ b/pynicotine/gtkgui/widgets/theme.py
@@ -617,13 +617,9 @@ def update_custom_css():
 
 def update_tag_visuals(tag, color_id):
 
-    enable_colored_usernames = config.sections["ui"]["usernamehotspots"]
     is_hotspot_tag = (color_id in {"useraway", "useronline", "useroffline"})
     color_hex = config.sections["ui"].get(color_id)
     tag_props = tag.props
-
-    if is_hotspot_tag and not enable_colored_usernames:
-        color_hex = None
 
     if not color_hex:
         if tag_props.foreground_rgba:


### PR DESCRIPTION
- Removed: "Enable colored usernames" option toggle from User Interface Preferences

This will also remove the `"usernamehotspots"` config setting, because there doesn't seem to be any advantage having uncolored username tags in chat, and disabling the option causes `None` color to be set in the theme implementation [which is problematic](https://github.com/nicotine-plus/nicotine-plus/pull/3340#issuecomment-2888560770).