### PR TITLE
ui: set "no-emoji" input hint on GtkEntry widgets

### DIFF
--- a/pynicotine/gtkgui/ui/buddies.ui
+++ b/pynicotine/gtkgui/ui/buddies.ui
@@ -28,6 +28,7 @@
           <object class="GtkEntry">
             <property name="height-request">0</property>
             <property name="hexpand">True</property>
+            <property name="input-hints">no-emoji</property>
             <property name="placeholder-text" translatable="yes">Add buddy…</property>
             <property name="primary-icon-name">system-users-symbolic</property>
             <property name="visible">True</property>

--- a/pynicotine/gtkgui/ui/mainwindow.ui
+++ b/pynicotine/gtkgui/ui/mainwindow.ui
@@ -39,6 +39,7 @@
   </object>
   <object class="GtkEntry" id="room_search_entry">
     <property name="hexpand">False</property>
+    <property name="input-hints">no-emoji</property>
     <property name="max-width-chars">20</property>
     <property name="placeholder-text" translatable="yes">Room…</property>
     <property name="visible">True</property>
@@ -47,6 +48,7 @@
   </object>
   <object class="GtkEntry" id="user_search_entry">
     <property name="hexpand">False</property>
+    <property name="input-hints">no-emoji</property>
     <property name="max-width-chars">20</property>
     <property name="placeholder-text" translatable="yes">Username…</property>
     <property name="visible">True</property>
@@ -727,6 +729,7 @@
     </child>
   </object>
   <object class="GtkEntry" id="userbrowse_entry">
+    <property name="input-hints">no-emoji</property>
     <property name="max-width-chars">45</property>
     <property name="placeholder-text" translatable="yes">Username…</property>
     <property name="primary-icon-name">avatar-default-symbolic</property>
@@ -895,6 +898,7 @@
     </child>
   </object>
   <object class="GtkEntry" id="userinfo_entry">
+    <property name="input-hints">no-emoji</property>
     <property name="max-width-chars">45</property>
     <property name="placeholder-text" translatable="yes">Username…</property>
     <property name="primary-icon-name">avatar-default-symbolic</property>
@@ -1090,6 +1094,7 @@
                     <property name="visible">True</property>
                     <child>
                       <object class="GtkEntry" id="private_entry">
+                        <property name="input-hints">no-emoji</property>
                         <property name="max-width-chars">40</property>
                         <property name="placeholder-text" translatable="yes">Username…</property>
                         <property name="primary-icon-name">avatar-default-symbolic</property>
@@ -1253,6 +1258,7 @@
                     <property name="visible">True</property>
                     <child>
                       <object class="GtkEntry" id="add_buddy_entry">
+                        <property name="input-hints">no-emoji</property>
                         <property name="max-width-chars">45</property>
                         <property name="placeholder-text" translatable="yes">Add buddy…</property>
                         <property name="primary-icon-name">system-users-symbolic</property>

--- a/pynicotine/gtkgui/ui/search.ui
+++ b/pynicotine/gtkgui/ui/search.ui
@@ -31,6 +31,7 @@
   </object>
   <object class="GtkEntry" id="filter_file_type_entry">
     <property name="hexpand">True</property>
+    <property name="input-hints">no-emoji</property>
     <property name="max-width-chars">0</property>
     <property name="placeholder-text" translatable="yes">File type…</property>
     <property name="primary-icon-name">folder-documents-symbolic</property>
@@ -42,6 +43,7 @@
   </object>
   <object class="GtkEntry" id="filter_file_size_entry">
     <property name="hexpand">True</property>
+    <property name="input-hints">no-emoji</property>
     <property name="max-width-chars">0</property>
     <property name="placeholder-text" translatable="yes">File size…</property>
     <property name="primary-icon-name">drive-harddisk-symbolic</property>
@@ -53,6 +55,7 @@
   </object>
   <object class="GtkEntry" id="filter_bitrate_entry">
     <property name="hexpand">True</property>
+    <property name="input-hints">no-emoji</property>
     <property name="max-width-chars">0</property>
     <property name="placeholder-text" translatable="yes">Bitrate…</property>
     <property name="primary-icon-name">audio-volume-high-symbolic</property>
@@ -64,6 +67,7 @@
   </object>
   <object class="GtkEntry" id="filter_length_entry">
     <property name="hexpand">True</property>
+    <property name="input-hints">no-emoji</property>
     <property name="max-width-chars">0</property>
     <property name="placeholder-text" translatable="yes">Duration…</property>
     <property name="primary-icon-name">media-playback-start-symbolic</property>
@@ -75,6 +79,7 @@
   </object>
   <object class="GtkEntry" id="filter_country_entry">
     <property name="hexpand">True</property>
+    <property name="input-hints">no-emoji</property>
     <property name="max-width-chars">0</property>
     <property name="placeholder-text" translatable="yes">Country code…</property>
     <property name="primary-icon-name">mark-location-symbolic</property>

--- a/pynicotine/gtkgui/ui/settings/network.ui
+++ b/pynicotine/gtkgui/ui/settings/network.ui
@@ -347,6 +347,7 @@
             </child>
             <child>
               <object class="GtkEntry" id="soulseek_server_entry">
+                <property name="input-hints">no-emoji</property>
                 <property name="secondary-icon-name">edit-undo-symbolic</property>
                 <property name="secondary-icon-tooltip-text" translatable="yes">Default</property>
                 <property name="valign">center</property>

--- a/pynicotine/gtkgui/ui/settings/search.ui
+++ b/pynicotine/gtkgui/ui/settings/search.ui
@@ -269,6 +269,7 @@
                         <child>
                           <object class="GtkEntry" id="filter_file_type_entry">
                             <property name="halign">end</property>
+                            <property name="input-hints">no-emoji</property>
                             <property name="max-width-chars">26</property>
                             <property name="tooltip-text" translatable="yes">File type, e.g. flac wav or !mp3 !m4a</property>
                             <property name="valign">center</property>
@@ -296,6 +297,7 @@
                         <child>
                           <object class="GtkEntry" id="filter_file_size_entry">
                             <property name="halign">end</property>
+                            <property name="input-hints">no-emoji</property>
                             <property name="max-width-chars">26</property>
                             <property name="tooltip-text" translatable="yes">File size, e.g. &gt;10.5m &lt;1g</property>
                             <property name="valign">center</property>
@@ -323,6 +325,7 @@
                         <child>
                           <object class="GtkEntry" id="filter_bitrate_entry">
                             <property name="halign">end</property>
+                            <property name="input-hints">no-emoji</property>
                             <property name="max-width-chars">26</property>
                             <property name="tooltip-text" translatable="yes">Bitrate, e.g. 256 &lt;1412</property>
                             <property name="valign">center</property>
@@ -350,6 +353,7 @@
                         <child>
                           <object class="GtkEntry" id="filter_length_entry">
                             <property name="halign">end</property>
+                            <property name="input-hints">no-emoji</property>
                             <property name="max-width-chars">26</property>
                             <property name="tooltip-text" translatable="yes">Duration, e.g. &gt;6:00 &lt;12:00 !6:54</property>
                             <property name="valign">center</property>
@@ -377,6 +381,7 @@
                         <child>
                           <object class="GtkEntry" id="filter_country_entry">
                             <property name="halign">end</property>
+                            <property name="input-hints">no-emoji</property>
                             <property name="max-width-chars">26</property>
                             <property name="tooltip-text" translatable="yes">Country code, e.g. US ES or !DE !GB</property>
                             <property name="valign">center</property>


### PR DESCRIPTION
- Removed: "Insert Emoji" menu item from context menu of GtkEntry widgets where emoji are definitely invalid

This PR doesn't deal with Entry fields that are programmatically created within ComboBox and Spinner widgets, dialogs, etc.