### PR TITLE
searchfilterhelp.ui: Public Files

### DIFF
--- a/pynicotine/gtkgui/ui/popovers/searchfilterhelp.ui
+++ b/pynicotine/gtkgui/ui/popovers/searchfilterhelp.ui
@@ -436,6 +436,27 @@
             <property name="xalign">0</property>
           </object>
         </child>
+        <child>
+          <object class="GtkLabel">
+            <property name="label" translatable="yes">Public Files</property>
+            <property name="selectable">True</property>
+            <property name="visible">True</property>
+            <property name="xalign">0</property>
+            <style>
+              <class name="italic"/>
+            </style>
+          </object>
+        </child>
+        <child>
+          <object class="GtkLabel">
+            <property name="label" translatable="yes">Only show files that are shared publicly, and hide privately shared files which cannot be downloaded until the uploader gives explicit permission.</property>
+            <property name="margin-start">12</property>
+            <property name="selectable">True</property>
+            <property name="visible">True</property>
+            <property name="wrap">True</property>
+            <property name="xalign">0</property>
+          </object>
+        </child>
       </object>
     </child>
   </object>


### PR DESCRIPTION
+ Added: Public Files section in Search Result Filters Help popover

> _Public Files_
>
> Only show files that are shared publicly, and hide privately shared files which cannot be downloaded until the uploader gives explicit permission.