### PR TITLE
utils.py: new human_duration() function using ngettext()

### DIFF
--- a/pynicotine/i18n.py
+++ b/pynicotine/i18n.py
@@ -105,4 +105,4 @@ def apply_translations(language=None):
     _set_system_language(language)
 
     # Install translations for Python
-    gettext.install(TRANSLATION_DOMAIN, LOCALE_PATH)
+    gettext.install(TRANSLATION_DOMAIN, LOCALE_PATH, names=["ngettext"])

--- a/pynicotine/search.py
+++ b/pynicotine/search.py
@@ -39,6 +39,7 @@ from pynicotine.slskmessages import SEARCH_TOKENS_ALLOWED
 from pynicotine.slskmessages import UserSearch
 from pynicotine.slskmessages import WishlistSearch
 from pynicotine.utils import TRANSLATE_PUNCTUATION
+from pynicotine.utils import human_duration_approx
 
 
 class SearchRequest:
@@ -421,8 +422,10 @@ class Search:
         self.wishlist_interval = msg.seconds
 
         if self.wishlist_interval > 0:
-            log.add_search(_("Wishlist wait period set to %s seconds"), self.wishlist_interval)
-
+            log.add_search(
+                _("Wishlist wait period set to %(duration)s"),
+                {"duration": human_duration_approx(self.wishlist_interval)}
+            )
             events.cancel_scheduled(self._wishlist_timer_id)
             self._wishlist_timer_id = events.schedule(
                 delay=self.wishlist_interval, callback=self._do_next_wishlist_search, repeat=True)

--- a/pynicotine/slskproto.py
+++ b/pynicotine/slskproto.py
@@ -87,6 +87,7 @@ from pynicotine.slskmessages import UserStatus
 from pynicotine.slskmessages import WatchUser
 from pynicotine.slskmessages import increment_token
 from pynicotine.slskmessages import initial_token
+from pynicotine.utils import human_duration_approx
 from pynicotine.utils import human_speed
 
 
@@ -1095,7 +1096,8 @@ class NetworkThread(Thread):
             self._server_timeout_value *= 2
 
         self._server_timeout_time = time.monotonic() + self._server_timeout_value
-        log.add(_("Reconnecting to server in %s seconds"), self._server_timeout_value)
+        log.add(_("Reconnecting to server in %(duration)s"),
+                {"duration": human_duration_approx(self._server_timeout_value)})
 
     @staticmethod
     def _set_server_socket_keepalive(sock, idle=10, interval=2):

--- a/pynicotine/users.py
+++ b/pynicotine/users.py
@@ -33,6 +33,7 @@ from pynicotine.slskmessages import UnwatchUser
 from pynicotine.slskmessages import UserStatus
 from pynicotine.slskmessages import WatchUser
 from pynicotine.utils import UINT32_LIMIT
+from pynicotine.utils import human_duration_approx
 from pynicotine.utils import open_uri
 
 
@@ -428,26 +429,18 @@ class Users:
     def _check_privileges(self, msg):
         """Server code 92."""
 
-        mins = msg.seconds // 60
-        hours = mins // 60
-        days = hours // 24
+        seconds = msg.seconds
 
-        if msg.seconds <= 0:
+        if seconds <= 0:
             log.add(_("You have no Soulseek privileges. While privileges are active, your downloads "
                       "will be queued ahead of those of non-privileged users."))
 
             if self._should_open_privileges_url:
                 self.open_privileges_url()
         else:
-            log.add(_("%(days)i days, %(hours)i hours, %(minutes)i minutes, %(seconds)i seconds of "
-                      "Soulseek privileges left"), {
-                "days": days,
-                "hours": hours % 24,
-                "minutes": mins % 60,
-                "seconds": msg.seconds % 60
-            })
+            log.add(_("%(duration)s of Soulseek privileges left"), {"duration": human_duration_approx(seconds)})
 
-        self.privileges_left = msg.seconds
+        self.privileges_left = seconds
         self._should_open_privileges_url = False
 
     @staticmethod

--- a/pynicotine/utils.py
+++ b/pynicotine/utils.py
@@ -203,7 +203,32 @@ def encode_path(path, prefix=True):
     return path.encode("utf-8")
 
 
+def human_duration_approx(seconds):
+    """Returns a string for an approximatation of any amount of time in a
+    sensible unit of measurement, for use where precision isn't required."""
+
+    seconds = int(seconds)
+
+    if seconds < 120:
+        return ngettext("%(num)s second", "%(num)s seconds", seconds) % {"num": seconds}
+
+    minutes = seconds // 60
+
+    if minutes < 60:
+        return ngettext("%(num)s minute", "%(num)s minutes", minutes) % {"num": minutes}
+
+    hours = minutes // 60
+
+    if hours < 48:
+        return ngettext("%(num)s hour", "%(num)s hours", hours) % {"num": hours}
+
+    days = hours // 24
+
+    return ngettext("%(num)s day", "%(num)s days", days) % {"num": humanize(days)}
+
+
 def human_length(seconds):
+    """Returns a string for exact ISO 8601 timestamp for track playing length"""
 
     minutes, seconds = divmod(int(seconds), 60)
     hours, minutes = divmod(minutes, 60)

--- a/setup.cfg
+++ b/setup.cfg
@@ -132,4 +132,4 @@ max-nested-blocks = 6
 min-similarity-lines = 15
 
 [pylint.variables]
-additional-builtins = _
+additional-builtins = _, ngettext


### PR DESCRIPTION
+ Added: 8 pluralized translatable strings that represent basic units of time in day(s), hour(s), minute(s) or second(s).
+ Changed: 3 translatable strings for the sake of demonstrating the use of `ngettext()` where `$(duration)s` are involved.

These time strings aren't ever concatenated with each other, only a singular unit of measurement needs to be displayed at a time for these rounded values because they don't need to have the same degree of precision as something like an audio track length.

For instance, it is clearer to say "**_n_ days** of Soulseek privileges left" because it isn't useful to know the exact number of hours, minutes nor seconds until the amount left falls low enough for it to become "**_n_ hours** of Soulseek privileges left", and so on.

https://www.gnu.org/software/gettext/manual/html_node/Plural-forms.html
https://www.gnu.org/software/gettext/manual/html_node/Translating-plural-forms.html

Related to PR #3397.