### PR TITLE
gtkgui/userbrowse.py: fix remember selection after refresh

### DIFF
--- a/pynicotine/gtkgui/userbrowse.py
+++ b/pynicotine/gtkgui/userbrowse.py
@@ -158,9 +158,6 @@ class UserBrowses(IconNotebook):
                              close_callback=page.on_close, user=user)
             page.set_label(self.get_tab_label_inner(page.container))
 
-        page.queued_path = path
-        page.browse_queued_path()
-
         if switch_page:
             self.set_current_page(page.container)
             self.window.change_main_page(self.window.userbrowse_page)
@@ -168,6 +165,9 @@ class UserBrowses(IconNotebook):
         if new_request:
             page.clear_model()
             page.set_indeterminate_progress()
+
+        page.queued_path = path
+        page.browse_queued_path()
 
     def remove_user(self, user):
 


### PR DESCRIPTION
+ Fixed: Remember selection after refresh functionality was broken due to selection being cleared during the new_request

Regression in https://github.com/nicotine-plus/nicotine-plus/commit/74023ff21e0f249d8cb3a8892b3674e46605089d