### PR TITLE
PluginSettings: settings and plugin_name object naming cleanup

### DIFF
--- a/pynicotine/gtkgui/dialogs/pluginsettings.py
+++ b/pynicotine/gtkgui/dialogs/pluginsettings.py
@@ -35,8 +35,8 @@ class PluginSettings(Dialog):
     def __init__(self, application):
 
         self.application = application
-        self.plugin_id = None
-        self.plugin_settings = None
+        self.plugin_name = None
+        self.plugin_metasettings = None
         self.option_widgets = {}
 
         cancel_button = Gtk.Button(label=_("_Cancel"), use_underline=True, visible=True)
@@ -274,14 +274,14 @@ class PluginSettings(Dialog):
         for child in list(self.primary_container):
             self.primary_container.remove(child)
 
-        for option_name, data in self.plugin_settings.items():
+        for option_name, data in self.plugin_metasettings.items():
             option_type = data.get("type")
 
             if not option_type:
                 continue
 
             description = data.get("description", "")
-            option_value = config.sections["plugins"][self.plugin_id.lower()][option_name]
+            option_value = config.sections["plugins"][self.plugin_name.lower()][option_name]
 
             if option_type in {"integer", "int", "float"}:
                 self._add_numerical_option(
@@ -360,13 +360,13 @@ class PluginSettings(Dialog):
 
         return None
 
-    def update_settings(self, plugin_id, plugin_settings):
+    def load_options(self, plugin_name, plugin_metasettings):
 
-        self.plugin_id = plugin_id
-        self.plugin_settings = plugin_settings
-        plugin_name = core.pluginhandler.get_plugin_info(plugin_id).get("Name", plugin_id)
+        self.plugin_name = plugin_name
+        self.plugin_metasettings = plugin_metasettings
+        plugin_human_name = core.pluginhandler.get_plugin_info(plugin_name).get("Name", plugin_name)
 
-        self.set_title(_("%s Settings") % plugin_name)
+        self.set_title(_("%s Settings") % plugin_human_name)
         self._add_options()
 
     def on_add_response(self, window, _response_id, treeview):
@@ -438,13 +438,13 @@ class PluginSettings(Dialog):
 
     def on_ok(self, *_args):
 
-        plugin = core.pluginhandler.enabled_plugins[self.plugin_id]
+        plugin = core.pluginhandler.enabled_plugins[self.plugin_name]
 
-        for name in self.plugin_settings:
-            value = self._get_widget_data(self.option_widgets[name])
+        for option_name in self.plugin_metasettings:
+            new_value = self._get_widget_data(self.option_widgets[option_name])
 
-            if value is not None:
-                plugin.settings[name] = value
+            if new_value is not None:
+                plugin.settings[option_name] = new_value
 
         self.close()
 

--- a/pynicotine/gtkgui/dialogs/preferences.py
+++ b/pynicotine/gtkgui/dialogs/preferences.py
@@ -2964,7 +2964,7 @@ class PluginsPage:
     def on_add_plugins(self, *_args):
         open_folder_path(core.pluginhandler.user_plugin_folder, create_folder=True)
 
-    def on_click_plugin_settings(self, *_args):
+    def on_show_plugin_settings(self, *_args):
 
         if self.selected_plugin is None:
             return
@@ -2982,7 +2982,7 @@ class PluginsPage:
 
     def on_row_activated(self, _list_view, _iterator, column_id):
         if column_id == "human_name":
-            self.on_click_plugin_settings()
+            self.on_show_plugin_settings()
 
 
 class Preferences(Dialog):

--- a/pynicotine/gtkgui/dialogs/preferences.py
+++ b/pynicotine/gtkgui/dialogs/preferences.py
@@ -2836,7 +2836,7 @@ class PluginsPage:
 
         self.application = application
         self.selected_plugin = None
-        self.plugin_settings = None
+        self.plugin_settings_dialog = None
 
         self.options = {
             "plugins": {
@@ -2855,17 +2855,17 @@ class PluginsPage:
                     "column_type": "toggle",
                     "title": _("Enabled"),
                     "width": 0,
-                    "toggle_callback": self.on_plugin_toggle,
+                    "toggle_callback": self.on_toggle_plugin,
                     "hide_header": True
                 },
-                "plugin": {
+                "human_name": {
                     "column_type": "text",
                     "title": _("Plugin"),
                     "default_sort_type": "ascending"
                 },
 
                 # Hidden data columns
-                "plugin_id": {"data_type": GObject.TYPE_STRING, "iterator_key": True}
+                "name_data": {"data_type": GObject.TYPE_STRING, "iterator_key": True}
             }
         )
         self.add_plugins_button.set_visible(not self.application.isolated_mode)
@@ -2875,8 +2875,8 @@ class PluginsPage:
         self.plugin_description_view.destroy()
         self.plugin_list_view.destroy()
 
-        if self.plugin_settings is not None:
-            self.plugin_settings.destroy()
+        if self.plugin_settings_dialog is not None:
+            self.plugin_settings_dialog.destroy()
 
         self.__dict__.clear()
 
@@ -2887,15 +2887,15 @@ class PluginsPage:
 
         self.application.preferences.set_widgets_data(self.options)
 
-        for plugin_id in core.pluginhandler.list_installed_plugins():
+        for plugin_name in core.pluginhandler.list_installed_plugins():
             try:
-                info = core.pluginhandler.get_plugin_info(plugin_id)
+                info = core.pluginhandler.get_plugin_info(plugin_name)
             except OSError:
                 continue
 
-            plugin_name = info.get("Name", plugin_id)
-            enabled = (plugin_id in config.sections["plugins"]["enabled"])
-            self.plugin_list_view.add_row([enabled, plugin_name, plugin_id], select_row=False)
+            plugin_human_name = info.get("Name", plugin_name)
+            enabled = (plugin_name in config.sections["plugins"]["enabled"])
+            self.plugin_list_view.add_row([enabled, plugin_human_name, plugin_name], select_row=False)
 
         self.plugin_list_view.unfreeze()
 
@@ -2907,8 +2907,8 @@ class PluginsPage:
             }
         }
 
-    def check_plugin_settings_button(self, plugin):
-        self.plugin_settings_button.set_sensitive(bool(core.pluginhandler.get_plugin_settings(plugin)))
+    def check_plugin_settings_button(self, plugin_name):
+        self.plugin_settings_button.set_sensitive(bool(core.pluginhandler.get_plugin_metasettings(plugin_name)))
 
     def on_select_plugin(self, list_view, iterator):
 
@@ -2916,15 +2916,15 @@ class PluginsPage:
             self.selected_plugin = _("No Plugin Selected")
             info = {}
         else:
-            self.selected_plugin = list_view.get_row_value(iterator, "plugin_id")
+            self.selected_plugin = list_view.get_row_value(iterator, "name_data")
             info = core.pluginhandler.get_plugin_info(self.selected_plugin)
 
-        plugin_name = info.get("Name", self.selected_plugin)
+        plugin_human_name = info.get("Name", self.selected_plugin)
         plugin_version = info.get("Version", "-")
         plugin_authors = ", ".join(info.get("Authors", "-"))
         plugin_description = info.get("Description", "").replace(r"\n", "\n")
 
-        self.plugin_name_label.set_text(plugin_name)
+        self.plugin_name_label.set_text(plugin_human_name)
         self.plugin_version_label.set_text(plugin_version)
         self.plugin_authors_label.set_text(plugin_authors)
 
@@ -2934,55 +2934,55 @@ class PluginsPage:
 
         self.check_plugin_settings_button(self.selected_plugin)
 
-    def on_plugin_toggle(self, list_view, iterator):
+    def on_toggle_plugin(self, list_view, iterator):
 
-        plugin_id = list_view.get_row_value(iterator, "plugin_id")
-        enabled = core.pluginhandler.toggle_plugin(plugin_id)
+        plugin_name = list_view.get_row_value(iterator, "name_data")
+        enabled = core.pluginhandler.toggle_plugin(plugin_name)
 
         list_view.set_row_value(iterator, "enabled", enabled)
-        self.check_plugin_settings_button(plugin_id)
+        self.check_plugin_settings_button(plugin_name)
 
-    def on_enable_plugins(self, *_args):
+    def on_toggle_enable_plugins(self, *_args):
 
-        enabled_plugin_ids = config.sections["plugins"]["enabled"].copy()
+        plugins_enabled = config.sections["plugins"]["enabled"].copy()
 
         if self.enable_plugins_toggle.get_active():
             # Enable all selected plugins
-            for plugin_id in enabled_plugin_ids:
-                core.pluginhandler.enable_plugin(plugin_id)
+            for plugin_name in plugins_enabled:
+                core.pluginhandler.enable_plugin(plugin_name)
 
             self.check_plugin_settings_button(self.selected_plugin)
             return
 
         # Disable all plugins
-        for plugin in core.pluginhandler.enabled_plugins.copy():
-            core.pluginhandler.disable_plugin(plugin)
+        for plugin_name in core.pluginhandler.enabled_plugins.copy():
+            core.pluginhandler.disable_plugin(plugin_name)
 
-        config.sections["plugins"]["enabled"] = enabled_plugin_ids
+        config.sections["plugins"]["enabled"] = plugins_enabled
         self.plugin_settings_button.set_sensitive(False)
 
     def on_add_plugins(self, *_args):
         open_folder_path(core.pluginhandler.user_plugin_folder, create_folder=True)
 
-    def on_plugin_settings(self, *_args):
+    def on_click_plugin_settings(self, *_args):
 
         if self.selected_plugin is None:
             return
 
-        settings = core.pluginhandler.get_plugin_settings(self.selected_plugin)
+        metasettings = core.pluginhandler.get_plugin_metasettings(self.selected_plugin)
 
-        if not settings:
+        if not metasettings:
             return
 
-        if self.plugin_settings is None:
-            self.plugin_settings = PluginSettings(self.application)
+        if self.plugin_settings_dialog is None:
+            self.plugin_settings_dialog = PluginSettings(self.application)
 
-        self.plugin_settings.update_settings(plugin_id=self.selected_plugin, plugin_settings=settings)
-        self.plugin_settings.present()
+        self.plugin_settings_dialog.load_options(self.selected_plugin, metasettings)
+        self.plugin_settings_dialog.present()
 
     def on_row_activated(self, _list_view, _iterator, column_id):
-        if column_id == "plugin":
-            self.on_plugin_settings()
+        if column_id == "human_name":
+            self.on_click_plugin_settings()
 
 
 class Preferences(Dialog):

--- a/pynicotine/gtkgui/ui/settings/plugin.ui
+++ b/pynicotine/gtkgui/ui/settings/plugin.ui
@@ -57,7 +57,7 @@
                       <object class="GtkSwitch" id="enable_plugins_toggle">
                         <property name="valign">center</property>
                         <property name="visible">True</property>
-                        <signal name="notify::active" handler="on_enable_plugins"/>
+                        <signal name="notify::active" handler="on_toggle_enable_plugins"/>
                       </object>
                     </child>
                   </object>
@@ -131,7 +131,7 @@
                                     <property name="sensitive">False</property>
                                     <property name="tooltip-text" translatable="yes">Settings</property>
                                     <property name="visible">True</property>
-                                    <signal name="clicked" handler="on_plugin_settings"/>
+                                    <signal name="clicked" handler="on_click_plugin_settings"/>
                                     <child>
                                       <object class="GtkBox">
                                         <property name="spacing">6</property>

--- a/pynicotine/gtkgui/ui/settings/plugin.ui
+++ b/pynicotine/gtkgui/ui/settings/plugin.ui
@@ -131,7 +131,7 @@
                                     <property name="sensitive">False</property>
                                     <property name="tooltip-text" translatable="yes">Settings</property>
                                     <property name="visible">True</property>
-                                    <signal name="clicked" handler="on_click_plugin_settings"/>
+                                    <signal name="clicked" handler="on_show_plugin_settings"/>
                                     <child>
                                       <object class="GtkBox">
                                         <property name="spacing">6</property>

--- a/pynicotine/pluginsystem.py
+++ b/pynicotine/pluginsystem.py
@@ -495,7 +495,7 @@ class PluginHandler:
         # Reset class attributes
         BasePlugin.internal_name = BasePlugin.human_name = BasePlugin.path = None
 
-        self.plugin_settings(plugin_name, instance)
+        self.load_plugin_settings(instance)
 
         if hasattr(plugin, "enable"):
             instance.log("top-level enable() function is obsolete, please use BasePlugin.__init__() instead")
@@ -705,7 +705,7 @@ class PluginHandler:
         self.disable_plugin(plugin_name)
         self.enable_plugin(plugin_name)
 
-    def get_plugin_settings(self, plugin_name):
+    def get_plugin_metasettings(self, plugin_name):
 
         if plugin_name in self.enabled_plugins:
             plugin = self.enabled_plugins[plugin_name]
@@ -757,9 +757,9 @@ class PluginHandler:
             "trace": "".join(format_tb(error.__traceback__))
         })
 
-    def plugin_settings(self, plugin_name, plugin):
+    def load_plugin_settings(self, plugin):
 
-        plugin_name = plugin_name.lower()
+        plugin_name = plugin.internal_name.lower()
 
         if not plugin.settings:
             return


### PR DESCRIPTION
No breaking changes in this PR. It is a minor code cleanup only.

Code cleanups related to logical naming for plugin settings, metasettings and pluginsettings dialog only:

- Renamed: `plugin` -> `plugin_name` where it is a string of the plugin.internal_name and not the plugin object itself
- Renamed: `plugin_id` -> `plugin_name` everywhere
- Renamed: `plugin_name` -> `plugin_human_name` where the string is plugin.human_name and not plugin.internal_name
- Renamed: `name` -> `option_name` where the key is the name of an option and not either of the names of the plugin
- Renamed: `settings` -> `metasettings` where the object is a plugin's metasettings dict() and not a plugin's config settings
- Renamed: `plugin_settings` -> `plugin_settings_dialog` where the widget is a GtkDialog and not plugin.settings
- Renamed: `plugin_settings()` -> `load_plugin_settings()` as the callable is a method and not plugin.settings
- Renamed: `get_plugin_settings` -> `get_plugin_metasettings` as output is plugin.metasettings and not plugin.settings
- Renamed: `on_plugin_settings` -> `on_plugin_metasettings` as the input is plugin.metasettings and not plugin.settings
- Renamed: `on_plugin_settings` -> `on_plugin_settings_button` it is a GtkButton handler and not plugin.settings
- Renamed: `update_settings()` -> `load_options()` as values are read into UI widgets and not written out to the config file
- Renamed: `on_enable_plugin` -> `on_enable_plugin_toggle` is a GtkSwitch handler and not triggered by enable_plugins()

This PR doesn't address why changed plugin settings are not immediately written into the config file. There must be something which is the wrong way around or missing somewhere but I can't work out what it is because the misleading names in the code make it too difficult to follow at the moment. I hope this will help me to clarify things a bit.

After merging then I propose a new function `PluginHandler().save_plugin_settings()` and slight (non-breaking) refactoring of the plugin options loading and plugin settings saving mechanisms, with the aim of simplification, if possible.

No breaking changes in this PR. It is a minor code cleanup only.