### PR TITLE
cli.py: remove "log-message" event when stdout is gone

### DIFF
--- a/pynicotine/cli.py
+++ b/pynicotine/cli.py
@@ -16,7 +16,6 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import os
 import sys
 import time
 
@@ -150,7 +149,8 @@ class CLI:
 
         except OSError:
             # stdout is gone, prevent future errors
-            sys.stdout = open(os.devnull, "w", encoding="utf-8")  # pylint: disable=consider-using-with
+            events.disconnect("log-message", self._log_message)
+            self._log_message_queue.clear()
 
     def _cli_prompt_finished(self):
         while self._log_message_queue:


### PR DESCRIPTION
- Fixed: Sometimes the terminal console seems dead after the program terminates abnormally