### PR TITLE
transfers.py: Replace bare key shortcuts with more sensible ones

### DIFF
--- a/pynicotine/gtkgui/application.py
+++ b/pynicotine/gtkgui/application.py
@@ -260,8 +260,8 @@ class Application:
             ("accel.download-to", ["<Primary>Return"]),
             ("accel.file-properties", ["<Alt>Return"]),
             ("accel.back", ["BackSpace"]),
-            ("accel.retry-transfer", ["r"]),
-            ("accel.abort-transfer", ["t"])
+            ("accel.retry-transfer", ["<Primary>s"]),
+            ("accel.abort-transfer", ["<Primary>t"])
         ):
             self._set_accels_for_action(action_name, accelerators)
 

--- a/pynicotine/gtkgui/transfers.py
+++ b/pynicotine/gtkgui/transfers.py
@@ -220,8 +220,8 @@ class Transfers:
             }
         )
 
-        Accelerator("t", self.tree_view.widget, self.on_abort_transfers_accelerator)
-        Accelerator("r", self.tree_view.widget, self.on_retry_transfers_accelerator)
+        Accelerator("<Primary>t", self.tree_view.widget, self.on_abort_transfers_accelerator)
+        Accelerator("<Primary>s", self.tree_view.widget, self.on_retry_transfers_accelerator)
         Accelerator("<Alt>Return", self.tree_view.widget, self.on_file_properties_accelerator)
 
         menu = create_grouping_menu(


### PR DESCRIPTION
We currently have a R shortcut for resuming/retrying transfers, and T shortcut for pausing/aborting transfers. There are two issues with these shortcuts:

- They are bare keys, which conflict with 'type to search' in the transfer list.
- They are right next to each other, which is good for reachability, but makes it too easy to press the wrong key.

I've replaced the shortcuts with Ctrl+S (S as in start) for resuming/retrying transfers, and Ctrl+T (T as in terminate) for pausing/aborting transfers.

The goal is to use shortcuts that are easy to activate with a single hand, and fairly close to each other, but not close enough to cause confusion. We also want to avoid using shortcuts that are very common and have different meanings in other contexts. While Ctrl+S is commonly used for saving files, it seemed appropriate in this context (to resume a transfer to save it to disk).

<!--
   Before submitting a PR, please discuss changes you wish to make in an
   issue report or discussion thread (small bug fixes are an exception).
   Talking with the maintainers before writing a large amount of code saves
   everyone's time. Thank you!
-->
