### PR TITLE
logging: reduce UPnP success noise; add debug for folder browse

### DIFF
--- a/pynicotine/portmapper.py
+++ b/pynicotine/portmapper.py
@@ -649,8 +649,9 @@ class PortMapper:
                 self._is_mapping_port = False
                 return
 
-        log.add(_("%(protocol)s: External port %(external_port)s successfully forwarded to local "
-                  "IP address %(ip_address)s port %(local_port)s"), {
+        # Demote frequent success message to connection-level to reduce default log noise
+        log.add_conn(_("%(protocol)s: External port %(external_port)s successfully forwarded to local "
+                       "IP address %(ip_address)s port %(local_port)s"), {
             "protocol": self._active_implementation.NAME,
             "external_port": self._active_implementation.port,
             "ip_address": self._active_implementation.local_ip_address,

--- a/pynicotine/shares.py
+++ b/pynicotine/shares.py
@@ -1267,6 +1267,8 @@ class Shares:
         ip_address, _port = msg.addr
         username = msg.username
         folder_path = msg.dir
+        # Add a debug log for folder contents requests to observe browsing activity
+        log.add_debug("Folder contents requested by %s for %s", (username, folder_path))
         permission_level, _reject_reason = self.check_user_permission(username, ip_address)
         folder_data = None
 


### PR DESCRIPTION
Users reported apparent pause of "User is browsing your shared files" messages amid periodic UPnP renewals. Demote recurring UPnP success message to connection log to avoid drowning important entries. Also add a debug trace for folder contents requests to verify ongoing browse activity in long-running sessions.