### PR TITLE
shares.py: split virtual_folder_words before iterating file entries

### DIFF
--- a/pynicotine/shares.py
+++ b/pynicotine/shares.py
@@ -534,6 +534,7 @@ class Scanner:
 
             file_list = []
             virtual_folder_path_lower = virtual_folder_path.lower()
+            virtual_folder_words = virtual_folder_path_lower.translate(TRANSLATE_PUNCTUATION).split()
 
             try:
                 with os.scandir(encode_path(folder_path, prefix=False)) as entries:
@@ -566,7 +567,6 @@ class Scanner:
                                 continue
 
                             file_stat = entry.stat()
-                            file_index = self.current_file_index
                             self.mtimes[path] = file_mtime = file_stat.st_mtime
                             virtual_file_path = f"{virtual_folder_path}\\{basename_escaped}"
 
@@ -580,11 +580,16 @@ class Scanner:
                             basename_file_data[0] = basename_escaped
                             file_list.append(basename_file_data)
 
-                            for k in set(virtual_file_path.lower().translate(TRANSLATE_PUNCTUATION).split()):
+                            file_index = self.current_file_index
+                            basename_escaped_lower = basename_escaped.lower()
+
+                            for k in set(
+                                virtual_folder_words + basename_escaped_lower.translate(TRANSLATE_PUNCTUATION).split()
+                            ):
                                 self.word_index[k].append(file_index)
 
                             self.files[path] = full_path_file_data
-                            self.lowercase_paths[virtual_folder_path_lower][basename_escaped.lower()] = file_index
+                            self.lowercase_paths[virtual_folder_path_lower][basename_escaped_lower] = file_index
 
                             self.current_file_index += 1
 


### PR DESCRIPTION
Closes #3485 (hopefully; the affected user needs to test this)

+ Changed: Split the folder words only once for each folder rather than doing the whole path for each file entry.

The main benefit is eliminating the path separator from the translate operation (which seems to invoke some kind of unicode string formatting quirk in Python 3.12). There seems to be no measurable difference in speed.