### PR TITLE
Use os.fsencode() and os.fsdecode() for pathlike byte strings

### DIFF
--- a/pynicotine/shares.py
+++ b/pynicotine/shares.py
@@ -565,7 +565,7 @@ class Scanner:
             try:
                 with os.scandir(encode_path(folder_path, prefix=False)) as entries:
                     for entry in entries:
-                        basename = basename_escaped = entry.name.decode("utf-8", "replace")
+                        basename = basename_escaped = os.fsdecode(entry.name)
 
                         if "\\" in basename:
                             # Substitute backslashes with backslash sentinels in basenames. This is necessary

--- a/pynicotine/utils.py
+++ b/pynicotine/utils.py
@@ -185,7 +185,7 @@ def encode_path(path, prefix=True):
 
         path = LONG_PATH_PREFIX + path
 
-    return path.encode("utf-8")
+    return os.fsencode(path)
 
 
 def human_duration_approx(seconds):


### PR DESCRIPTION
Closes #3485 (possibly - testing todo)

- https://peps.python.org/pep-0519/ "Adding a file system path protocol" (Python-Version: 3.6)
_" If a str is desired and the encoding of bytes should be assumed to be the default file system encoding, then [os.fsdecode()](https://docs.python.org/3/library/os.html#os.fsdecode) should be used."_

- https://peps.python.org/pep-0529/ "Change Windows filesystem encoding to UTF-8" (Python-Version: 3.6)
_"On Windows bytes cannot round-trip all characters used in paths, as Python internally uses the *A functions and hence the encoding is “whatever the active code page is”. Since the active code page cannot represent all Unicode characters, the conversion of a path into bytes can lose information without warning or any available indication."_

- https://docs.python.org/3/library/sys.html#sys.getfilesystemencoding
_"[os.fsencode()](https://docs.python.org/3/library/os.html#os.fsencode) and [os.fsdecode()](https://docs.python.org/3/library/os.html#os.fsdecode) should be used to ensure that the correct encoding and errors mode are used."_