### PR TITLE
GUI: add missing mnemonics to action buttons

### DIFF
--- a/pynicotine/gtkgui/dialogs/pluginsettings.py
+++ b/pynicotine/gtkgui/dialogs/pluginsettings.py
@@ -223,15 +223,18 @@ class PluginSettings(Dialog):
         button_container = Gtk.Box(margin_end=6, margin_bottom=6, margin_start=6, margin_top=6,
                                    spacing=6, visible=True)
 
-        for icon_name, label_text, callback in (
-            ("list-add-symbolic", _("Add…"), self.on_add),
-            ("document-edit-symbolic", _("Edit…"), self.on_edit),
-            ("list-remove-symbolic", _("Remove"), self.on_remove)
+        for icon_name, label_text, tooltip_text, callback in (
+            ("list-add-symbolic", _("_Add…"), _("_Add…"), self.on_add),
+            ("document-edit-symbolic", _("_Edit…"), _("Edit…"), self.on_edit),
+            ("list-remove-symbolic", _("Remove"), _("Remove"), self.on_remove)
         ):
             button = Gtk.Button(visible=True)
             label_container = Gtk.Box(spacing=6, visible=True)
             icon = Gtk.Image(icon_name=icon_name, visible=True)
-            label = Gtk.Label(label=label_text, mnemonic_widget=button, visible=True)
+            label = Gtk.Label(
+                label=label_text, mnemonic_widget=button, tooltip_text=tooltip_text,
+                use_underline=True, visible=True
+            )
 
             button.connect("clicked", callback, treeview)
             add_css_class(button, "flat")

--- a/pynicotine/gtkgui/ui/dialogs/download.ui
+++ b/pynicotine/gtkgui/ui/dialogs/download.ui
@@ -177,8 +177,9 @@
                         <child>
                           <object class="GtkLabel">
                             <property name="ellipsize">end</property>
-                            <property name="label" translatable="yes">Rename…</property>
+                            <property name="label" translatable="yes">_Rename…</property>
                             <property name="mnemonic-widget">rename_button</property>
+                            <property name="use-underline">True</property>
                             <property name="visible">True</property>
                           </object>
                         </child>
@@ -213,8 +214,9 @@
                             <child>
                               <object class="GtkLabel">
                                 <property name="ellipsize">end</property>
-                                <property name="label" translatable="yes">Select All</property>
+                                <property name="label" translatable="yes">Select _All</property>
                                 <property name="mnemonic-widget">_select_all_button</property>
+                                <property name="use-underline">True</property>
                                 <property name="visible">True</property>
                               </object>
                             </child>
@@ -243,8 +245,9 @@
                             <child>
                               <object class="GtkLabel">
                                 <property name="ellipsize">end</property>
-                                <property name="label" translatable="yes">Deselect All</property>
+                                <property name="label" translatable="yes">Deselect _All</property>
                                 <property name="mnemonic-widget">unselect_all_button</property>
+                                <property name="use-underline">True</property>
                                 <property name="visible">True</property>
                               </object>
                             </child>
@@ -273,8 +276,9 @@
                             <child>
                               <object class="GtkLabel">
                                 <property name="ellipsize">end</property>
-                                <property name="label" translatable="yes">Select Initial</property>
+                                <property name="label" translatable="yes">Select _Initial</property>
                                 <property name="mnemonic-widget">select_initial_button</property>
+                                <property name="use-underline">True</property>
                                 <property name="visible">True</property>
                               </object>
                             </child>

--- a/pynicotine/gtkgui/ui/dialogs/fastconfigure.ui
+++ b/pynicotine/gtkgui/ui/dialogs/fastconfigure.ui
@@ -468,7 +468,7 @@
                                 <child>
                                   <object class="GtkLabel">
                                     <property name="ellipsize">end</property>
-                                    <property name="label" translatable="yes">Add…</property>
+                                    <property name="label" translatable="yes">_Add…</property>
                                     <property name="mnemonic-widget">_add_shared_folder_button</property>
                                     <property name="use-underline">True</property>
                                     <property name="visible">True</property>
@@ -499,7 +499,7 @@
                                 <child>
                                   <object class="GtkLabel">
                                     <property name="ellipsize">end</property>
-                                    <property name="label" translatable="yes">Edit…</property>
+                                    <property name="label" translatable="yes">_Edit…</property>
                                     <property name="mnemonic-widget">_edit_shared_folder_button</property>
                                     <property name="use-underline">True</property>
                                     <property name="visible">True</property>
@@ -532,7 +532,6 @@
                                     <property name="ellipsize">end</property>
                                     <property name="label" translatable="yes">Remove</property>
                                     <property name="mnemonic-widget">_remove_shared_folder_button</property>
-                                    <property name="use-underline">True</property>
                                     <property name="visible">True</property>
                                   </object>
                                 </child>

--- a/pynicotine/gtkgui/ui/dialogs/preferences.ui
+++ b/pynicotine/gtkgui/ui/dialogs/preferences.ui
@@ -12,13 +12,13 @@
     <signal name="clicked" handler="on_cancel"/>
   </object>
   <object class="GtkButton" id="export_button">
-    <property name="label" translatable="yes">_Export…</property>
+    <property name="label" translatable="yes">E_xport…</property>
     <property name="use-underline">True</property>
     <property name="visible">True</property>
     <signal name="clicked" handler="on_back_up_config"/>
   </object>
   <object class="GtkButton" id="apply_button">
-    <property name="label" translatable="yes">_Apply</property>
+    <property name="label" translatable="yes">A_pply</property>
     <property name="use-underline">True</property>
     <property name="visible">True</property>
     <signal name="clicked" handler="on_apply"/>

--- a/pynicotine/gtkgui/ui/dialogs/wishlist.ui
+++ b/pynicotine/gtkgui/ui/dialogs/wishlist.ui
@@ -80,8 +80,9 @@
                         <child>
                           <object class="GtkLabel">
                             <property name="ellipsize">end</property>
-                            <property name="label" translatable="yes">Edit…</property>
+                            <property name="label" translatable="yes">_Edit…</property>
                             <property name="mnemonic-widget">_edit_button</property>
+                            <property name="use-underline">True</property>
                             <property name="visible">True</property>
                           </object>
                         </child>

--- a/pynicotine/gtkgui/ui/downloads.ui
+++ b/pynicotine/gtkgui/ui/downloads.ui
@@ -42,7 +42,7 @@
             <property name="visible">True</property>
             <child>
               <object class="GtkButton" id="_resume_button">
-                <property name="tooltip-text" bind-source="_resume_label" bind-property="label" bind-flags="bidirectional|sync-create"/>
+                <property name="tooltip-text" translatable="yes">Resume</property>
                 <property name="visible">True</property>
                 <signal name="clicked" handler="on_retry_transfer"/>
                 <child>
@@ -58,8 +58,9 @@
                     <child>
                       <object class="GtkLabel" id="_resume_label">
                         <property name="ellipsize">end</property>
-                        <property name="label" translatable="yes">Resume</property>
+                        <property name="label" translatable="yes">Re_sume</property>
                         <property name="mnemonic-widget">_resume_button</property>
+                        <property name="use-underline">True</property>
                         <property name="visible">True</property>
                       </object>
                     </child>
@@ -72,7 +73,7 @@
             </child>
             <child>
               <object class="GtkButton" id="_pause_button">
-                <property name="tooltip-text" bind-source="_pause_label" bind-property="label" bind-flags="bidirectional|sync-create"/>
+                <property name="tooltip-text" translatable="yes">Pause</property>
                 <property name="visible">True</property>
                 <signal name="clicked" handler="on_abort_transfer"/>
                 <child>
@@ -88,8 +89,9 @@
                     <child>
                       <object class="GtkLabel" id="_pause_label">
                         <property name="ellipsize">end</property>
-                        <property name="label" translatable="yes">Pause</property>
+                        <property name="label" translatable="yes">_Pause</property>
                         <property name="mnemonic-widget">_pause_button</property>
+                        <property name="use-underline">True</property>
                         <property name="visible">True</property>
                       </object>
                     </child>
@@ -102,7 +104,7 @@
             </child>
             <child>
               <object class="GtkButton" id="_remove_button">
-                <property name="tooltip-text" bind-source="_remove_label" bind-property="label" bind-flags="bidirectional|sync-create"/>
+                <property name="tooltip-text" translatable="yes">Remove</property>
                 <property name="visible">True</property>
                 <signal name="clicked" handler="on_remove_transfer"/>
                 <child>

--- a/pynicotine/gtkgui/ui/settings/ban.ui
+++ b/pynicotine/gtkgui/ui/settings/ban.ui
@@ -181,7 +181,7 @@
                                     <child>
                                       <object class="GtkLabel">
                                         <property name="ellipsize">end</property>
-                                        <property name="label" translatable="yes">Add…</property>
+                                        <property name="label" translatable="yes">_Add…</property>
                                         <property name="mnemonic-widget">_add_banned_user_button</property>
                                         <property name="use-underline">True</property>
                                         <property name="visible">True</property>
@@ -214,7 +214,6 @@
                                         <property name="ellipsize">end</property>
                                         <property name="label" translatable="yes">Remove</property>
                                         <property name="mnemonic-widget">_remove_banned_user_button</property>
-                                        <property name="use-underline">True</property>
                                         <property name="visible">True</property>
                                       </object>
                                     </child>
@@ -303,7 +302,7 @@
                                     <child>
                                       <object class="GtkLabel">
                                         <property name="ellipsize">end</property>
-                                        <property name="label" translatable="yes">Add…</property>
+                                        <property name="label" translatable="yes">_Add…</property>
                                         <property name="mnemonic-widget">_add_banned_ip_button</property>
                                         <property name="use-underline">True</property>
                                         <property name="visible">True</property>
@@ -336,7 +335,6 @@
                                         <property name="ellipsize">end</property>
                                         <property name="label" translatable="yes">Remove</property>
                                         <property name="mnemonic-widget">_remove_banned_ip_button</property>
-                                        <property name="use-underline">True</property>
                                         <property name="visible">True</property>
                                       </object>
                                     </child>

--- a/pynicotine/gtkgui/ui/settings/chats.ui
+++ b/pynicotine/gtkgui/ui/settings/chats.ui
@@ -97,7 +97,7 @@
                         <child>
                           <object class="GtkLabel">
                             <property name="ellipsize">end</property>
-                            <property name="label" translatable="yes">Add…</property>
+                            <property name="label" translatable="yes">_Add…</property>
                             <property name="mnemonic-widget">_add_replacement_button</property>
                             <property name="use-underline">True</property>
                             <property name="visible">True</property>
@@ -128,7 +128,7 @@
                         <child>
                           <object class="GtkLabel">
                             <property name="ellipsize">end</property>
-                            <property name="label" translatable="yes">Edit…</property>
+                            <property name="label" translatable="yes">_Edit…</property>
                             <property name="mnemonic-widget">_edit_replacement_button</property>
                             <property name="use-underline">True</property>
                             <property name="visible">True</property>
@@ -161,7 +161,6 @@
                             <property name="ellipsize">end</property>
                             <property name="label" translatable="yes">Remove</property>
                             <property name="mnemonic-widget">_remove_replacement_button</property>
-                            <property name="use-underline">True</property>
                             <property name="visible">True</property>
                           </object>
                         </child>
@@ -253,7 +252,7 @@
                         <child>
                           <object class="GtkLabel">
                             <property name="ellipsize">end</property>
-                            <property name="label" translatable="yes">Add…</property>
+                            <property name="label" translatable="yes">_Add…</property>
                             <property name="mnemonic-widget">_add_censored_button</property>
                             <property name="use-underline">True</property>
                             <property name="visible">True</property>
@@ -268,7 +267,7 @@
                 </child>
                 <child>
                   <object class="GtkButton" id="_edit_censored_button">
-                    <property name="tooltip-text" translatable="yes">Edit…</property>
+                    <property name="tooltip-text" translatable="yes">_Edit…</property>
                     <property name="visible">True</property>
                     <signal name="clicked" handler="on_edit_censored"/>
                     <child>
@@ -317,7 +316,6 @@
                             <property name="ellipsize">end</property>
                             <property name="label" translatable="yes">Remove</property>
                             <property name="mnemonic-widget">_remove_censored_button</property>
-                            <property name="use-underline">True</property>
                             <property name="visible">True</property>
                           </object>
                         </child>
@@ -365,9 +363,8 @@
               <object class="GtkLabel">
                 <property name="height-request">24</property>
                 <property name="hexpand">True</property>
-                <property name="label" translatable="yes">_Accept private room invitations</property>
+                <property name="label" translatable="yes">Accept private room invitations</property>
                 <property name="mnemonic-widget">private_room_toggle</property>
-                <property name="use-underline">True</property>
                 <property name="visible">True</property>
                 <property name="wrap">True</property>
                 <property name="wrap-mode">word-char</property>

--- a/pynicotine/gtkgui/ui/settings/downloads.ui
+++ b/pynicotine/gtkgui/ui/settings/downloads.ui
@@ -450,7 +450,7 @@
                     <property name="visible">True</property>
                     <child>
                       <object class="GtkButton" id="_add_filter_button">
-                        <property name="tooltip-text" translatable="yes">Add</property>
+                        <property name="tooltip-text" translatable="yes">Add…</property>
                         <property name="visible">True</property>
                         <signal name="clicked" handler="on_add_filter"/>
                         <child>
@@ -466,7 +466,7 @@
                             <child>
                               <object class="GtkLabel">
                                 <property name="ellipsize">end</property>
-                                <property name="label" translatable="yes">Add…</property>
+                                <property name="label" translatable="yes">_Add…</property>
                                 <property name="mnemonic-widget">_add_filter_button</property>
                                 <property name="use-underline">True</property>
                                 <property name="visible">True</property>
@@ -497,7 +497,7 @@
                             <child>
                               <object class="GtkLabel">
                                 <property name="ellipsize">end</property>
-                                <property name="label" translatable="yes">Edit…</property>
+                                <property name="label" translatable="yes">_Edit…</property>
                                 <property name="mnemonic-widget">_edit_filter_button</property>
                                 <property name="use-underline">True</property>
                                 <property name="visible">True</property>
@@ -530,7 +530,6 @@
                                 <property name="ellipsize">end</property>
                                 <property name="label" translatable="yes">Remove</property>
                                 <property name="mnemonic-widget">_remove_filter_button</property>
-                                <property name="use-underline">True</property>
                                 <property name="visible">True</property>
                               </object>
                             </child>
@@ -607,7 +606,7 @@
                     </child>
                     <child>
                       <object class="GtkLabel">
-                        <property name="label" translatable="yes">Verify Filters</property>
+                        <property name="label" translatable="yes">_Verify Filters</property>
                         <property name="mnemonic-widget">_verify_filters_button</property>
                         <property name="use-underline">True</property>
                         <property name="visible">True</property>

--- a/pynicotine/gtkgui/ui/settings/ignore.ui
+++ b/pynicotine/gtkgui/ui/settings/ignore.ui
@@ -115,7 +115,7 @@
                                     <child>
                                       <object class="GtkLabel">
                                         <property name="ellipsize">end</property>
-                                        <property name="label" translatable="yes">Add…</property>
+                                        <property name="label" translatable="yes">_Add…</property>
                                         <property name="mnemonic-widget">_add_ignored_user_button</property>
                                         <property name="use-underline">True</property>
                                         <property name="visible">True</property>
@@ -148,7 +148,6 @@
                                         <property name="ellipsize">end</property>
                                         <property name="label" translatable="yes">Remove</property>
                                         <property name="mnemonic-widget">_remove_ignored_user_button</property>
-                                        <property name="use-underline">True</property>
                                         <property name="visible">True</property>
                                       </object>
                                     </child>
@@ -236,7 +235,7 @@
                                     <child>
                                       <object class="GtkLabel">
                                         <property name="ellipsize">end</property>
-                                        <property name="label" translatable="yes">Add…</property>
+                                        <property name="label" translatable="yes">_Add…</property>
                                         <property name="mnemonic-widget">_add_ignored_ip_button</property>
                                         <property name="use-underline">True</property>
                                         <property name="visible">True</property>
@@ -269,7 +268,6 @@
                                         <property name="ellipsize">end</property>
                                         <property name="label" translatable="yes">Remove</property>
                                         <property name="mnemonic-widget">_remove_ignored_ip_button</property>
-                                        <property name="use-underline">True</property>
                                         <property name="visible">True</property>
                                       </object>
                                     </child>

--- a/pynicotine/gtkgui/ui/settings/network.ui
+++ b/pynicotine/gtkgui/ui/settings/network.ui
@@ -98,8 +98,9 @@
                         <child>
                           <object class="GtkLabel">
                             <property name="ellipsize">end</property>
-                            <property name="label" translatable="yes">Change Password</property>
+                            <property name="label" translatable="yes">Change Pass_word</property>
                             <property name="mnemonic-widget">_change_password_button</property>
+                            <property name="use-underline">True</property>
                             <property name="visible">True</property>
                           </object>
                         </child>
@@ -207,8 +208,9 @@
                         <child>
                           <object class="GtkLabel" id="check_port_status_label">
                             <property name="ellipsize">end</property>
-                            <property name="label" translatable="yes">Port Check</property>
+                            <property name="label" translatable="yes">_Port Check</property>
                             <property name="mnemonic-widget">check_port_status_button</property>
+                            <property name="use-underline">True</property>
                             <property name="visible">True</property>
                           </object>
                         </child>

--- a/pynicotine/gtkgui/ui/settings/nowplaying.ui
+++ b/pynicotine/gtkgui/ui/settings/nowplaying.ui
@@ -164,8 +164,9 @@
                     </child>
                     <child>
                       <object class="GtkLabel">
-                        <property name="label" translatable="yes">Test Configuration</property>
+                        <property name="label" translatable="yes">_Test Configuration</property>
                         <property name="mnemonic-widget">test_configuration_button</property>
+                        <property name="use-underline">True</property>
                         <property name="visible">True</property>
                       </object>
                     </child>

--- a/pynicotine/gtkgui/ui/settings/shares.ui
+++ b/pynicotine/gtkgui/ui/settings/shares.ui
@@ -152,7 +152,7 @@
                         <child>
                           <object class="GtkLabel">
                             <property name="ellipsize">end</property>
-                            <property name="label" translatable="yes">Add…</property>
+                            <property name="label" translatable="yes">_Add…</property>
                             <property name="mnemonic-widget">_add_shared_folder_button</property>
                             <property name="use-underline">True</property>
                             <property name="visible">True</property>
@@ -183,7 +183,7 @@
                         <child>
                           <object class="GtkLabel">
                             <property name="ellipsize">end</property>
-                            <property name="label" translatable="yes">Edit…</property>
+                            <property name="label" translatable="yes">_Edit…</property>
                             <property name="mnemonic-widget">_edit_shared_folder_button</property>
                             <property name="use-underline">True</property>
                             <property name="visible">True</property>
@@ -216,7 +216,6 @@
                             <property name="ellipsize">end</property>
                             <property name="label" translatable="yes">Remove</property>
                             <property name="mnemonic-widget">_remove_shared_folder_button</property>
-                            <property name="use-underline">True</property>
                             <property name="visible">True</property>
                           </object>
                         </child>
@@ -251,7 +250,7 @@
                             <child>
                               <object class="GtkLabel">
                                 <property name="ellipsize">end</property>
-                                <property name="label" translatable="yes">File Manager</property>
+                                <property name="label" translatable="yes">File _Manager</property>
                                 <property name="mnemonic-widget">file_manager_button</property>
                                 <property name="use-underline">True</property>
                                 <property name="visible">True</property>

--- a/pynicotine/gtkgui/ui/settings/urlhandlers.ui
+++ b/pynicotine/gtkgui/ui/settings/urlhandlers.ui
@@ -94,7 +94,7 @@
                         <child>
                           <object class="GtkLabel">
                             <property name="ellipsize">end</property>
-                            <property name="label" translatable="yes">Add…</property>
+                            <property name="label" translatable="yes">_Add…</property>
                             <property name="mnemonic-widget">_add_handler_button</property>
                             <property name="use-underline">True</property>
                             <property name="visible">True</property>
@@ -125,7 +125,7 @@
                         <child>
                           <object class="GtkLabel">
                             <property name="ellipsize">end</property>
-                            <property name="label" translatable="yes">Edit…</property>
+                            <property name="label" translatable="yes">_Edit…</property>
                             <property name="mnemonic-widget">_edit_handler_button</property>
                             <property name="use-underline">True</property>
                             <property name="visible">True</property>
@@ -158,7 +158,6 @@
                             <property name="ellipsize">end</property>
                             <property name="label" translatable="yes">Remove</property>
                             <property name="mnemonic-widget">_remove_handler_button</property>
-                            <property name="use-underline">True</property>
                             <property name="visible">True</property>
                           </object>
                         </child>

--- a/pynicotine/gtkgui/ui/uploads.ui
+++ b/pynicotine/gtkgui/ui/uploads.ui
@@ -42,7 +42,7 @@
             <property name="visible">True</property>
             <child>
               <object class="GtkButton" id="_abort_button">
-                <property name="tooltip-text" bind-source="_abort_label" bind-property="label" bind-flags="bidirectional|sync-create"/>
+                <property name="tooltip-text" translatable="yes">Abort</property>
                 <property name="visible">True</property>
                 <signal name="clicked" handler="on_abort_transfer"/>
                 <child>
@@ -56,10 +56,11 @@
                       </object>
                     </child>
                     <child>
-                      <object class="GtkLabel" id="_abort_label">
+                      <object class="GtkLabel">
                         <property name="ellipsize">end</property>
-                        <property name="label" translatable="yes">Abort</property>
+                        <property name="label" translatable="yes">Abor_t</property>
                         <property name="mnemonic-widget">_abort_button</property>
+                        <property name="use-underline">True</property>
                         <property name="visible">True</property>
                       </object>
                     </child>
@@ -72,7 +73,7 @@
             </child>
             <child>
               <object class="GtkButton" id="_abort_users_button">
-                <property name="tooltip-text" bind-source="_abort_users_label" bind-property="label" bind-flags="bidirectional|sync-create"/>
+                <property name="tooltip-text" translatable="yes">Abort Users</property>
                 <property name="visible">True</property>
                 <signal name="clicked" handler="on_abort_users"/>
                 <child>
@@ -86,10 +87,11 @@
                       </object>
                     </child>
                     <child>
-                      <object class="GtkLabel" id="_abort_users_label">
+                      <object class="GtkLabel">
                         <property name="ellipsize">end</property>
-                        <property name="label" translatable="yes">Abort User(s)</property>
+                        <property name="label" translatable="yes">Abort _Users</property>
                         <property name="mnemonic-widget">_abort_users_button</property>
+                        <property name="use-underline">True</property>
                         <property name="visible">True</property>
                       </object>
                     </child>
@@ -126,8 +128,9 @@
                     <child>
                       <object class="GtkLabel">
                         <property name="ellipsize">end</property>
-                        <property name="label" translatable="yes">Message All</property>
+                        <property name="label" translatable="yes">_Message All</property>
                         <property name="mnemonic-widget">_message_all_button</property>
+                        <property name="use-underline">True</property>
                         <property name="visible">True</property>
                       </object>
                     </child>


### PR DESCRIPTION
Provide quick access to these buttons with the Alt key. Exclude remove/clear buttons, since they would be too easy to activate by mistake.
