### PR TITLE
privatechat.py: stricter check for redirecting server room messages

### DIFF
--- a/pynicotine/privatechat.py
+++ b/pynicotine/privatechat.py
@@ -211,15 +211,13 @@ class PrivateChat:
 
             if username == self.SERVER_USERNAME:
                 # Redirect the following messages to chat room tab:
-                # - The room you are trying to enter (name) is registered as private.
-                # - Room (name) is registered as public.
-                for start_str in (
-                    "The room you are trying to enter (",
-                    "Room ("
+                for start_str, end_str in (
+                    ("The room you are trying to enter (", ") is registered as private."),
+                    ("Room (", ") is registered as public.")
                 ):
-                    if message.startswith(start_str) and ") " in message:
+                    if message.startswith(start_str) and message.endswith(end_str):
                         msg.user = None
-                        room = message[len(start_str):message.rfind(") ")]
+                        room = message[len(start_str):message.rfind(end_str)]
                         events.emit("say-chat-room", SayChatroom(room=room, message=message, user=username))
                         return
             else:


### PR DESCRIPTION
+ Fixed: A room containing a closed-bracket "`) `" character could be misidentified so the chat message from the server is lost.