### PR TITLE
fastconfigure.py: set rescan_required flag after rescan

### DIFF
--- a/pynicotine/gtkgui/dialogs/fastconfigure.py
+++ b/pynicotine/gtkgui/dialogs/fastconfigure.py
@@ -8,6 +8,7 @@ from gi.repository import Gtk
 import pynicotine
 from pynicotine.config import config
 from pynicotine.core import core
+from pynicotine.events import events
 from pynicotine.gtkgui.application import GTK_API_VERSION
 from pynicotine.gtkgui.widgets import ui
 from pynicotine.gtkgui.widgets.filechooser import FileChooserButton
@@ -107,6 +108,8 @@ class FastConfigure(Dialog):
         )
 
         self.reset_completeness()
+
+        events.connect("shares-ready", self._shares_ready)
 
     def destroy(self):
 
@@ -287,7 +290,9 @@ class FastConfigure(Dialog):
 
     def on_close(self, *_args):
         self.invalid_password = False
-        self.rescan_required = False
+
+    def _shares_ready(self, successful):
+        self.rescan_required = (not successful)
 
     def on_show(self, *_args):
 


### PR DESCRIPTION
+ **Fixed**: Shares added/edited using the Setup Assistant didn't scan if the dialog was dismissed and reopened at a later time or if the the assistant was Finished but a Shares Not Available error was encountered and the setup assistant was reattempted.
+ **Added**: Rescan shares if required after finishing Setup Assistant for any reason unrelated to changes made using the dialog.

After encountering a disk mount error it seems natural to try running the Setup Assistant again, and it's very likely that the dialog shall get dismissed in such a scenario if other applications need to be launched in order to resolve some kind of system configuration issue during initial setup, then the expectation is that the dialog realizes whenever a rescan is still required.