### PR TITLE
search.py: indicate which results were downloaded

### DIFF
--- a/pynicotine/gtkgui/dialogs/download.py
+++ b/pynicotine/gtkgui/dialogs/download.py
@@ -28,7 +28,7 @@ from pynicotine.utils import humanize
 
 class Download(Dialog):
 
-    def __init__(self, application):
+    def __init__(self, application, download_callback=None):
 
         (
             self.cancel_button,
@@ -63,6 +63,7 @@ class Download(Dialog):
         application.add_window(self.widget)
 
         self.application = application
+        self.download_callback = download_callback
         self.file_properties = None
         self.parent_iterators = {}
         self.initial_selected_iterators = set()
@@ -346,6 +347,9 @@ class Download(Dialog):
                 username, file_path, folder_path=destination_folder_path, size=size,
                 file_attributes=file_attributes, paused=paused
             )
+
+        if self.download_callback is not None:
+            self.download_callback(files)
 
         self.application.previous_download_folder = self.download_folder_button.get_path(dynamic=False)
         self.close()

--- a/pynicotine/gtkgui/widgets/theme.py
+++ b/pynicotine/gtkgui/widgets/theme.py
@@ -247,6 +247,10 @@ else:
     ICON_THEME = Gtk.IconTheme.get_default()  # pylint: disable=no-member
 
 CUSTOM_ICON_THEME_NAME = ".nicotine-icon-theme"
+FILE_STATUS_ICON_LABELS = {
+    "changes-prevent-symbolic": _("Private"),
+    "folder-download-symbolic": _("Downloading")
+}
 FILE_TYPE_ICON_LABELS = {
     "application-x-executable-symbolic": _("Executable"),
     "folder-music-symbolic": _("Audio"),
@@ -256,9 +260,6 @@ FILE_TYPE_ICON_LABELS = {
     "folder-videos-symbolic": _("Video"),
     "x-office-document-symbolic": _("Document"),
     "emblem-documents-symbolic": _("Text")
-}
-PRIVATE_ICON_LABELS = {
-    "changes-prevent-symbolic": _("Private")
 }
 SHARED_FOLDER_ICON_LABELS = {
     "dialog-warning-symbolic": _("Unreadable Folder")

--- a/pynicotine/gtkgui/widgets/treeview.py
+++ b/pynicotine/gtkgui/widgets/treeview.py
@@ -21,8 +21,8 @@ from pynicotine.gtkgui.application import GTK_API_VERSION
 from pynicotine.gtkgui.widgets import clipboard
 from pynicotine.gtkgui.widgets.accelerator import Accelerator
 from pynicotine.gtkgui.widgets.popupmenu import PopupMenu
+from pynicotine.gtkgui.widgets.theme import FILE_STATUS_ICON_LABELS
 from pynicotine.gtkgui.widgets.theme import FILE_TYPE_ICON_LABELS
-from pynicotine.gtkgui.widgets.theme import PRIVATE_ICON_LABELS
 from pynicotine.gtkgui.widgets.theme import SHARED_FOLDER_ICON_LABELS
 from pynicotine.gtkgui.widgets.theme import USER_STATUS_ICON_LABELS
 from pynicotine.gtkgui.widgets.theme import add_css_class
@@ -705,11 +705,11 @@ class TreeView:
         if column.id == "status":
             return USER_STATUS_ICON_LABELS[icon_name]
 
-        if column.id == "private":
-            return PRIVATE_ICON_LABELS.get(icon_name, "")
-
         if column.id == "file_type":
             return FILE_TYPE_ICON_LABELS[icon_name]
+
+        if column.id in {"downloading", "private"}:
+            return FILE_STATUS_ICON_LABELS.get(icon_name, "")
 
         if column.id == "readable":
             return SHARED_FOLDER_ICON_LABELS.get(icon_name, "")


### PR DESCRIPTION
Adds an icon column that indicates if a search result was downloaded. It doesn't track downloads started outside of the search tab, but it's a start.

Closes #3498 