### PR TITLE
Strip newline characters from outgoing chat messages

### DIFF
--- a/pynicotine/chatrooms.py
+++ b/pynicotine/chatrooms.py
@@ -208,6 +208,9 @@ class ChatRooms:
             for word, replacement in config.sections["words"]["autoreplaced"].items():
                 message = message.replace(str(word), str(replacement))
 
+        # Server rejects messages containing newlines, filter them
+        message = message.replace("\r", "").replace("\n", " ")
+
         core.send_message_to_server(SayChatroom(room, message))
         core.pluginhandler.outgoing_public_chat_notification(room, message)
 

--- a/pynicotine/privatechat.py
+++ b/pynicotine/privatechat.py
@@ -129,6 +129,9 @@ class PrivateChat:
             for word, replacement in config.sections["words"]["autoreplaced"].items():
                 message = message.replace(str(word), str(replacement))
 
+        # Server rejects messages containing newlines, filter them
+        message = message.replace("\r", "").replace("\n", " ")
+
         core.send_message_to_server(MessageUser(username, message))
         core.pluginhandler.outgoing_private_chat_notification(username, message)
 


### PR DESCRIPTION
Otherwise the server will reject them, leaving the user wondering why their message didn't go through. Strip the characters after plugins have processed the message, in order to keep plugins like Multi Paste working.