### PR TITLE
Redesign account management in Preferences dialog

### DIFF
--- a/pynicotine/gtkgui/application.py
+++ b/pynicotine/gtkgui/application.py
@@ -648,12 +648,19 @@ class Application:
             from pynicotine.gtkgui.dialogs.fastconfigure import FastConfigure
             self.fast_configure = FastConfigure(self)
 
-        if (invalid_password or invalid_username) and self.fast_configure.is_visible():
+        change_account = invalid_password or invalid_username
+        preferences_visible = self.preferences is not None and self.preferences.is_visible()
+
+        if change_account and self.fast_configure.is_visible():
             self.fast_configure.hide()
+
+        if not change_account and preferences_visible:
+            return
 
         self.fast_configure.invalid_password = invalid_password
         self.fast_configure.invalid_username = invalid_username
 
+        self.fast_configure.set_parent(self.preferences if preferences_visible else self.window)
         self.fast_configure.present()
 
     def on_keyboard_shortcuts(self, *_args):

--- a/pynicotine/gtkgui/dialogs/preferences.py
+++ b/pynicotine/gtkgui/dialogs/preferences.py
@@ -73,18 +73,17 @@ class NetworkPage:
             self.current_port_label,
             self.listen_port_spinner,
             self.network_interface_label,
+            self.password_row_revealer,
             self.soulseek_server_entry,
             self.upnp_toggle,
-            self.username_entry
+            self.username_label
         ) = self.widgets = ui.load(scope=self, path="settings/network.ui")
 
         self.application = application
 
-        self.username_entry.set_max_length(core.users.USERNAME_MAX_LENGTH)
-
         for event_name, callback in (
-            ("server-disconnect", self.update_port),
-            ("server-login", self.update_port)
+            ("server-disconnect", self.server_disconnect),
+            ("server-login", self.server_login)
         ):
             events.connect(event_name, callback)
 
@@ -103,7 +102,6 @@ class NetworkPage:
         self.options = {
             "server": {
                 "server": None,  # Special case in set_settings
-                "login": self.username_entry,
                 "portrange": None,  # Special case in set_settings
                 "autoaway": self.auto_away_spinner,
                 "autoreply": self.auto_reply_message_entry,
@@ -131,6 +129,19 @@ class NetworkPage:
 
         self.port_checker.port = core.users.public_port
 
+    def server_login(self, *_args):
+        self.password_row_revealer.set_reveal_child(True)
+        self.update_port()
+
+    def server_disconnect(self, *_args):
+
+        for dialog in self.application.preferences.active_dialogs:
+            if isinstance(dialog, MessageDialog) and dialog.callback is self.on_change_password_response:
+                dialog.close()
+
+        self.password_row_revealer.set_reveal_child(False)
+        self.update_port()
+
     def set_settings(self):
 
         # Network interfaces
@@ -150,6 +161,10 @@ class NetworkPage:
         self.update_port()
 
         # Special options
+        username = core.users.login_username or config.sections["server"]["login"]
+        self.username_label.set_markup(f"<b>{username}</b>" if username else _("No account added"))
+        self.password_row_revealer.set_reveal_child(core.users.login_status != UserStatus.OFFLINE)
+
         server_hostname, server_port = config.sections["server"]["server"]
         self.soulseek_server_entry.set_text(f"{server_hostname}:{server_port}")
 
@@ -170,7 +185,6 @@ class NetworkPage:
         return {
             "server": {
                 "server": server_addr,
-                "login": self.username_entry.get_text(),
                 "portrange": (listen_port, listen_port),
                 "autoaway": self.auto_away_spinner.get_value_as_int(),
                 "autoreply": self.auto_reply_message_entry.get_text(),
@@ -184,38 +198,67 @@ class NetworkPage:
         open_uri(url)
         return True
 
-    def on_change_password_response(self, dialog, _response_id, user_status):
+    def on_log_in_as_response(self, dialog, _response_id, _data):
+
+        username = dialog.get_entry_value().strip()
+        password = dialog.get_second_entry_value()
+
+        if username and not password:
+            self.on_log_in_as(
+                username=username,
+                error=_("Please enter a password, or leave the username empty to log out.")
+            )
+            return
+
+        self.username_label.set_markup(f"<b>{username}</b>" if username else _("No account added"))
+        core.users.log_in_as(username, password)
+
+    def on_log_in_as(self, *_args, username=None, error=None):
+
+        message = ""
+
+        if error:
+            message += error + "\n\n"
+
+        message += _("Enter a username and password to log in as. If the user does not exist,"
+                     " a new account will be registered.")
+
+        if not username:
+            username = core.users.login_username or config.sections["server"]["login"]
+
+        EntryDialog(
+            parent=self.application.preferences,
+            title=_("Log In As"),
+            message=message,
+            default=username,
+            use_second_entry=True,
+            second_max_length=core.users.USERNAME_MAX_LENGTH,
+            second_visibility=False,
+            action_button_label=_("_Log In"),
+            callback=self.on_log_in_as_response
+        ).present()
+
+    def on_change_password_response(self, dialog, _response_id, _data):
 
         password = dialog.get_entry_value()
 
-        if user_status != core.users.login_status:
-            MessageDialog(
-                parent=self.application.preferences,
-                title=_("Password Change Rejected"),
-                message=("Since your login status changed, your password has not been changed. Please try again.")
-            ).present()
-            return
-
         if not password:
-            self.on_change_password()
-            return
-
-        if core.users.login_status == UserStatus.OFFLINE:
-            config.sections["server"]["passw"] = password
-            config.write_configuration()
+            self.on_change_password(error=_("Please enter a password."))
             return
 
         core.users.request_change_password(password)
 
-    def on_change_password(self, *_args):
+    def on_change_password(self, *_args, error=None):
 
-        if core.users.login_status != UserStatus.OFFLINE:
-            message = _("Enter a new password for your Soulseek account:")
-        else:
-            message = (_("You are currently logged out of the Soulseek network. If you want to change "
-                         "the password of an existing Soulseek account, you need to be logged into that account.")
-                       + "\n\n"
-                       + _("Enter password to use when logging in:"))
+        if core.users.login_status == UserStatus.OFFLINE:
+            return
+
+        message = ""
+
+        if error is not None:
+            message += error + "\n\n"
+
+        message += _("Enter a new password for your account %s:") % core.users.login_username
 
         EntryDialog(
             parent=self.application.preferences,
@@ -223,8 +266,7 @@ class NetworkPage:
             message=message,
             visibility=False,
             action_button_label=_("_Change"),
-            callback=self.on_change_password_response,
-            callback_data=core.users.login_status
+            callback=self.on_change_password_response
         ).present()
 
     def on_default_server(self, *_args):
@@ -3623,7 +3665,6 @@ class Preferences(Dialog):
                 options[key].update(data)
 
         for section, key in (
-            ("server", "login"),
             ("server", "portrange"),
             ("server", "interface"),
             ("server", "server")

--- a/pynicotine/gtkgui/ui/settings/network.ui
+++ b/pynicotine/gtkgui/ui/settings/network.ui
@@ -51,57 +51,124 @@
         <child>
           <object class="GtkBox">
             <property name="margin-top">6</property>
-            <property name="spacing">12</property>
+            <property name="orientation">vertical</property>
             <property name="visible">True</property>
-            <child>
-              <object class="GtkLabel">
-                <property name="hexpand">True</property>
-                <property name="label" translatable="yes">Username: </property>
-                <property name="mnemonic-widget">username_entry</property>
-                <property name="visible">True</property>
-                <property name="wrap">True</property>
-                <property name="wrap-mode">word-char</property>
-                <property name="xalign">0</property>
-              </object>
-            </child>
             <child>
               <object class="GtkBox">
                 <property name="spacing">12</property>
-                <property name="valign">center</property>
                 <property name="visible">True</property>
                 <child>
-                  <object class="GtkEntry" id="username_entry">
+                  <object class="GtkLabel">
                     <property name="hexpand">True</property>
-                    <property name="input-hints">no-emoji</property>
-                    <property name="max-width-chars">10</property>
-                    <property name="truncate-multiline">True</property>
+                    <property name="label" translatable="yes">Account:</property>
+                    <property name="mnemonic-widget">username_label</property>
                     <property name="visible">True</property>
-                    <property name="width-chars">10</property>
+                    <property name="wrap">True</property>
+                    <property name="wrap-mode">word-char</property>
+                    <property name="xalign">0</property>
                   </object>
                 </child>
                 <child>
-                  <object class="GtkButton" id="_change_password_button">
-                    <property name="halign">end</property>
-                    <property name="tooltip-text" translatable="yes">Change Password</property>
+                  <object class="GtkBox">
+                    <property name="spacing">12</property>
+                    <property name="valign">center</property>
                     <property name="visible">True</property>
-                    <signal name="clicked" handler="on_change_password"/>
                     <child>
-                      <object class="GtkBox">
-                        <property name="spacing">6</property>
+                      <object class="GtkLabel" id="username_label">
+                        <property name="label" translatable="yes">No account added</property>
+                        <property name="selectable">True</property>
                         <property name="visible">True</property>
+                        <property name="wrap">True</property>
+                        <property name="wrap-mode">word</property>
+                        <property name="xalign">0</property>
+                      </object>
+                    </child>
+                    <child>
+                      <object class="GtkButton" id="_log_in_as_button">
+                        <property name="halign">end</property>
+                        <property name="tooltip-text" translatable="yes">Log In As</property>
+                        <property name="visible">True</property>
+                        <signal name="clicked" handler="on_log_in_as"/>
                         <child>
-                          <object class="GtkImage">
-                            <property name="icon-name">dialog-password-symbolic</property>
+                          <object class="GtkBox">
+                            <property name="spacing">6</property>
                             <property name="visible">True</property>
+                            <child>
+                              <object class="GtkImage">
+                                <property name="icon-name">avatar-default-symbolic</property>
+                                <property name="visible">True</property>
+                              </object>
+                            </child>
+                            <child>
+                              <object class="GtkLabel">
+                                <property name="ellipsize">end</property>
+                                <property name="label" translatable="yes">_Log In As</property>
+                                <property name="mnemonic-widget">_log_in_as_button</property>
+                                <property name="use-underline">True</property>
+                                <property name="visible">True</property>
+                              </object>
+                            </child>
                           </object>
                         </child>
+                      </object>
+                    </child>
+                  </object>
+                </child>
+              </object>
+            </child>
+            <child>
+              <object class="GtkRevealer" id ="password_row_revealer">
+                <property name="reveal-child">False</property>
+                <property name="transition-type">slide-down</property>
+                <property name="visible">True</property>
+                <child>
+                  <object class="GtkBox">
+                    <property name="margin-top">12</property>
+                    <property name="spacing">12</property>
+                    <property name="visible">True</property>
+                    <child>
+                      <object class="GtkLabel">
+                        <property name="hexpand">True</property>
+                        <property name="label" translatable="yes">Account Password:</property>
+                        <property name="mnemonic-widget">_change_password_button</property>
+                        <property name="visible">True</property>
+                        <property name="wrap">True</property>
+                        <property name="wrap-mode">word-char</property>
+                        <property name="xalign">0</property>
+                      </object>
+                    </child>
+                    <child>
+                      <object class="GtkBox">
+                        <property name="spacing">12</property>
+                        <property name="valign">center</property>
+                        <property name="visible">True</property>
                         <child>
-                          <object class="GtkLabel">
-                            <property name="ellipsize">end</property>
-                            <property name="label" translatable="yes">Change Pass_word</property>
-                            <property name="mnemonic-widget">_change_password_button</property>
-                            <property name="use-underline">True</property>
+                          <object class="GtkButton" id="_change_password_button">
+                            <property name="halign">end</property>
+                            <property name="tooltip-text" translatable="yes">Change Password</property>
                             <property name="visible">True</property>
+                            <signal name="clicked" handler="on_change_password"/>
+                            <child>
+                              <object class="GtkBox">
+                                <property name="spacing">6</property>
+                                <property name="visible">True</property>
+                                <child>
+                                  <object class="GtkImage">
+                                    <property name="icon-name">dialog-password-symbolic</property>
+                                    <property name="visible">True</property>
+                                  </object>
+                                </child>
+                                <child>
+                                  <object class="GtkLabel">
+                                    <property name="ellipsize">end</property>
+                                    <property name="label" translatable="yes">Change Pass_word</property>
+                                    <property name="mnemonic-widget">_change_password_button</property>
+                                    <property name="use-underline">True</property>
+                                    <property name="visible">True</property>
+                                  </object>
+                                </child>
+                              </object>
+                            </child>
                           </object>
                         </child>
                       </object>
@@ -114,6 +181,7 @@
         </child>
         <child>
           <object class="GtkBox">
+            <property name="margin-top">6</property>
             <property name="spacing">12</property>
             <property name="visible">True</property>
             <child>

--- a/pynicotine/gtkgui/widgets/dialogs.py
+++ b/pynicotine/gtkgui/widgets/dialogs.py
@@ -249,6 +249,10 @@ class Dialog(Window):
         else:
             header_bar.set_show_close_button(visible)     # pylint: disable=no-member
 
+    def set_parent(self, parent):
+        self.parent = parent
+        self.widget.set_transient_for(self.parent.widget)
+
     def present(self):
 
         if self not in Window.active_dialogs:
@@ -504,7 +508,8 @@ class EntryDialog(OptionDialog):
 
     def __init__(self, *args, default="", use_second_entry=False, second_entry_editable=True,
                  second_default="", action_button_label=_("_OK"), droplist=None, second_droplist=None,
-                 visibility=True, max_length=0, multiline=False, show_emoji_icon=False, **kwargs):
+                 visibility=True, second_visibility=True, max_length=0, second_max_length=0,
+                 multiline=False, show_emoji_icon=False, **kwargs):
 
         super().__init__(*args, buttons=[
             ("cancel", _("_Cancel")),
@@ -522,9 +527,9 @@ class EntryDialog(OptionDialog):
 
         if use_second_entry:
             self.second_entry_combobox = self._add_entry_combobox(
-                second_default, has_entry=second_entry_editable, activates_default=False, visibility=visibility,
-                max_length=max_length, show_emoji_icon=show_emoji_icon, multiline=multiline,
-                droplist=second_droplist
+                second_default, has_entry=second_entry_editable, activates_default=False,
+                visibility=second_visibility, max_length=second_max_length, show_emoji_icon=show_emoji_icon,
+                multiline=multiline, droplist=second_droplist
             )
 
     def _add_combobox(self, items, has_entry=True, max_length=0, visibility=True, activates_default=True):

--- a/pynicotine/users.py
+++ b/pynicotine/users.py
@@ -75,6 +75,18 @@ class Users:
         ):
             events.connect(event_name, callback)
 
+    def log_in_as(self, username, password):
+
+        config.sections["server"]["login"] = username
+        config.sections["server"]["passw"] = password
+        config.write_configuration()
+
+        if self.login_status != UserStatus.OFFLINE:
+            core.reconnect()
+            return
+
+        core.connect()
+
     def set_away_mode(self, is_away, save_state=False):
 
         if save_state:


### PR DESCRIPTION
The old 'Change Password' dialog used for both logins and password changes was a clunky relic from a time when we didn't have an event system or dual-entry dialogs. Use two separate dialogs instead, 'Log In As' and 'Change Password'.