### PR TITLE
Redesign buddy share visibility option in Preferences dialog

### DIFF
--- a/pynicotine/gtkgui/ui/settings/shares.ui
+++ b/pynicotine/gtkgui/ui/settings/shares.ui
@@ -341,7 +341,7 @@
   </object>
   <object class="GtkBox" id="container">
     <property name="orientation">vertical</property>
-    <property name="spacing">30</property>
+    <property name="spacing">24</property>
     <property name="visible">True</property>
     <child>
       <object class="GtkBox">
@@ -418,43 +418,6 @@
             </child>
           </object>
         </child>
-        <child>
-          <object class="GtkBox">
-            <property name="spacing">12</property>
-            <property name="visible">True</property>
-            <child>
-              <object class="GtkLabel">
-                <property name="hexpand">True</property>
-                <property name="label" translatable="yes">Visible to everyone:</property>
-                <property name="mnemonic-widget">reveal_buddy_shares_toggle</property>
-                <property name="visible">True</property>
-                <property name="wrap">True</property>
-                <property name="wrap-mode">word-char</property>
-                <property name="xalign">0</property>
-              </object>
-            </child>
-            <child>
-              <object class="GtkBox">
-                <property name="spacing">6</property>
-                <property name="visible">True</property>
-                <child>
-                  <object class="GtkCheckButton" id="reveal_buddy_shares_toggle">
-                    <property name="label" translatable="yes">Buddy shares</property>
-                    <property name="use-underline">True</property>
-                    <property name="visible">True</property>
-                  </object>
-                </child>
-                <child>
-                  <object class="GtkCheckButton" id="reveal_trusted_shares_toggle">
-                    <property name="label" translatable="yes">Trusted shares</property>
-                    <property name="use-underline">True</property>
-                    <property name="visible">True</property>
-                  </object>
-                </child>
-              </object>
-            </child>
-          </object>
-        </child>
       </object>
     </child>
     <child>
@@ -463,17 +426,53 @@
         <property name="spacing">6</property>
         <property name="visible">True</property>
         <child>
-          <object class="GtkScrolledWindow">
+          <object class="GtkBox">
+            <property name="spacing">6</property>
             <property name="visible">True</property>
-            <property name="vscrollbar-policy">never</property>
             <child>
-              <object class="GtkStackSwitcher">
-                <property name="halign">start</property>
-                <property name="stack">stack</property>
+              <object class="GtkScrolledWindow">
+                <property name="hexpand">True</property>
                 <property name="visible">True</property>
-                <style>
-                  <class name="heading"/>
-                </style>
+                <property name="vscrollbar-policy">never</property>
+                <child>
+                  <object class="GtkStackSwitcher">
+                    <property name="halign">start</property>
+                    <property name="stack">stack</property>
+                    <property name="visible">True</property>
+                    <style>
+                      <class name="heading"/>
+                    </style>
+                  </object>
+                </child>
+              </object>
+            </child>
+            <child>
+              <object class="GtkButton" id="visible_to_button">
+                <property name="halign">end</property>
+                <property name="tooltip-text" translatable="yes">Visible To</property>
+                <property name="visible">True</property>
+                <signal name="clicked" handler="on_visibility_to"/>
+                <child>
+                  <object class="GtkBox">
+                    <property name="spacing">6</property>
+                    <property name="visible">True</property>
+                    <child>
+                      <object class="GtkImage">
+                        <property name="icon-name">changes-prevent-symbolic</property>
+                        <property name="visible">True</property>
+                      </object>
+                    </child>
+                    <child>
+                      <object class="GtkLabel">
+                        <property name="ellipsize">end</property>
+                        <property name="label" translatable="yes">_Visible To</property>
+                        <property name="mnemonic-widget">visible_to_button</property>
+                        <property name="use-underline">True</property>
+                        <property name="visible">True</property>
+                      </object>
+                    </child>
+                  </object>
+                </child>
               </object>
             </child>
           </object>
@@ -481,6 +480,7 @@
         <child>
           <object class="GtkStack" id="stack">
             <property name="visible">True</property>
+            <signal name="notify::visible-child-name" handler="on_change_stack_page"/>
           </object>
         </child>
       </object>

--- a/pynicotine/gtkgui/widgets/combobox.py
+++ b/pynicotine/gtkgui/widgets/combobox.py
@@ -439,7 +439,11 @@ class ComboBox:
             self._button.set_sensitive(False)
 
     def grab_focus(self):
-        self.entry.grab_focus()
+
+        if self.entry is not None:
+            self.entry.grab_focus()
+
+        self.widget.grab_focus()
 
     def set_completion_popup_enabled(self, enabled):
 

--- a/pynicotine/gtkgui/widgets/dialogs.py
+++ b/pynicotine/gtkgui/widgets/dialogs.py
@@ -502,7 +502,7 @@ class OptionDialog(MessageDialog):
 
 class EntryDialog(OptionDialog):
 
-    def __init__(self, *args, default="", use_second_entry=False, second_entry_editable=True,
+    def __init__(self, *args, default="", use_second_entry=False, entry_editable=True, second_entry_editable=True,
                  second_default="", action_button_label=_("_OK"), droplist=None, second_droplist=None,
                  visibility=True, max_length=0, multiline=False, show_emoji_icon=False, **kwargs):
 
@@ -516,8 +516,8 @@ class EntryDialog(OptionDialog):
         self.second_entry_combobox = None
 
         self.entry_combobox = self.default_focus_widget = self._add_entry_combobox(
-            default, activates_default=not use_second_entry, visibility=visibility, max_length=max_length,
-            multiline=multiline, show_emoji_icon=show_emoji_icon, droplist=droplist
+            default, has_entry=entry_editable, activates_default=not use_second_entry, visibility=visibility,
+            max_length=max_length, multiline=multiline, show_emoji_icon=show_emoji_icon, droplist=droplist
         )
 
         if use_second_entry:


### PR DESCRIPTION
Make it more difficult to enable the option by accident, and provide a description about what it does.

<img width="707" height="234" alt="image" src="https://github.com/user-attachments/assets/3e47dd3a-03c8-433d-ae27-b99d47105f44" />

<img width="628" height="406" alt="image" src="https://github.com/user-attachments/assets/d0baa77e-4900-40ff-8773-e7bb747decd8" />
