### PR TITLE
GUI: implement multi-level row expansion in user/file trees

### DIFF
--- a/pynicotine/config.py
+++ b/pynicotine/config.py
@@ -238,8 +238,8 @@ class Config:
                 ],
                 "download_doubleclick": transfer_double_click_action,
                 "upload_doubleclick": transfer_double_click_action,
-                "downloadsexpanded": True,
-                "uploadsexpanded": True
+                "expand_downloads": "all",
+                "expand_uploads": "all"
             },
             "userbrowse": {
                 "expand_folders": True
@@ -308,7 +308,7 @@ class Config:
                 "chat_room": {}
             },
             "searches": {
-                "expand_searches": True,
+                "expand_results": "all",
                 "group_searches": "folder_grouping",
                 "maxresults": 300,
                 "enable_history": True,
@@ -463,7 +463,9 @@ class Config:
                 "uploadsinsubdirs",
                 "reverseorder",
                 "lock",
-                "buddysharestrustedonly"
+                "buddysharestrustedonly",
+                "downloadsexpanded",
+                "uploadsexpanded"
             ),
             "server": (
                 "lastportstatuscheck",
@@ -537,7 +539,8 @@ class Config:
                 "reopen_tabs",
                 "max_stored_results",
                 "re_filter",
-                "remove_special_chars"
+                "remove_special_chars",
+                "expand_searches"
             ),
             "userinfo": (
                 "descrutf8",
@@ -672,6 +675,20 @@ class Config:
         # Enable previously disabled header bar on macOS (3.3.0)
         if sys.platform == "darwin" and old_default_player is not None:
             self.sections["ui"]["header_bar"] = True
+
+        # Migrate row expansion state (3.4.0)
+        expand_downloads = self.sections["transfers"].get("downloadsexpanded", None)
+        expand_uploads = self.sections["transfers"].get("uploadsexpanded", None)
+        expand_searches = self.sections["searches"].get("expand_searches", None)
+
+        if expand_downloads is not None:
+            self.sections["transfers"]["expand_downloads"] = "all" if expand_downloads else "none"
+
+        if expand_uploads is not None:
+            self.sections["transfers"]["expand_uploads"] = "all" if expand_uploads else "none"
+
+        if expand_searches is not None:
+            self.sections["searches"]["expand_results"] = "all" if expand_searches else "none"
 
     def _set_config(self):
         """Set config values parsed from file earlier."""

--- a/pynicotine/gtkgui/ui/search.ui
+++ b/pynicotine/gtkgui/ui/search.ui
@@ -245,7 +245,6 @@
                 <child>
                   <object class="GtkToggleButton" id="expand_button">
                     <property name="tooltip-text" translatable="yes">Expand All</property>
-                    <signal name="toggled" handler="on_toggle_expand_all"/>
                     <child>
                       <object class="GtkImage" id="expand_icon">
                         <property name="icon-name">view-fullscreen-symbolic</property>


### PR DESCRIPTION
When pressing the Expand/Collapse All button, cycle through all row levels if folder grouping is enabled.

Closes #3497
