### PR TITLE
Make spam filter properly case-insensitive for phrases

### DIFF
--- a/pynicotine/plugins/spamfilter/__init__.py
+++ b/pynicotine/plugins/spamfilter/__init__.py
@@ -47,7 +47,7 @@ class Plugin(BasePlugin):
     def check_phrases(self, user, line):
 
         for phrase in self.settings["badprivatephrases"]:
-            if line.lower().find(phrase) > -1:
+            if line.lower().find(phrase.lower()) > -1:
                 self.log("Blocked spam from %s: %s", (user, line))
                 return returncode["zap"]
 


### PR DESCRIPTION
added missing `.lower()` for the phrase part of the spam filter check, so that it filters regardless of casing, which seems to have been the intent. this makes the spam filter work for all entered phrases, where previously matches could only be found for phrases which had been entered all-lowercase by the user.

<!--
   Before submitting a PR, please discuss changes you wish to make in an
   issue report or discussion thread (small bug fixes are an exception).
   Talking with the maintainers before writing a large amount of code saves
   everyone's time. Thank you!
-->
