### PR TITLE
download.py: Show Deselect All button if Reset Selection selects all

### DIFF
--- a/pynicotine/gtkgui/dialogs/download.py
+++ b/pynicotine/gtkgui/dialogs/download.py
@@ -709,7 +709,7 @@ class Download(Dialog):
             )
             self.tree_view.set_row_value(parent_iterator, "selected", True)
 
-        self.unselect_all_button.set_visible(False)
+        self.unselect_all_button.set_visible(self.num_selected_files == self.num_files)
         self.update_title()
 
     def on_expand_tree(self, *_args):


### PR DESCRIPTION
- Fixed: On resetting the selection the Select All button was made visible in cases where all of the files were initially selected

Comparing the equality of the two dictionaries works as expected because they are compared regardless of ordering.