### PR TITLE
fastconfigure.py: write configuration immediately when changing account

### DIFF
--- a/pynicotine/gtkgui/dialogs/fastconfigure.py
+++ b/pynicotine/gtkgui/dialogs/fastconfigure.py
@@ -281,10 +281,9 @@ class FastConfigure(Dialog):
 
         # account_page
         if self.invalid_password or self.invalid_username or config.need_config():
-            config.sections["server"]["login"] = self.username_entry.get_text()
-            config.sections["server"]["passw"] = self.password_entry.get_text()
+            core.users.log_in_as(self.username_entry.get_text(), self.password_entry.get_text())
 
-        if core.users.login_status == UserStatus.OFFLINE:
+        elif core.users.login_status == UserStatus.OFFLINE:
             core.connect()
 
         self.close()

--- a/pynicotine/users.py
+++ b/pynicotine/users.py
@@ -81,6 +81,8 @@ class Users:
         config.sections["server"]["passw"] = password
         config.write_configuration()
 
+        log.add_conn("Configured new log in as user %s", username)
+
         if self.login_status != UserStatus.OFFLINE:
             core.reconnect()
             return


### PR DESCRIPTION
+ Fixed: New user account login configuration was lost if a critical error crash or force termination occurs during first session

Matches the new behaviour of the Preferences dialog, where the config file is written before a (re)connection attempt is made.