### PR TITLE
Implement allowed protocol message response IDs

### DIFF
--- a/pynicotine/gtkgui/dialogs/download.py
+++ b/pynicotine/gtkgui/dialogs/download.py
@@ -418,17 +418,24 @@ class Download(Dialog):
 
     def folder_contents_response(self, msg):
 
-        self.tree_view.freeze()
+        if msg.dir is None:
+            return
 
         username = msg.username
+
+        if username not in self.pending_folders:
+            return
+
+        if msg.dir not in self.pending_folders[username]:
+            return
+
+        self.tree_view.freeze()
+
         selected = True
         has_added_file = False
 
         for folder_path, files in msg.list.items():
-            if username not in self.pending_folders:
-                continue
-
-            if folder_path not in self.pending_folders[username]:
+            if folder_path != msg.dir:
                 continue
 
             parent_iterator, child_iterators = self.parent_iterators[username + folder_path]

--- a/pynicotine/search.py
+++ b/pynicotine/search.py
@@ -19,12 +19,13 @@ from pynicotine.core import core
 from pynicotine.events import events
 from pynicotine.logfacility import log
 from pynicotine.shares import PermissionLevel
+from pynicotine.slskmessages import AddAllowedResponse
 from pynicotine.slskmessages import FileSearch
 from pynicotine.slskmessages import FileSearchResponse
 from pynicotine.slskmessages import increment_token
 from pynicotine.slskmessages import initial_token
+from pynicotine.slskmessages import RemoveAllowedResponse
 from pynicotine.slskmessages import RoomSearch
-from pynicotine.slskmessages import SEARCH_TOKENS_ALLOWED
 from pynicotine.slskmessages import UserSearch
 from pynicotine.slskmessages import WishlistSearch
 from pynicotine.utils import TRANSLATE_PUNCTUATION
@@ -212,12 +213,12 @@ class Search:
     @staticmethod
     def add_allowed_token(token):
         """Allow parsing search result messages for a search ID."""
-        SEARCH_TOKENS_ALLOWED.add(token)
+        core.send_message_to_network_thread(AddAllowedResponse(FileSearchResponse, token))
 
     @staticmethod
     def remove_allowed_token(token):
         """Disallow parsing search result messages for a search ID."""
-        SEARCH_TOKENS_ALLOWED.discard(token)
+        core.send_message_to_network_thread(RemoveAllowedResponse(FileSearchResponse, token))
 
     def do_search(self, search_term, mode, room=None, users=None, switch_page=True):
 
@@ -605,7 +606,8 @@ class Search:
     def _file_search_response(self, msg):
         """Peer code 9."""
 
-        if msg.token not in SEARCH_TOKENS_ALLOWED:
+        if msg.list is None:
+            # Response was rejected
             msg.token = None
             return
 


### PR DESCRIPTION
Allows for skipping some heavy work for unsolicited message responses, such as decompression.

Also fixes an issue where requesting a user's shares in the background to get their number of shared files/folders wasn't possible, since the response message was rejected.