### PR TITLE
shares.py: support termination of scanner processes

### DIFF
--- a/pynicotine/gtkgui/mainwindow.py
+++ b/pynicotine/gtkgui/mainwindow.py
@@ -1230,6 +1230,11 @@ class MainWindow(Window):
         self.scan_progress_spinner.start()
 
     def shares_ready(self, _successful):
+
+        if core.shares.rescanning:
+            # Scanner was restarted
+            return
+
         self.scan_progress_container.set_visible(False)
         self.scan_progress_spinner.stop()
 

--- a/pynicotine/shares.py
+++ b/pynicotine/shares.py
@@ -741,7 +741,7 @@ class Scanner:
 
 
 class Shares:
-    __slots__ = ("share_dbs", "requested_share_times", "initialized", "rescanning", "compressed_shares",
+    __slots__ = ("share_dbs", "requested_share_times", "initialized", "compressed_shares",
                  "share_db_paths", "file_path_index", "_scanner_process", "_scanner_reader",
                  "_rescan_daily_timer_id")
 
@@ -752,7 +752,6 @@ class Shares:
         self.share_dbs = {}
         self.requested_share_times = {}
         self.initialized = False
-        self.rescanning = False
         self.compressed_shares = {
             PermissionLevel.PUBLIC: SharedFileListResponse(permission_level=PermissionLevel.PUBLIC),
             PermissionLevel.BUDDY: SharedFileListResponse(permission_level=PermissionLevel.BUDDY),
@@ -803,16 +802,9 @@ class Shares:
 
     def _quit(self):
 
+        self.stop_scanner()
         self.close_shares(self.share_dbs)
         self.initialized = False
-
-        if self._scanner_process is not None:
-            self._scanner_process.terminate()
-            self._scanner_process = None
-
-        if self._scanner_reader is not None:
-            self._scanner_reader.close()
-            self._scanner_reader = None
 
     def _server_login(self, msg):
         if msg.success:
@@ -1141,8 +1133,7 @@ class Shares:
 
     def rescan_shares(self, init=False, rescan=True, rebuild=False, use_thread=True, force=False):
 
-        if self.rescanning:
-            return None
+        self.stop_scanner()
 
         if rescan and not force:
             # Verify all shares are mounted before allowing destructive rescan
@@ -1158,16 +1149,14 @@ class Shares:
                     return None
 
         # Hand over database control to the scanner process
-        self.rescanning = True
+        share_groups = self.get_shared_folders()
+        self._scanner_process, self._scanner_reader, writer = self._build_scanner_process(
+            share_groups, init, rescan, rebuild)
+
         self.close_shares(self.share_dbs)
         self.file_path_index = ()
 
         events.emit("shares-scanning")
-
-        share_groups = self.get_shared_folders()
-        self._scanner_process, self._scanner_reader, writer = self._build_scanner_process(
-            share_groups, init, rescan, rebuild
-        )
         self._scanner_process.start()
 
         # Ensure only the scanner process owns a handle, in order to promptly exit the
@@ -1176,12 +1165,37 @@ class Shares:
 
         if use_thread:
             Thread(
-                target=self._process_scanner, args=(self._scanner_reader, events.emit_main_thread),
+                target=self._process_scanner, args=(
+                    self._scanner_process, self._scanner_reader, events.emit_main_thread
+                ),
                 name="ProcessShareScanner"
             ).start()
             return None
 
-        return self._process_scanner(self._scanner_reader)
+        successful = self._process_scanner(self._scanner_process, self._scanner_reader)
+        self._scanner_process = None
+        self._scanner_reader = None
+
+        return successful
+
+    @property
+    def rescanning(self):
+        return self._scanner_process is not None
+
+    def stop_scanner(self):
+
+        if self._scanner_reader is not None:
+            try:
+                self._scanner_reader.close()
+            except OSError:
+                # Already closed
+                pass
+
+            self._scanner_reader = None
+
+        if self._scanner_process is not None:
+            self._scanner_process.terminate()
+            self._scanner_process = None
 
     def check_shares_available(self):
 
@@ -1234,7 +1248,7 @@ class Shares:
         scanner = context.Process(target=scanner_obj.run, daemon=True)
         return scanner, reader, writer
 
-    def _process_scanner(self, reader, emit_event=None):
+    def _process_scanner(self, process, reader, emit_event=None):
 
         successful = False
         current_folder_count = None
@@ -1279,11 +1293,7 @@ class Shares:
             # Already closed in the main thread
             pass
 
-        self._scanner_reader = None
-
-        if self._scanner_process is not None:
-            self._scanner_process.join()
-            self._scanner_process = None
+        process.join()
 
         if emit_event is not None:
             emit_event("shares-ready", successful)
@@ -1291,6 +1301,13 @@ class Shares:
         return successful
 
     def _shares_ready(self, successful):
+
+        if self._scanner_process is not None and self._scanner_process.is_alive():
+            # Scanner was restarted
+            return
+
+        self._scanner_process = None
+        self._scanner_reader = None
 
         # Scanning done, load shares in the main process again
         if successful:
@@ -1304,7 +1321,6 @@ class Shares:
             except Exception:
                 successful = False
 
-        self.rescanning = False
         self.start_rescan_daily_timer()
 
         if not successful:


### PR DESCRIPTION
And terminate the previous scanner process when reinitiating a scan.

Depends on #3662 