### PR TITLE
Bump minimum Python version to 3.10

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python: ['3.9', '3.10', '3.11', '3.12', '3.13', '3.14', '3.15-dev',
+        python: ['3.10', '3.11', '3.12', '3.13', '3.14', '3.15-dev',
                  'pypy-3.11']
     steps:
       - name: Checkout code

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -57,7 +57,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        container: ['debian:bullseye', 'debian:bookworm', 'debian:trixie', 'debian:unstable',
+        container: ['debian:bookworm', 'debian:trixie', 'debian:unstable',
                     'ubuntu:jammy', 'ubuntu:noble', 'ubuntu:devel']
     container: ${{ matrix.container }}
     steps:

--- a/debian/control
+++ b/debian/control
@@ -16,7 +16,7 @@ Build-Depends: debhelper-compat (= 10),
                python3-setuptools
 Vcs-Git: https://github.com/nicotine-plus/nicotine-plus.git
 Vcs-Browser: https://github.com/nicotine-plus/nicotine-plus
-X-Python3-Version: >= 3.9
+X-Python3-Version: >= 3.10
 Homepage: https://nicotine-plus.org
 Rules-Requires-Root: no
 

--- a/doc/DEPENDENCIES.md
+++ b/doc/DEPENDENCIES.md
@@ -9,7 +9,7 @@
 
 ### Required
 
- - [python3](https://www.python.org/) >= 3.9
+ - [python3](https://www.python.org/) >= 3.10
       for runtime language;
  - [gtk4](https://gtk.org/) >= 4.6.9 or [gtk3](https://gtk.org/) >= 3.24.24
       for graphical interface;

--- a/pynicotine/__init__.py
+++ b/pynicotine/__init__.py
@@ -101,7 +101,7 @@ def check_arguments():
 def check_python_version():
 
     # Require minimum Python version
-    python_version = (3, 9)
+    python_version = (3, 10)
 
     if sys.version_info < python_version:
         return _("""You are using an unsupported version of Python (%(old_version)s).

--- a/setup.cfg
+++ b/setup.cfg
@@ -30,7 +30,7 @@ classifiers =
 [options]
 scripts = nicotine
 packages = find:
-python_requires = >=3.9
+python_requires = >=3.10
 install_requires = PyGObject>=3.38
 
 [options.packages.find]
@@ -110,7 +110,7 @@ load-plugins =
     pylint.extensions.private_import,
     pylint.extensions.set_membership,
     pylint.extensions.typing
-py-version = 3.9
+py-version = 3.10
 
 [pylint.design]
 max-args = 18


### PR DESCRIPTION
<!--
   Before submitting a PR, please discuss the change you wish to make in an
   issue report or discussion thread, in order to see if it fits the direction
   of the project. If you skip this step, a PR containing anything other than
   a trivial bug fix will likely be rejected.
-->

Python 3.9 is EOL as of October last year, and is no longer supported by Python nor packaged by Ubuntu LTS[^1].

Motivation-wise, I'm interested in adding type hints (#3495, [my fork](https://github.com/ernieIzde8ski/nicotine-plus#typings)). Certain features like `TypeAlias`, the dedicated `A | B` syntax for `Union[A, B]`, and the `slots` param of `dataclass` (if desirable) would be nice to have.

[^1]: v3.10 is supported: <https://packages.ubuntu.com/questing/python3>