### PR TITLE
Use conda-forge instead of Homebrew for dependencies on macOS

### DIFF
--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -169,30 +169,34 @@ jobs:
           path: build-aux/windows/build/package
 
   macos:
+    timeout-minutes: 15
     strategy:
       matrix:
         include:
           - arch: x86_64
-            platform: macos-15-intel
+            platform: macos-26-intel
           - arch: arm64
-            platform: macos-15
+            platform: macos-26
     runs-on: ${{ matrix.platform }}
-    timeout-minutes: 20
+    defaults:
+      run:
+        shell: bash -el {0}
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
 
-      - name: Create Python virtual environment
-        run: |
-          brew uninstall --ignore-dependencies python@3.14
-          brew install --overwrite python@3.14
-          python3.14 -m venv venv
+      - name: Set up Miniforge
+        uses: conda-incubator/setup-miniconda@v3
+        with:
+          activate-environment: nicotine-plus
+          miniforge-version: latest
+          conda-remove-defaults: "true"
 
-      - name: Install build dependencies
-        run: venv/bin/python3 build-aux/macos/dependencies.py
+      - name: Install dependencies
+        run: python3 build-aux/macos/dependencies.py
 
       - name: Freeze application
-        run: venv/bin/python3 build-aux/macos/setup.py bdist_dmg
+        run: python3 build-aux/macos/setup.py bdist_dmg
 
       - name: Archive installer artifacts
         uses: actions/upload-artifact@v7

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -299,34 +299,38 @@ jobs:
         run: python3 -m build --no-isolation
 
   macos:
+    timeout-minutes: 15
     strategy:
       fail-fast: false
       matrix:
         include:
           - arch: x86_64
-            platform: macos-15-intel
+            platform: macos-26-intel
           - arch: arm64
-            platform: macos-15
+            platform: macos-26
     runs-on: ${{ matrix.platform }}
-    timeout-minutes: 20
+    defaults:
+      run:
+        shell: bash -el {0}
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
 
-      - name: Create Python virtual environment
-        run: |
-          brew uninstall --ignore-dependencies python@3.14
-          brew install --overwrite python@3.14
-          python3.14 -m venv venv
+      - name: Set up Miniforge
+        uses: conda-incubator/setup-miniconda@v3
+        with:
+          activate-environment: nicotine-plus
+          miniforge-version: latest
+          conda-remove-defaults: "true"
 
       - name: Install dependencies
-        run: venv/bin/python3 build-aux/macos/dependencies.py
+        run: python3 build-aux/macos/dependencies.py
 
       - name: Integration and unit tests
-        run: venv/bin/python3 -m unittest -v
+        run: python3 -m unittest -v
 
       - name: Build
-        run: venv/bin/python3 -m build
+        run: python3 -m build
 
       - name: Build without isolation
-        run: venv/bin/python3 -m build --no-isolation
+        run: python3 -m build --no-isolation

--- a/build-aux/macos/dependencies.py
+++ b/build-aux/macos/dependencies.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# SPDX-FileCopyrightText: 2020-2025 Nicotine+ Contributors
+# SPDX-FileCopyrightText: 2020-2026 Nicotine+ Contributors
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import os
@@ -7,40 +7,26 @@ import subprocess
 import sys
 
 
-def install_brew():
-    """Install dependencies from the main Homebrew repos."""
+def install_conda_forge():
+    """Install dependencies from the main conda-forge repos."""
 
-    # Workaround for https://github.com/Homebrew/homebrew-core/issues/139497
-    os.environ["HOMEBREW_NO_INSTALL_FROM_API"] = "1"
+    environment_name = "nicotine-plus"
 
-    packages = ["gettext",
+    # Temporarily install older icu version to force non-icu variant of libsqlite
+    pre_packages = ["icu<78",
+                    "libsqlite"]
+
+    packages = ["icu",
+                "cx_freeze",
                 "gobject-introspection",
                 "gtk4",
                 "libadwaita",
-                "webp-pixbuf-loader"]
+                "pygobject",
+                "python-build"]
 
-    subprocess.check_call(["brew", "install", "--quiet"] + packages)
-
-
-def install_pypi():
-    """Install dependencies from PyPi."""
-
-    subprocess.check_call([
-        sys.executable, "-m", "pip", "install",
-
-        # For consistency, avoid including pre-built binaries from PyPI
-        # in the application.
-        "--no-binary", "cx_Freeze",
-        "--no-binary", "PyGObject",
-        "--no-binary", "pycairo",
-
-        "-e", ".[packaging,tests]",
-        "build",
-        "setuptools",
-        "wheel"
-    ])
+    subprocess.check_call(["mamba", "install", "-n", environment_name, "-y"] + pre_packages)
+    subprocess.check_call(["mamba", "install", "-n", environment_name, "-y"] + packages)
 
 
 if __name__ == "__main__":
-    install_brew()
-    install_pypi()
+    install_conda_forge()

--- a/build-aux/macos/pixbuf-loaders.cache
+++ b/build-aux/macos/pixbuf-loaders.cache
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2025 Nicotine+ Contributors
+# SPDX-FileCopyrightText: 2025-2026 Nicotine+ Contributors
 # SPDX-License-Identifier: GPL-3.0-or-later
 #
 "@executable_path/lib/libpixbufloader-bmp.so"
@@ -12,9 +12,3 @@
 "image/gif" ""
 "gif" ""
 "GIF8" "" 100
-
-"@executable_path/lib/libpixbufloader-webp.so"
-"webp" 5 "gdk-pixbuf" "The WebP image format" "LGPL"
-"image/webp" "audio/x-riff" ""
-"webp" ""
-"RIFFsizeWEBP" "    xxxx    " 100

--- a/build-aux/windows/setup.py
+++ b/build-aux/windows/setup.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# SPDX-FileCopyrightText: 2021-2025 Nicotine+ Contributors
+# SPDX-FileCopyrightText: 2021-2026 Nicotine+ Contributors
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import glob
@@ -29,12 +29,14 @@ if sys.platform == "win32":
     UNAVAILABLE_MODULES = [
         "fcntl", "grp", "posix", "pwd", "readline", "resource", "syslog", "termios"
     ]
+    BIN_EXCLUDES = []
     ICON_NAME = "icon.ico"
 
 elif sys.platform == "darwin":
-    SYS_BASE_PATH = "/opt/homebrew" if platform.machine() == "arm64" else "/usr/local"
+    SYS_BASE_PATH = sys.prefix
     LIB_PATH = os.path.join(SYS_BASE_PATH, "lib")
     UNAVAILABLE_MODULES = ["msvcrt", "nt", "nturl2path", "winreg", "winsound"]
+    BIN_EXCLUDES = ["libappstream*.dylib"]
     ICON_NAME = "icon.icns"
 
 else:
@@ -102,10 +104,14 @@ def add_pixbuf_loaders():
 
     pixbuf_loaders_path = os.path.join(SYS_BASE_PATH, "lib/gdk-pixbuf-2.0/2.10.0/loaders")
     loader_extension = "dll" if sys.platform == "win32" else "so"
+    image_formats = ["bmp", "gif"]
+
+    if sys.platform == "win32":
+        image_formats += ["webp"]
 
     add_file(file_path=os.path.join(CURRENT_PATH, "pixbuf-loaders.cache"), output_path="lib/pixbuf-loaders.cache")
 
-    for image_format in ("bmp", "gif", "webp"):
+    for image_format in image_formats:
         basename = f"libpixbufloader-{image_format}"
         add_file(
             file_path=os.path.realpath(os.path.join(pixbuf_loaders_path, f"{basename}.{loader_extension}")),
@@ -233,6 +239,7 @@ setup(
             "packages": INCLUDED_MODULES,
             "excludes": EXCLUDED_MODULES,
             "include_files": include_files,
+            "bin_excludes": BIN_EXCLUDES,
             "zip_include_packages": ["*"],
             "zip_exclude_packages": [MODULE_NAME],
             "optimize": 2

--- a/doc/PACKAGING.md
+++ b/doc/PACKAGING.md
@@ -1,5 +1,5 @@
 <!--
-  SPDX-FileCopyrightText: 2016-2025 Nicotine+ Contributors
+  SPDX-FileCopyrightText: 2016-2026 Nicotine+ Contributors
   SPDX-License-Identifier: GPL-3.0-or-later
 -->
 
@@ -102,7 +102,14 @@ own machine.
 
 ### Building a Frozen Application with cx_Freeze
 
-Follow the instructions on [installing Homebrew](https://brew.sh/).
+Follow the instructions on [installing Miniforge](https://conda-forge.org/download/).
+
+Create and activate an environment:
+
+```sh
+mamba create --name nicotine-plus
+mamba activate nicotine-plus
+```
 
 Clone the `nicotine-plus` Git repository:
 
@@ -114,15 +121,13 @@ cd nicotine-plus
 Install dependencies:
 
 ```sh
-brew install python@3.14
-python3.14 -m venv venv
-venv/bin/python3 build-aux/macos/dependencies.py
+python3 build-aux/macos/dependencies.py
 ```
 
 Build the application:
 
 ```sh
-venv/bin/python3 build-aux/macos/setup.py bdist_dmg
+python3 build-aux/macos/setup.py bdist_dmg
 ```
 
 When the application has finished building, it is located in the

--- a/doc/TESTING.md
+++ b/doc/TESTING.md
@@ -1,5 +1,5 @@
 <!--
-  SPDX-FileCopyrightText: 2016-2025 Nicotine+ Contributors
+  SPDX-FileCopyrightText: 2016-2026 Nicotine+ Contributors
   SPDX-License-Identifier: GPL-3.0-or-later
 -->
 
@@ -110,11 +110,11 @@ Unstable installers are built after every commit to the master branch.
 
  - [Download Unstable macOS Intel Installer](https://nightly.link/nicotine-plus/nicotine-plus/workflows/packaging/master/macos-x86_64-installer.zip)
     — [`INFO`](https://nightly.link/nicotine-plus/nicotine-plus/workflows/packaging/master/macos-x86_64-installer)  
-   for macOS 15 Sequoia or later
+   for macOS 11 Big Sur or later
 
  - [Download Unstable macOS Apple Silicon Installer](https://nightly.link/nicotine-plus/nicotine-plus/workflows/packaging/master/macos-arm64-installer.zip)
     — [`INFO`](https://nightly.link/nicotine-plus/nicotine-plus/workflows/packaging/master/macos-arm64-installer)  
-   for macOS 15 Sequoia or later
+   for macOS 11 Big Sur or later
 
 
 ## All Platforms


### PR DESCRIPTION
Homebrew has been a source of frustration for a few years, due to its tendency to quickly drop support for EOL macOS versions. It has forced us to drop support for older macOS versions mid-cycle, which is not ideal.

conda-forge recently gained a libadwaita package, and supports macOS >=11. Use it as a source of dependencies instead of Homebrew.

TODO:
- [x] Enable introspection in the libadwaita package on arm64 (https://github.com/conda-forge/libadwaita-feedstock/issues/10)
