### PR TITLE
SLSKPROTOCOL.md: add list of reserved client version numbers

### DIFF
--- a/doc/SLSKPROTOCOL.md
+++ b/doc/SLSKPROTOCOL.md
@@ -5,7 +5,7 @@
 
 # Soulseek Protocol Documentation
 
-[Last updated on April 1, 2026](https://github.com/nicotine-plus/nicotine-plus/commits/master/doc/SLSKPROTOCOL.md)
+[Last updated on April 20, 2026](https://github.com/nicotine-plus/nicotine-plus/commits/master/doc/SLSKPROTOCOL.md)
 
 Since the official Soulseek client and server is proprietary software, this
 documentation has been compiled thanks to years of reverse engineering efforts.
@@ -222,73 +222,77 @@ missing if a file does not provide them.
     -   `{1: duration, 4: sample rate, 5: bit depth}`
 
 
-## Client Types *(Major Versions)*
+## Major Versions
 
-Projects must choose a unique type number to avoid impersonating other clients.
+Established clients have unique numbers to avoid impersonating each other.
 
 ### Reserved
 
-| Type   | Client                                  |
-|--------|-----------------------------------------|
-| `157`  | [Soulseek NS](#soulseek) and SoulseekQt |
-| `158`  | *Reserved for SoulseekQt development*   |
-| `159`  | *Reserved for SoulseekQt development*   |
-| `160`  | [Nicotine+](#nicotine)                  |
-| `169`  | seeleseek                               |
-| `170`  | [Soulseek.NET](#soulseeknet) *(API)*    |
-| `175`  | *Experimental development and testing*  |
-| `178`  | Museek+                                 |
+| Major Version | Client                                  |
+|---------------|-----------------------------------------|
+| `157`         | [Soulseek NS and SoulseekQt](#soulseek) |
+| `158`         | *Reserved for SoulseekQt development*   |
+| `159`         | *Reserved for SoulseekQt development*   |
+| `160`         | [Nicotine+](#nicotine)                  |
+| `169`         | seeleseek                               |
+| `170`         | [Soulseek.NET](#soulseeknet) *(API)*    |
+| `177`         | *Experimental development and testing*  |
 
 ### Obsolete
 
-| Type   | Client                    |
-|--------|---------------------------|
-| `156`  | Soulseek 156 *(pre 2008)* |
-| `180`  | PySoulSeek                |
-| `181`  | Nicotine+ 1.2.0 to 1.2.11 |
-| `182`  | Museek+                   |
-| `198`  | Nicotine 1.0.6 to 1.0.8   |
-| `200`  | Nicotine 1.0.4 and below  |
+| Major Version | Client                     |
+|---------------|----------------------------|
+| `139`...`155` | Soulseek® *(2002 onwards)* |
+| `156`         | Soulseek® *(2008)*         |
+| `178`         | Museek+                    |
+| `180`         | PySoulSeek                 |
+| `181`         | Nicotine+ 1.2.0 to 1.2.11  |
+| `182`         | Museek+                    |
+| `198`         | Nicotine 1.0.6 to 1.0.8    |
+| `200`         | Nicotine 1.0.4 and below   |
 
 
-## Client Subtypes *(Minor Versions)*
+## Minor Versions
 
-Projects have thier own rules for subtypes. The number can be set to anything.
+Projects have thier own rules for versioning. The number can be any **uint32**.
 
 ### Nicotine+
 
-The project maintainer increments the subtype number for new capabilities.
+The project maintainer increments the minor version when adding support for
+significant network capabilities.
 
-#### Client type `160`
+#### Major Version `160`
 
-| Subtype | Versions        |
-|---------|-----------------|
-| `1`     | 2.2.1 to 3.2.9  |
-| `2`     | 3.3.0 to 3.3.10 |
-| `3`     | 3.4.0 and above |
+| Minor Version | Release Versions |
+|---------------|------------------|
+| `1`           | 2.2.1 to 3.2.9   |
+| `2`           | 3.3.0 to 3.3.11  |
+| `3`           | 3.4.0 and above  |
 
 ### Soulseek.NET
 
-API library requires clients to choose a `minorVersion` as their subtype.
+API library requires each downstream project to choose a unique `minorVersion`.
 
-#### Client type `170`
+#### Major Version `170`
 
-| Subtype | Client                                    |
-|---------|-------------------------------------------|
-| `100`   | *All legacy clients up to API 8.5.0*      |
-| `760`   | slskd *(Reference implementation of API)* |
-| `9999`  | *Experimental development and testing*    |
+| Minor Version | Client                                    |
+|---------------|-------------------------------------------|
+| `100`         | *All legacy clients up to API 8.5.0*      |
+| `760`         | slskd *(Reference implementation of API)* |
+| `9999`        | *Experimental development and testing*    |
 
 ### Soulseek®
 
-Official client subtype number is incremented for each released version.
+Official client minor version number is incremented for each release.
 
-#### Client type `157`
+#### Major Version `157`
 
-| Subtype             | Version |
-|---------------------|---------|
-| `17` (`0x11000000`) | NS 13c  |
-| `19` (`0x13000000`) | NS 13e  |
+| Minor Version | Release                    |
+|---------------|----------------------------|
+| `17` (`0x11`) | NS 13c                     |
+| `19` (`0x13`) | NS 13e                     |
+| ...           | Qt Public Build 1 *(2011)* |
+|               | Qt *(2012 onwards)*        |
 
 
 # Server Messages
@@ -297,8 +301,8 @@ Server messages are used by clients to interface with the server over a
 connection (TCP). In Nicotine+, these messages are defined in slskmessages.py.
 
 If you want a Soulseek server, [Soulfind](https://github.com/soulfind-dev/soulfind)
-is open source and not exactly the same as the official proprietary Soulseek
-server, but it handles the protocol well enough for development and testing.
+is open source (unrelated to the official proprietary Soulseek server). It handles
+the protocol well enough for development and testing of client implementations.
 
 
 ## Server Message Format
@@ -423,10 +427,11 @@ server, but it handles the protocol well enough for development and testing.
 We send this to the server right after the connection has been established.
 Server responds with the greeting message.
 
-The server may use the client type and subtype (formally known here as
-the major and minor protocol versions) to differentiate between client
-implementations. Projects must choose a unique type number to avoid
-impersonating other clients, and have thier own rules for subtypes.
+The server uses the major and minor versions to differentiate between
+clients. Numbers are chosen that avoid impersonating clients with reserved
+[Major Versions](#major-versions). Downstream projects have their own rules
+for [Minor Versions](#minor-versions). Experimental scripts may use major
+version `177` and any minor version number they choose for each project.
 
 ### Sending Login Example
 
@@ -439,15 +444,15 @@ impersonating other clients, and have thier own rules for subtypes.
 
 #### ...continued
 
-| Data      | Client Type   | Hash Length   | Hash of Username + Password                                                                       | Client Subtype |
-|-----------|---------------|---------------|---------------------------------------------------------------------------------------------------|----------------|
-| **Human** | 175           | 32            | d51c9a7e9353746a6020f9602d452929                                                                  | 1              |
-| **Hex**   | `af 00 00 00` | `20 00 00 00` | `64 35 31 63 39 61 37 65 39 33 35 33 37 34 36 61 36 30 32 30 66 39 36 30 32 64 34 35 32 39 32 39` | `01 00 00 00`  |
+| Data      | Major Version | Hash Length   | Hash of Username + Password                                                                       | Minor Version |
+|-----------|---------------|---------------|---------------------------------------------------------------------------------------------------|---------------|
+| **Human** | 177           | 32            | d51c9a7e9353746a6020f9602d452929                                                                  | 1             |
+| **Hex**   | `b1 00 00 00` | `20 00 00 00` | `64 35 31 63 39 61 37 65 39 33 35 33 37 34 36 61 36 30 32 30 66 39 36 30 32 64 34 35 32 39 32 39` | `01 00 00 00` |
 
 #### Message as Hex Stream
 
 ```
-48 00 00 00 01 00 00 00 08 00 00 00 75 73 65 72 6e 61 6d 65 08 00 00 00 70 61 73 73 77 6f 72 64 af 00 00 00 20 00
+48 00 00 00 01 00 00 00 08 00 00 00 75 73 65 72 6e 61 6d 65 08 00 00 00 70 61 73 73 77 6f 72 64 b1 00 00 00 20 00
 00 00 64 35 31 63 39 61 37 65 39 33 35 33 37 34 36 61 36 30 32 30 66 39 36 30 32 64 34 35 32 39 32 39 01 00 00 00
 ```
 
@@ -456,12 +461,12 @@ impersonating other clients, and have thier own rules for subtypes.
     1.  **string** *username*
     2.  **string** *password*  
         A non-empty string is required
-    3.  **uint32** *client type*
-        See [Client Types](#client-types-major-versions)
-    4.  **string** *hash*
+    3.  **uint32** *major version*  
+        See [Major Versions](#major-versions)
+    4.  **string** *hash*  
         MD5 hex digest of concatenated username and password
-    5.  **uint32** *client subtype*
-        See [Client Subtypes](#client-subtypes-minor-versions)
+    5.  **uint32** *minor version*  
+        See [Minor Versions](#minor-versions)
   - Receive
     1.  **bool** *success*
     2.  If *success* is true

--- a/doc/SLSKPROTOCOL.md
+++ b/doc/SLSKPROTOCOL.md
@@ -5,7 +5,7 @@
 
 # Soulseek Protocol Documentation
 
-[Last updated on March 22, 2026](https://github.com/nicotine-plus/nicotine-plus/commits/master/doc/SLSKPROTOCOL.md)
+[Last updated on March 24, 2026](https://github.com/nicotine-plus/nicotine-plus/commits/master/doc/SLSKPROTOCOL.md)
 
 Since the official Soulseek client and server is proprietary software, this
 documentation has been compiled thanks to years of reverse engineering efforts.
@@ -216,14 +216,81 @@ missing if a file does not provide them.
     -   `{1: duration, 4: sample rate, 5: bit depth}`
 
 
+## Client Types *(Major Versions)*
+
+Projects must choose a unique type number to avoid impersonating other clients.
+
+### Reserved
+
+| Type   | Client                                     | Compliance   |
+|--------|--------------------------------------------|--------------|
+| `157`  | [Soulseek NS](#soulseek) and SoulseekQt    | **OFFICIAL** |
+| `160`  | [Nicotine+](#nicotine)                     | **FULL**     |
+| `169`  | seeleseek *(for macOS)*                    | DEVELOPING   |
+| `170`  | [Soulseek.NET](#soulseeknet) *(API)*       | *(Various)*  |
+| `175`  | *Reserved for development and testing*     | EXPERIMENTAL |
+
+### Obsolete
+
+| Type   | Client                     | Compliance   |
+|--------|----------------------------|--------------|
+| `156`  | Old server *(pre 2008)*    | *(Offline)*  |
+| `157`* | Nicotine+ 1.2.12 to 2.2.0  | IMPERSONATED |
+| `180`  | PySoulSeek                 | MINIMAL      |
+| `181`  | Nicotine+ 1.2.0 to 1.2.11  | PARTIAL      |
+| `182`  | Museek+                    | PARTIAL      |
+| `198`  | Nicotine 1.0.6 to 1.0.8    | MINIMAL      |
+| `200`  | Nicotine 1.0.4 and below   | NO           |
+
+
+## Client Subtypes *(Minor Versions)*
+
+Projects have thier own rules for subtypes. The number can be set to anything.
+
+### Nicotine+
+
+The project maintainer increments the subtype number for new capabilities.
+
+#### Client type `160`
+
+| Subtype | Versions        | Protocol implementation details                               | Compliance   |
+|---------|-----------------|---------------------------------------------------------------|--------------|
+| *None*  | 1.x             | *The protocol minor subtype was not previously implemented*   | MINIMAL      |
+| `19`*   | 2.0.0 to 2.2.0  | Impersonated NS for experimental distributed network support  | IMPERSONATED |
+| `1`     | 2.2.1 to 3.2.9  | Send custom version number to server instead of Soulseek NS's | PARTIAL      |
+| `2`     | 3.3.0 to 3.3.10 | Added distributed child peer support                          | ALMOST FULL  |
+| `3`     | 3.4.0 and above | Distribute raw messages to child peers                        | **FULL**     |
+
+### Soulseek.NET
+
+API library requires projects to choose a `minorVersion` for their subtype.
+
+#### Client type `170`
+
+| Subtype | Project Name | Protocol implementation details | Compliance |
+|---------|--------------|---------------------------------|------------|
+| `760`   | slskd        | Reference implementation of API | **FULL**   |
+
+### Soulseek®
+
+Official client subtype number is incremented for each released version.
+
+#### Client type `157`
+
+| Subtype             | Version | Protocol implementation details                      | Compliance                         |
+|---------------------|---------|------------------------------------------------------|------------------------------------|
+| `17` (`0x11000000`) | NS 13c  | 2GB transfer limit; lowercase paths; not distributed | **OBSOLETE, no longer used**       |
+| `19` (`0x13000000`) | NS 13e  | 2GB transfer limit; lowercase paths; legacy encoding | **OBSOLETE, no longer functional** |
+
+
 # Server Messages
 
 Server messages are used by clients to interface with the server over a
 connection (TCP). In Nicotine+, these messages are defined in slskmessages.py.
 
-If you want a Soulseek server, check out [Soulfind](https://github.com/soulfind-dev/soulfind).
-Soulfind is obviously not exactly the same as the official proprietary Soulseek
-server, but it handles the protocol well enough (and can be modified).
+If you want a Soulseek server, [Soulfind](https://github.com/soulfind-dev/soulfind)
+is open source and not exactly the same as the official proprietary Soulseek
+server, but it handles the protocol well enough for development and testing.
 
 
 ## Server Message Format
@@ -348,11 +415,10 @@ server, but it handles the protocol well enough (and can be modified).
 We send this to the server right after the connection has been established.
 Server responds with the greeting message.
 
-The server uses the major and minor versions to differentiate between
-clients. Use unique version numbers when possible, to avoid impersonating
-other clients. Major versions reserved for popular Soulseek clients include
-157 for Soulseek NS and SoulseekQt, 160 for Nicotine+, and 170 for slskd
-(Soulseek.NET). These clients have their own rules for minor versions.
+The server may use the client type and subtype (formally known here as
+the major and minor protocol versions) to differentiate between client
+implementations. Projects must choose a unique type number to avoid
+impersonating other clients, and have thier own rules for subtypes.
 
 ### Sending Login Example
 
@@ -365,10 +431,10 @@ other clients. Major versions reserved for popular Soulseek clients include
 
 #### ...continued
 
-| Data      | Version       | Hash Length   | Hash                                                                                              | Minor Version |
-|-----------|---------------|---------------|---------------------------------------------------------------------------------------------------|---------------|
-| **Human** | 175           | 32            | d51c9a7e9353746a6020f9602d452929                                                                  | 1             |
-| **Hex**   | `af 00 00 00` | `20 00 00 00` | `64 35 31 63 39 61 37 65 39 33 35 33 37 34 36 61 36 30 32 30 66 39 36 30 32 64 34 35 32 39 32 39` | `01 00 00 00` |
+| Data      | Client Type   | Hash Length   | Hash of Username + Password                                                                       | Client Subtype |
+|-----------|---------------|---------------|---------------------------------------------------------------------------------------------------|----------------|
+| **Human** | 175           | 32            | d51c9a7e9353746a6020f9602d452929                                                                  | 1              |
+| **Hex**   | `af 00 00 00` | `20 00 00 00` | `64 35 31 63 39 61 37 65 39 33 35 33 37 34 36 61 36 30 32 30 66 39 36 30 32 64 34 35 32 39 32 39` | `01 00 00 00`  |
 
 #### Message as Hex Stream
 
@@ -382,10 +448,12 @@ other clients. Major versions reserved for popular Soulseek clients include
     1.  **string** *username*
     2.  **string** *password*  
         A non-empty string is required
-    3.  **uint32** *major version*
-    4.  **string** *hash*  
+    3.  **uint32** *client type*
+        See [Client Types](#client-types-major-versions)
+    4.  **string** *hash*
         MD5 hex digest of concatenated username and password
-    5.  **uint32** *minor version*
+    5.  **uint32** *client subtype*
+        See [Client Subtypes](#client-subtypes-minor-versions)
   - Receive
     1.  **bool** *success*
     2.  If *success* is true

--- a/doc/SLSKPROTOCOL.md
+++ b/doc/SLSKPROTOCOL.md
@@ -275,6 +275,7 @@ API library requires clients to choose a `minorVersion` as their subtype.
 
 | Subtype | Client                                    |
 |---------|-------------------------------------------|
+| `100`   | *All legacy clients up to API 8.5.0*      |
 | `760`   | slskd *(Reference implementation of API)* |
 | `9999`  | *Experimental development and testing*    |
 

--- a/doc/SLSKPROTOCOL.md
+++ b/doc/SLSKPROTOCOL.md
@@ -228,25 +228,27 @@ Projects must choose a unique type number to avoid impersonating other clients.
 
 ### Reserved
 
-| Type   | Client                                     | Compliance   |
-|--------|--------------------------------------------|--------------|
-| `157`  | [Soulseek NS](#soulseek) and SoulseekQt    | **OFFICIAL** |
-| `160`  | [Nicotine+](#nicotine)                     | **FULL**     |
-| `169`  | seeleseek *(for macOS)*                    | DEVELOPING   |
-| `170`  | [Soulseek.NET](#soulseeknet) *(API)*       | *(Various)*  |
-| `175`  | *Reserved for development and testing*     | EXPERIMENTAL |
+| Type   | Client                                  |
+|--------|-----------------------------------------|
+| `157`  | [Soulseek NS](#soulseek) and SoulseekQt |
+| `158`  | *Reserved for SoulseekQt development*   |
+| `159`  | *Reserved for SoulseekQt development*   |
+| `160`  | [Nicotine+](#nicotine)                  |
+| `169`  | seeleseek                               |
+| `170`  | [Soulseek.NET](#soulseeknet) *(API)*    |
+| `175`  | *Experimental development and testing*  |
+| `178`  | Museek+                                 |
 
 ### Obsolete
 
-| Type   | Client                     | Compliance   |
-|--------|----------------------------|--------------|
-| `156`  | Old server *(pre 2008)*    | *(Offline)*  |
-| `157`* | Nicotine+ 1.2.12 to 2.2.0  | IMPERSONATED |
-| `180`  | PySoulSeek                 | MINIMAL      |
-| `181`  | Nicotine+ 1.2.0 to 1.2.11  | PARTIAL      |
-| `182`  | Museek+                    | PARTIAL      |
-| `198`  | Nicotine 1.0.6 to 1.0.8    | MINIMAL      |
-| `200`  | Nicotine 1.0.4 and below   | NO           |
+| Type   | Client                    |
+|--------|---------------------------|
+| `156`  | Soulseek 156 *(pre 2008)* |
+| `180`  | PySoulSeek                |
+| `181`  | Nicotine+ 1.2.0 to 1.2.11 |
+| `182`  | Museek+                   |
+| `198`  | Nicotine 1.0.6 to 1.0.8   |
+| `200`  | Nicotine 1.0.4 and below  |
 
 
 ## Client Subtypes *(Minor Versions)*
@@ -259,23 +261,22 @@ The project maintainer increments the subtype number for new capabilities.
 
 #### Client type `160`
 
-| Subtype | Versions        | Protocol implementation details                               | Compliance   |
-|---------|-----------------|---------------------------------------------------------------|--------------|
-| *None*  | 1.x             | *The protocol minor subtype was not previously implemented*   | MINIMAL      |
-| `19`*   | 2.0.0 to 2.2.0  | Impersonated NS for experimental distributed network support  | IMPERSONATED |
-| `1`     | 2.2.1 to 3.2.9  | Send custom version number to server instead of Soulseek NS's | PARTIAL      |
-| `2`     | 3.3.0 to 3.3.10 | Added distributed child peer support                          | ALMOST FULL  |
-| `3`     | 3.4.0 and above | Distribute raw messages to child peers                        | **FULL**     |
+| Subtype | Versions        |
+|---------|-----------------|
+| `1`     | 2.2.1 to 3.2.9  |
+| `2`     | 3.3.0 to 3.3.10 |
+| `3`     | 3.4.0 and above |
 
 ### Soulseek.NET
 
-API library requires projects to choose a `minorVersion` for their subtype.
+API library requires clients to choose a `minorVersion` as their subtype.
 
 #### Client type `170`
 
-| Subtype | Project Name | Protocol implementation details | Compliance |
-|---------|--------------|---------------------------------|------------|
-| `760`   | slskd        | Reference implementation of API | **FULL**   |
+| Subtype | Client                                    |
+|---------|-------------------------------------------|
+| `760`   | slskd *(Reference implementation of API)* |
+| `9999`  | *Experimental development and testing*    |
 
 ### Soulseek®
 
@@ -283,10 +284,10 @@ Official client subtype number is incremented for each released version.
 
 #### Client type `157`
 
-| Subtype             | Version | Protocol implementation details                      | Compliance                         |
-|---------------------|---------|------------------------------------------------------|------------------------------------|
-| `17` (`0x11000000`) | NS 13c  | 2GB transfer limit; lowercase paths; not distributed | **OBSOLETE, no longer used**       |
-| `19` (`0x13000000`) | NS 13e  | 2GB transfer limit; lowercase paths; legacy encoding | **OBSOLETE, no longer functional** |
+| Subtype             | Version |
+|---------------------|---------|
+| `17` (`0x11000000`) | NS 13c  |
+| `19` (`0x13000000`) | NS 13e  |
 
 
 # Server Messages

--- a/doc/SLSKPROTOCOL.md
+++ b/doc/SLSKPROTOCOL.md
@@ -225,14 +225,16 @@ missing if a file does not provide them.
 ## Major Versions
 
 Established clients have unique numbers to avoid impersonating each other.
+Obsolete clients cannot [Login](#server-code-1) to the server since 2/17/2005
+due to the `INVALIDVERSION` [Rejection Reason](#login-rejection-reasons).
 
 ### Reserved
 
 | Major Version | Client                                  |
 |---------------|-----------------------------------------|
+| `155` / `156` | [Soulseek®](#soulseek) *(2005 to 2008)* |
 | `157`         | [Soulseek NS and SoulseekQt](#soulseek) |
-| `158`         | *Reserved for SoulseekQt development*   |
-| `159`         | *Reserved for SoulseekQt development*   |
+| `158` / `159` | *Reserved for SoulseekQt development*   |
 | `160`         | [Nicotine+](#nicotine)                  |
 | `169`         | seeleseek                               |
 | `170`         | [Soulseek.NET](#soulseeknet) *(API)*    |
@@ -240,21 +242,22 @@ Established clients have unique numbers to avoid impersonating each other.
 
 ### Obsolete
 
-| Major Version | Client                     |
-|---------------|----------------------------|
-| `139`...`155` | Soulseek® *(2002 onwards)* |
-| `156`         | Soulseek® *(2008)*         |
-| `178`         | Museek+                    |
-| `180`         | PySoulSeek                 |
-| `181`         | Nicotine+ 1.2.0 to 1.2.11  |
-| `182`         | Museek+                    |
-| `198`         | Nicotine 1.0.6 to 1.0.8    |
-| `200`         | Nicotine 1.0.4 and below   |
+| Major Version | Client                    |
+|---------------|---------------------------|
+| `154` or less | Soulseek® *(up to 2004)*  |
+| `178`         | Museek+                   |
+| `180`         | PySoulSeek                |
+| `181`         | Nicotine+ 1.2.0 to 1.2.11 |
+| `182`         | Museek+                   |
+| `198`         | Nicotine 1.0.6 to 1.0.8   |
+| `200`         | Nicotine 1.0.4 and below  |
 
 
 ## Minor Versions
 
-Projects have their own rules for versioning. The number can be any **uint32**.
+Projects have their own rules for versioning. Any **uint32** number may be
+chosen, but if it is `0` (zero; or if nothing is sent) then the client cannot
+participate in the [distributed search network](#distributed-messages).
 
 ### Nicotine+
 
@@ -275,24 +278,26 @@ API library requires each downstream project to choose a unique `minorVersion`.
 
 #### Major Version `170`
 
-| Minor Version | Client                                    |
-|---------------|-------------------------------------------|
-| `100`         | *All legacy clients up to API 8.5.0*      |
-| `760`         | slskd *(Reference implementation of API)* |
-| `9999`        | *Experimental development and testing*    |
+| Minor Version | Client                                 |
+|---------------|----------------------------------------|
+| `100`         | *All legacy clients up to API 8.5.0*   |
+| `760`         | slskd *(API reference implementation)* |
+| `9999`        | *Experimental development and testing* |
 
 ### Soulseek®
 
-Official client minor version number is incremented for each release.
+Official client minor version number seems to be incremented for each release.
+Legacy clients (<=`156`) had no such concept of a minor version number.
 
 #### Major Version `157`
 
-| Minor Version | Release                    |
-|---------------|----------------------------|
-| `17` (`0x11`) | NS 13c                     |
-| `19` (`0x13`) | NS 13e                     |
-| ...           | Qt Public Build 1 *(2011)* |
-|               | Qt *(2012 onwards)*        |
+| Minor Version | Release                     |
+|---------------|-----------------------------|
+| `0` to `11`   | NS *(Obsolete test builds)* |
+| `17` (`0x11`) | NS 13c                      |
+| `19` (`0x13`) | NS 13e                      |
+| ...           | Qt Public Build 1 *(2011)*  |
+|               | Qt *(2012 onwards)*         |
 
 
 # Server Messages

--- a/doc/SLSKPROTOCOL.md
+++ b/doc/SLSKPROTOCOL.md
@@ -312,8 +312,9 @@ Server messages are used by clients to interface with the server over a
 connection (TCP). In Nicotine+, these messages are defined in slskmessages.py.
 
 If you want a Soulseek server, [Soulfind](https://github.com/soulfind-dev/soulfind)
-is open source (unrelated to the official proprietary Soulseek server). It handles
-the protocol well enough for development and testing of client implementations.
+is an open source implementation (unrelated to the official proprietary Soulseek
+server). It handles the protocol well enough for development and testing of client
+implementations.
 
 
 ## Server Message Format

--- a/doc/SLSKPROTOCOL.md
+++ b/doc/SLSKPROTOCOL.md
@@ -254,7 +254,7 @@ Established clients have unique numbers to avoid impersonating each other.
 
 ## Minor Versions
 
-Projects have thier own rules for versioning. The number can be any **uint32**.
+Projects have their own rules for versioning. The number can be any **uint32**.
 
 ### Nicotine+
 

--- a/doc/SLSKPROTOCOL.md
+++ b/doc/SLSKPROTOCOL.md
@@ -5,7 +5,7 @@
 
 # Soulseek Protocol Documentation
 
-[Last updated on April 20, 2026](https://github.com/nicotine-plus/nicotine-plus/commits/master/doc/SLSKPROTOCOL.md)
+[Last updated on May 7, 2026](https://github.com/nicotine-plus/nicotine-plus/commits/master/doc/SLSKPROTOCOL.md)
 
 Since the official Soulseek client and server is proprietary software, this
 documentation has been compiled thanks to years of reverse engineering efforts.
@@ -225,8 +225,8 @@ missing if a file does not provide them.
 ## Major Versions
 
 Established clients have unique numbers to avoid impersonating each other.
-Obsolete clients cannot [Login](#server-code-1) to the server since 2/17/2005
-due to the `INVALIDVERSION` [Rejection Reason](#login-rejection-reasons).
+Obsolete clients cannot [Login](#server-code-1) to the server since Feb 17,
+2005 due to the `INVALIDVERSION` [Rejection Reason](#login-rejection-reasons).
 
 ### Reserved
 
@@ -237,7 +237,8 @@ due to the `INVALIDVERSION` [Rejection Reason](#login-rejection-reasons).
 | `158` / `159` | *Reserved for SoulseekQt development*   |
 | `160`         | [Nicotine+](#nicotine)                  |
 | `169`         | seeleseek                               |
-| `170`         | [Soulseek.NET](#soulseeknet) *(API)*    |
+| `170`         | [Soulseek.NET](#soulseeknet) *(C# API)* |
+| `175`         | aioslsk *(Python API)*                  |
 | `177`         | *Experimental development and testing*  |
 
 ### Obsolete
@@ -3341,6 +3342,7 @@ SoulseekQt in early 2026.
 This documentation exists thanks to efforts from the following projects:
 
  - Nicotine+ (Hyriand, daelstorm, mathiascode)
+ - aioslsk (JurgenR)
  - slskd (jpdillingham)
  - Museek+ (lbponey)
  - SoleSeek (BriEnigma)

--- a/doc/SLSKPROTOCOL.md
+++ b/doc/SLSKPROTOCOL.md
@@ -5,7 +5,7 @@
 
 # Soulseek Protocol Documentation
 
-[Last updated on May 7, 2026](https://github.com/nicotine-plus/nicotine-plus/commits/master/doc/SLSKPROTOCOL.md)
+[Last updated on May 10, 2026](https://github.com/nicotine-plus/nicotine-plus/commits/master/doc/SLSKPROTOCOL.md)
 
 Since the official Soulseek client and server is proprietary software, this
 documentation has been compiled thanks to years of reverse engineering efforts.
@@ -225,14 +225,11 @@ missing if a file does not provide them.
 ## Major Versions
 
 Established clients have unique numbers to avoid impersonating each other.
-Obsolete clients cannot [Login](#server-code-1) to the server since Feb 17,
-2005 due to the `INVALIDVERSION` [Rejection Reason](#login-rejection-reasons).
 
 ### Reserved
 
 | Major Version | Client                                  |
 |---------------|-----------------------------------------|
-| `155` / `156` | [Soulseek®](#soulseek) *(2005 to 2008)* |
 | `157`         | [Soulseek NS and SoulseekQt](#soulseek) |
 | `158` / `159` | *Reserved for SoulseekQt development*   |
 | `160`         | [Nicotine+](#nicotine)                  |
@@ -245,7 +242,7 @@ Obsolete clients cannot [Login](#server-code-1) to the server since Feb 17,
 
 | Major Version | Client                    |
 |---------------|---------------------------|
-| `154` or less | Soulseek® *(up to 2004)*  |
+| `156` or less | Soulseek® *(pre-NS)*      |
 | `178`         | Museek+                   |
 | `180`         | PySoulSeek                |
 | `181`         | Nicotine+ 1.2.0 to 1.2.11 |
@@ -256,9 +253,8 @@ Obsolete clients cannot [Login](#server-code-1) to the server since Feb 17,
 
 ## Minor Versions
 
-Projects have their own rules for versioning. Any **uint32** number may be
-chosen, but if it is `0` (zero; or if nothing is sent) then the client cannot
-participate in the [distributed search network](#distributed-messages).
+Any non-zero **uint32** number may be chosen. These projects have made their
+own rules for versioning.
 
 ### Nicotine+
 
@@ -287,18 +283,27 @@ API library requires each downstream project to choose a unique `minorVersion`.
 
 ### Soulseek®
 
-Official client minor version number seems to be incremented for each release.
-Legacy clients (<=`156`) had no such concept of a minor version number.
+Official client minor version only increments occasionally. It may signify
+different server functionality.
 
 #### Major Version `157`
 
-| Minor Version | Release                     |
-|---------------|-----------------------------|
-| `0` to `11`   | NS *(Obsolete test builds)* |
-| `17` (`0x11`) | NS 13c                      |
-| `19` (`0x13`) | NS 13e                      |
-| ...           | Qt Public Build 1 *(2011)*  |
-|               | Qt *(2012 onwards)*         |
+| Minor Version | Release                                      |
+|---------------|----------------------------------------------|
+| `1` to `11`   | *"New Server Test"* <=12d (`INVALIDVERSION`) |
+| `17` (`0x11`) | NS 13c                                       |
+| `19` (`0x13`) | NS 13e                                       |
+| `19`          | Qt 2011-4-19 *"Public Build 1"*              |
+| `19`          | Qt 2011-5-08 *"Public Build 2"*              |
+| `100`         | Qt 2011-5-18 *"Public Build 3"*              |
+| `100`         | Qt 2011-6-14 *"Public Build 4"*              |
+| `100`         | Qt 2011-6-29 *"Public Build 5"*              |
+| `100`         | Qt 2011-7-20 *"Public Build 6"*              |
+| `100`         | Qt 2011-7-28                                 |
+| `100`         | Qt ...                                       |
+| `100`         | Qt 2023-1-15                                 |
+| `101`         | Qt 2024-2-01                                 |
+| `101`         | Qt 2026-4-30                                 |
 
 
 # Server Messages

--- a/pynicotine/slskmessages.py
+++ b/pynicotine/slskmessages.py
@@ -695,11 +695,10 @@ class Login(ServerMessage):
     We send this to the server right after the connection has been
     established. Server responds with the greeting message.
 
-    The server uses the major and minor versions to differentiate between
-    clients. Use unique version numbers when possible, to avoid impersonating
-    other clients. Major versions reserved for popular Soulseek clients include
-    157 for Soulseek NS and SoulseekQt, 160 for Nicotine+, and 170 for slskd
-    (Soulseek.NET). These clients have their own rules for minor versions.
+    The server may use the client type and subtype (formally known here as
+    the major and minor protocol versions) to differentiate between client
+    implementations. Projects must choose a unique type number to avoid
+    impersonating other clients, and have thier own rules for subtypes.
     """
 
     __slots__ = ("username", "passwd", "version", "minorversion", "success", "rejection_reason",
@@ -710,8 +709,8 @@ class Login(ServerMessage):
     def __init__(self, username=None, passwd=None, version=None, minorversion=None):
         self.username = username
         self.passwd = passwd
-        self.version = version
-        self.minorversion = minorversion
+        self.version = version  # client_type
+        self.minorversion = minorversion  # client_subtype
         self.success = None
         self.rejection_reason = None
         self.rejection_detail = None
@@ -726,13 +725,13 @@ class Login(ServerMessage):
         msg = bytearray()
         msg += self.pack_string(self.username)
         msg += self.pack_string(self.passwd)
-        msg += self.pack_uint32(self.version)
+        msg += self.pack_uint32(self.version)  # client_type
 
         payload = self.username + self.passwd
         md5hash = md5(payload.encode()).hexdigest()
         msg += self.pack_string(md5hash)
 
-        msg += self.pack_uint32(self.minorversion)
+        msg += self.pack_uint32(self.minorversion)  # client_subtype
 
         return msg
 

--- a/pynicotine/slskmessages.py
+++ b/pynicotine/slskmessages.py
@@ -695,10 +695,11 @@ class Login(ServerMessage):
     We send this to the server right after the connection has been
     established. Server responds with the greeting message.
 
-    The server may use the client type and subtype (formally known here as
-    the major and minor protocol versions) to differentiate between client
-    implementations. Projects must choose a unique type number to avoid
-    impersonating other clients, and have thier own rules for subtypes.
+    The server uses the major and minor versions to differentiate between
+    clients. Numbers are chosen that avoid impersonating clients with reserved
+    major versions. Downstream projects have their own rules for minor
+    versions. Experimental scripts may use major version `177` and any minor
+    version number they choose for each project.
     """
 
     __slots__ = ("username", "passwd", "version", "minorversion", "success", "rejection_reason",
@@ -709,8 +710,8 @@ class Login(ServerMessage):
     def __init__(self, username=None, passwd=None, version=None, minorversion=None):
         self.username = username
         self.passwd = passwd
-        self.version = version  # client_type
-        self.minorversion = minorversion  # client_subtype
+        self.version = version
+        self.minorversion = minorversion
         self.success = None
         self.rejection_reason = None
         self.rejection_detail = None
@@ -725,13 +726,13 @@ class Login(ServerMessage):
         msg = bytearray()
         msg += self.pack_string(self.username)
         msg += self.pack_string(self.passwd)
-        msg += self.pack_uint32(self.version)  # client_type
+        msg += self.pack_uint32(self.version)
 
         payload = self.username + self.passwd
         md5hash = md5(payload.encode()).hexdigest()
         msg += self.pack_string(md5hash)
 
-        msg += self.pack_uint32(self.minorversion)  # client_subtype
+        msg += self.pack_uint32(self.minorversion)
 
         return msg
 

--- a/pynicotine/slskproto.py
+++ b/pynicotine/slskproto.py
@@ -1269,15 +1269,15 @@ class NetworkThread(Thread):
         self._send_message_to_server(
             Login(
                 login, password,
-                # Soulseek client type
-                # NS and SoulseekQt use 157, slskd and Soulseek.NET use 170
-                # We use our reserved client type number for Nicotine+
+                # Soulseek client major version
+                # NS and SoulseekQt use 157, Soulseek.NET and slskd use 170
+                # We use our reserved major version number for Nicotine+
                 160,
 
-                # Soulseek client subtype
+                # Soulseek client minor version
                 # 17 stands for 157 ns 13c, 19 for 157 ns 13e
                 # SoulseekQt seems to go higher than this
-                # Nicotine+ increments the subtype number for new capabilities
+                # Nicotine+ increments the number for new network capabilities
                 # 1 was >=2.2.1, 2 was >=3.3.0, 3 since >=3.4.0
                 3
             )

--- a/pynicotine/slskproto.py
+++ b/pynicotine/slskproto.py
@@ -1269,15 +1269,16 @@ class NetworkThread(Thread):
         self._send_message_to_server(
             Login(
                 login, password,
-                # Soulseek client version
-                # NS and SoulseekQt use 157
-                # We use a custom version number for Nicotine+
+                # Soulseek client type
+                # NS and SoulseekQt use 157, slskd and Soulseek.NET use 170
+                # We use our reserved client type number for Nicotine+
                 160,
 
-                # Soulseek client minor version
+                # Soulseek client subtype
                 # 17 stands for 157 ns 13c, 19 for 157 ns 13e
                 # SoulseekQt seems to go higher than this
-                # We use a custom minor version for Nicotine+
+                # Nicotine+ increments the subtype number for new capabilities
+                # 1 was >=2.2.1, 2 was >=3.3.0, 3 since >=3.4.0
                 3
             )
         )


### PR DESCRIPTION
There is ambiguity about the purpose of the "major version" and "minor version" values as to what they are supposed to represent.

We designated these names before so many other third-party clients existed in the wild, but nowadays it needs to be made clearer that project maintainers must avoid impersonating other client implementations.

+ Added: Table of reserved major versions for known clients, developers of new projects need to know this
+ Added: Table of well known client minor versions, these may become helpful for server admins
- Removed: Known clients from the Login() docstring, forcing developers to refer to the full documentation

_Other possible alternatives (request for comments @mathiascode @jpdillingham @JurgenR @bretth18):_
`major_version` -> `client_type    | client_vendor   | client_identifier | client_family ` 
`minor_version` -> `client_subtype | client_variant  | client_revision   | client_generation ` 