### PR TITLE
uploads.py: differentiate 'started' vs 'resumed' uploads

### DIFF
--- a/pynicotine/uploads.py
+++ b/pynicotine/uploads.py
@@ -1165,9 +1165,10 @@ class Uploads(Transfers):
         sock = upload.sock = msg.sock
         need_update = True
         upload_started = False
+        is_resume = bool(upload.current_byte_offset)
 
-        log.add_transfer("Initializing upload with token %s for file %s to user %s",
-                         (token, virtual_path, username))
+        log.add_transfer("%s upload with token %s for file %s to user %s",
+                         ("Resuming" if is_resume else "Initializing", token, virtual_path, username))
 
         real_path = core.shares.virtual2real(
             virtual_path,
@@ -1191,8 +1192,13 @@ class Uploads(Transfers):
             core.statistics.append_stat_value("started_uploads", 1)
             upload_started = True
 
+            if is_resume:
+                log_message_template = _("Upload resumed: user %(user)s, IP address %(ip)s, file %(file)s")
+            else:
+                log_message_template = _("Upload started: user %(user)s, IP address %(ip)s, file %(file)s")
+
             log.add_upload(
-                _("Upload started: user %(user)s, IP address %(ip)s, file %(file)s"), {
+                log_message_template, {
                     "user": username,
                     "ip": core.users.addresses.get(username),
                     "file": virtual_path


### PR DESCRIPTION
@mathiascode This is just an idea I haven't tested properly. Basically I think it will help if we could somehow identify when an upload is resumed vs started from the beginning.

I think the Transfer() object already contains most data we would need to identify if a non-compliant peer never got the beginning of a file (that's assuming auto-clear uploads list isn't enabled) and just went in for a chunk.

So it's just a matter of presenting a warning in the interface or at least in the log so we start investigating what action should be taken to gracefully handle this kind of scenario (like not sending the speed nor incrementing the stats unless it's known that all of the entire file bytes had actually been transferred).

+ Added: Identify resumed uploads in the transfer logs

Draft PR, not for merge.