### PR TITLE
tests.yml: add Xvfb display server for FreeBSD CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -168,7 +168,11 @@ jobs:
           version: '15.0'
           run: |
             sudo pkg install -y dejavu gettext gtk4 python3 devel/py-build devel/py-pygobject \
-              devel/py-setuptools devel/py-wheel
+              devel/py-setuptools devel/py-wheel xorg-vfbserver
+
+            export DISPLAY=:99
+            Xvfb :99 > /dev/null 2>&1 &
+
             python3 -m unittest -v
             python3 -m build
             python3 -m build --no-isolation


### PR DESCRIPTION
The FreeBSD test job consistently fails on `test_gui_startup` because no display server is available. The Broadway backend isn't found, and without a fallback display, GTK crashes immediately (`GDK_IS_DISPLAY (display)` assertion failure).

This mirrors the existing OpenBSD job which already installs and starts Xvfb. Adds `xorg-vfbserver` to the FreeBSD package list and starts `Xvfb :99` before running tests.