### PR TITLE
utils.py: disallow path traversal in clean_path()

### DIFF
--- a/pynicotine/tests/unit/test_utils.py
+++ b/pynicotine/tests/unit/test_utils.py
@@ -1,0 +1,68 @@
+# SPDX-FileCopyrightText: 2026 Nicotine+ Contributors
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+import os
+
+from unittest import TestCase
+
+from pynicotine.utils import clean_file
+from pynicotine.utils import clean_path
+
+
+class UtilsTest(TestCase):
+
+    def test_clean_file(self):
+        """Verify that file basenames are sanitized correctly."""
+
+        self.assertEqual(
+            clean_file("/basename-with-illegal-?chars?-?:><|*\"-extra-\\/"),
+            "_basename-with-illegal-_chars_-_______-extra-__"
+        )
+        self.assertEqual(
+            clean_file(
+                "/basename-with-control-?chars?-\u0000\u0001\u0002\u0003\u0004\u0005\u0006\u0007\u0008"
+                "\u0009\u000A\u000B\u000C\u000D\u000E\u000F\u0010\u0011\u0012\u0013\u0014\u0015\u0016"
+                "\u0017\u0018\u0019\u001A\u001B\u001C\u001D\u001E\u001F"
+            ),
+            "_basename-with-control-_chars_-________________________________"
+        )
+        self.assertEqual(
+            clean_file(". . . ."),
+            "_"
+        )
+
+    def test_clean_path(self):
+        """Verify that file paths are sanitized correctly."""
+
+        self.assertEqual(
+            clean_path(os.sep.join([":path", "with", "forbidden", "?chars?", "?:><|*\""])),
+            os.sep.join(["_path", "with", "forbidden", "_chars_", "_______"])
+        )
+        self.assertEqual(
+            clean_path(os.sep.join([
+                ":path", "with", "control", "?chars?", "\u0000\u0001\u0002\u0003\u0004\u0005\u0006\u0007\u0008"
+                "\u0009\u000A\u000B\u000C\u000D\u000E\u000F\u0010\u0011\u0012\u0013\u0014\u0015\u0016"
+                "\u0017\u0018\u0019\u001A\u001B\u001C\u001D\u001E\u001F"
+            ])),
+            os.sep.join(["_path", "with", "control", "_chars_", "________________________________"])
+        )
+        self.assertEqual(
+            clean_path(os.sep.join(["C:", ":winpath", "with", "forbidden", "?chars?", "?:><|*\""])),
+            os.sep.join(["C:", "_winpath", "with", "forbidden", "_chars_", "_______"])
+        )
+        self.assertEqual(
+            clean_path(os.sep.join(["path", "with", "trailing", "period", "space. "])),
+            os.sep.join(["path", "with", "trailing", "period", "space"])
+        )
+        self.assertEqual(
+            clean_path(os.sep.join(["path", "with", "trailing", "period", "space", ". . . .   "])),
+            os.sep.join(["path", "with", "trailing", "period", "space", "_"])
+        )
+        self.assertEqual(
+            clean_path(
+                os.sep.join([
+                    "", "..", "normalized", "", "", "..", ".", "path", "/", "/", ".", "..", ""
+                ]) + "//end///"
+            ),
+            os.sep.join(["", "__", "normalized", "__", "_", "path", "_", "__", "end"])
+        )

--- a/pynicotine/utils.py
+++ b/pynicotine/utils.py
@@ -148,6 +148,14 @@ def clean_file(basename):
 
 def clean_path(path):
 
+    # Disallow path traversal
+    path = os.sep.join([
+        REPLACEMENTCHAR if part == "."
+        else REPLACEMENTCHAR * 2 if part == ".."
+        else part
+        for part in path.replace("/", os.sep).split(os.sep)
+    ])
+
     path = os.path.normpath(path)
 
     # Without hacks it is (up to Vista) not possible to have more
@@ -167,6 +175,9 @@ def clean_path(path):
 
     # Path can never end with a period or space on Windows machines
     path = path.rstrip(". ")
+
+    if path.endswith(os.sep):
+        path += REPLACEMENTCHAR
 
     return path
 


### PR DESCRIPTION
File downloads always process the destination path using this function. Ensure file downloads can't be stored outside of the selected download folder, by replacing '.' and '..' path components with underscores.

Other solutions were initially considered, such as rejecting these kind of paths when processing protocol messages, or normalizing the path and replacing it if it falls outside the download folder.

I ultimately concluded that rejecting paths on the protocol level was too aggressive, for the following reasons:
- '.' and '..' path components have never had any special meaning in the Soulseek protocol. We risk excluding valid files from results, if e.g. the virtual folder name is '.' or '..'.
- Restrictions/rules added to the protocol can effectively never be reverted or changed once clients adopt them. It's better to be forgiving, and process the paths locally to be compatible with our OS and file system.
- Path traversal can still be introduced after receiving the path, such as when renaming folders in the download dialog.

As for normalizing the path and replacing it with a safe location if it falls outside the download folder, I decided against it after a few attempts. It's difficult to get right and destroys the directory structure.

@slook