### PR TITLE
Add `py.typed` marker file

### DIFF
--- a/pynicotine/py.typed
+++ b/pynicotine/py.typed
@@ -1,0 +1,2 @@
+# SPDX-FileCopyrightText: 2026 Nicotine+ Contributors
+# SPDX-License-Identifier: GPL-3.0-or-later

--- a/pynicotine/py.typed
+++ b/pynicotine/py.typed
@@ -1,6 +1,6 @@
 # SPDX-FileCopyrightText: 2026 Nicotine+ Contributors
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-This file marks the pynicotine module as supporting typing. See:
+This file marks the pynicotine package as supporting typing. See:
 * https://peps.python.org/pep-0561/#packaging-type-information
 * https://github.com/python/typing/discussions/1429

--- a/pynicotine/py.typed
+++ b/pynicotine/py.typed
@@ -1,2 +1,6 @@
 # SPDX-FileCopyrightText: 2026 Nicotine+ Contributors
 # SPDX-License-Identifier: GPL-3.0-or-later
+
+This file marks the pynicotine module as supporting typing. See:
+* https://peps.python.org/pep-0561/#packaging-type-information
+* https://github.com/python/typing/discussions/1429


### PR DESCRIPTION
The `py.typed` file declares a module to be typed: https://peps.python.org/pep-0561/#packaging-type-information

In my experience, adding `py.typed` to a library means both pyright & mypy get better at providing type annotations to third parties, even when a program is mostly untyped. That is, no effect on N+ itself, but hopefully useful for plugin developers.