### PR TITLE
utils.py: truncate with CRC suffix for UDF compliant path name component

### DIFF
--- a/pynicotine/utils.py
+++ b/pynicotine/utils.py
@@ -302,7 +302,7 @@ def factorize(
 
 
 def truncate_string_byte(
-    string: str, byte_limit: int, encoding: str = "utf-8", ellipsize: bool = False
+    string: str, byte_limit: int, encoding: str = "utf-8", ellipsize: bool = False, crc_suffix: bool = False
 ) -> str:
     """Truncates a string to fit inside a byte limit."""
 
@@ -311,6 +311,21 @@ def truncate_string_byte(
     if len(string_bytes) <= byte_limit:
         # Nothing to do, return original string
         return string
+
+    if crc_suffix:
+        # Append suffix to ensure a UDF compliant path or file name component
+        from binascii import crc_hqx  # CRC-CCITT (poly 0x1021)
+
+        crc = f"#{crc_hqx(string_bytes, 0xFFFF) & 0xFFF:03X}"  # 4 ASCII chars
+        _base, dot, ext = string.rpartition(".")
+        ext_bytes = ext.encode(encoding)
+
+        if dot and len(ext_bytes) <= 5:
+            basename = string_bytes[:byte_limit - 5 - len(ext_bytes)].decode(encoding, "ignore")
+            return f"{basename}{crc}.{ext}"  # "#XYZ" (4) + "." (1) + ext
+
+        basename = string_bytes[:byte_limit - 4].decode(encoding, "ignore")
+        return f"{basename}{crc}"  # "#XYZ" (4)
 
     if ellipsize:
         ellipsis_char = "…".encode(encoding)


### PR DESCRIPTION
+ Added: Standard truncation algorithm that could be used to avoid the risk of filename collisions when renaming path or file name components that are too long or contain illegal characters.

Note I used AI to help me write the `crc_hqx()` hex calculation on line 319, so I'm not sure if the generated characters are mathematically correct since I do not understand how the heck that bit works exactly.

Based on the rules specified in "ECMA TR/112-7 Universal Disk Format (UDF) specification – Part 7 (Revision 1.02)"...
Section 4.2.2.1.2 "OS/2 FileIdentifier" step 5 (page 64) and the  CRC Calculation in appendix 6.5, at link:
https://ecma-international.org/wp-content/uploads/ECMA_TR-112-7_1st_edition_december_2023.pdf

> **Universal Disk Format Revision 1.02 Part 7 (Revision 1.02) Section 4**
> User Interface Requirements - File System
> 
> **Definitions**:
> A _FileIdentifier_ shall be considered as being composed of two parts, a file
> name and file extension.
> 
> The character '.' (`#002E`) shall be considered as the separator for the
> FileIdentifier of a file; characters appearing subsequent to the last '.'
> (`#002E`) shall be considered as constituting the file extension if and only if
> it is less than or equal to 5 characters in length, otherwise the file
> extension shall not exist. Characters appearing prior to the file extension,
> excluding the last '.' (`#002E`), shall be considered as constituting the file
> name.
> 
> **NOTE**: Even though OS/2 , Macintosh , and UNIX do not have an
> official concept of a filename extension it is common file naming
> conventions to end a file with “.” followed by a 1 to 5 character
> extension. Therefore the following algorithms attempt to preserve
> the file extension up to a maximum of 5 characters.
> 
> ...
> 5. **FileIdentifier CRC**: Since through the above process character
> information from the original FileIdentifier is lost the chance of
> creating a duplicate FileIdentifier in the same directory
> increases. To greatly reduce the chance of having a duplicate
> FileIdentifier the file name shall be modified to contain a CRC of
> the original FileIdentifier.
> 
> If there is a file extension then the new FileIdentifier shall be
> composed of up to the first (254 - (length of (new file extension) + 1 
> (for the '.')) - 4 (for the #CRC)) characters constituting the
> file name at this step in the process, followed by the separator
> '#' (`#0023`); followed by a 3 digit CS0 Hex representation of the
> least significant 12 bits of the 16-bit CRC of the original CS0
> FileIdentifier, followed by '.' (`#002E`) and the file extension at
> this step in the process.
> 
> Otherwise if there is no file extension the new FileIdentifier shall
> be composed of up to the first (254 - 4 (for the #CRC))
> characters constituting the file name at this step in the process.
> Followed by the separator '#' (`#0023`); followed by a 3 digit CS0
> Hex representation of the least significant 12 bits of the 16-bit
> CRC of the original CS0 FileIdentifier.

_Note: The above text is from a 2023 revision but hasn't changed much since the original 1998 version of this document._

It is (was) most commonly used to burn files onto Compact Discs and DVD's, but several embedded filesystems such as used on many MP3 players apparently also implement this same algorithm, as far as I can tell, is or was also similar to that used by old or current Windows FAT and NTFS filesystems (with the exception of the legacy character encoding) after IBM's version of HPFS support was merged in the early NT kernels (~before~ in NT4 ~or maybe even since before NT3.51~).

https://ss64.com/nt/syntax-filenames.html