### PR TITLE
PeerMessage: parse_virtual_path() to validate directory name components

### DIFF
--- a/pynicotine/shares.py
+++ b/pynicotine/shares.py
@@ -570,10 +570,14 @@ class Scanner:
 
             file_list = []
             has_filtered_files = False
+            has_parsed_folder = False
             virtual_folder_path_lower = virtual_folder_path.lower()
             virtual_folder_words = virtual_folder_path_lower.translate(TRANSLATE_PUNCTUATION).split()
 
             try:
+                SharedFileListResponse.parse_virtual_path(virtual_folder_path, dir_n=self.current_folder_count)
+                has_parsed_folder = True
+
                 with os.scandir(encode_path(folder_path, prefix=False)) as entries:
                     for entry in entries:
                         basename = basename_escaped = entry.name.decode("utf-8", "replace")
@@ -603,6 +607,9 @@ class Scanner:
                             if self.is_hidden(folder_path, basename, entry):
                                 continue
 
+                            SharedFileListResponse.parse_virtual_path(
+                                basename_escaped, dir_n=self.current_folder_count, file_n=len(file_list) + 1
+                            )
                             virtual_file_path = f"{virtual_folder_path}\\{basename_escaped}"
 
                             if (self.file_filter_regex
@@ -636,7 +643,7 @@ class Scanner:
 
                             self.current_file_index += 1
 
-                        except OSError as error:
+                        except (OSError, RuntimeError) as error:
                             self.writer.send(
                                 ScannerLogMessage(
                                     _("Error while scanning file %(path)s: %(error)s"),
@@ -644,7 +651,7 @@ class Scanner:
                                 )
                             )
 
-            except OSError as error:
+            except (OSError, RuntimeError) as error:
                 self.writer.send(
                     ScannerLogMessage(
                         _("Error while scanning folder %(path)s: %(error)s"),
@@ -652,7 +659,7 @@ class Scanner:
                     )
                 )
 
-            if not has_filtered_files or file_list:
+            if has_parsed_folder and (not has_filtered_files or file_list):
                 self.streams[virtual_folder_path] = self.get_folder_stream(file_list)
 
             self.current_folder_count += 1

--- a/pynicotine/slskmessages.py
+++ b/pynicotine/slskmessages.py
@@ -21,6 +21,7 @@ from socket import inet_ntoa
 from struct import Struct
 
 from pynicotine.utils import UINT32_LIMIT
+from pynicotine.utils import encode_name
 from pynicotine.utils import human_length
 
 # This module contains message classes, that networking and UI thread
@@ -3205,6 +3206,55 @@ class PeerMessage(SlskMessage):
         self.addr = None
         self.allowed_responses = set()
 
+    @staticmethod
+    def parse_virtual_path(path, dir_n=0, file_n=0, errors="strict", name_too_long=255, path_too_long=4096,
+                           path_too_deep=512, too_many_dirs=4194304, too_many_files=65536):
+        """Validate shared directory entry compliance with Soulseek UNC paths
+        and UDF names (limits on Windows, Compact Discs, flash drives, etc).
+
+        errors="ignore" : Either return original name or invalidated sentinal to skip peer entry
+        errors="strict" : Either return original name or raise RuntimeError() to log scanner error
+        """
+
+        depth = 0
+        total = -1
+        try:
+            for depth, name in enumerate(path.split("\\")):
+                encoded_name = encode_name(name, too_long=name_too_long, errors=errors)
+                total += len(encoded_name) + 1
+
+                if total >= path_too_long or depth >= path_too_deep:
+                    raise OverflowError(f'total +{total}B too deep {depth} parents of path entry name "{name[:31]}|~"')
+
+                if file_n >= too_many_files or dir_n >= too_many_dirs:
+                    raise OverflowError(f'too many siblings already exist in directory aside path entry name >{name}<')
+
+                if dir_n and file_n and depth:
+                    raise ValueError(f'basename cannot be inside a subdirectory of itself in file entry name >{name}<')
+
+        except OverflowError as error:
+            trunc_path, ident = f"{repr(path[:31])}|~+{total}B~\\~|{repr(name[-31:])}", f"<D{dir_n}@{depth}:F{file_n}>"
+
+            if errors == "strict":
+                raise RuntimeError(f'Bad directory path entry name {trunc_path} {ident} {error}') from error
+
+            path = f"__INVALID_SHARE__{trunc_path}{ident}"
+
+        except ValueError as error:
+            ident = f"<D{dir_n}@{depth}:F{file_n}>"
+
+            if errors == "strict":
+                raise RuntimeError(f'Bad directory path entry name {repr(path)} {ident} {error}') from error
+
+            path = f"__INVALID_SHARE__{repr(path)}{ident}"
+
+        return path
+
+    def unpack_file_name(self, dir_n=0, file_n=0, errors="ignore"):
+        path = self.unpack_string()
+        return self.parse_virtual_path(path, dir_n=dir_n, file_n=file_n, errors=errors,
+                                       name_too_long=4096, path_too_long=32768, path_too_deep=1024)
+
     def unpack_file_size(self):
 
         if self._message[self._offset + 7] == 255:
@@ -3367,26 +3417,28 @@ class SharedFileListResponse(PeerMessage):
         ext = None
         shares = []
 
-        for _ in range(ndir):
-            directory = self.unpack_string().replace("/", "\\")
+        for dir_n in range(1, ndir + 1):
+            directory = self.unpack_file_name(dir_n=dir_n)
             nfiles = self.unpack_uint32()
 
             files = []
 
-            for _ in range(nfiles):
+            for file_n in range(1, nfiles + 1):
                 code = self.unpack_uint8()
-                name = self.unpack_string()
+                name = self.unpack_file_name(dir_n=dir_n, file_n=file_n)
                 size = self.unpack_file_size()
                 ext_len = self.unpack_uint32()  # Obsolete, ignore
                 self._offset += ext_len
                 attrs = self.unpack_file_attributes()
 
-                files.append((code, name, size, ext, attrs))
+                if file_n < 65536:  # code == 1 and not name.startswith("__INVALID_SHARE__")
+                    files.append((code, name, size, ext, attrs))
 
-            if nfiles > 1:
-                files.sort(key=itemgetter(1))
+            if dir_n < 4194304:  # not directory.startswith("__INVALID_SHARE__")
+                if nfiles > 1 and ndir < 65536:
+                    files.sort(key=itemgetter(1))
 
-            shares.append((directory, files))
+                shares.append((directory, files))
 
         if ndir > 1:
             shares.sort(key=itemgetter(0))
@@ -3517,15 +3569,16 @@ class FileSearchResponse(PeerMessage):
         ext = None
         results = []
 
-        for _ in range(nfiles):
+        for file_n in range(1, nfiles + 1):
             code = self.unpack_uint8()
-            name = self.unpack_string()
+            name = self.unpack_file_name(file_n=file_n)
             size = self.unpack_file_size()
             ext_len = self.unpack_uint32()  # Obsolete, ignore
             self._offset += ext_len
             attrs = self.unpack_file_attributes()
 
-            results.append((code, name.replace("/", "\\"), size, ext, attrs))
+            if file_n <= 25000:  # code == 1 and not name.startswith("__INVALID_SHARE__")
+                results.append((code, name, size, ext, attrs))
 
         if nfiles > 1:
             results.sort(key=itemgetter(1))
@@ -3658,9 +3711,9 @@ class FolderContentsResponse(PeerMessage):
 
         self._offset = 4  # Skip token
         self._message = memoryview(message_bytes + decompressor.decompress(decompressor.unconsumed_tail, dir_len))
-        self.dir = self.unpack_string()
+        self.dir = self.unpack_file_name(errors="strict")
 
-        if self.username + self.dir not in self.allowed_responses:
+        if self.username + self.dir not in self.allowed_responses:  # or self.dir.startswith("__INVALID_SHARE__")
             return
 
         # Optimization: only decompress the rest of the message when needed
@@ -3672,26 +3725,27 @@ class FolderContentsResponse(PeerMessage):
 
     def _parse_remaining_network_message(self):
         ndir = self.unpack_uint32()
+        ext = None
         folders = {}
 
-        for _ in range(ndir):
-            directory = self.unpack_string().replace("/", "\\")
+        for dir_n in range(1, min(ndir, 65536) + 1):
+            directory = self.unpack_file_name(dir_n=dir_n)
             nfiles = self.unpack_uint32()
 
-            ext = None
             folders[directory] = []
 
-            for _ in range(nfiles):
+            for file_n in range(1, nfiles + 1):
                 code = self.unpack_uint8()
-                name = self.unpack_string()
+                name = self.unpack_file_name(dir_n=dir_n, file_n=file_n)
                 size = self.unpack_file_size()
                 ext_len = self.unpack_uint32()  # Obsolete, ignore
                 self._offset += ext_len
                 attrs = self.unpack_file_attributes()
 
-                folders[directory].append((code, name, size, ext, attrs))
+                if file_n < 65536:  # code == 1 and not name.startswith("__INVALID_SHARE__")
+                    folders[directory].append((code, name, size, ext, attrs))
 
-            if nfiles > 1:
+            if nfiles > 1:  # and not directory.startswith("__INVALID_SHARE__")
                 folders[directory].sort(key=itemgetter(1))
 
         self.list = folders
@@ -3751,7 +3805,7 @@ class TransferRequest(PeerMessage):
     def parse_network_message(self):
         self.direction = self.unpack_uint32()
         self.token = self.unpack_uint32()
-        self.file = self.unpack_string()
+        self.file = self.unpack_string()  # TODO: path\file name parser
 
         if self.direction == TransferDirection.UPLOAD:
             self.filesize = self.unpack_uint64()
@@ -3822,7 +3876,7 @@ class PlaceholdUpload(PeerMessage):
         return self.pack_string(self.file)
 
     def parse_network_message(self):
-        self.file = self.unpack_string()
+        self.file = self.unpack_string()  # TODO: path\file name parser
 
 
 class QueueUpload(PeerMessage):
@@ -3844,7 +3898,7 @@ class QueueUpload(PeerMessage):
         return self.pack_string(self.file, is_legacy=self.legacy_client)
 
     def parse_network_message(self):
-        self.file = self.unpack_string()
+        self.file = self.unpack_string()  # TODO: path\file name parser
 
 
 class PlaceInQueueResponse(PeerMessage):
@@ -3869,7 +3923,7 @@ class PlaceInQueueResponse(PeerMessage):
         return msg
 
     def parse_network_message(self):
-        self.filename = self.unpack_string()
+        self.filename = self.unpack_string()  # TODO: path\file name parser
         self.place = self.unpack_uint32()
 
 
@@ -3892,7 +3946,7 @@ class UploadFailed(PeerMessage):
         return self.pack_string(self.file)
 
     def parse_network_message(self):
-        self.file = self.unpack_string()
+        self.file = self.unpack_string()  # TODO: path\file name parser
 
 
 class UploadDenied(PeerMessage):
@@ -3918,7 +3972,7 @@ class UploadDenied(PeerMessage):
         return msg
 
     def parse_network_message(self):
-        self.file = self.unpack_string()
+        self.file = self.unpack_string()  # TODO: path\file name parser
         self.reason = self.unpack_string()
 
 
@@ -3940,7 +3994,7 @@ class PlaceInQueueRequest(PeerMessage):
         return self.pack_string(self.file, is_legacy=self.legacy_client)
 
     def parse_network_message(self):
-        self.file = self.unpack_string()
+        self.file = self.unpack_string()  # TODO: path\file name parser
 
 
 class UploadQueueNotification(PeerMessage):

--- a/pynicotine/utils.py
+++ b/pynicotine/utils.py
@@ -118,17 +118,20 @@ PUNCTUATION = [  # ASCII and Unicode punctuation
     "\U00016B44", "\U00016E97", "\U00016E98", "\U00016E99", "\U00016E9A", "\U00016FE2", "\U0001BC9F",
     "\U0001DA87", "\U0001DA88", "\U0001DA89", "\U0001DA8A", "\U0001DA8B", "\U0001E95E", "\U0001E95F"
 ]
-ILLEGALPATHCHARS = [
-    # ASCII printable characters
-    "?", ":", ">", "<", "|", "*", '"',
-
-    # ASCII control characters
+ILLEGALCTRLCHARS = frozenset({  # ASCII control characters
     "\u0000", "\u0001", "\u0002", "\u0003", "\u0004", "\u0005", "\u0006", "\u0007", "\u0008",
     "\u0009", "\u000A", "\u000B", "\u000C", "\u000D", "\u000E", "\u000F", "\u0010", "\u0011",
     "\u0012", "\u0013", "\u0014", "\u0015", "\u0016", "\u0017", "\u0018", "\u0019", "\u001A",
     "\u001B", "\u001C", "\u001D", "\u001E", "\u001F"
-]
-ILLEGALFILECHARS = ["\\", "/"] + ILLEGALPATHCHARS
+})
+ILLEGALPATHCHARS = frozenset(ILLEGALCTRLCHARS | {"?", ":", ">", "<", "|", "*", '"'})
+ILLEGALFILECHARS = frozenset(ILLEGALPATHCHARS | {"\\", "/"})
+ILLEGALFILENAMES = frozenset(ILLEGALFILECHARS | {".", "..", "~", ""})  # "" is split("\\")
+RESERVEFILESTEMS = frozenset({
+    "CON", "PRN", "AUX", "NUL", "COM¹", "COM²", "COM³", "LPT¹", "LPT²", "LPT³",
+    "COM0", "COM1", "COM2", "COM3", "COM4", "COM5", "COM6", "COM7", "COM8", "COM9",
+    "LPT0", "LPT1", "LPT2", "LPT3", "LPT4", "LPT5", "LPT6", "LPT7", "LPT8", "LPT9"
+})
 LONG_PATH_PREFIX = "\\\\?\\"
 REPLACEMENTCHAR = "_"
 TRANSLATE_PUNCTUATION = str.maketrans(dict.fromkeys(PUNCTUATION, " "))
@@ -172,6 +175,31 @@ def clean_path(path: str) -> str:
     path = path.rstrip(". ")
 
     return path
+
+
+def encode_name(name: str, too_long: int = 255, errors: str = "strict") -> bytes:
+    """Encode only if a valid Universal Disk Format path or file name entry."""
+
+    encoded_name = name.encode("utf-8")
+
+    if len(encoded_name) >= too_long:
+        raise OverflowError(f'too long {len(encoded_name)}B in virtual path name "{name[:31]}|~"')
+
+    if name.strip() in ILLEGALFILENAMES:
+        raise ValueError(f'forbidden relative path identifier as virtual path name >{name}<')
+
+    if name.partition(".")[0].strip().upper() in RESERVEFILESTEMS:
+        raise ValueError(f'forbidden reserved file identifier as virtual path name >{name}<')
+
+    for char in ILLEGALCTRLCHARS:
+        if char not in name:
+            continue
+        raise ValueError(f'illegal control character code {ord(char)} in virtual path name >{repr(name)}<')
+
+    if errors == "strict" and name[-1] in {".", " "}:
+        raise ValueError(f'illegal trailing space or dot path identifier after virtual path name >{name}<')
+
+    return encoded_name
 
 
 def encode_path(path: str, prefix: bool = True):


### PR DESCRIPTION
This is a draft PR intended to aid development and testing to try out if an approach to impose limits upon what names and how many files can be shared, searched and browsed at the protocol level, as to if it would be feasible and not be too restrictive.

- Removed: Don't replace forward slashes of incoming directory entries. No peer should transmit improper path separators in their shared folder listings. As a side effect of not replacing these, files that contain forward-slashes "`/`" in their names could be better supported (i.e. so they don't fracture the tree view nodes, and so that such files could be looked up by the peer).

+ Added: Validate virtual path and file name components to aim for partial UDF naming compliance when:
    - Scanning shares - to prevent from the client from sharing faulty directory listings to other peers on the network
    - Receiving search results
    - Receiving list of a folder contents from a peer
    - Receiving list of shared files from a browsed peer

+ Changed: Use unordered sets for ILLEGAL constants instead of ordered lists, because sets are immutable and hashable.

<details><summary>Restrictions imposed BOTH ways, on what cannot be listed for sharing AND what cannot be received...</summary>
    - No folder or file name that contains an illegal CTRL character IN it (names with illegal PRINTABLE chars ARE still allowed)</br>
    - No folder or file basename that is only 1 character long AND is an illegal file character</br>
    - No folder or file basename that is, or would strip down to, a relative directory path traversal identifier (ie, `.`, `..`, `~`, `/`)</br>
    - No folder or file basename that is, or would strip down to, an absolute zero-length string (ie, ` ` -> `\\`)</br>
    - No folder or file base stem that is, or would strip down to, a Windows system reserved name (ie, `NUL`, `CON.ext`, etc)</br>
    - No more than `4194304` total number of folders in a shared directory listing (silently drop entry or log scanner errors)</br>
    - No more than `65535` file entries within any single shared folder (silently drop entry or log scanner errors)</br>
    - _(todo note: there is no limit on the total number of files in all folders, suggest max count 65536*65536=`UINT32`)_</br>
</details>

<details><summary>Restrictions imposed on what cannot be listed by other peers when receiving responses FROM them...</summary>
    - No directory entry containing any single folder or file name component that is larger than 4 KiB (`4096` Bytes)</br>
    - No directory entry with a concatenated path+filename larger than a sum total of 32 KiB (`32768` Bytes)</br>
    - No directory entry containing a folder path that is nested deeper than `1024` parent levels in a shared tree listing</br>
    - _(note: above errors will result in a `__INVALID_SHARE__<>` sentinel being prepended to invalidate only that directory entry)_</br>
    - No more than `25000` search result entries in any single search response from a peer (any excess are silently dropped)</br>
</details>

<details><summary>Additional restrictions imposed on what cannot be listed for sharing out TO other peers...</summary>
    - No directory entry containing any single folder or file name component that is larger than `254` Bytes</br>
    - No directory entry with a concatenated path+filename larger than a sum total of 4 KiB (`4096` Bytes)</br>
    - No folder that is nested more than `512` levels deep in the shared directory tree listing</br>
    - No folder or file name that ends with a space or dot (` `, `.`)</br>
    - _(note: such errors will result in a logged message raised when rescanning shares, and that entry won't be shared)_</br>
</details>

Disallowing such shared directory entries is not intended to be total tyranny, since entries caught by the parser as implemented in this PR would probably lead to an unresolvable path later on, or it would not be downloadable by some other clients anyway.

This doesn't prevent illegal characters being within a name (provided that that character is not the only character in the name), so a further implementation to normalize path component names when saving files to disk would still be required as well.

UDF 1.02 is used a reference because it uses defacto standards relevant to multimedia filesystem interoperability. See link:
https://dev.ecma-international.org/wp-content/uploads/ECMA_TR-112-7_1st_edition_december_2023.pdf