### PR TITLE
Disable listening port changes when --port is provided

### DIFF
--- a/pynicotine/gtkgui/dialogs/fastconfigure.py
+++ b/pynicotine/gtkgui/dialogs/fastconfigure.py
@@ -34,6 +34,7 @@ class FastConfigure(Dialog):
             self.download_folder_container,
             self.invalid_username_password_label,
             self.listen_port_entry,
+            self.listen_port_label,
             self.main_icon,
             self.next_button,
             self.next_label,
@@ -276,8 +277,9 @@ class FastConfigure(Dialog):
             core.shares.rescan_shares()
 
         # port_page
-        listen_port = self.listen_port_entry.get_value_as_int()
-        config.sections["server"]["portrange"] = (listen_port, listen_port)
+        if core.cli_listen_port is not None:
+            listen_port = self.listen_port_entry.get_value_as_int()
+            config.sections["server"]["portrange"] = (listen_port, listen_port)
 
         # account_page
         if self.invalid_password or self.invalid_username or config.need_config():
@@ -324,8 +326,12 @@ class FastConfigure(Dialog):
         self.password_entry.set_text(config.sections["server"]["passw"])
 
         # port_page
-        listen_port, _unused_port = config.sections["server"]["portrange"]
-        self.listen_port_entry.set_value(listen_port)
+        if core.cli_listen_port is not None:
+            self.listen_port_label.set_label(str(core.cli_listen_port))
+            self.listen_port_label.set_visible(True)
+        else:
+            listen_port, _unused_port = config.sections["server"]["portrange"]
+            self.listen_port_entry.set_value(listen_port)
 
         # share_page
         self.download_folder_button.set_path(core.downloads.get_default_download_folder())

--- a/pynicotine/gtkgui/dialogs/preferences.py
+++ b/pynicotine/gtkgui/dialogs/preferences.py
@@ -72,6 +72,8 @@ class NetworkPage:
             self.check_port_status_label,
             self.container,
             self.current_port_label,
+            self.listen_port_description_label,
+            self.listen_port_label,
             self.listen_port_spinner,
             self.network_interface_label,
             self.password_row_revealer,
@@ -177,6 +179,13 @@ class NetworkPage:
 
         server_hostname, server_port = config.sections["server"]["server"]
         self.soulseek_server_entry.set_text(f"{server_hostname}:{server_port}")
+
+        if core.cli_listen_port is not None:
+            self.listen_port_label.set_label(str(core.cli_listen_port))
+            self.listen_port_label.set_visible(True)
+            self.listen_port_description_label.set_mnemonic_widget(self.listen_port_label)
+        else:
+            self.listen_port_description_label.set_mnemonic_widget(self.listen_port_spinner)
 
         listen_port, _unused_port = config.sections["server"]["portrange"]
         self.listen_port_spinner.set_value(listen_port)

--- a/pynicotine/gtkgui/ui/dialogs/fastconfigure.ui
+++ b/pynicotine/gtkgui/ui/dialogs/fastconfigure.ui
@@ -346,7 +346,17 @@
                 <property name="label" translatable="yes">If necessary, choose a different listening port below. This can also be done later in the preferences.</property>
                 <property name="max-width-chars">60</property>
                 <property name="selectable">True</property>
-                <property name="visible">True</property>
+                <property name="visible" bind-source="listen_port_entry" bind-property="visible" bind-flags="bidirectional|sync-create"/>
+                <property name="wrap">True</property>
+                <property name="xalign">0</property>
+              </object>
+            </child>
+            <child>
+              <object class="GtkLabel">
+                <property name="label" translatable="yes">The following listening port has been set by your environment:</property>
+                <property name="max-width-chars">60</property>
+                <property name="selectable">True</property>
+                <property name="visible" bind-source="listen_port_label" bind-property="visible" bind-flags="bidirectional|sync-create"/>
                 <property name="wrap">True</property>
                 <property name="xalign">0</property>
               </object>
@@ -360,6 +370,17 @@
             <property name="numeric">True</property>
             <property name="valign">center</property>
             <property name="visible">True</property>
+          </object>
+        </child>
+        <child>
+          <object class="GtkLabel" id="listen_port_label">
+            <property name="halign">center</property>
+            <property name="selectable">True</property>
+            <property name="visible" bind-source="listen_port_entry" bind-property="visible" bind-flags="bidirectional|invert-boolean|sync-create"/>
+            <property name="xalign">0</property>
+            <style>
+              <class name="bold"/>
+            </style>
           </object>
         </child>
       </object>

--- a/pynicotine/gtkgui/ui/settings/network.ui
+++ b/pynicotine/gtkgui/ui/settings/network.ui
@@ -185,10 +185,9 @@
             <property name="spacing">12</property>
             <property name="visible">True</property>
             <child>
-              <object class="GtkLabel">
+              <object class="GtkLabel" id="listen_port_description_label">
                 <property name="hexpand">True</property>
                 <property name="label" translatable="yes">Listening port (TCP):</property>
-                <property name="mnemonic-widget">listen_port_spinner</property>
                 <property name="visible">True</property>
                 <property name="wrap">True</property>
                 <property name="wrap-mode">word</property>
@@ -201,6 +200,17 @@
                 <property name="numeric">True</property>
                 <property name="valign">center</property>
                 <property name="visible">True</property>
+              </object>
+            </child>
+            <child>
+              <object class="GtkLabel" id="listen_port_label">
+                <property name="height-request">24</property>
+                <property name="selectable">True</property>
+                <property name="visible" bind-source="listen_port_spinner" bind-property="visible" bind-flags="bidirectional|invert-boolean|sync-create"/>
+                <property name="xalign">0</property>
+                <style>
+                  <class name="bold"/>
+                </style>
               </object>
             </child>
           </object>


### PR DESCRIPTION
When providing a listening port through the command line, the port specified in the config is not used. Disable the option to change the port in the preferences in this case, since it just causes confusion.