### PR TITLE
Implement plugin action system

### DIFF
--- a/pynicotine/events.py
+++ b/pynicotine/events.py
@@ -25,6 +25,12 @@ EVENT_NAMES = {
     "start",
     "thread-callback",
 
+    # Plugins
+    "enable-plugin",
+    "enable-plugin-action",
+    "disable-plugin",
+    "disable-plugin-action",
+
     # Users
     "admin-message",
     "change-password",

--- a/pynicotine/gtkgui/application.py
+++ b/pynicotine/gtkgui/application.py
@@ -71,6 +71,8 @@ class Application:
         self.about = None
         self.fast_configure = None
         self.preferences = None
+        self.plugin_menu = None
+        self.plugin_settings = None
         self.chat_history = None
         self.room_list = None
         self.file_properties = None
@@ -97,6 +99,10 @@ class Application:
 
         for event_name, callback in (
             ("confirm-quit", self.on_confirm_quit),
+            ("disable-plugin", self.on_disable_plugin),
+            ("disable-plugin-action", self.on_enable_disable_plugin_action),
+            ("enable-plugin", self.on_enable_plugin),
+            ("enable-plugin-action", self.on_enable_disable_plugin_action),
             ("invalid-password", self.on_invalid_password),
             ("invalid-username", self.on_invalid_username),
             ("quit", self._instance.quit),
@@ -172,6 +178,7 @@ class Application:
             ("personal-profile", self.on_personal_profile, None, True),
             ("configure-shares", self.on_configure_shares, None, True),
             ("configure-ignored-users", self.on_configure_ignored_users, None, True),
+            ("configure-plugins", self.on_configure_plugins, None, True),
             ("preferences", self.on_preferences, None, True),
             ("confirm-quit", self.on_confirm_quit_request, None, True),
             ("force-quit", self.on_force_quit_request, None, True),
@@ -377,6 +384,77 @@ class Application:
 
         return menu
 
+    def create_plugin_menu(self, *_args):
+
+        from pynicotine.gtkgui.widgets.popupmenu import PopupMenu
+
+        if self.plugin_menu is None:
+            self.plugin_menu = PopupMenu(self)
+
+        has_actions = bool(core.pluginhandler.actions)
+        menu_button = self.plugin_menu.menu_button
+
+        if menu_button is not None:
+            self.plugin_menu.set_menu_button(None)
+
+        self.plugin_menu.clear()
+
+        if not has_actions:
+            self.plugin_menu.add_items(("#" + _("No Plugin Actions"), None))
+
+        for plugin_name, actions in sorted(core.pluginhandler.actions.items()):
+            submenu = PopupMenu(self)
+            has_settings = bool(core.pluginhandler.get_plugin_metasettings(plugin_name))
+
+            try:
+                info = core.pluginhandler.get_plugin_info(plugin_name)
+                human_plugin_name = info.get("Name", plugin_name)
+            except OSError:
+                human_plugin_name = plugin_name
+
+            for data in actions.values():
+                label = data["label"]
+                callback = data["callback"]
+
+                def on_callback(_action, _state, callback):
+                    callback()
+
+                submenu.add_items(("=" + label, on_callback, callback))
+
+            if has_settings:
+                def on_plugin_settings(_action, _state, plugin_name):
+                    self.on_plugin_settings(plugin_name=plugin_name)
+
+                submenu.add_items(
+                    ("", None),
+                    ("#" + _("Plugin _Settings"), on_plugin_settings, plugin_name)
+                )
+
+            submenu.update_model()
+
+            for data in actions.values():
+                label = data["label"]
+                enabled = data["enabled"]
+
+                submenu.actions[label].set_enabled(enabled)
+
+            self.plugin_menu.add_items((">" + human_plugin_name.replace("_", "__"), submenu))
+
+        self.plugin_menu.add_items(
+            ("", None),
+            ("#" + _("_Manage Plugins"), "app.configure-plugins")
+        )
+
+        self.plugin_menu.update_model()
+
+        if not has_actions:
+            self.plugin_menu.actions[_("No Plugin Actions")].set_enabled(False)
+
+        if menu_button is not None:
+            self.plugin_menu.set_menu_button(menu_button)
+
+        return self.plugin_menu
+
     def _create_help_menu(self):
 
         from pynicotine.gtkgui.widgets.popupmenu import PopupMenu
@@ -408,6 +486,7 @@ class Application:
         menu.add_items(
             (">" + _("_File"), self._create_file_menu()),
             (">" + _("_Shares"), self._create_shares_menu()),
+            (">" + _("_Plugins"), self.create_plugin_menu()),
             (">" + _("_Help"), self._create_help_menu())
         )
 
@@ -597,6 +676,40 @@ class Application:
         if msg.user == core.users.login_username:
             self._update_user_status()
 
+    def on_enable_plugin(self, plugin_name):
+        if plugin_name in core.pluginhandler.actions:
+            self.create_plugin_menu()
+
+    def on_disable_plugin(self, _plugin_name):
+        self.create_plugin_menu()
+
+    def on_enable_disable_plugin_action(self, plugin_name, action_id):
+
+        if plugin_name not in core.pluginhandler.actions:
+            return
+
+        if action_id not in core.pluginhandler.actions[plugin_name]:
+            return
+
+        try:
+            info = core.pluginhandler.get_plugin_info(plugin_name)
+            human_plugin_name = info.get("Name", plugin_name)
+        except OSError:
+            human_plugin_name = plugin_name
+
+        human_plugin_name = human_plugin_name.replace("_", "__")
+
+        if human_plugin_name not in self.plugin_menu.items:
+            return
+
+        data = core.pluginhandler.actions[plugin_name][action_id]
+        label = data["label"]
+        enabled = data["enabled"]
+        submenu_model = self.plugin_menu.items[human_plugin_name].get_link("submenu")
+        submenu = next(menu for menu in self.plugin_menu.submenus if menu.model == submenu_model)
+
+        submenu.actions[label].set_enabled(enabled)
+
     # Actions #
 
     def on_connect(self, *_args):
@@ -637,6 +750,23 @@ class Application:
             self.preferences.set_active_page(page_id)
 
         self.preferences.present()
+
+    def on_plugin_settings(self, *_args, plugin_name=None):
+
+        if plugin_name is None:
+            return
+
+        metasettings = core.pluginhandler.get_plugin_metasettings(plugin_name)
+
+        if not metasettings:
+            return
+
+        if self.plugin_settings is None:
+            from pynicotine.gtkgui.dialogs.pluginsettings import PluginSettings
+            self.plugin_settings = PluginSettings(self)
+
+        self.plugin_settings.load_options(plugin_name, metasettings)
+        self.plugin_settings.present()
 
     def on_set_debug_level(self, action, state, level):
 
@@ -853,6 +983,9 @@ class Application:
     def on_configure_ignored_users(self, *_args):
         self.on_preferences(page_id="ignored-users")
 
+    def on_configure_plugins(self, *_args):
+        self.on_preferences(page_id="plugins")
+
     def on_window_hide_unhide(self, *_args):
 
         if self.window.is_visible():
@@ -1048,6 +1181,12 @@ class Application:
 
         if self.preferences is not None:
             self.preferences.destroy()
+
+        if self.plugin_menu is not None:
+            self.plugin_menu.destroy()
+
+        if self.plugin_settings is not None:
+            self.plugin_settings.destroy()
 
         if self.chat_history is not None:
             self.chat_history.destroy()

--- a/pynicotine/gtkgui/dialogs/pluginsettings.py
+++ b/pynicotine/gtkgui/dialogs/pluginsettings.py
@@ -14,6 +14,7 @@ from pynicotine.gtkgui.widgets.filechooser import FileChooserButton
 from pynicotine.gtkgui.widgets.popupmenu import PopupMenu
 from pynicotine.gtkgui.widgets.textview import TextView
 from pynicotine.gtkgui.widgets.theme import add_css_class
+from pynicotine.utils import unescape
 
 
 class PluginSettings(Dialog):
@@ -100,7 +101,7 @@ class PluginSettings(Dialog):
 
         label = self._generate_widget_container(description, button)
         label.set_mnemonic_widget(button)
-        self.application.preferences.set_widget(button, option_value)
+        self.set_widget(button, option_value)
 
     def _add_boolean_option(self, option_name, option_value, description):
 
@@ -111,7 +112,7 @@ class PluginSettings(Dialog):
         label = self._generate_widget_container(description, button)
         label.set_mnemonic_widget(button)
 
-        self.application.preferences.set_widget(button, option_value)
+        self.set_widget(button, option_value)
 
     def _add_radio_option(self, option_name, option_value, description, items):
 
@@ -141,7 +142,7 @@ class PluginSettings(Dialog):
 
         label.set_mnemonic_widget(self.option_widgets[option_name])
         self.option_widgets[option_name].group_radios = group_radios
-        self.application.preferences.set_widget(self.option_widgets[option_name], option_value)
+        self.set_widget(self.option_widgets[option_name], option_value)
 
     def _add_dropdown_option(self, option_name, option_value, description, items):
 
@@ -149,7 +150,7 @@ class PluginSettings(Dialog):
         self.option_widgets[option_name] = combobox = ComboBox(
             container=label.get_parent(), label=label, items=items
         )
-        self.application.preferences.set_widget(combobox, option_value)
+        self.set_widget(combobox, option_value)
 
     def _add_entry_option(self, option_name, option_value, description):
 
@@ -158,7 +159,7 @@ class PluginSettings(Dialog):
         label = self._generate_widget_container(description, entry, homogeneous=True)
         label.set_mnemonic_widget(entry)
 
-        self.application.preferences.set_widget(entry, option_value)
+        self.set_widget(entry, option_value)
 
     def _add_textview_option(self, option_name, option_value, description):
 
@@ -175,7 +176,7 @@ class PluginSettings(Dialog):
         self.option_widgets[option_name] = textview = TextView(scrolled_window)
         label = self._generate_widget_container(description, frame_container, orientation=Gtk.Orientation.VERTICAL)
         label.set_mnemonic_widget(textview.widget)
-        self.application.preferences.set_widget(textview, option_value)
+        self.set_widget(textview, option_value)
 
     def _add_list_option(self, option_name, option_value, description):
 
@@ -209,7 +210,7 @@ class PluginSettings(Dialog):
         rows = [[item, index] for index, item in enumerate(option_value)]
         treeview.description = description
         treeview.row_id = len(rows)
-        self.application.preferences.set_widget(treeview, rows)
+        self.set_widget(treeview, rows)
 
         treeview.popup_menu = PopupMenu(self.application, treeview.widget)
         treeview.popup_menu.add_items(
@@ -268,7 +269,7 @@ class PluginSettings(Dialog):
             container, application=self.application, label=label, chooser_type=file_chooser_type,
             show_open_external_button=not self.application.isolated_mode
         )
-        self.application.preferences.set_widget(self.option_widgets[option_name], option_value)
+        self.set_widget(self.option_widgets[option_name], option_value)
 
     def _add_options(self):
 
@@ -363,6 +364,67 @@ class PluginSettings(Dialog):
 
         return None
 
+    @staticmethod
+    def set_widget(widget, value):
+
+        from pynicotine.gtkgui.widgets.treeview import TreeView
+
+        if isinstance(widget, Gtk.SpinButton):
+            try:
+                widget.set_value(value)
+
+            except TypeError:
+                # Not a numerical value
+                pass
+
+        elif isinstance(widget, Gtk.Entry):
+            if isinstance(value, (str, int)) and widget.get_text() != value:
+                widget.set_text(value)
+
+        elif isinstance(widget, TextView):
+            if isinstance(value, str):
+                widget.set_text(unescape(value))
+
+        elif isinstance(widget, Gtk.Switch):
+            widget.set_active(value)
+
+        elif isinstance(widget, Gtk.CheckButton):
+            try:
+                # Radio button
+                if isinstance(value, int) and value < len(widget.group_radios):
+                    widget.group_radios[value].set_active(True)
+
+            except (AttributeError, TypeError):
+                # Regular check button
+                widget.set_active(value)
+
+        elif isinstance(widget, ComboBox):
+            if widget.entry is not None:
+                widget.set_text(value)
+            else:
+                widget.set_selected_id(value)
+
+        elif isinstance(widget, TreeView):
+            widget.freeze()
+
+            if isinstance(value, list):
+                for item in value:
+                    if isinstance(item, list):
+                        row = item
+                    else:
+                        row = [item]
+
+                    widget.add_row(row, select_row=False)
+
+            elif isinstance(value, dict):
+                for item1, item2 in value.items():
+                    widget.add_row([str(item1), str(item2)], select_row=False)
+
+            widget.unfreeze()
+
+        elif isinstance(widget, FileChooserButton):
+            widget.set_path(value)
+
     def load_options(self, plugin_name, plugin_metasettings):
 
         self.plugin_name = plugin_name
@@ -456,6 +518,7 @@ class PluginSettings(Dialog):
             if new_value is not None:
                 plugin.settings[option_name] = new_value
 
+        plugin.settings_changed_notification()
         self.close()
 
     def on_close(self, *_args):

--- a/pynicotine/gtkgui/dialogs/preferences.py
+++ b/pynicotine/gtkgui/dialogs/preferences.py
@@ -25,7 +25,6 @@ from pynicotine.core import core
 from pynicotine.events import events
 from pynicotine.gtkgui.application import GTK_API_VERSION
 from pynicotine.gtkgui.application import GTK_MINOR_VERSION
-from pynicotine.gtkgui.dialogs.pluginsettings import PluginSettings
 from pynicotine.gtkgui.popovers.portchecker import PortChecker
 from pynicotine.gtkgui.popovers.searchfilterhelp import SearchFilterHelp
 from pynicotine.gtkgui.widgets import ui
@@ -3387,7 +3386,6 @@ class PluginsPage:
 
         self.application = application
         self.selected_plugin = None
-        self.plugin_settings_dialog = None
 
         self.options = {
             "plugins": {
@@ -3427,7 +3425,7 @@ class PluginsPage:
         self.plugin_popup_menu.add_items(
             ("=" + _("_Enable"), self.on_toggle_selected_plugin),
             ("=" + _("_Disable"), self.on_toggle_selected_plugin),
-            ("#" + _("_Settings"), self.on_show_plugin_settings),
+            ("#" + _("_Settings"), self.on_plugin_settings),
             ("", None),
             ("=" + _("Open in File _Manager"), self.on_open_file_manager),
             ("=" + _("_Uninstall…"), self.on_uninstall_plugin)
@@ -3439,9 +3437,6 @@ class PluginsPage:
         self.info_bar.destroy()
         self.plugin_description_view.destroy()
         self.plugin_list_view.destroy()
-
-        if self.plugin_settings_dialog is not None:
-            self.plugin_settings_dialog.destroy()
 
         self.__dict__.clear()
 
@@ -3618,25 +3613,12 @@ class PluginsPage:
         folder_path = core.pluginhandler.get_plugin_path(self.selected_plugin)
         open_folder_path(folder_path, create_folder=True)
 
-    def on_show_plugin_settings(self, *_args):
-
-        if self.selected_plugin is None:
-            return
-
-        metasettings = core.pluginhandler.get_plugin_metasettings(self.selected_plugin)
-
-        if not metasettings:
-            return
-
-        if self.plugin_settings_dialog is None:
-            self.plugin_settings_dialog = PluginSettings(self.application)
-
-        self.plugin_settings_dialog.load_options(self.selected_plugin, metasettings)
-        self.plugin_settings_dialog.present()
+    def on_plugin_settings(self, *_args):
+        self.application.on_plugin_settings(plugin_name=self.selected_plugin)
 
     def on_row_activated(self, _list_view, _iterator, column_id):
         if column_id == "human_name":
-            self.on_show_plugin_settings()
+            self.on_plugin_settings()
 
 
 class Preferences(Dialog):

--- a/pynicotine/gtkgui/mainwindow.py
+++ b/pynicotine/gtkgui/mainwindow.py
@@ -97,7 +97,7 @@ class MainWindow(Window):
             self.header_bar,
             self.header_end,
             self.header_end_container,
-            self.header_menu,
+            self.header_menu_button,
             self.header_title,
             self.hide_window_button,
             self.horizontal_paned,
@@ -109,6 +109,7 @@ class MainWindow(Window):
             self.log_container,
             self.log_search_bar,
             self.log_view_container,
+            self.plugin_menu_button,
             self.private_content,
             self.private_end,
             self.private_entry,
@@ -238,6 +239,8 @@ class MainWindow(Window):
             ("quit", self.on_quit),
             ("server-login", self.update_user_status),
             ("server-disconnect", self.update_user_status),
+            ("enable-plugin", self.set_plugin_menu_visible),
+            ("disable-plugin", self.set_plugin_menu_visible),
             ("set-connection-stats", self.set_connection_stats),
             ("shares-ready", self.shares_ready),
             ("shares-scanning", self.shares_scanning),
@@ -279,6 +282,7 @@ class MainWindow(Window):
         # Actions and menu
         self.set_up_actions()
         self.set_up_menu()
+        self.set_up_plugin_menu()
 
         # Tab visibility/order
         self.append_main_tabs()
@@ -561,21 +565,28 @@ class MainWindow(Window):
     def set_up_menu(self):
 
         menu = self.application.create_hamburger_menu()
-        menu.set_menu_button(self.header_menu)
+        menu.set_menu_button(self.header_menu_button)
 
         if GTK_API_VERSION == 3:
             return
 
         # F10 shortcut to open menu
-        self.header_menu.set_primary(True)
+        self.header_menu_button.set_primary(True)
 
         # Ensure menu button always gets focus after closing menu (fixed in GTK 4.16)
         if (GTK_API_VERSION, GTK_MINOR_VERSION) < (4, 16):
-            popover = self.header_menu.get_popover()
-            popover.connect("closed", lambda *_args: self.header_menu.grab_focus())
+            popover = self.header_menu_button.get_popover()
+            popover.connect("closed", lambda *_args: self.header_menu_button.grab_focus())
+
+    def set_up_plugin_menu(self):
+        menu = self.application.create_plugin_menu()
+        menu.set_menu_button(self.plugin_menu_button)
+
+    def set_plugin_menu_visible(self, *_args):
+        self.plugin_menu_button.set_visible(bool(core.pluginhandler.actions))
 
     def on_menu(self, *_args):
-        self.header_menu.set_active(not self.header_menu.get_active())
+        self.header_menu_button.set_active(not self.header_menu_button.get_active())
 
     # Headerbar/Toolbar #
 
@@ -643,7 +654,7 @@ class MainWindow(Window):
 
         if not self.widget.get_show_menubar():
             self.widget.set_show_menubar(True)
-            self.header_menu.get_popover().set_visible(False)
+            self.header_menu_button.get_popover().set_visible(False)
 
             if GTK_API_VERSION == 3:
                 # Don't override builtin accelerator for menu bar

--- a/pynicotine/gtkgui/ui/mainwindow.ui
+++ b/pynicotine/gtkgui/ui/mainwindow.ui
@@ -27,7 +27,22 @@
       </object>
     </child>
     <child>
-      <object class="GtkMenuButton" id="header_menu">
+      <object class="GtkMenuButton" id="plugin_menu_button">
+        <property name="tooltip-text" translatable="yes">Plugins</property>
+        <property name="visible">False</property>
+        <child>
+          <object class="GtkImage">
+            <property name="icon-name">application-x-addon-symbolic</property>
+            <property name="visible">True</property>
+          </object>
+        </child>
+        <style>
+          <class name="image-button"/>
+        </style>
+      </object>
+    </child>
+    <child>
+      <object class="GtkMenuButton" id="header_menu_button">
         <property name="tooltip-text" translatable="yes">Main Menu</property>
         <property name="visible">True</property>
         <child>

--- a/pynicotine/gtkgui/ui/settings/plugin.ui
+++ b/pynicotine/gtkgui/ui/settings/plugin.ui
@@ -135,7 +135,7 @@
                                     <property name="sensitive">False</property>
                                     <property name="tooltip-text" translatable="yes">Settings</property>
                                     <property name="visible">True</property>
-                                    <signal name="clicked" handler="on_show_plugin_settings"/>
+                                    <signal name="clicked" handler="on_plugin_settings"/>
                                     <child>
                                       <object class="GtkBox">
                                         <property name="spacing">6</property>

--- a/pynicotine/plugins/README.md
+++ b/pynicotine/plugins/README.md
@@ -19,6 +19,17 @@ In order to load your own custom plugins, you need to:
 
 ## For Developers
 
+### Actions
+
+Actions provide a way to interact with your plugin from the UI. An action takes a label and callback function, and is
+presented as a menu item in the global plugin menu. This menu can be accessed from the `Plugins` button next to the
+main menu, or the `Plugins` submenu in the menu bar if header bars are disabled.
+
+See the [actions](https://github.com/nicotine-plus/nicotine-plus/tree/HEAD/pynicotine/plugins/examplars/actions/)
+plugin for examples on how to add actions to your plugins.
+
+Actions were introduced in Nicotine+ 3.4.0.
+
 ### Commands
 
 There are three types of commands available:
@@ -31,13 +42,15 @@ By default, commands are grouped under the same name as your plugin.
 
 Until this section is fully documented, see the [core_commands](https://github.com/nicotine-plus/nicotine-plus/tree/HEAD/pynicotine/plugins/core_commands/) plugin for examples on how to add commands to your plugins.
 
+The current comamnd system was introduced in Nicotine+ 3.3.0. The previous command system should no longer be used. 
+
 ### Events and Notifications
 
-There are two kinds of actions you can hook into:
+There are two kinds of signals you can hook into:
 
 - Events: gives the plugin the ability to alter things. These are time critical, plugins should finish their execution as fast as possible. Only use Events if you really have to, because every ms you linger around processing the user will be looking at a frozen Nicotine+.
 
-- Notifications: gives the plugin the ability to respond to things, without being able to alter them. The plugin can take as long as it wants. This is the preferred action to hook into.
+- Notifications: gives the plugin the ability to respond to things, without being able to alter them. The plugin can take as long as it wants. This is the preferred signal to hook into.
 
 ### Other
 

--- a/pynicotine/plugins/examplars/actions/PLUGININFO
+++ b/pynicotine/plugins/examplars/actions/PLUGININFO
@@ -1,0 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Nicotine+ Contributors
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+Version = "2026-05-20r00"
+Authors = ["Nicotine+"]
+Name = "Sample Actions"
+Description = "Plugin to demonstrate the new action system in Nicotine+ 3.4.0 and above."

--- a/pynicotine/plugins/examplars/actions/__init__.py
+++ b/pynicotine/plugins/examplars/actions/__init__.py
@@ -1,0 +1,34 @@
+# SPDX-FileCopyrightText: 2026 Nicotine+ Contributors
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from pynicotine.pluginsystem import BasePlugin
+
+
+class Plugin(BasePlugin):
+
+    def __init__(self, *args, **kwargs):
+
+        super().__init__(*args, **kwargs)
+
+        self.actions = {
+            "show_upload_statistics": {
+                "label": "Upload Statistics",
+                "callback": self.show_upload_statistics
+            },
+            "export_upload_statistics": {
+                "label": "Export Upload Statistics",
+                "callback": self.export_upload_statistics
+            }
+        }
+
+    def show_upload_statistics(self):
+        pass
+
+    def export_upload_statistics(self):
+        pass
+
+    def enable_export(self):
+        self.enable_action("export_upload_statistics")
+
+    def disable_export(self):
+        self.disable_action("export_upload_statistics")

--- a/pynicotine/plugins/plugin_debugger/__init__.py
+++ b/pynicotine/plugins/plugin_debugger/__init__.py
@@ -13,8 +13,25 @@ class Plugin(BasePlugin):
 
         super().__init__(*args, **kwargs)
 
-        self.settings = {}
-        self.metasettings = {}
+        self.settings = {
+            "log_events": False
+        }
+        self.metasettings = {
+            "log_events": {
+                "description": "Log plugin events",
+                "type": "bool"
+            }
+        }
+        self.actions = {
+            "start_logging_events": {
+                "label": "Start Logging Events",
+                "callback": self._start_logging_events
+            },
+            "stop_logging_events": {
+                "label": "Stop Logging Events",
+                "callback": self._stop_logging_events
+            }
+        }
 
         # These are too noisy, don't enable them by default
         verbose_events = {"public_room_message_notification", "distrib_search_notification"}
@@ -31,7 +48,32 @@ class Plugin(BasePlugin):
 
         self.log("__init__()")
 
+    def _start_logging_events(self):
+        self.settings["log_events"] = True
+        self._update_action_state()
+
+    def _stop_logging_events(self):
+        self.settings["log_events"] = False
+        self._update_action_state()
+
+    def _update_action_state(self):
+
+        if self.settings["log_events"]:
+            self.disable_action("start_logging_events")
+            self.enable_action("stop_logging_events")
+
+            self.log("Enabled plugin event logging")
+            return
+
+        self.enable_action("start_logging_events")
+        self.disable_action("stop_logging_events")
+
+        self.log("Disabled plugin event logging")
+
     def _trigger_log(self, parameter_arguments=""):
+
+        if not self.settings["log_events"]:
+            return
 
         function_name = currentframe().f_back.f_code.co_name
 
@@ -47,9 +89,14 @@ class Plugin(BasePlugin):
         self._trigger_log()
 
     def loaded_notification(self):
+        self._update_action_state()
         self._trigger_log()
 
     def unloaded_notification(self):
+        self._trigger_log()
+
+    def settings_changed_notification(self):
+        self._update_action_state()
         self._trigger_log()
 
     def shutdown_notification(self):

--- a/pynicotine/pluginsystem.py
+++ b/pynicotine/pluginsystem.py
@@ -33,6 +33,7 @@ class BasePlugin:
     # Attributes that can be modified, see examples in the pynicotine/plugins/ folder
     __publiccommands__ = []
     __privatecommands__ = []
+    actions = {}
     commands = {}
     settings = {}
     metasettings = {}
@@ -55,6 +56,10 @@ class BasePlugin:
 
     def loaded_notification(self):
         # The plugin has finished loaded, commands are registered
+        pass
+
+    def settings_changed_notification(self):
+        # Plugin settings were changed externally
         pass
 
     def disable(self):
@@ -300,6 +305,12 @@ class BasePlugin:
     def output(self, text):
         self.echo_message(text, message_type="command")
 
+    def enable_action(self, action_id):
+        self.parent.enable_action(self.internal_name, action_id)
+
+    def disable_action(self, action_id):
+        self.parent.disable_action(self.internal_name, action_id)
+
 
 class ResponseThrottle:
     """
@@ -393,13 +404,14 @@ class InstallException(Exception):
 
 
 class PluginHandler:
-    __slots__ = ("plugin_folders", "enabled_plugins", "command_source", "commands",
+    __slots__ = ("plugin_folders", "enabled_plugins", "actions", "command_source", "commands",
                  "internal_plugin_folder", "user_plugin_folder", "_load_now_playing_sender")
 
     def __init__(self, isolated_mode=False):
 
         self.plugin_folders = []
         self.enabled_plugins = {}
+        self.actions = defaultdict(dict)
         self.command_source = None
         self.commands = {
             "chatroom": {},
@@ -698,7 +710,29 @@ class PluginHandler:
                                 {"interface": command_interface, "name": plugin.human_name, "command": f"/{command}"})
                         continue
 
-                    command_list[command] = data
+                    command_list[command] = data.copy()
+
+            for action_id, data in plugin.actions.items():
+                for key, value_type in (
+                    ("label", str),
+                    ("callback", None)
+                ):
+                    if value_type is None and callable(data.get(key)):
+                        continue
+
+                    if isinstance(data.get(key), value_type):
+                        continue
+
+                    log.add(
+                        _("Action %(action)s in plugin %(name)s missing a valid '%(key)s' value"), {
+                            "action": action_id,
+                            "name": plugin.human_name,
+                            "key": key
+                        }
+                    )
+
+                self.actions[plugin_name][action_id] = data.copy()
+                self.actions[plugin_name][action_id]["enabled"] = True
 
             # Legacy commands
             for command_interface, attribute_name, plugin_commands in (
@@ -729,6 +763,7 @@ class PluginHandler:
                     {"module": plugin_name, "exc_trace": format_exc()})
             return False
 
+        events.emit("enable-plugin", plugin_name)
         return True
 
     def disable_plugin(self, plugin_name, is_permanent=True):
@@ -751,6 +786,8 @@ class PluginHandler:
                     # Remove only if data matches command as defined in this plugin
                     if data and data == command_list.get(command):
                         del command_list[command]
+
+            self.actions.pop(plugin_name, None)
 
             # Legacy commands
             for command_interface, plugin_commands in (
@@ -813,6 +850,7 @@ class PluginHandler:
             del self.enabled_plugins[plugin_name]
             del plugin
 
+        events.emit("disable-plugin", plugin_name)
         return True
 
     def toggle_plugin(self, plugin_name):
@@ -900,6 +938,28 @@ class PluginHandler:
 
         # Persist plugin settings in the config
         config.sections["plugins"][plugin_name] = plugin.settings
+
+    def enable_action(self, plugin_name, action_id):
+
+        if plugin_name not in self.actions:
+            return
+
+        if action_id not in self.actions[plugin_name]:
+            return
+
+        self.actions[plugin_name][action_id]["enabled"] = True
+        events.emit("enable-plugin-action", plugin_name, action_id)
+
+    def disable_action(self, plugin_name, action_id):
+
+        if plugin_name not in self.actions:
+            return
+
+        if action_id not in self.actions[plugin_name]:
+            return
+
+        self.actions[plugin_name][action_id]["enabled"] = False
+        events.emit("disable-plugin-action", plugin_name, action_id)
 
     def get_command_list(self, command_interface):
         """Returns a list of every command and alias available.

--- a/setup.cfg
+++ b/setup.cfg
@@ -114,7 +114,7 @@ py-version = 3.10
 
 [pylint.design]
 max-args = 18
-max-attributes = 125
+max-attributes = 130
 max-bool-expr = 6
 max-branches = 40
 max-locals = 40


### PR DESCRIPTION
Allows plugins to specify actions, a combination of a label and callback, for presentation in the UI. The action system complements the command system, by providing a way to easily interact with a plugin without requiring the use of CLI/chat commands.

For now, only global plugin actions can be defined, which appear in a plugin action menu next to the main menu (or a Plugins submenu in the menu bar, if header bars are disabled).

In the future, contexts can be introduced, which the UI can use to show actions in specific parts of the application, e.g. as menu items for transfers or chats.

<!--
   Before submitting a PR, please discuss the change you wish to make in an
   issue report or discussion thread, in order to see if it fits the direction
   of the project. If you skip this step, a PR containing anything other than
   a trivial bug fix will likely be rejected.
-->
