### PR TITLE
chatrooms.py: append new room to end of autojoin list

### DIFF
--- a/pynicotine/chatrooms.py
+++ b/pynicotine/chatrooms.py
@@ -135,8 +135,10 @@ class ChatRooms:
             self.joined_rooms[room] = room_obj = JoinedRoom(name=room, is_private=is_private)
 
             if room not in config.sections["server"]["autojoin"]:
-                position = 0 if room == self.GLOBAL_ROOM_NAME else -1
-                config.sections["server"]["autojoin"].insert(position, room)
+                if room == self.GLOBAL_ROOM_NAME:
+                    config.sections["server"]["autojoin"].insert(0, room)
+                else:
+                    config.sections["server"]["autojoin"].append(room)
 
         if not room_obj.users:
             if room == self.GLOBAL_ROOM_NAME:


### PR DESCRIPTION
+ Fixed: If the chat tabs were never reordered during the last session then a newly added room appeared one position to the left of the last tab whereas it should be at the very end.