### PR TITLE
headless: don't print unavailable shares list within prompt message

### DIFF
--- a/pynicotine/cli.py
+++ b/pynicotine/cli.py
@@ -142,6 +142,10 @@ class CLI:
         if not self._has_tty:
             return
 
+        if "\n" in message:
+            self._print_log_message("CLI prompt failed (message cannot be multiple lines)")
+            return
+
         self._input_processor.prompt_message = message
         self._input_processor.prompt_callback = callback
         self._input_processor.prompt_silent = is_silent

--- a/pynicotine/headless/application.py
+++ b/pynicotine/headless/application.py
@@ -111,12 +111,12 @@ class Application:
     def on_shares_unavailable(self, shares):
 
         responses = "[Y/n/force] "
-        message = _("The following shares are unavailable:") + "\n\n"
+        shares_list_message = _("The following shares are unavailable:") + "\n\n"
 
         for virtual_name, folder_path in shares:
-            message += f'• "{virtual_name}" {folder_path}\n'
+            shares_list_message += f'• "{virtual_name}" {folder_path}\n'
 
-        message += "\n" + _("Verify that external disks are mounted and folder permissions are correct.")
-        message += "\n" + _("Retry rescan? %s") % responses
+        shares_list_message += "\n" + _("Verify that external disks are mounted and folder permissions are correct.")
 
-        cli.prompt(message, callback=self.on_shares_unavailable_response)
+        log.add(shares_list_message)
+        cli.prompt(_("Retry rescan? %s") % responses, callback=self.on_shares_unavailable_response)


### PR DESCRIPTION
+ Fixed: When the logger prints while the custom prompt is active then the entire shares list was repeatedly reprinted
+ Added: Print a warning if the message has multiple lines, since that usage is a programming or translation error

_For example:_
```
$ ./nicotine --headless
[2026-06-01 20:16:46] [Misc] Using configuration: /home/user/.config/nicotine/config
[2026-06-01 20:16:46] Translation files (.mo) are unavailable, using default English strings
[2026-06-01 20:16:46] Starting Nicotine+ 3.4.0.dev1
[2026-06-01 20:16:46] Loaded Python 3.11.2
[2026-06-01 20:16:46] [Misc] Using Nicotine+ executable: /home/user/nicotine-plus/nicotine-plus/pynicotine
[2026-06-01 20:16:46] [Misc] Using Python executable: /usr/bin/python3
[2026-06-01 20:16:46] Rescan aborted due to unavailable shares: [('Shared Folder 1', '/media/user/drive/Shared Folder 1')]
                                                                                                                                                 [2026-06-01 20:16:46] Loading plugin system         
The following shares are unavailable:

• "Shared Folder 1" /media/user/drive/Shared Folder 1

Verify that external disks are mounted and folder permissions are correct.
                                                                                                                                                 [2026-06-01 20:16:46] Loaded plugin Nicotine+ Commands
The following shares are unavailable:

• "Shared Folder 1" /media/user/drive/Shared Folder 1

Verify that external disks are mounted and folder permissions are correct.
                                                                                                                                                 [2026-06-01 20:16:46] [Misc] Enabled plugins: core_commands, now_playing, headless_browse, port_checker, testreplier, plugin_debugger
The following shares are unavailable:

• "Shared Folder 1" /media/user/drive/Shared Folder 1

Verify that external disks are mounted and folder permissions are correct.
                                                                                                                                                 [2026-06-01 20:16:46] Unable to load plugin now_playing
Traceback (most recent call last):
  File "/home/user/nicotine-plus/nicotine-plus/pynicotine/pluginsystem.py", line 667, in enable_plugin
    plugin = self._import_plugin_instance(plugin_name)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/user/nicotine-plus/nicotine-plus/pynicotine/pluginsystem.py", line 631, in _import_plugin_instance
    instance = plugin.Plugin()
               ^^^^^^^^^^^^^
AttributeError: module 'pynicotine.plugins.now_playing' has no attribute 'Plugin'

The following shares are unavailable:

• "Shared Folder 1" /media/user/drive/Shared Folder 1

Verify that external disks are mounted and folder permissions are correct.
                                                                                                                                                 [2026-06-01 20:16:46] [Misc] Failed to load plugin 'headless_browse', could not find it
The following shares are unavailable:

• "Shared Folder 1" /media/user/drive/Shared Folder 1

Verify that external disks are mounted and folder permissions are correct.
                                                                                                                                                 [2026-06-01 20:16:46] Loaded plugin Port Checker    
The following shares are unavailable:

• "Shared Folder 1" /media/user/drive/Shared Folder 1

Verify that external disks are mounted and folder permissions are correct.
                                                                                                                                                 [2026-06-01 20:16:46] Loaded plugin Test Replier    
The following shares are unavailable:

• "Shared Folder 1" /media/user/drive/Shared Folder 1

Verify that external disks are mounted and folder permissions are correct.
                                                                                                                                                 [2026-06-01 20:16:46] Plugin Debugger: __init__()   
The following shares are unavailable:

• "Shared Folder 1" /media/user/drive/Shared Folder 1

Verify that external disks are mounted and folder permissions are correct.
                                                                                                                                                 [2026-06-01 20:16:46] Plugin Debugger: loaded_notification()
The following shares are unavailable:

• "Shared Folder 1" /media/user/drive/Shared Folder 1

Verify that external disks are mounted and folder permissions are correct.
                                                                                                                                                 [2026-06-01 20:16:46] Loaded plugin Plugin Debugger 
The following shares are unavailable:

• "Shared Folder 1" /media/user/drive/Shared Folder 1

Verify that external disks are mounted and folder permissions are correct.
                                                                                                                                                 [2026-06-01 20:16:46] Type /connect to connect to Soulseek
The following shares are unavailable:

• "Shared Folder 1" /media/user/drive/Shared Folder 1

Verify that external disks are mounted and folder permissions are correct.
Retry rescan? [Y/n/force] The following shares are unavailable:

• "Shared Folder 1" /media/user/drive/Shared Folder 1

Verify that external disks are mounted and folder permissions are correct.
                                                                                                                                                 [2026-06-01 20:19:46] [Misc] Backed up and saved file /home/user/.config/nicotine/config
The following shares are unavailable:

• "Shared Folder 1" /media/user/drive/Shared Folder 1

Verify that external disks are mounted and folder permissions are correct.
                                                                                                                                                 [2026-06-01 20:19:46] [Misc] Backed up and saved file /home/user/.local/share/nicotine/wishlist.json
The following shares are unavailable:

• "Shared Folder 1" /media/user/drive/Shared Folder 1

Verify that external disks are mounted and folder permissions are correct.
                                                                                                                                                 [2026-06-01 20:19:46] [Misc] Backed up and saved file /home/user/.local/share/nicotine/downloads.json
The following shares are unavailable:

• "Shared Folder 1" /media/user/drive/Shared Folder 1

Verify that external disks are mounted and folder permissions are correct.
                                                                                                                                                 [2026-06-01 20:19:46] [Misc] Backed up and saved file /home/user/.local/share/nicotine/uploads.json
The following shares are unavailable:

• "Shared Folder 1" /media/user/drive/Shared Folder 1

Verify that external disks are mounted and folder permissions are correct.
Retry rescan? [Y/n/force] Retry rescan? [Y/n/force] 
```
(scroll to the right to see further corruption of the line breaks)