### PR TITLE
headless: carriage return prefix on input prompt message

### DIFF
--- a/pynicotine/cli.py
+++ b/pynicotine/cli.py
@@ -78,7 +78,7 @@ class CLIInputProcessor(Thread):
         input_func = getpass if self.prompt_silent else input
         self.has_custom_prompt = (callback is not None)
 
-        user_input = input_func(self.prompt_message)
+        user_input = input_func(f"\r{self.prompt_message}")
 
         self.has_custom_prompt = False
         self.prompt_message = ""


### PR DESCRIPTION
+ Fixed: The reprompter had already reprompted if new log messages arrived on the typewriter during the 0.25s time while waiting for the custom prompt input function to be invoked, such as during startup, resulting in the prompt sometimes being written twice, so always return the carriage to the start of the printing line when calling an input prompt to cause the message overwrite itself if needed.

_For example:_
`Retry rescan? [Y/n/force] Retry rescan? [Y/n/force] `

The other way to fix this is to prevent the reprompter from pre-printing the message by adding conditions or changing the order of how the custom prompt is set, but it works well the way it is so this is the least disruptive solution.