### PR TITLE
core_commands: list installed plugins if name not found

### DIFF
--- a/pynicotine/plugins/core_commands/__init__.py
+++ b/pynicotine/plugins/core_commands/__init__.py
@@ -601,7 +601,15 @@ class Plugin(BasePlugin):
 
         action, plugin_name = args.split(maxsplit=1)
 
-        if action == "toggle":
+        if self.parent.get_plugin_path(plugin_name) is None:
+            self.output(_("Installed plugins:"))
+
+            for basename in sorted(self.parent.list_installed_plugins()):
+                self.output(f"{'‣' if basename in self.parent.enabled_plugins else '•'} {basename}")
+
+            self.output(_("No plugin with name \"%s\"") % plugin_name)
+
+        elif action == "toggle":
             self.parent.toggle_plugin(plugin_name)
 
         elif action == "reload":


### PR DESCRIPTION
+ Added: When a non-existant name is given as the argument to any action of the plugin command, then output a list of all the installed plugin names instead of nothing. This is helpful to have something to copy from when entering a command.

```
plugin toggle qwertyuiop
Installed plugins:
• __pycache__
• anti_shout
• auto_buddy_rooms
• auto_user_browse
• examplars
‣ headless_browse
• leech_detector
• multipaste
• now_playing
• now_playing_search
• now_playing_sender
‣ plugin_debugger
• port_checker
• spamfilter
‣ test_plugin
‣ testreplier
• ttktui
• youtube_info
No plugin with name "qwertyuiop"

```


