### PR TITLE
Implement safe path joining to prevent path traversal

### DIFF
--- a/pynicotine/downloads.py
+++ b/pynicotine/downloads.py
@@ -48,8 +48,8 @@ from pynicotine.transfers import Transfers
 from pynicotine.transfers import TransferStatus
 from pynicotine.utils import execute_command
 from pynicotine.utils import clean_file
-from pynicotine.utils import clean_path
 from pynicotine.utils import encode_path
+from pynicotine.utils import safe_path_join
 from pynicotine.utils import truncate_string_byte
 
 
@@ -417,7 +417,7 @@ class Downloads(Transfers):
         download_folder_path_encoded = encode_path(download_folder_path)
 
         download_basename = self.get_download_basename(transfer.virtual_path, download_folder_path, avoid_conflict=True)
-        download_file_path = os.path.join(download_folder_path, download_basename)
+        download_file_path = safe_path_join(download_folder_path, download_basename)
 
         try:
             if not os.path.isdir(download_folder_path_encoded):
@@ -624,14 +624,14 @@ class Downloads(Transfers):
         # Remove parent folders of the requested folder from path
         parent_folder_path = root_folder_path if root_folder_path else folder_path
         removed_parent_folders = parent_folder_path.rpartition("\\")[0]
-        target_folders = folder_path.replace(removed_parent_folders, "", 1).lstrip("\\").replace("\\", os.sep)
+        target_folders = folder_path.replace(removed_parent_folders, "", 1).split("\\")
 
         # Check if a custom download location was specified
         if not download_folder_path:
             download_folder_path = self.get_default_download_folder(username)
 
         # Merge download path with target folder name
-        return os.path.join(download_folder_path, target_folders)
+        return safe_path_join(download_folder_path, *target_folders)
 
     def get_default_download_folder(self, username=None):
 
@@ -639,7 +639,7 @@ class Downloads(Transfers):
 
         # Check if username subfolders should be created for downloads
         if username and config.sections["transfers"]["usernamesubfolders"]:
-            download_folder_path = os.path.join(download_folder_path, clean_file(username))
+            download_folder_path = safe_path_join(download_folder_path, username)
 
         return download_folder_path
 
@@ -685,7 +685,7 @@ class Downloads(Transfers):
 
         counter = 1
 
-        while os.path.exists(encode_path(os.path.join(download_folder_path, corrected_basename))):
+        while os.path.exists(encode_path(safe_path_join(download_folder_path, corrected_basename))):
             corrected_basename = f"{basename_no_extension} ({counter}){extension}"
             counter += 1
 
@@ -699,7 +699,7 @@ class Downloads(Transfers):
 
         basename = self.get_download_basename(virtual_path, download_folder_path)
         basename_no_extension, extension = os.path.splitext(basename)
-        download_file_path = os.path.join(download_folder_path, basename)
+        download_file_path = safe_path_join(download_folder_path, basename)
         file_exists = False
         counter = 1
 
@@ -710,7 +710,7 @@ class Downloads(Transfers):
                 break
 
             basename = f"{basename_no_extension} ({counter}){extension}"
-            download_file_path = os.path.join(download_folder_path, basename)
+            download_file_path = safe_path_join(download_folder_path, basename)
             counter += 1
 
         return download_file_path, file_exists
@@ -735,7 +735,7 @@ class Downloads(Transfers):
         if basename_limit < 0:
             extension = truncate_string_byte(extension, max_bytes - len(prefix))
 
-        return os.path.join(incomplete_folder_path, prefix + basename_no_extension + extension)
+        return safe_path_join(incomplete_folder_path, prefix + basename_no_extension + extension)
 
     def get_current_download_file_path(self, transfer):
         """Returns the current file path of a download."""
@@ -783,9 +783,7 @@ class Downloads(Transfers):
 
         transfer = self.transfers.get(username + virtual_path)
 
-        if folder_path:
-            folder_path = clean_path(folder_path)
-        else:
+        if not folder_path:
             folder_path = self.get_default_download_folder(username)
 
         if transfer is not None and transfer.folder_path != folder_path and transfer.status == TransferStatus.FINISHED:
@@ -1097,7 +1095,7 @@ class Downloads(Transfers):
                 # a remotely initiated download and someone is manually uploading to you
                 parent_folder_path = virtual_path.replace("/", "\\").split("\\")[-2]
                 received_folder_path = os.path.normpath(os.path.expandvars(config.sections["transfers"]["uploaddir"]))
-                folder_path = os.path.join(received_folder_path, username, parent_folder_path)
+                folder_path = safe_path_join(received_folder_path, username, parent_folder_path)
 
                 transfer = Transfer(username, virtual_path, folder_path, size)
 

--- a/pynicotine/gtkgui/dialogs/download.py
+++ b/pynicotine/gtkgui/dialogs/download.py
@@ -24,6 +24,7 @@ from pynicotine.gtkgui.widgets.popupmenu import PopupMenu
 from pynicotine.gtkgui.widgets.treeview import TreeView
 from pynicotine.utils import human_size
 from pynicotine.utils import humanize
+from pynicotine.utils import safe_path_join
 
 
 class Download(Dialog):
@@ -336,7 +337,7 @@ class Download(Dialog):
                 download_folder_path = core.downloads.get_default_download_folder(username)
 
             destination_folder_name = self.folder_names[folder_path]
-            destination_folder_path = os.path.join(download_folder_path, destination_folder_name)
+            destination_folder_path = safe_path_join(download_folder_path, *destination_folder_name.split(os.sep))
 
             files.append((username, file_path, destination_folder_path, size, file_attributes))
 

--- a/pynicotine/logfacility.py
+++ b/pynicotine/logfacility.py
@@ -14,9 +14,9 @@ from pynicotine.slskmessages import DistribEmbeddedMessage
 from pynicotine.slskmessages import DistribSearch
 from pynicotine.slskmessages import EmbeddedMessage
 from pynicotine.slskmessages import UnknownPeerMessage
-from pynicotine.utils import clean_file
 from pynicotine.utils import encode_path
 from pynicotine.utils import open_file_path
+from pynicotine.utils import safe_path_join
 
 
 class LogFile:
@@ -118,7 +118,7 @@ class Logger:
 
     def _get_log_file(self, folder_path, basename, should_create_file=True):
 
-        file_path = os.path.join(folder_path, clean_file(f"{basename}.log"))
+        file_path = safe_path_join(folder_path, f"{basename}.log")
         log_file = self._log_files.get(file_path)
 
         if log_file is not None:
@@ -164,7 +164,7 @@ class Logger:
             should_log_file = (folder_path != self.debug_folder_path)
 
             self._add(_('Couldn\'t write to log file "%(filename)s": %(error)s'), {
-                "filename": os.path.join(folder_path, clean_file(f"{basename}.log")),
+                "filename": safe_path_join(folder_path, f"{basename}.log"),
                 "error": error
             }, should_log_file=should_log_file)
 
@@ -250,7 +250,7 @@ class Logger:
 
         except Exception as error:
             self._add(_("Cannot access log file %(path)s: %(error)s"), {
-                "path": os.path.join(folder_path, clean_file(f"{basename}.log")),
+                "path": safe_path_join(folder_path, f"{basename}.log"),
                 "error": error
             })
 
@@ -265,7 +265,7 @@ class Logger:
     def _log_file_operation(self, folder_path, basename, callback):
 
         folder_path_encoded = encode_path(folder_path)
-        file_path = os.path.join(folder_path, clean_file(f"{basename}.log"))
+        file_path = safe_path_join(folder_path, f"{basename}.log")
 
         try:
             if not os.path.isdir(folder_path_encoded):

--- a/pynicotine/tests/unit/test_utils.py
+++ b/pynicotine/tests/unit/test_utils.py
@@ -1,0 +1,117 @@
+# SPDX-FileCopyrightText: 2026 Nicotine+ Contributors
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+import os
+
+from unittest import TestCase
+
+from pynicotine.utils import clean_file
+from pynicotine.utils import safe_path_join
+
+
+class UtilsTest(TestCase):
+
+    def test_clean_file(self):
+        """Verify that file path components are sanitized correctly."""
+
+        self.assertEqual(
+            clean_file("/basename-with-illegal-?chars?-?:><|*\"-extra-\\/"),
+            "_basename-with-illegal-_chars_-_______-extra-__"
+        )
+        self.assertEqual(
+            clean_file(
+                "/basename-with-control-?chars?-\u0000\u0001\u0002\u0003\u0004\u0005\u0006\u0007\u0008"
+                "\u0009\u000A\u000B\u000C\u000D\u000E\u000F\u0010\u0011\u0012\u0013\u0014\u0015\u0016"
+                "\u0017\u0018\u0019\u001A\u001B\u001C\u001D\u001E\u001F"
+            ),
+            "_basename-with-control-_chars_-________________________________"
+        )
+        self.assertEqual(clean_file(" .path. "), ".path")
+        self.assertEqual(clean_file(" . . . . "), "_________")
+        self.assertEqual(clean_file("..."), "___")
+        self.assertEqual(clean_file(".."), "__")
+        self.assertEqual(clean_file(" .."), "___")
+        self.assertEqual(clean_file(".. "), "___")
+        self.assertEqual(clean_file(" .. "), "____")
+        self.assertEqual(clean_file("."), "_")
+        self.assertEqual(clean_file(" ."), "__")
+        self.assertEqual(clean_file(". "), "__")
+        self.assertEqual(clean_file(" . "), "___")
+        self.assertEqual(clean_file(" "), "_")
+        self.assertEqual(clean_file(""), "")
+        self.assertEqual(clean_file("/"), "_")
+        self.assertEqual(clean_file("/absolute"), "_absolute")
+        self.assertEqual(clean_file("\\absolute"), "_absolute")
+
+    def test_safe_path_join(self):
+        """Verify that path components are joined and sanitized correctly."""
+
+        base = os.path.abspath(".")
+
+        self.assertEqual(
+            safe_path_join(
+                os.sep.join(["C:", "basepath", "folder"]),
+                "..", ".", " .. ", "\\", "", "\\name", "", "D:relative", "", "C:\\absolute"
+            ),
+            os.path.abspath(
+                os.sep.join(["C:", "basepath", "folder", "__", "_", "____", "_", "_name", "D_relative", "C__absolute"])
+            )
+        )
+        self.assertEqual(
+            safe_path_join(
+                os.sep.join(["relative", "basepath", "folder"]),
+                "..", ".", " .. ", "/", "", "/name", "", "relative", "", "/absolute"
+            ),
+            os.sep.join([
+                base, "relative", "basepath", "folder", "__", "_", "____", "_", "_name", "relative", "_absolute"
+            ])
+        )
+        self.assertEqual(
+            safe_path_join(
+                os.sep.join(["", "absolute", "basepath", "folder"]),
+                "..", ".", " .. ", "/", "", "/name", "", "relative", "", "/absolute"
+            ),
+            os.path.abspath(
+                os.sep.join([
+                    "", "absolute", "basepath", "folder", "__", "_", "____", "_", "_name", "relative", "_absolute"
+                ])
+            )
+        )
+        self.assertEqual(
+            safe_path_join(
+                os.sep.join(["base", "path"]),
+                "/basename-with-illegal-?chars?-?:><|*\"-extra-\\/", "//", "/absolute"
+            ),
+            os.sep.join([base, "base", "path", "_basename-with-illegal-_chars_-_______-extra-__", "__", "_absolute"])
+        )
+        self.assertEqual(
+            safe_path_join(
+                os.sep.join(["base", "path"]),
+                "/basename-with-control-?chars?-\u0000\u0001\u0002\u0003\u0004\u0005\u0006\u0007\u0008"
+                "\u0009\u000A\u000B\u000C\u000D\u000E\u000F\u0010\u0011\u0012\u0013\u0014\u0015\u0016"
+                "\u0017\u0018\u0019\u001A\u001B\u001C\u001D\u001E\u001F",
+                "/absolute"
+            ),
+            os.sep.join([
+                base, "base", "path", "_basename-with-control-_chars_-________________________________", "_absolute"
+            ])
+        )
+        self.assertEqual(
+            safe_path_join(
+                os.sep.join(["base", "path"]),
+                " .path. ", " . . . . ", "...", "..", " ..", ".. ", " .. ", ".", " .", ". ", " . ", " ", "", "/",
+                "/absolute"
+            ),
+            os.sep.join([
+                base, "base", "path", ".path", "_________", "___", "__", "___", "___", "____", "_", "__", "__", "___",
+                "_", "_", "_absolute"
+            ])
+        )
+        self.assertEqual(
+            safe_path_join(os.sep.join(["base", "path"]), "/absolute", "..", "."),
+            os.sep.join([base, "base", "path", "_absolute", "__", "_"])
+        )
+        self.assertEqual(
+            safe_path_join(os.sep.join(["base", "path"]), "\\absolute", "..", "."),
+            os.sep.join([base, "base", "path", "_absolute", "__", "_"])
+        )

--- a/pynicotine/tests/unit/transfers/test_downloads.py
+++ b/pynicotine/tests/unit/transfers/test_downloads.py
@@ -205,6 +205,7 @@ class DownloadsTest(TestCase):
     def test_download_folder_destination(self):
         """Verify that the correct download destination is used."""
 
+        base = os.path.abspath(".")
         username = "newuser"
         folder_path = "Hello\\Path"
         config.sections["transfers"]["usernamesubfolders"] = False
@@ -223,7 +224,7 @@ class DownloadsTest(TestCase):
         destination_depth = core.downloads.get_folder_destination(username, folder_path)
 
         self.assertEqual(destination_default, os.path.join(config.data_folder_path, "Path"))
-        self.assertEqual(destination_custom, os.path.join("Hello Test Path 2", "Path"))
+        self.assertEqual(destination_custom, os.path.join(base, "Hello Test Path 2", "Path"))
         self.assertEqual(destination_user, os.path.join(config.data_folder_path, "newuser", "Path"))
         self.assertEqual(destination_root, os.path.join(config.data_folder_path, "newuser", "Hello"))
         self.assertEqual(destination_depth, os.path.join(config.data_folder_path, "newuser", "Hello Depth Test Path"))
@@ -231,6 +232,7 @@ class DownloadsTest(TestCase):
     def test_download_subfolders(self):
         """Verify that subfolders are downloaded to the correct location."""
 
+        base = os.path.abspath(".")
         username = "random"
         browsed_user = core.userbrowse.users[username] = BrowsedUser(username)
         browsed_user.public_folders = dict([
@@ -272,17 +274,17 @@ class DownloadsTest(TestCase):
         transfers = list(core.downloads.transfers.values())
         self.assertEqual(len(transfers), 11)
 
-        self.assertEqual(transfers[10].folder_path, os.path.join("test", "share", "SoulseekSecond"))
-        self.assertEqual(transfers[9].folder_path, os.path.join("test", "share", "SoulseekSecond"))
-        self.assertEqual(transfers[8].folder_path, os.path.join("test", "share", "Soulseek", "folder2", "sub2"))
-        self.assertEqual(transfers[7].folder_path, os.path.join("test", "share", "Soulseek", "folder2"))
-        self.assertEqual(transfers[6].folder_path, os.path.join("test", "share", "Soulseek", "folder1", "sub1"))
-        self.assertEqual(transfers[5].folder_path, os.path.join("test", "share", "Soulseek", "folder1"))
-        self.assertEqual(transfers[4].folder_path, os.path.join("test", "share", "Soulseek"))
-        self.assertEqual(transfers[3].folder_path, os.path.join("test", "share", "Soulseek"))
-        self.assertEqual(transfers[2].folder_path, os.path.join("test", "share", "Music"))
-        self.assertEqual(transfers[1].folder_path, os.path.join("test", "share", "Music"))
-        self.assertEqual(transfers[0].folder_path, os.path.join("test", "share"))
+        self.assertEqual(transfers[10].folder_path, os.path.join(base, "test", "share", "SoulseekSecond"))
+        self.assertEqual(transfers[9].folder_path, os.path.join(base, "test", "share", "SoulseekSecond"))
+        self.assertEqual(transfers[8].folder_path, os.path.join(base, "test", "share", "Soulseek", "folder2", "sub2"))
+        self.assertEqual(transfers[7].folder_path, os.path.join(base, "test", "share", "Soulseek", "folder2"))
+        self.assertEqual(transfers[6].folder_path, os.path.join(base, "test", "share", "Soulseek", "folder1", "sub1"))
+        self.assertEqual(transfers[5].folder_path, os.path.join(base, "test", "share", "Soulseek", "folder1"))
+        self.assertEqual(transfers[4].folder_path, os.path.join(base, "test", "share", "Soulseek"))
+        self.assertEqual(transfers[3].folder_path, os.path.join(base, "test", "share", "Soulseek"))
+        self.assertEqual(transfers[2].folder_path, os.path.join(base, "test", "share", "Music"))
+        self.assertEqual(transfers[1].folder_path, os.path.join(base, "test", "share", "Music"))
+        self.assertEqual(transfers[0].folder_path, os.path.join(base, "test", "share"))
 
         # Share subfolder
         target_folder_path = "share\\Soulseek"
@@ -293,12 +295,12 @@ class DownloadsTest(TestCase):
         transfers = list(core.downloads.transfers.values())
         self.assertEqual(len(transfers), 6)
 
-        self.assertEqual(transfers[5].folder_path, os.path.join("test2", "Soulseek", "folder2", "sub2"))
-        self.assertEqual(transfers[4].folder_path, os.path.join("test2", "Soulseek", "folder2"))
-        self.assertEqual(transfers[3].folder_path, os.path.join("test2", "Soulseek", "folder1", "sub1"))
-        self.assertEqual(transfers[2].folder_path, os.path.join("test2", "Soulseek", "folder1"))
-        self.assertEqual(transfers[1].folder_path, os.path.join("test2", "Soulseek"))
-        self.assertEqual(transfers[0].folder_path, os.path.join("test2", "Soulseek"))
+        self.assertEqual(transfers[5].folder_path, os.path.join(base, "test2", "Soulseek", "folder2", "sub2"))
+        self.assertEqual(transfers[4].folder_path, os.path.join(base, "test2", "Soulseek", "folder2"))
+        self.assertEqual(transfers[3].folder_path, os.path.join(base, "test2", "Soulseek", "folder1", "sub1"))
+        self.assertEqual(transfers[2].folder_path, os.path.join(base, "test2", "Soulseek", "folder1"))
+        self.assertEqual(transfers[1].folder_path, os.path.join(base, "test2", "Soulseek"))
+        self.assertEqual(transfers[0].folder_path, os.path.join(base, "test2", "Soulseek"))
 
     def test_delete_stale_incomplete_downloads(self):
         """Verify that only files matching the pattern for incomplete downloads are deleted."""

--- a/pynicotine/userbrowse.py
+++ b/pynicotine/userbrowse.py
@@ -19,10 +19,10 @@ from pynicotine.slskmessages import RemoveAllowedResponse
 from pynicotine.slskmessages import SharedFileListRequest
 from pynicotine.slskmessages import SharedFileListResponse
 from pynicotine.slskmessages import UploadQueueNotification
-from pynicotine.utils import clean_file
 from pynicotine.utils import encode_path
 from pynicotine.utils import human_size
 from pynicotine.utils import humanize
+from pynicotine.utils import safe_path_join
 
 
 class BrowsedUser:
@@ -298,7 +298,7 @@ class UserBrowse:
             return
 
         try:
-            file_path = os.path.join(folder_path, clean_file(username))
+            file_path = safe_path_join(folder_path, username)
             browsed_user = self.users[username]
 
             with open(encode_path(file_path), "w", encoding="utf-8") as file_handle:

--- a/pynicotine/utils.py
+++ b/pynicotine/utils.py
@@ -134,42 +134,33 @@ REPLACEMENTCHAR = "_"
 TRANSLATE_PUNCTUATION = str.maketrans(dict.fromkeys(PUNCTUATION, " "))
 
 
-def clean_file(basename: str) -> str:
+def clean_file(part: str) -> str:
+    """Sanitizes a file path component."""
 
     for char in ILLEGALFILECHARS:
-        if char in basename:
-            basename = basename.replace(char, REPLACEMENTCHAR)
+        if char in part:
+            part = part.replace(char, REPLACEMENTCHAR)
 
-    # Filename can never end with a period or space on Windows machines
-    basename = basename.rstrip(". ")
+    # Path component can never end with a period or space on Windows machines.
+    # Also remove . and .. path traversal components.
+    part_stripped = part.lstrip(" ").rstrip(". ")
 
-    if not basename:
-        basename = REPLACEMENTCHAR
+    if not part_stripped:
+        part_stripped = REPLACEMENTCHAR * len(part)
 
-    return basename
+    return part_stripped
 
 
-def clean_path(path: str) -> str:
+def safe_path_join(base_path: str, *parts) -> str:
+    """Safely joins a path, by removing illegal path characters and path
+    traversal components from provided parts."""
 
-    path = os.path.normpath(path)
+    base_path = os.path.abspath(base_path)
+    path = os.path.join(base_path, *(clean_file(part) for part in parts if part))
 
-    # Without hacks it is (up to Vista) not possible to have more
-    # than 26 drives mounted, so we can assume a '[a-zA-Z]:\' prefix
-    # for drives - we shouldn't escape that
-    drive = ""
-
-    if len(path) >= 3 and path[1] == ":" and path[2] == os.sep:
-        drive = path[:3]
-        path = path[3:]
-
-    for char in ILLEGALPATHCHARS:
-        if char in path:
-            path = path.replace(char, REPLACEMENTCHAR)
-
-    path = "".join([drive, path])
-
-    # Path can never end with a period or space on Windows machines
-    path = path.rstrip(". ")
+    # Final containment check, just in case.
+    if os.path.commonpath([base_path, path]) != base_path:
+        path = base_path
 
     return path
 


### PR DESCRIPTION
Adds a new safe_path_join() function that removes illegal characters and path traversal components from the final path, and ensures it remains within the base path.