### PR TITLE
downloads.py: several cleanups for download filter implementation

### DIFF
--- a/pynicotine/config.py
+++ b/pynicotine/config.py
@@ -227,7 +227,6 @@ class Config:
                 "rescan_shares_daily": True,
                 "rescan_shares_hour": 0,
                 "enablefilters": False,
-                "downloadregexp": "",
                 "downloadfilters": [
                     ["*.DS_Store", 1],
                     ["*.exe", 1],
@@ -464,7 +463,8 @@ class Config:
                 "lock",
                 "buddysharestrustedonly",
                 "downloadsexpanded",
-                "uploadsexpanded"
+                "uploadsexpanded",
+                "downloadregexp"
             ),
             "server": (
                 "lastportstatuscheck",

--- a/pynicotine/downloads.py
+++ b/pynicotine/downloads.py
@@ -65,17 +65,17 @@ class RequestedFolder:
 
 
 class Downloads(Transfers):
-    __slots__ = ("_requested_folders", "_requested_folder_token", "_folder_basename_byte_limits",
-                 "_pending_queue_messages", "_download_queue_timer_id", "_retry_connection_downloads_timer_id",
-                 "_retry_io_downloads_timer_id")
+    __slots__ = ("_download_filter_regex", "_requested_folders", "_requested_folder_token",
+                 "_folder_basename_byte_limits", "_pending_queue_messages", "_download_queue_timer_id",
+                 "_retry_connection_downloads_timer_id", "_retry_io_downloads_timer_id")
 
     def __init__(self):
 
         super().__init__(name="downloads")
 
+        self._download_filter_regex = None
         self._requested_folders = defaultdict(dict)
         self._requested_folder_token = initial_token()
-
         self._folder_basename_byte_limits = {}
         self._pending_queue_messages = {}
 
@@ -271,51 +271,38 @@ class Downloads(Transfers):
 
     def update_download_filters(self):
 
-        failed = {}
-        outfilter = "(\\\\("
-        download_filters = sorted(config.sections["transfers"]["downloadfilters"])
-        # Get Filters from config file and check their escaped status
-        # Test if they are valid regular expressions and save error messages
+        download_filters = []
+        num_failed_filters = 0
 
-        for item in download_filters:
+        for item in sorted(config.sections["transfers"]["downloadfilters"]):
             dfilter, escaped = item
+
             if escaped:
-                dfilter = re.escape(dfilter)
-                dfilter = dfilter.replace("\\*", ".*")
+                escaped_filter = re.escape(dfilter).replace("\\*", ".*")
+                download_filters.append(escaped_filter)
+                continue
 
             try:
                 re.compile(f"({dfilter})")
-                outfilter += dfilter
 
-                if item is not download_filters[-1]:
-                    outfilter += "|"
+            except re.error:
+                num_failed_filters += 1
+                continue
 
-            except re.error as error:
-                failed[dfilter] = error
+            download_filters.append(dfilter)
 
-        outfilter += ")$)"
+        self._download_filter_regex = re.compile("(\\\\(" + "|".join(download_filters) + ")$)", flags=re.IGNORECASE)
 
-        try:
-            re.compile(outfilter)
-
-        except re.error as error:
-            # Strange that individual filters _and_ the composite filter both fail
-            log.add(_("Error: Download Filter failed! Verify your filters. Reason: %s"), error)
-            config.sections["transfers"]["downloadregexp"] = ""
+        if not num_failed_filters:
             return
 
-        config.sections["transfers"]["downloadregexp"] = outfilter
-
-        # Send error messages for each failed filter to log window
-        if not failed:
-            return
-
-        errors = ""
-
-        for dfilter, error in failed.items():
-            errors += f"Filter: {dfilter} Error: {error} "
-
-        log.add(_("Error: %(num)d Download filters failed! %(error)s "), {"num": len(failed), "error": errors})
+        log.add(
+            ngettext(
+                "%(num)s download filter contains an invalid regular expression",
+                "%(num)s download filters contain invalid regular expressions",
+                num_failed_filters
+            ), {"num": num_failed_filters}
+        )
 
     def update_transfer_limits(self):
 
@@ -361,20 +348,14 @@ class Downloads(Transfers):
 
             self._close_file(transfer)
 
-        if not bypass_filter and config.sections["transfers"]["enablefilters"]:
-            try:
-                downloadregexp = re.compile(config.sections["transfers"]["downloadregexp"], flags=re.IGNORECASE)
+        if (not bypass_filter and config.sections["transfers"]["enablefilters"]
+                and self._download_filter_regex.search(virtual_path) is not None):
+            log.add_transfer("Filtering: %s", virtual_path)
 
-                if downloadregexp.search(virtual_path) is not None:
-                    log.add_transfer("Filtering: %s", virtual_path)
+            if not self._auto_clear_transfer(transfer):
+                self._abort_transfer(transfer, status=TransferStatus.FILTERED)
 
-                    if not self._auto_clear_transfer(transfer):
-                        self._abort_transfer(transfer, status=TransferStatus.FILTERED)
-
-                    return False
-
-            except re.error:
-                pass
+            return False
 
         _file_path, file_exists = self.get_complete_download_file_path(
             username, virtual_path, size, transfer.folder_path)


### PR DESCRIPTION
- Remove unnecessary 'downloadregexp' option from config file
- Clean up the filter-related code to match the share filters
- Replace an ancient log string

A follow-up PR will replace the `Verify Filters` button with an icon column and a tooltip.