### PR TITLE
Migrate accidentally inverted CTCP option

### DIFF
--- a/pynicotine/config.py
+++ b/pynicotine/config.py
@@ -159,7 +159,6 @@ class Config:
                 "login": "",
                 "passw": "",
                 "interface": "",
-                "ctcpmsgs": False,
                 "autosearch": [],
                 "autoreply": "",
                 "portrange": (2234, 2234),
@@ -433,6 +432,9 @@ class Config:
                 "enable": True,
                 "enabled": []
             },
+            "ctcp": {
+                "enable": True
+            },
             "statistics": {
                 "since_timestamp": 0,
                 "started_downloads": 0,
@@ -475,7 +477,8 @@ class Config:
                 "userencoding",
                 "firewalled",
                 "command_aliases",
-                "upnp_interval"
+                "upnp_interval",
+                "ctcpmsgs"
             ),
             "ui": (
                 "enabletrans",
@@ -689,6 +692,12 @@ class Config:
 
         if expand_searches is not None:
             self.sections["searches"]["expand_results"] = "all" if expand_searches else "none"
+
+        # Migrate accidentally inverted CTCP option (3.4.0)
+        enable_ctcp = self.sections["server"].get("ctcpmsgs", None)
+
+        if enable_ctcp is not None:
+            self.sections["ctcp"]["enable"] = not enable_ctcp
 
     def _set_config(self):
         """Set config values parsed from file earlier."""

--- a/pynicotine/config.py
+++ b/pynicotine/config.py
@@ -159,7 +159,6 @@ class Config:
                 "login": "",
                 "passw": "",
                 "interface": "",
-                "ctcpmsgs": False,
                 "autosearch": [],
                 "autoreply": "",
                 "portrange": (2234, 2234),
@@ -433,6 +432,9 @@ class Config:
                 "enable": True,
                 "enabled": []
             },
+            "ctcp": {
+                "enable": True
+            },
             "statistics": {
                 "since_timestamp": 0,
                 "started_downloads": 0,
@@ -475,7 +477,8 @@ class Config:
                 "userencoding",
                 "firewalled",
                 "command_aliases",
-                "upnp_interval"
+                "upnp_interval",
+                "ctcpmsgs"
             ),
             "ui": (
                 "enabletrans",
@@ -689,6 +692,10 @@ class Config:
 
         if expand_searches is not None:
             self.sections["searches"]["expand_results"] = "all" if expand_searches else "none"
+
+        # Migrate accidentally inverted CTCP option (3.4.0)
+        if self.sections["server"].get("ctcpmsgs", False):
+            self.sections["ctcp"]["enable"] = False
 
     def _set_config(self):
         """Set config values parsed from file earlier."""

--- a/pynicotine/gtkgui/dialogs/preferences.py
+++ b/pynicotine/gtkgui/dialogs/preferences.py
@@ -1848,7 +1848,6 @@ class ChatsPage:
 
         self.options = {
             "server": {
-                "ctcpmsgs": None,  # Special case in set_settings
                 "private_chatrooms": self.room_invitations_toggle
             },
             "logging": {
@@ -1877,6 +1876,9 @@ class ChatsPage:
             },
             "ui": {
                 "spellcheck": self.enable_spell_checker_toggle
+            },
+            "ctcp": {
+                "enable": self.enable_ctcp_toggle
             }
         }
 
@@ -1903,7 +1905,6 @@ class ChatsPage:
         self.application.preferences.set_widgets_data(self.options)
 
         self.enable_spell_checker_toggle.get_parent().set_visible(SpellChecker.is_available())
-        self.enable_ctcp_toggle.set_active(not config.sections["server"]["ctcpmsgs"])
         self.format_codes_label.set_visible(not self.application.isolated_mode)
 
         self.keywords = config.sections["words"]["keywords"][:]
@@ -1914,7 +1915,6 @@ class ChatsPage:
 
         return {
             "server": {
-                "ctcpmsgs": not self.enable_ctcp_toggle.get_active(),
                 "private_chatrooms": self.room_invitations_toggle.get_active()
             },
             "logging": {
@@ -1943,6 +1943,9 @@ class ChatsPage:
             },
             "ui": {
                 "spellcheck": self.enable_spell_checker_toggle.get_active()
+            },
+            "ctcp": {
+                "enable": self.enable_ctcp_toggle.get_active()
             }
         }
 
@@ -3866,7 +3869,8 @@ class Preferences(Dialog):
             "players": {},
             "words": {},
             "notifications": {},
-            "plugins": {}
+            "plugins": {},
+            "ctcp": {}
         }
 
         for page in self.pages.values():

--- a/pynicotine/gtkgui/dialogs/preferences.py
+++ b/pynicotine/gtkgui/dialogs/preferences.py
@@ -1846,7 +1846,6 @@ class ChatsPage:
 
         self.options = {
             "server": {
-                "ctcpmsgs": None,  # Special case in set_settings
                 "private_chatrooms": self.room_invitations_toggle
             },
             "logging": {
@@ -1875,6 +1874,9 @@ class ChatsPage:
             },
             "ui": {
                 "spellcheck": self.enable_spell_checker_toggle
+            },
+            "ctcp": {
+                "enable": self.enable_ctcp_toggle
             }
         }
 
@@ -1901,7 +1903,6 @@ class ChatsPage:
         self.application.preferences.set_widgets_data(self.options)
 
         self.enable_spell_checker_toggle.get_parent().set_visible(SpellChecker.is_available())
-        self.enable_ctcp_toggle.set_active(not config.sections["server"]["ctcpmsgs"])
         self.format_codes_label.set_visible(not self.application.isolated_mode)
 
         self.keywords = config.sections["words"]["keywords"][:]
@@ -1912,7 +1913,6 @@ class ChatsPage:
 
         return {
             "server": {
-                "ctcpmsgs": not self.enable_ctcp_toggle.get_active(),
                 "private_chatrooms": self.room_invitations_toggle.get_active()
             },
             "logging": {
@@ -1941,6 +1941,9 @@ class ChatsPage:
             },
             "ui": {
                 "spellcheck": self.enable_spell_checker_toggle.get_active()
+            },
+            "ctcp": {
+                "enable": self.enable_ctcp_toggle.get_active()
             }
         }
 
@@ -3872,7 +3875,8 @@ class Preferences(Dialog):
             "players": {},
             "words": {},
             "notifications": {},
-            "plugins": {}
+            "plugins": {},
+            "ctcp": {}
         }
 
         for page in self.pages.values():


### PR DESCRIPTION
Fix this 20 year old mistake at last. Introduce a new ctcp config category, to leave room for future CTCP-related options, if needed.
