### PR TITLE
SLSKPROTOCOL.md: soulseek-rs claims major version 176

### DIFF
--- a/doc/SLSKPROTOCOL.md
+++ b/doc/SLSKPROTOCOL.md
@@ -236,6 +236,7 @@ Established clients have unique numbers to avoid impersonating each other.
 | `169`         | seeleseek                               |
 | `170`         | [Soulseek.NET](#soulseeknet) *(C# API)* |
 | `175`         | aioslsk *(Python API)*                  |
+| `176`         | soulseek-rs *(Rust API)*                |
 | `177`         | *Experimental development and testing*  |
 
 ### Obsolete


### PR DESCRIPTION
https://re-invention.nl/soulseek-rs/
https://github.com/michel/soulseek-rs

+ Added: Major Version `176` (soulseek-rs and soulseek-rs-lib)

Minor versions: the reference CLI/TUI client "soulseek-rs" logs in with 100; projects built on the "soulseek-rs-lib" API keep major 176 and pick their own minor (the library defaults to 1).

> _"**A soulseek client for the terminal...**_
> 
> _Search the network, share your files, browse someone’s collection, join a room. It runs over ssh on the machine where your music already lives."_

Michel de Graaf <michel@re-invention.nl> - Tech Lead / Software Engineer
https://re-invention.nl/about
https://re-invention.nl/posts/learning-rust-the-hard-way

https://github.com/michel/soulseek-rs/pull/13