### PR TITLE
ChatEntry: focus chat view before making active entry insensitive

### DIFF
--- a/pynicotine/gtkgui/widgets/textentry.py
+++ b/pynicotine/gtkgui/widgets/textentry.py
@@ -172,6 +172,10 @@ class ChatEntry:
         self.widget.set_position(position)
 
     def set_sensitive(self, sensitive):
+
+        if not sensitive and self.chat_view is not None and self.container.get_focus_child():
+            self.chat_view.grab_focus()
+
         self.widget.set_sensitive(sensitive)
 
     def set_text(self, text):


### PR DESCRIPTION
Makes sure the widget focus ends up somewhere sensible, and avoids a 'GtkText - did not receive a focus-out event.' warning in GTK 4.