### PR TITLE
shares.py: log number of previous folders at the start of rescan

### DIFF
--- a/pynicotine/shares.py
+++ b/pynicotine/shares.py
@@ -247,11 +247,12 @@ class Scanner:
                  "rescan", "rebuild", "reveal_buddy_shares", "reveal_trusted_shares",
                  "files", "streams", "mtimes", "word_index", "processed_share_names",
                  "processed_share_paths", "current_file_index", "current_folder_count",
-                 "lowercase_paths", "share_filters", "file_filter_regex", "folder_filter_regex")
+                 "lowercase_paths", "share_filters", "file_filter_regex", "folder_filter_regex",
+                 "num_previous_folders")
 
     def __init__(self, writer, share_groups, share_db_paths, init=False, rescan=True,
                  rebuild=False, reveal_buddy_shares=False, reveal_trusted_shares=False,
-                 share_filters=None):
+                 num_previous_folders=0, share_filters=None):
 
         self.writer = writer
         self.share_groups = share_groups
@@ -262,6 +263,7 @@ class Scanner:
         self.rebuild = rebuild
         self.reveal_buddy_shares = reveal_buddy_shares
         self.reveal_trusted_shares = reveal_trusted_shares
+        self.num_previous_folders = num_previous_folders
         self.share_filters = share_filters
         self.files = {}
         self.streams = {}
@@ -303,7 +305,17 @@ class Scanner:
 
             if self.rescan:
                 self.writer.send(
-                    ScannerLogMessage(_("Rebuilding shares…") if self.rebuild else _("Rescanning shares…"))
+                    ScannerLogMessage(
+                        ngettext(
+                            "%(num)s folder found previously, %(action)s…",
+                            "%(num)s folders found previously, %(action)s…",
+                            self.num_previous_folders
+                        ),
+                        {
+                            "num": self.num_previous_folders,
+                            "action": _("rebuilding shares") if self.rebuild else _("rescanning shares")
+                        }
+                    )
                 )
                 self.load_filters()
 
@@ -408,13 +420,13 @@ class Scanner:
 
     def create_compressed_shares(self):
 
-        Shares.load_shares(
-            self.share_dbs, self.share_db_paths, destinations={"public_streams", "buddy_streams", "trusted_streams"}
-        )
+        destinations = {"public_streams", "buddy_streams", "trusted_streams"}
+        Shares.load_shares(self.share_dbs, self.share_db_paths, destinations=destinations)
 
         for permission_level in (PermissionLevel.PUBLIC, PermissionLevel.BUDDY, PermissionLevel.TRUSTED):
             self.create_compressed_shares_message(permission_level)
 
+        self.num_previous_folders = sum(len(self.share_dbs[destination]) for destination in destinations)
         Shares.close_shares(self.share_dbs)
 
     def create_file_path_index(self):
@@ -1245,6 +1257,10 @@ class Shares:
             rebuild,
             reveal_buddy_shares=config.sections["transfers"]["reveal_buddy_shares"],
             reveal_trusted_shares=config.sections["transfers"]["reveal_trusted_shares"],
+            num_previous_folders=sum(
+                len(self.share_dbs.get(destination, {}))
+                for destination in ("public_streams", "buddy_streams", "trusted_streams")
+            ),
             share_filters=config.sections["transfers"]["share_filters"]
         )
         scanner = context.Process(target=scanner_obj.run, daemon=True)


### PR DESCRIPTION
An old friend from 3.2.x, adapted for our current share databases.

Related to #3439