### PR TITLE
fix: detect portable mode in frozen state on Windows

### DIFF
--- a/pynicotine/config.py
+++ b/pynicotine/config.py
@@ -57,8 +57,13 @@ class Config:
         - the data folder
         """
 
-        script_folder_path = os.path.dirname(sys.argv[0])
-        portable_folder_path = os.path.join(script_folder_path, "portable")
+        is_frozen = getattr(sys, "frozen", False)
+
+        if is_frozen and sys.platform == "win32":
+            root_folder_path = os.path.dirname(sys.executable)
+        else:
+            root_folder_path = os.path.dirname(sys.argv[0])
+        portable_folder_path = os.path.join(root_folder_path, "portable")
 
         if os.path.isdir(portable_folder_path):
             data_folder_path = os.path.join(portable_folder_path, "data")

--- a/pynicotine/config.py
+++ b/pynicotine/config.py
@@ -58,11 +58,7 @@ class Config:
         """
 
         is_frozen = getattr(sys, "frozen", False)
-
-        if is_frozen and sys.platform == "win32":
-            root_folder_path = os.path.dirname(sys.executable)
-        else:
-            root_folder_path = os.path.dirname(sys.argv[0])
+        root_folder_path = os.path.dirname(sys.executable if is_frozen else sys.argv[0])
         portable_folder_path = os.path.join(root_folder_path, "portable")
 
         if os.path.isdir(portable_folder_path):


### PR DESCRIPTION
fix small issue when frozen executable can't detect portable folder (mode)