### PR TITLE
Implement global command entry in log view

### DIFF
--- a/pynicotine/events.py
+++ b/pynicotine/events.py
@@ -12,8 +12,6 @@ EVENT_NAMES = {
     # General
     "check-latest-version",
     "check-port-status",
-    "cli-command",
-    "cli-prompt-finished",
     "confirm-quit",
     "enable-message-queue",
     "log-message",
@@ -24,6 +22,11 @@ EVENT_NAMES = {
     "setup",
     "start",
     "thread-callback",
+
+    # CLI
+    "cli-command",
+    "cli-completions",
+    "cli-prompt-finished",
 
     # Users
     "admin-message",

--- a/pynicotine/gtkgui/chatrooms.py
+++ b/pynicotine/gtkgui/chatrooms.py
@@ -18,7 +18,7 @@ from pynicotine.config import config
 from pynicotine.core import core
 from pynicotine.events import events
 from pynicotine.gtkgui.application import GTK_API_VERSION
-from pynicotine.gtkgui.popovers.chatcommandhelp import ChatCommandHelp
+from pynicotine.gtkgui.popovers.commandhelp import CommandHelp
 from pynicotine.gtkgui.popovers.roomwall import RoomWall
 from pynicotine.gtkgui.widgets import ui
 from pynicotine.gtkgui.widgets.combobox import ComboBox
@@ -27,7 +27,7 @@ from pynicotine.gtkgui.widgets.dialogs import EntryDialog
 from pynicotine.gtkgui.widgets.dialogs import OptionDialog
 from pynicotine.gtkgui.widgets.popupmenu import PopupMenu
 from pynicotine.gtkgui.widgets.popupmenu import UserPopupMenu
-from pynicotine.gtkgui.widgets.textentry import ChatEntry
+from pynicotine.gtkgui.widgets.textentry import MessageEntry
 from pynicotine.gtkgui.widgets.textentry import TextSearchBar
 from pynicotine.gtkgui.widgets.textview import ChatView
 from pynicotine.gtkgui.widgets.textview import TextView
@@ -61,10 +61,14 @@ class ChatRooms(IconNotebook):
         self.toolbar_end_content = window.chatrooms_end
         self.toolbar_default_widget = window.chatrooms_entry
 
-        self.chat_entry = ChatEntry(
-            self.window.application, send_message_callback=core.chatrooms.send_message,
+        self.message_entry = MessageEntry(
+            self.window.application,
             command_callback=core.pluginhandler.trigger_chatroom_command_event,
-            enable_spell_check=config.sections["ui"]["spellcheck"]
+            send_message_callback=core.chatrooms.send_message,
+            enable_spell_check=config.sections["ui"]["spellcheck"],
+            enable_tab_completion=config.sections["words"]["tab"],
+            enable_completion_popup=config.sections["words"]["dropdown"],
+            min_completion_key_length=config.sections["words"]["characters"]
         )
         self.command_help = None
         self.room_wall = None
@@ -128,7 +132,7 @@ class ChatRooms(IconNotebook):
 
     def destroy(self):
 
-        self.chat_entry.destroy()
+        self.message_entry.destroy()
         self.join_room_combobox.destroy()
 
         if self.command_help is not None:
@@ -182,13 +186,13 @@ class ChatRooms(IconNotebook):
 
             joined_room = core.chatrooms.joined_rooms.get(room)
 
-            self.chat_entry.set_parent(room, tab.chat_entry_container, tab.chat_view)
-            self.chat_entry.set_sensitive(joined_room is not None and joined_room.users)
+            self.message_entry.set_parent(tab.message_entry_container, tab.chat_view, room)
+            self.message_entry.set_sensitive(joined_room is not None and joined_room.users)
             tab.toggle_chat_buttons()
             tab.update_room_user_completions()
 
             if self.command_help is None:
-                self.command_help = ChatCommandHelp(window=self.window, interface="chatroom")
+                self.command_help = CommandHelp(window=self.window, interface="chatroom")
 
             if self.room_wall is None:
                 self.room_wall = RoomWall(window=self.window)
@@ -285,7 +289,7 @@ class ChatRooms(IconNotebook):
             return
 
         if page.container == self.get_current_page():
-            self.chat_entry.set_parent(None)
+            self.message_entry.set_parent(None)
 
             if self.command_help is not None:
                 self.command_help.set_menu_button(None)
@@ -299,7 +303,7 @@ class ChatRooms(IconNotebook):
         del self.pages[room]
         page.destroy()
 
-        self.chat_entry.clear_unsent_message(room)
+        self.message_entry.clear_unsent_message(room)
 
         if room != core.chatrooms.GLOBAL_ROOM_NAME:
             combobox = self.window.search.room_search_combobox
@@ -334,7 +338,7 @@ class ChatRooms(IconNotebook):
         page.join_room(msg)
 
         if page.container == self.get_current_page():
-            self.chat_entry.set_sensitive(True)
+            self.message_entry.set_sensitive(True)
             page.on_focus()
 
     def leave_room(self, msg):
@@ -479,6 +483,11 @@ class ChatRooms(IconNotebook):
 
         page = self.get_current_page()
 
+        self.message_entry.set_tab_completion_enabled(config.sections["words"]["tab"])
+        self.message_entry.set_completion_popup_enabled(
+            config.sections["words"]["dropdown"], config.sections["words"]["characters"]
+        )
+
         for tab in self.pages.values():
             if tab.container == page:
                 tab.update_completions(completions)
@@ -486,7 +495,7 @@ class ChatRooms(IconNotebook):
 
     def update_widgets(self):
 
-        self.chat_entry.set_spell_check_enabled(config.sections["ui"]["spellcheck"])
+        self.message_entry.set_spell_check_enabled(config.sections["ui"]["spellcheck"])
 
         for tab in self.pages.values():
             tab.toggle_chat_buttons()
@@ -494,7 +503,7 @@ class ChatRooms(IconNotebook):
 
     def server_disconnect(self, *_args):
 
-        self.chat_entry.set_sensitive(False)
+        self.message_entry.set_sensitive(False)
 
         for page in self.pages.values():
             page.server_disconnect()
@@ -510,14 +519,14 @@ class ChatRoom:
             self.activity_view_container,
             self.add_room_member_button,
             self.chat_container,
-            self.chat_entry_container,
-            self.chat_entry_row,
             self.chat_paned,
             self.chat_search_bar,
             self.chat_view_container,
             self.container,
             self.help_button,
             self.log_toggle,
+            self.message_entry_container,
+            self.message_entry_row,
             self.room_wall_button,
             self.room_wall_label,
             self.user_list_button,
@@ -550,7 +559,7 @@ class ChatRoom:
             horizontal_margin=10, vertical_margin=5, pixels_below_lines=2
         )
         self.chat_view = ChatView(
-            self.chat_view_container, chat_entry=self.chatrooms.chat_entry, editable=False,
+            self.chat_view_container, message_entry=self.chatrooms.message_entry, editable=False,
             horizontal_margin=10, vertical_margin=5, pixels_below_lines=2,
             status_users=core.chatrooms.joined_rooms[room].users,
             roomname_event=(self.roomname_event if is_global else None),
@@ -566,7 +575,7 @@ class ChatRoom:
         # Chat Text Search
         self.chat_search_bar = TextSearchBar(
             self.chat_view.widget, self.chat_search_bar,
-            controller_widget=self.chat_container, focus_widget=self.chatrooms.chat_entry,
+            controller_widget=self.chat_container, focus_widget=self.chatrooms.message_entry,
             placeholder_text=_("Search chat log…")
         )
 
@@ -719,10 +728,10 @@ class ChatRoom:
         if not self.is_global:
             return
 
-        for widget in (self.activity_container, self.chat_entry_container, self.help_button, self.user_list_button):
+        for widget in (self.activity_container, self.message_entry_container, self.help_button, self.user_list_button):
             widget.set_visible(False)
 
-        self.chat_entry_row.set_halign(Gtk.Align.END)
+        self.message_entry_row.set_halign(Gtk.Align.END)
 
     def add_user_row(self, userdata):
 
@@ -876,7 +885,7 @@ class ChatRoom:
         self.log_toggle.set_visible(is_log_toggle_visible)
 
         if self.is_global:
-            self.chat_entry_row.set_visible(is_log_toggle_visible)
+            self.message_entry_row.set_visible(is_log_toggle_visible)
 
         self.user_list_button.set_active(config.sections["chatrooms"]["user_list_visible"])
 
@@ -999,7 +1008,7 @@ class ChatRoom:
 
         # Add to completion list, and completion drop-down
         if self.chatrooms.get_current_page() == self.container:
-            self.chatrooms.chat_entry.add_completion(username)
+            self.chatrooms.message_entry.add_completion(username)
 
         if (username != core.users.login_username
                 and not core.network_filter.is_user_ignored(username)
@@ -1024,7 +1033,7 @@ class ChatRoom:
 
         # Remove from completion list, and completion drop-down
         if self.chatrooms.get_current_page() == self.container and username not in core.buddies.users:
-            self.chatrooms.chat_entry.remove_completion(username)
+            self.chatrooms.message_entry.remove_completion(username)
 
         if not core.network_filter.is_user_ignored(username) and \
                 not core.network_filter.is_user_ip_ignored(username):
@@ -1299,7 +1308,7 @@ class ChatRoom:
     def on_focus(self, *_args):
 
         if self.window.current_page_id == self.window.chatrooms_page.id:
-            widget = self.chatrooms.chat_entry if self.chatrooms.chat_entry.get_sensitive() else self.chat_view
+            widget = self.chatrooms.message_entry if self.chatrooms.message_entry.get_sensitive() else self.chat_view
             widget.grab_focus()
 
         return True
@@ -1439,4 +1448,4 @@ class ChatRoom:
             room_users = core.chatrooms.joined_rooms[self.room].users
             completions.update(room_users)
 
-        self.chatrooms.chat_entry.set_completions(completions)
+        self.chatrooms.message_entry.set_completions(completions)

--- a/pynicotine/gtkgui/css/style.css
+++ b/pynicotine/gtkgui/css/style.css
@@ -154,3 +154,11 @@ treeview button:not(:first-child):dir(rtl) > box {
     box-shadow: 1px 0 0 0 alpha(@borders, 2.8);
 }
 
+entry.compact:focus,
+entry.compact:focus-within {
+    /* Remove focus ring from compact command entries */
+    border-color: transparent;
+    box-shadow: none;
+    outline: none;
+}
+

--- a/pynicotine/gtkgui/mainwindow.py
+++ b/pynicotine/gtkgui/mainwindow.py
@@ -35,6 +35,7 @@ from pynicotine.gtkgui.widgets import ui
 from pynicotine.gtkgui.widgets.dialogs import MessageDialog
 from pynicotine.gtkgui.widgets.iconnotebook import IconNotebook
 from pynicotine.gtkgui.widgets.popupmenu import PopupMenu
+from pynicotine.gtkgui.widgets.textentry import MessageEntry
 from pynicotine.gtkgui.widgets.textentry import TextSearchBar
 from pynicotine.gtkgui.widgets.textview import TextView
 from pynicotine.gtkgui.widgets.theme import USER_STATUS_ICON_NAMES
@@ -109,6 +110,7 @@ class MainWindow(Window):
             self.log_container,
             self.log_search_bar,
             self.log_view_container,
+            self.message_entry_container,
             self.private_content,
             self.private_end,
             self.private_entry,
@@ -221,20 +223,27 @@ class MainWindow(Window):
         self.scan_progress_label.freeze_notify()
 
         # Logging
+        self.message_entry = MessageEntry(
+            self.application, command_callback=core.pluginhandler.trigger_cli_command_event,
+            is_compact=True, enable_tab_completion=True
+        )
         self.log_view = TextView(
             self.log_view_container, auto_scroll=not config.sections["logging"]["logcollapsed"],
-            parse_urls=False, editable=False, vertical_margin=5, pixels_below_lines=2
+            parse_urls=False, editable=False, vertical_margin=2, pixels_below_lines=2,
+            message_entry=self.message_entry
         )
         self.log_search_bar = TextSearchBar(
             self.log_view.widget, self.log_search_bar, controller_widget=self.log_container,
             placeholder_text=_("Search log…")
         )
+        self.message_entry.set_parent(container=self.message_entry_container, chat_view=self.log_view)
 
         self.create_log_context_menu()
-        events.connect("log-message", self.log_callback)
 
         # Events
         for event_name, callback in (
+            ("cli-completions", self.update_completions),
+            ("log-message", self.log_callback),
             ("quit", self.on_quit),
             ("server-login", self.update_user_status),
             ("server-disconnect", self.update_user_status),
@@ -1164,13 +1173,16 @@ class MainWindow(Window):
     def log_callback(self, timestamp_format, msg, title, level):
         events.invoke_main_thread(self.update_log, timestamp_format, msg, title, level)
 
+    def update_completions(self, completions):
+        self.message_entry.set_completions(completions)
+
     def update_log(self, timestamp_format, msg, title, level):
 
         if title:
             MessageDialog(application=self.application, title=title, message=msg, selectable=True).present()
 
         # Keep verbose debug messages out of statusbar to make it more useful
-        if level not in {"transfer", "connection", "message", "miscellaneous"}:
+        if level not in {"transfer", "connection", "message", "miscellaneous", "command"}:
             self.set_status_text(msg)
 
         self.log_view.add_line(msg, timestamp_format=timestamp_format)
@@ -1349,6 +1361,7 @@ class MainWindow(Window):
         self.notebook.destroy()
         self.log_search_bar.destroy()
         self.log_view.destroy()
+        self.message_entry.destroy()
         self.popup_menu_log_view.destroy()
         self.popup_menu_log_categories.destroy()
 

--- a/pynicotine/gtkgui/popovers/commandhelp.py
+++ b/pynicotine/gtkgui/popovers/commandhelp.py
@@ -9,7 +9,7 @@ from pynicotine.gtkgui.widgets.popover import Popover
 from pynicotine.gtkgui.widgets.theme import add_css_class
 
 
-class ChatCommandHelp(Popover):
+class CommandHelp(Popover):
 
     def __init__(self, window, interface):
 

--- a/pynicotine/gtkgui/privatechat.py
+++ b/pynicotine/gtkgui/privatechat.py
@@ -12,14 +12,14 @@ from pynicotine.config import config
 from pynicotine.core import core
 from pynicotine.events import events
 from pynicotine.gtkgui.application import GTK_API_VERSION
-from pynicotine.gtkgui.popovers.chatcommandhelp import ChatCommandHelp
+from pynicotine.gtkgui.popovers.commandhelp import CommandHelp
 from pynicotine.gtkgui.widgets import ui
 from pynicotine.gtkgui.widgets.combobox import ComboBox
 from pynicotine.gtkgui.widgets.iconnotebook import IconNotebook
 from pynicotine.gtkgui.widgets.popupmenu import PopupMenu
 from pynicotine.gtkgui.widgets.popupmenu import UserPopupMenu
 from pynicotine.gtkgui.widgets.dialogs import OptionDialog
-from pynicotine.gtkgui.widgets.textentry import ChatEntry
+from pynicotine.gtkgui.widgets.textentry import MessageEntry
 from pynicotine.gtkgui.widgets.textentry import TextSearchBar
 from pynicotine.gtkgui.widgets.textview import ChatView
 from pynicotine.gtkgui.widgets.theme import add_css_class
@@ -46,10 +46,14 @@ class PrivateChats(IconNotebook):
         self.toolbar_end_content = window.private_end
         self.toolbar_default_widget = window.private_entry
 
-        self.chat_entry = ChatEntry(
-            window.application, send_message_callback=core.privatechat.send_message,
+        self.message_entry = MessageEntry(
+            window.application,
             command_callback=core.pluginhandler.trigger_private_chat_command_event,
-            enable_spell_check=config.sections["ui"]["spellcheck"]
+            send_message_callback=core.privatechat.send_message,
+            enable_spell_check=config.sections["ui"]["spellcheck"],
+            enable_tab_completion=config.sections["words"]["tab"],
+            enable_completion_popup=config.sections["words"]["dropdown"],
+            min_completion_key_length=config.sections["words"]["characters"]
         )
         self.username_combobox = ComboBox(
             container=window.private_entry_container, has_entry=True, has_dropdown=False,
@@ -87,7 +91,7 @@ class PrivateChats(IconNotebook):
 
     def destroy(self):
 
-        self.chat_entry.destroy()
+        self.message_entry.destroy()
         self.username_combobox.destroy()
 
         if self.command_help is not None:
@@ -135,11 +139,11 @@ class PrivateChats(IconNotebook):
             if tab.container != page:
                 continue
 
-            self.chat_entry.set_parent(user, tab.chat_entry_container, tab.chat_view)
+            self.message_entry.set_parent(tab.message_entry_container, tab.chat_view, user)
             tab.update_room_user_completions()
 
             if self.command_help is None:
-                self.command_help = ChatCommandHelp(window=self.window, interface="private_chat")
+                self.command_help = CommandHelp(window=self.window, interface="private_chat")
 
             self.command_help.set_menu_button(tab.help_button)
 
@@ -217,7 +221,7 @@ class PrivateChats(IconNotebook):
             return
 
         if page.container == self.get_current_page():
-            self.chat_entry.set_parent(None)
+            self.message_entry.set_parent(None)
 
             if self.command_help is not None:
                 self.command_help.set_menu_button(None)
@@ -227,7 +231,7 @@ class PrivateChats(IconNotebook):
         del self.pages[user]
         page.destroy()
 
-        self.chat_entry.clear_unsent_message(user)
+        self.message_entry.clear_unsent_message(user)
 
     def highlight_user(self, user, mention_type, mention_keyword):
 
@@ -265,6 +269,11 @@ class PrivateChats(IconNotebook):
 
         page = self.get_current_page()
 
+        self.message_entry.set_tab_completion_enabled(config.sections["words"]["tab"])
+        self.message_entry.set_completion_popup_enabled(
+            config.sections["words"]["dropdown"], config.sections["words"]["characters"]
+        )
+
         for tab in self.pages.values():
             if tab.container == page:
                 tab.update_completions(completions)
@@ -272,7 +281,7 @@ class PrivateChats(IconNotebook):
 
     def update_widgets(self):
 
-        self.chat_entry.set_spell_check_enabled(config.sections["ui"]["spellcheck"])
+        self.message_entry.set_spell_check_enabled(config.sections["ui"]["spellcheck"])
 
         for tab in self.pages.values():
             tab.toggle_chat_buttons()
@@ -284,7 +293,7 @@ class PrivateChats(IconNotebook):
             return
 
         page = self.get_current_page()
-        self.chat_entry.set_sensitive(True)
+        self.message_entry.set_sensitive(True)
 
         for tab in self.pages.values():
             if tab.container == page:
@@ -293,7 +302,7 @@ class PrivateChats(IconNotebook):
 
     def server_disconnect(self, *_args):
 
-        self.chat_entry.set_sensitive(False)
+        self.message_entry.set_sensitive(False)
 
         for user, page in self.pages.items():
             page.server_disconnect()
@@ -305,11 +314,11 @@ class PrivateChat:
     def __init__(self, chats, user):
 
         (
-            self.chat_entry_container,
             self.chat_view_container,
             self.container,
             self.help_button,
             self.log_toggle,
+            self.message_entry_container,
             self.search_bar
         ) = ui.load(scope=self, path="privatechat.ui")
 
@@ -321,7 +330,7 @@ class PrivateChat:
         self.offline_message = False
 
         self.chat_view = ChatView(
-            self.chat_view_container, chat_entry=self.chats.chat_entry, editable=False,
+            self.chat_view_container, message_entry=self.chats.message_entry, editable=False,
             horizontal_margin=10, vertical_margin=5, pixels_below_lines=2,
             username_event=self.username_event
         )
@@ -329,7 +338,7 @@ class PrivateChat:
         # Text Search
         self.search_bar = TextSearchBar(
             self.chat_view.widget, self.search_bar,
-            controller_widget=self.container, focus_widget=self.chats.chat_entry,
+            controller_widget=self.container, focus_widget=self.chats.message_entry,
             placeholder_text=_("Search chat log…")
         )
 
@@ -589,7 +598,7 @@ class PrivateChat:
     def on_focus(self, *_args):
 
         if self.window.current_page_id == self.window.private_page.id:
-            widget = self.chats.chat_entry if self.chats.chat_entry.get_sensitive() else self.chat_view
+            widget = self.chats.message_entry if self.chats.message_entry.get_sensitive() else self.chat_view
             widget.grab_focus()
 
         return True
@@ -608,4 +617,4 @@ class PrivateChat:
         # Tab-complete the recipient username
         completions.add(self.user)
 
-        self.chats.chat_entry.set_completions(completions)
+        self.chats.message_entry.set_completions(completions)

--- a/pynicotine/gtkgui/ui/chatrooms.ui
+++ b/pynicotine/gtkgui/ui/chatrooms.ui
@@ -74,7 +74,7 @@
                   </object>
                 </child>
                 <child>
-                  <object class="GtkBox" id="chat_entry_row">
+                  <object class="GtkBox" id="message_entry_row">
                     <property name="margin-bottom">8</property>
                     <property name="margin-end">8</property>
                     <property name="margin-start">8</property>
@@ -82,7 +82,7 @@
                     <property name="spacing">6</property>
                     <property name="visible">True</property>
                     <child>
-                      <object class="GtkBox" id="chat_entry_container">
+                      <object class="GtkBox" id="message_entry_container">
                         <property name="visible">True</property>
                       </object>
                     </child>

--- a/pynicotine/gtkgui/ui/mainwindow.ui
+++ b/pynicotine/gtkgui/ui/mainwindow.ui
@@ -1521,6 +1521,18 @@
                     </child>
                   </object>
                 </child>
+                <child>
+                  <object class="GtkBox" id="message_entry_container">
+                    <property name="margin-bottom">3</property>
+                    <property name="margin-end">5</property>
+                    <property name="margin-start">5</property>
+                    <property name="margin-top">2</property>
+                    <property name="visible">True</property>
+                  </object>
+                </child>
+                <style>
+                  <class name="view"/>
+                </style>
               </object>
             </child>
           </object>

--- a/pynicotine/gtkgui/ui/privatechat.ui
+++ b/pynicotine/gtkgui/ui/privatechat.ui
@@ -44,7 +44,7 @@
             <property name="spacing">6</property>
             <property name="visible">True</property>
             <child>
-              <object class="GtkBox" id="chat_entry_container">
+              <object class="GtkBox" id="message_entry_container">
                 <property name="visible">True</property>
               </object>
             </child>

--- a/pynicotine/gtkgui/widgets/popover.py
+++ b/pynicotine/gtkgui/widgets/popover.py
@@ -106,6 +106,14 @@ class Popover:
 
         self.menu_button = menu_button
 
+    def set_parent(self, widget):
+
+        if GTK_API_VERSION >= 4:
+            self.widget.set_parent(widget)   # pylint: disable=no-member
+            return
+
+        self.widget.set_relative_to(widget)  # pylint: disable=no-member
+
     def present(self):
         self.widget.popup()
 

--- a/pynicotine/gtkgui/widgets/textentry.py
+++ b/pynicotine/gtkgui/widgets/textentry.py
@@ -4,24 +4,31 @@
 import gi
 from gi.repository import Gtk
 
-from pynicotine.config import config
 from pynicotine.gtkgui.application import GTK_API_VERSION
+from pynicotine.gtkgui.popovers.commandhelp import CommandHelp
 from pynicotine.gtkgui.widgets.accelerator import Accelerator
 from pynicotine.gtkgui.widgets.combobox import ComboBox
+from pynicotine.gtkgui.widgets.popupmenu import PopupMenu
 from pynicotine.gtkgui.widgets.theme import add_css_class
 
 
-class ChatEntry:
+class MessageEntry:
     """Custom text entry with support for chat commands and completions."""
 
-    def __init__(self, application, send_message_callback, command_callback, enable_spell_check=False):
+    def __init__(self, application, command_callback, send_message_callback=None, is_compact=False,
+                 enable_spell_check=False, enable_tab_completion=False, enable_completion_popup=False,
+                 min_completion_key_length=1):
 
         self.application = application
         self.container = Gtk.Box(visible=True)
         self.widget = Gtk.Entry(
-            hexpand=True, placeholder_text=_("Send message…"), primary_icon_name="mail-send-symbolic",
-            sensitive=False, show_emoji_icon=True, width_chars=8, visible=True
+            placeholder_text=_("Send message…") if send_message_callback is not None else _("Run command…"),
+            primary_icon_name="mail-send-symbolic" if send_message_callback is not None else "pan-end-symbolic",
+            hexpand=True, sensitive=False, width_chars=8, visible=True
         )
+
+        if is_compact:
+            add_css_class(self.widget, "compact")
 
         # Create accelerators early to override ComboBox accelerators
         Accelerator("Down", self.widget, self.on_page_down_accelerator)
@@ -34,11 +41,14 @@ class ChatEntry:
             enable_arrow_keys=False, enable_word_completion=True, visible=True
         )
 
+        self.is_compact = is_compact
         self.send_message_callback = send_message_callback
         self.command_callback = command_callback
         self.spell_checker = None
         self.entity = None
         self.chat_view = None
+        self.extra_menu = None
+        self.command_help = None
         self.unsent_messages = {}
         self.completions = {}
         self.current_completions = []
@@ -46,9 +56,24 @@ class ChatEntry:
         self.midway_completion = False  # True if the user just used tab completion
         self.is_inserting_completion = False
 
+        self.set_tab_completion_enabled(enable_tab_completion)
+        self.set_completion_popup_enabled(enable_completion_popup, min_completion_key_length)
+
         self.widget.connect("activate", self.on_send_message)
         self.widget.connect("changed", self.on_changed)
         self.widget.connect("icon-press", self.on_icon_pressed)
+
+        if send_message_callback is None:
+            self.widget.props.secondary_icon_name = "dialog-question-symbolic"
+            self.widget.connect("icon-release", self.on_icon_released)
+
+            if GTK_API_VERSION >= 4:
+                self.extra_menu = PopupMenu(application)
+                self.extra_menu.add_items(("#" + _("Command Help"), self.on_command_help))
+                self.extra_menu.update_model()
+                self.widget.set_extra_menu(self.extra_menu.model)
+        else:
+            self.widget.props.show_emoji_icon = True
 
         Accelerator("<Shift>Tab", self.widget, self.on_tab_complete_accelerator, True)
         Accelerator("Tab", self.widget, self.on_tab_complete_accelerator)
@@ -59,6 +84,9 @@ class ChatEntry:
 
         if self.spell_checker is not None:
             self.spell_checker.destroy()
+
+        if self.extra_menu is not None:
+            self.extra_menu.destroy()
 
         self.__dict__.clear()
 
@@ -84,7 +112,7 @@ class ChatEntry:
         return self.widget.get_text()
 
     def is_completion_enabled(self):
-        return config.sections["words"]["tab"] or config.sections["words"]["dropdown"]
+        return self.enable_tab_completion or self.enable_completion_popup
 
     def insert_text(self, new_text, position):
         self.widget.insert_text(new_text, position)
@@ -100,7 +128,7 @@ class ChatEntry:
         if item in self.completions:
             return
 
-        if config.sections["words"]["dropdown"]:
+        if self.enable_completion_popup:
             self.combobox.append(item)
 
         self.completions[item] = None
@@ -112,7 +140,7 @@ class ChatEntry:
 
         self.combobox.remove_id(item)
 
-    def set_parent(self, entity=None, container=None, chat_view=None):
+    def set_parent(self, container=None, chat_view=None, entity=None):
 
         if self.entity:
             self.unsent_messages[self.entity] = self.widget.get_text()
@@ -135,15 +163,16 @@ class ChatEntry:
         else:
             container.add(self.container)     # pylint: disable=no-member
 
+        if self.is_compact:
+            self.widget.set_has_frame(False)
+
+        if entity is None:
+            self.set_sensitive(True)
+
         self.widget.set_text(unsent_message)
         self.widget.set_position(-1)
 
     def set_completions(self, completions):
-
-        config_words = config.sections["words"]
-
-        self.combobox.set_completion_popup_enabled(config_words["dropdown"])
-        self.combobox.set_completion_min_key_length(config_words["characters"])
 
         self.combobox.clear()
         self.completions.clear()
@@ -154,10 +183,21 @@ class ChatEntry:
         for word in sorted(completions):
             word = str(word)
 
-            if config_words["dropdown"]:
+            if self.enable_completion_popup:
                 self.combobox.append(word)
 
             self.completions[word] = None
+
+    def set_tab_completion_enabled(self, enabled):
+        self.enable_tab_completion = enabled
+
+    def set_completion_popup_enabled(self, enabled, min_length):
+
+        self.enable_completion_popup = enabled
+        self.min_completion_key_length = min_length
+
+        self.combobox.set_completion_popup_enabled(enabled)
+        self.combobox.set_completion_min_key_length(min_length)
 
     def set_spell_check_enabled(self, enabled):
 
@@ -195,7 +235,7 @@ class ChatEntry:
         is_double_slash_cmd = text.startswith("//")
         is_single_slash_cmd = (text.startswith("/") and not is_double_slash_cmd)
 
-        if not is_single_slash_cmd:
+        if not is_single_slash_cmd and self.send_message_callback is not None:
             # Regular chat message
 
             self.widget.set_text("")
@@ -210,7 +250,10 @@ class ChatEntry:
         cmd, _separator, args = text.partition(" ")
         args = args.strip()
 
-        if not self.command_callback(self.entity, cmd[1:], args):
+        if self.entity is not None and not self.command_callback(self.entity, cmd[1:], args):
+            return
+
+        if not self.command_callback(cmd[1:] if is_single_slash_cmd else cmd, args):
             return
 
         # Clear chat entry
@@ -219,6 +262,23 @@ class ChatEntry:
     def on_icon_pressed(self, _entry, icon_pos, *_args):
         if icon_pos == Gtk.EntryIconPosition.PRIMARY:
             self.on_send_message()
+
+    def on_icon_released(self, _entry, icon_pos, *_args):
+
+        if icon_pos != Gtk.EntryIconPosition.SECONDARY:
+            return
+
+        self.on_command_help()
+
+    def on_command_help(self, *_args):
+
+        if self.command_help is None:
+            self.command_help = CommandHelp(window=self.application.window, interface="cli")
+            self.command_help.set_parent(self.container)
+
+        icon_area = self.widget.get_icon_area(Gtk.EntryIconPosition.SECONDARY)
+        self.command_help.widget.set_pointing_to(icon_area)
+        self.command_help.present()
 
     def on_changed(self, *_args):
 
@@ -229,7 +289,7 @@ class ChatEntry:
     def on_tab_complete_accelerator(self, _widget, _state, backwards=False):
         """Tab and Shift+Tab: tab complete chat."""
 
-        if not config.sections["words"]["tab"]:
+        if not self.enable_tab_completion:
             return False
 
         text = self.widget.get_text()

--- a/pynicotine/gtkgui/widgets/textview.py
+++ b/pynicotine/gtkgui/widgets/textview.py
@@ -38,7 +38,8 @@ class TextView:
     URL_REGEX = re.compile("(\\w+\\://[^\\s]+)|(www\\.\\w+\\.[^\\s]+)|(mailto\\:[^\\s]+)")
 
     def __init__(self, parent, auto_scroll=False, parse_urls=True, editable=True,
-                 horizontal_margin=12, vertical_margin=8, pixels_above_lines=1, pixels_below_lines=1):
+                 horizontal_margin=12, vertical_margin=8, pixels_above_lines=1, pixels_below_lines=1,
+                 message_entry=None):
 
         self.widget = Gtk.TextView(
             accepts_tab=False, editable=editable,
@@ -69,6 +70,7 @@ class TextView:
 
         self.pressed_x = self.pressed_y = 0
         self.parse_urls = parse_urls
+        self.message_entry = message_entry
 
         if GTK_API_VERSION >= 4:
             self.textbuffer.set_enable_undo(editable)
@@ -98,6 +100,10 @@ class TextView:
         self.gesture_click_secondary.set_propagation_phase(Gtk.PropagationPhase.CAPTURE)
         self.gesture_click_secondary.set_button(Gdk.BUTTON_SECONDARY)
         self.gesture_click_secondary.connect("pressed", self.on_pressed_secondary)
+
+        if self.message_entry is not None:
+            Accelerator("Down", self.widget, self.on_page_down_accelerator)
+            Accelerator("Page_Down", self.widget, self.on_page_down_accelerator)
 
     def destroy(self):
 
@@ -359,15 +365,22 @@ class TextView:
 
         self.adjustment_value = new_value
 
+    def on_page_down_accelerator(self, *_args):
+        """Page_Down, Down: Give focus to text entry if already scrolled at the
+        bottom."""
+
+        if self.textbuffer.props.cursor_position >= self.textbuffer.get_char_count():
+            # Give focus to text entry upon scrolling down to the bottom
+            self.message_entry.grab_focus_without_selecting()
+
 
 class ChatView(TextView):
 
-    def __init__(self, *args, chat_entry=None, status_users=None, roomname_event=None, username_event=None, **kwargs):
+    def __init__(self, *args, status_users=None, roomname_event=None, username_event=None, **kwargs):
 
         super().__init__(*args, **kwargs)
 
         self.user_tags = self.status_users = {}
-        self.chat_entry = chat_entry
         self.roomname_event = roomname_event
         self.username_event = username_event
 
@@ -387,9 +400,6 @@ class ChatView(TextView):
         # Prevent long lines from adding a horizontal scroll bar. WORD_CHAR wrapping
         # is slower than WORD, but it's good enough for our chat views.
         self.widget.set_wrap_mode(Gtk.WrapMode.WORD_CHAR)
-
-        Accelerator("Down", self.widget, self.on_page_down_accelerator)
-        Accelerator("Page_Down", self.widget, self.on_page_down_accelerator)
 
     def add_line(self, message, prepend=False, timestamp_format=None, message_type=None,
                  timestamp=None, timestamp_string=None, roomname=None, username=None):
@@ -526,11 +536,3 @@ class ChatView(TextView):
     def update_user_tags(self):
         for username in self.user_tags:
             self.update_user_tag(username)
-
-    def on_page_down_accelerator(self, *_args):
-        """Page_Down, Down: Give focus to text entry if already scrolled at the
-        bottom."""
-
-        if self.textbuffer.props.cursor_position >= self.textbuffer.get_char_count():
-            # Give focus to text entry upon scrolling down to the bottom
-            self.chat_entry.grab_focus_without_selecting()

--- a/pynicotine/logfacility.py
+++ b/pynicotine/logfacility.py
@@ -38,6 +38,7 @@ class LogLevel:
     MESSAGE = "message"
     TRANSFER = "transfer"
     MISCELLANEOUS = "miscellaneous"
+    COMMAND = "command"
 
 
 class Logger:
@@ -309,6 +310,12 @@ class Logger:
     def _add(self, msg, msg_args=None, title=None, level=LogLevel.DEFAULT, should_log_file=True):
 
         msg = self._format_log_message(level, msg, msg_args)
+        timestamp_format = None
+
+        if level == LogLevel.COMMAND:
+            should_log_file = False
+        else:
+            timestamp_format = config.sections["logging"].get("log_timestamp", "%x %X")
 
         if should_log_file and config.sections["logging"].get("debug_file_output", False):
             events.invoke_main_thread(
@@ -316,7 +323,6 @@ class Logger:
                 basename=self.debug_file_name, text=msg)
 
         try:
-            timestamp_format = config.sections["logging"].get("log_timestamp", "%x %X")
             events.emit("log-message", timestamp_format, msg, title, level)
 
         except Exception as error:
@@ -399,6 +405,9 @@ class Logger:
 
         if level in self._log_levels:
             self._add(msg, msg_args, level=level)
+
+    def add_command(self, msg):
+        self._add(msg, level=LogLevel.COMMAND)
 
 
 log = Logger()

--- a/pynicotine/plugins/README.md
+++ b/pynicotine/plugins/README.md
@@ -40,7 +40,8 @@ There are three types of commands available:
 
 - `chatroom`: Can be used in the message entry widget in chat rooms
 - `private_chat`: Can be used in the message entry widget in private chats
-- `cli`: Can be used while Nicotine+ is running in a terminal
+- `cli`: Can be used in the command entry widget in the log pane (since
+  Nicotine+ 3.4.0), or the terminal if Nicotine+ is running in one
 
 By default, commands are grouped under the same name as your plugin.
 

--- a/pynicotine/pluginsystem.py
+++ b/pynicotine/pluginsystem.py
@@ -291,7 +291,7 @@ class BasePlugin:
         command_interface, source = self.parent.command_source
 
         if command_interface == "cli":
-            print(text)
+            log.add_command(text)
             return
 
         func = self.echo_public if command_interface == "chatroom" else self.echo_private
@@ -460,6 +460,8 @@ class PluginHandler:
         self.trigger_cli_command_event(command, args)
 
     def update_completions(self, plugin):
+
+        events.emit("cli-completions", self.get_command_list("private_chat"))
 
         if not config.sections["words"]["commands"]:
             return
@@ -877,7 +879,7 @@ class PluginHandler:
     def get_plugin_human_name(self, plugin_name):
 
         try:
-            info = core.pluginhandler.get_plugin_info(plugin_name)
+            info = self.get_plugin_info(plugin_name)
             plugin_human_name = info.get("Name", plugin_name)
 
         except OSError:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,7 @@ py-version = "3.10"
 
 [tool.pylint.design]
 max-args = 18
-max-attributes = 125
+max-attributes = 130
 max-bool-expr = 6
 max-branches = 40
 max-locals = 40


### PR DESCRIPTION
Allows for using commands without opening a chat or running Nicotine+ in a terminal. Also makes it easier to test CLI commands in plugins.

<img width="970" height="722" alt="command-entry" src="https://github.com/user-attachments/assets/2b4dbf33-c512-4fb4-a8bd-18e7802bdee3" />
