### PR TITLE
slskproto.py: truncate unparsable msg_content in debug log

### DIFF
--- a/pynicotine/slskproto.py
+++ b/pynicotine/slskproto.py
@@ -727,8 +727,8 @@ class NetworkThread(Thread):
             return msg
 
         except Exception as error:
-            log.add_debug("Unable to parse %s message type %s, size %s, contents %s. Error: %s",
-                          (conn_type, msg_class, msg_size, msg_content, error))
+            log.add_debug("Unable to parse %s message type %s, size %s, contents %s… Error: %s",
+                          (conn_type, msg_class, msg_size, msg_content[:50], error))
 
         finally:
             if msg is not None:


### PR DESCRIPTION
This entire unparsed string could potentially be quite large for displaying all of it in the log pane, whereas the most interesting thing to know about is usually the type of exception that was raised so it should be good enough for debugging purposes to identify any particular erroneous content payload from the peer by logging only the start of it, like we already do for unknown PeerInit messages.