### PR TITLE
slskproto.py: check root_username in DistribBranchRoot (D code 5)

### DIFF
--- a/pynicotine/slskmessages.py
+++ b/pynicotine/slskmessages.py
@@ -4156,17 +4156,19 @@ class DistribBranchRoot(DistribMessage):
     message regardless of our status in the distributed network.
     """
 
-    __slots__ = ("root_username",)
+    __slots__ = ("root_username", "root_username_size")
 
     def __init__(self, root_username=None, *, msg_content=None):
         DistribMessage.__init__(self, msg_content)
         self.root_username = root_username
+        self.root_username_size = None  # in bytes
 
     def make_network_message(self):
         return self.pack_string(self.root_username)
 
     def parse_network_message(self):
         self.root_username = self.unpack_string()
+        self.root_username_size = self._offset - 4
 
 
 class DistribChildDepth(DistribMessage):

--- a/pynicotine/slskproto.py
+++ b/pynicotine/slskproto.py
@@ -333,9 +333,10 @@ class NetworkThread(Thread):
     Soulseek server and peers. Communication with the core is done through
     events.
 
-    The server and peers send each other small binary messages that
-    start with length and message code followed by the actual message
-    data.
+    The server and peers send each other small binary messages that start with
+    length and message code followed by the actual message data payload. Each
+    client should be tolerant of receiving bad inputs, but must be strict about
+    only sending valid outputs, with respect to clients that are less capable.
     """
 
     CONNECTION_INIT_TIMEOUT = 2
@@ -348,10 +349,11 @@ class NetworkThread(Thread):
     MAX_INCOMING_MESSAGE_SIZE_16M = 16777216     # 16 MiB
     MAX_INCOMING_MESSAGE_SIZE_1M = 1048576       # 1 MiB
     MAX_INCOMING_MESSAGE_SIZE_16K = 16384        # 16 KiB
+    MAX_INCOMING_USERNAME_SIZE = 256             # 256 bytes, for future flexibility beyond the actual 30 byte limit
+    MAX_OUTGOING_USERNAME_SIZE = 30              # 30 bytes, is 30 printable ASCII characters accepted only
+    SERVER_USERNAME = "server"
     TCP_BUFFER_SIZE_MEDIUM = 208896              # 204 KiB, maximum limit NetBSD accepts by default
     TCP_BUFFER_SIZE_SMALL = 16384                # 16 KiB
-    MAX_ACCEPTED_USERNAME_SIZE = 256             # 256 bytes, for future flexibility beyond the actual 30 byte limit
-    SERVER_USERNAME = "server"
     ALLOWED_PEER_CONN_TYPES = {
         ConnectionType.PEER,
         ConnectionType.FILE,
@@ -1712,7 +1714,7 @@ class NetworkThread(Thread):
             conn_type = msg.conn_type
             addr = conn.addr
 
-            if (not 0 < msg.target_username_size <= self.MAX_ACCEPTED_USERNAME_SIZE
+            if (not 0 < msg.target_username_size <= self.MAX_INCOMING_USERNAME_SIZE
                     or username == self.SERVER_USERNAME or not username.isprintable()):
                 log.add_conn("Rejected incoming direct connection from address %s "
                              "due to invalid username: %r", (addr, username))
@@ -2306,7 +2308,7 @@ class NetworkThread(Thread):
         if conn is self._parent.conn:
             return ParentStatus.ACCEPTED
 
-        log.add_conn("Received a distributed message %s from user %s, who is not our parent. "
+        log.add_conn("Rejected a distributed message %s from user %s, who is not our parent. "
                      "Closing connection.", (msg_class, conn.init.target_user))
         return ParentStatus.REJECTED
 
@@ -2470,7 +2472,7 @@ class NetworkThread(Thread):
             if msg.level < 0:
                 # There are rare cases of parents sending a branch level value of -1,
                 # presumably buggy clients
-                log.add_conn("Received an invalid branch level value %s from user %s. "
+                log.add_conn("Rejected an invalid branch level value %s from user %s. "
                              "Closing connection.", (msg.level, username))
                 return False
 
@@ -2482,8 +2484,8 @@ class NetworkThread(Thread):
                 self._send_message_to_server(BranchLevel(self._branch_level))
                 self._send_message_to_child_peers(DistribBranchLevel(self._branch_level))
 
-                log.add_conn("Received a branch level update from our parent. Our new branch level is %s",
-                             self._branch_level)
+                log.add_conn("Received a branch level update from our parent %s. Our new branch level is %s",
+                             (username, self._branch_level))
 
             elif parent_status == ParentStatus.WAITING and username in self._potential_parents:
                 parent_candidate = self._potential_parents[username]
@@ -2501,20 +2503,25 @@ class NetworkThread(Thread):
                 return False
 
         elif msg_class is DistribBranchRoot:
-            if not msg.root_username:
-                log.add_conn("Received an empty branch root value from user %s. "
-                             "Closing connection.", username)
+            if (not 0 < msg.root_username_size <= self.MAX_OUTGOING_USERNAME_SIZE
+                    or not msg.root_username.isascii()
+                    or not msg.root_username.isprintable()
+                    or msg.root_username != msg.root_username.strip()
+                    or msg.root_username == self.SERVER_USERNAME):
+                log.add_conn("Rejected an invalid branch root username %r from user %s. "
+                             "Closing connection.", (msg.root_username, username))
                 return False
 
             parent_status = self._verify_parent_status(conn, msg_class)
 
             if parent_status == ParentStatus.ACCEPTED:
+                # Inform the server and child peers the name of our new branch root
                 self._branch_root = msg.root_username
                 self._send_message_to_server(BranchRoot(self._branch_root))
                 self._send_message_to_child_peers(DistribBranchRoot(self._branch_root))
 
-                log.add_conn("Received a branch root update from our parent. Our new branch root is %s",
-                             self._branch_root)
+                log.add_conn("Received a branch root update from our parent %s. Our new branch root is %s",
+                             (username, self._branch_root))
 
             elif parent_status == ParentStatus.WAITING and username in self._potential_parents:
                 parent_candidate = self._potential_parents[username]

--- a/pynicotine/slskproto.py
+++ b/pynicotine/slskproto.py
@@ -333,10 +333,9 @@ class NetworkThread(Thread):
     Soulseek server and peers. Communication with the core is done through
     events.
 
-    The server and peers send each other small binary messages that start with
-    length and message code followed by the actual message data payload. Each
-    client should be tolerant of receiving bad inputs, but must be strict about
-    only sending valid outputs, with respect to clients that are less capable.
+    The server and peers send each other small binary messages that
+    start with length and message code followed by the actual message
+    data.
     """
 
     CONNECTION_INIT_TIMEOUT = 2
@@ -349,11 +348,10 @@ class NetworkThread(Thread):
     MAX_INCOMING_MESSAGE_SIZE_16M = 16777216     # 16 MiB
     MAX_INCOMING_MESSAGE_SIZE_1M = 1048576       # 1 MiB
     MAX_INCOMING_MESSAGE_SIZE_16K = 16384        # 16 KiB
-    MAX_INCOMING_USERNAME_SIZE = 256             # 256 bytes, for future flexibility beyond the actual 30 byte limit
-    MAX_OUTGOING_USERNAME_SIZE = 30              # 30 bytes, is 30 printable ASCII characters accepted only
-    SERVER_USERNAME = "server"
     TCP_BUFFER_SIZE_MEDIUM = 208896              # 204 KiB, maximum limit NetBSD accepts by default
     TCP_BUFFER_SIZE_SMALL = 16384                # 16 KiB
+    MAX_ACCEPTED_USERNAME_SIZE = 256             # 256 bytes, for future flexibility beyond the actual 30 byte limit
+    SERVER_USERNAME = "server"
     ALLOWED_PEER_CONN_TYPES = {
         ConnectionType.PEER,
         ConnectionType.FILE,
@@ -1714,7 +1712,7 @@ class NetworkThread(Thread):
             conn_type = msg.conn_type
             addr = conn.addr
 
-            if (not 0 < msg.target_username_size <= self.MAX_INCOMING_USERNAME_SIZE
+            if (not 0 < msg.target_username_size <= self.MAX_ACCEPTED_USERNAME_SIZE
                     or username == self.SERVER_USERNAME or not username.isprintable()):
                 log.add_conn("Rejected incoming direct connection from address %s "
                              "due to invalid username: %r", (addr, username))
@@ -2503,11 +2501,8 @@ class NetworkThread(Thread):
                 return False
 
         elif msg_class is DistribBranchRoot:
-            if (not 0 < msg.root_username_size <= self.MAX_OUTGOING_USERNAME_SIZE
-                    or not msg.root_username.isascii()
-                    or not msg.root_username.isprintable()
-                    or msg.root_username != msg.root_username.strip()
-                    or msg.root_username == self.SERVER_USERNAME):
+            if (not 0 < msg.root_username_size <= self.MAX_ACCEPTED_USERNAME_SIZE
+                    or msg.root_username == self.SERVER_USERNAME or not msg.root_username.isprintable()):
                 log.add_conn("Rejected an invalid branch root username %r from user %s. "
                              "Closing connection.", (msg.root_username, username))
                 return False


### PR DESCRIPTION
+ Added: Validate the `root_username` string reported by a peer ~is a valid Soulseek username~ before we consider trying them as a possible parent, so that there can never be any risk of us later forwarding a faulty raw payload onto all our children.
+ ~Changed: A name of a class constant to avoid ambiguity about what usernames are actually "accepted" on the network.~
+ Changed: Slight adjustments to wording of Conn log lines ~and added explanatory text to the class docstring.~

This matches the same sort of checking that's done for PeerInit, ~but stricter~ because a remote possibility does exist that this value can end up being published to our children on the distributed network, whose reasonable expectation is that this string would be validated by us as their parent, whom they are likely assume to be a trustworthy source of such pivotal information.

It is warranted to check the peer input of this message because it is only a single string with no codepoint or check bit, so any arbitrary data could end up being put there by a faulty peer, or even a foreign entity from an alien network.

## For a ridiculous example:

Lets say you are having a bad day and plugged your router ports in the wrong way around and in doing so you accidentally connected a Napster server into the Soulseek distributed network by mistake, as you do, then according to the documentation for message Type `5` of that foreign protocol...

```markdown
**Client-Server protocol**

Napster uses TCP for client to server communication.  Typically the servers
run on ports 8888 and 7777.  Note that this is different from the `metaserver'
(or redirector) which runs on port 8875.

Each message to/from the server is in the form of <length><type><data>
where <length> and <type> are 2 bytes each.  <length> specifies the length in
bytes of the <data> portion of the message.

Note that unlike the IRC protocol, each line does NOT end in \r\n.  The
<length> field specifies exactly how much data you should read.

[You may ask yourself, what could possibly go wrong? -ed]

**Message Types**

The following section describes the format of the <data> section for each
specific message type.  Each field is denoted with <>.  The fields in a
message are separated by a single space character (ASCII 32).  Where
appropriate, examples of the <data> section for each message are given.

...
5       "auto-upgrade" [SERVER]

        Format: <version> <hostname:filename>

        Napster is out of date, get a new version.
        Or also known as gaping security hole.

        <version>  = string, the new version number.
        <hostname> = string, hostname of upgrade (http) server
        <filename> = string, filename

        Connections are always made to port 80.

        The HTTP Request:
                GET <filename> HTTP/1.0
                Connection: Keep-Alive
                Host: <hostname>

        Expected HTTP Response.
                Content-Length: <size>
                Content-Type: <doesn't matter>
                <data>

        Upgrade file is save as "upgrade.exe".
        And executed as: upgrade.exe UPGRADE "<current.exe>"

        As far as I can tell no confirmation is requested by Napster when it
        receives this message.  And immediately start to "auto-upgrade". To keep
        users informed that Napster is doing something potentially very harmful
        to their computer it displays a message saying it's "auto-upgrading".

        I think this pretty bad, since all someone has to do is hack a napster
        server et voila a zillion clients at your disposal.

        As far as I known this only affects the Win32 2.0b5a Napster client.
        Other clients/versions I don't know.

	[This section was contributed by Thomas van der Heijden <thom@bart.nl> -ed]
...
```

... all their payloads are crudely space-delimited, so such a horrendous misconnection event could theoretically result in our root user's name being stored and forwarded as:
- A UTF or Latin-1 string-encoded version number of an obscure client software package, followed by space,
- followed by an URL to page hosting an executable file that can be downloaded from some random place on the internet,
- followed by a colon, followed by the file name of that server's Napster installer ("upgrade.exe").
 
This would almost certainly lead to undefined behaviour. For instance, unless it happened to be a shortened URL this string probably wouldn't resolve to a valid Soulseek username and it would be very unlikely, although not impossible, to match the name of a registered account.

Thankfully, slsk isn't vulnerable to its clients automatically executing arbitrary executable binary payloads such as what routinely happens on naps, but nevertheless this PR reduces the potential maximum size our forwarded payload outputs from ~16000 UTF or Latin-1 characters down to ~30 ASCII characters~ 256 bytes or fewer, thereby substantially reducing the chances of us announcing to everyone the we adopted an alien parent who told us that our new distributed network branch root is a 32-bit Windows executable, or any other kinds of unbounded string payload encoding mishap of a similarly ridiculous nature, are now rejected.