### PR TITLE
mainwindow.py: OK button in Soulseek Announcement message dialog

### DIFF
--- a/pynicotine/gtkgui/mainwindow.py
+++ b/pynicotine/gtkgui/mainwindow.py
@@ -1164,7 +1164,9 @@ class MainWindow(Window):
     def update_log(self, timestamp_format, msg, title, level):
 
         if title:
-            MessageDialog(application=self.application, title=title, message=msg, selectable=True).present()
+            MessageDialog(
+                application=self.application, title=title, message=msg, buttons=[("ok", _("_OK"))], selectable=True
+            ).present()
 
         # Keep verbose debug messages out of statusbar to make it more useful
         if level not in {"transfer", "connection", "message", "miscellaneous"}:


### PR DESCRIPTION
"Close" doesn't exit the application, nor should it, but in context with the "going offline" wording in this particular announcement one could wrongly think that the entire session is going to be ending on pressing the button...
<img width="499" height="172" alt="image" src="https://github.com/user-attachments/assets/bb4f291e-6ab8-4684-b183-c1d9aa1643ed" />


+ Changed: "OK" makes more sense here, and the suggested action highlight makes it look more prominent too:
<img width="282" height="134" alt="image" src="https://github.com/user-attachments/assets/c835e1cd-c6b5-4203-b8a4-3a064c858284" />

+ ~Added: Also include the `title` within logged message line:~

    - ~Status bar...~
`Soulseek Announcement: [Test] Server Message Code 66.`

    - ~Log pane...~
`2026-09-06 16:20:50 Soulseek Announcement: [Test] Server Message Code 66.`

    - ~Console...~
`[2026-09-06 16:20:50] Soulseek Announcement: [Test] Server Message Code 66.`
