### PR TITLE
shares.py: flush file handle before descriptor fsync on close

### DIFF
--- a/pynicotine/shares.py
+++ b/pynicotine/shares.py
@@ -218,7 +218,8 @@ class Database:
     def close(self):
 
         if self._overwrite:
-            os.fsync(self._file_handle)
+            self._file_handle.flush()
+            os.fsync(self._file_handle.fileno())
 
         self._file_handle.close()
 


### PR DESCRIPTION
Potentially related to #3818 

+ Added: `flush()` the binary file_handle before synchronizing its buffered data onto the filesystem
+ Changed: Synchronize the `fileno()` descriptor instead of its file object, because the docs say to do this...

https://docs.python.org/3/library/os.html#os.fsync
_"If you’re starting with a buffered Python [file object](https://docs.python.org/3/glossary.html#term-file-object) `f`, first do `f.flush()`, and then do `os.fsync(f.fileno())`, to ensure that all internal buffers associated with `f` are written to disk."_

https://docs.python.org/3/library/os.html#file-descriptor-operations
_"The [fileno()](https://docs.python.org/3/library/io.html#io.IOBase.fileno) method can be used to obtain the file descriptor associated with a [file object](https://docs.python.org/3/glossary.html#term-file-object) when required. Note that using the file descriptor directly will bypass the file object methods, ignoring aspects such as internal buffering of data."_